### PR TITLE
Fixes for as constructor, type printing

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -905,8 +905,11 @@ term[CVC4::Expr& expr, CVC4::Expr& expr2]
         expr = MK_CONST( ::CVC4::EmptySet(type) );
       } else {
         if(f.getType() != type) {
+          Debug("parser") << "Type " << f.getType() << " and "
+                          << type << " not equal." <<  std::endl;
           PARSER_STATE->parseError("Type ascription not satisfied.");
         }
+        expr = f;
       }
     }
   | LPAREN_TOK quantOp[kind]

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -233,10 +233,25 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
 
   if(n.getKind() == kind::SORT_TYPE) {
     string name;
-    if(n.getAttribute(expr::VarNameAttr(), name)) {
+    if(!n.getAttribute(expr::VarNameAttr(), name)){
+      name = "???";
+    };
+
+    if (n.getNumChildren() == 0) {
       out << maybeQuoteSymbol(name);
-      return;
+    } else { /* n-arity */
+      out << "(" << maybeQuoteSymbol(name);
+      for(size_t i = 0; i < n.getNumChildren(); ++i) {
+        out << " ";
+        if(toDepth != 0) {
+          toStream(out, n[i], toDepth < 0 ? toDepth : toDepth - 1, types);
+        } else {
+          out << "(...)";
+        }
+      }
+      out << ")";
     }
+    return;
   }
 
   bool stillNeedToPrintParams = true;

--- a/test/regress/regress0/parser/Makefile.am
+++ b/test/regress/regress0/parser/Makefile.am
@@ -19,7 +19,8 @@ MAKEFLAGS = -k
 # If a test shouldn't be run in e.g. competition mode,
 # put it below in "TESTS +="
 TESTS =	\
-	declarefun-emptyset-uf.smt2
+	declarefun-emptyset-uf.smt2 \
+	as.smt2
 
 EXTRA_DIST = $(TESTS)
 

--- a/test/regress/regress0/parser/as.smt2
+++ b/test/regress/regress0/parser/as.smt2
@@ -1,0 +1,14 @@
+(set-logic QF_UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status sat)
+(declare-sort I 0)
+(declare-fun e0 () I)
+
+;; as was badly parsed in default case
+;; no specialization (emptyset) just dumb type-checking
+
+(assert (= (as e0 I) (as e0 I)))
+
+(check-sat)
+(exit)


### PR DESCRIPTION
Three fixes:
- `(as term type)` was not well parsed in the default case
- if a `kind::SORT_TYPE` doesn't have a `VarNameAttr` the `return` was not taken and the node printing was used which result in bad thing when `--print-expr-types` was used (a type is not type-checkable `Unhandled case`)
- The sub-term of a type were not printed, only the toplevel constructor.

PS: sorry for not rebasing it on master but the build system doesn't produce the cvc4 binary in master on my computer.
