### PR TITLE
[RFC] Add adhoc polymorphism

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -315,6 +315,8 @@ libcvc4_la_SOURCES = \
 	theory/quantifiers/first_order_reasoning.cpp \
 	theory/quantifiers/rewrite_engine.h \
 	theory/quantifiers/rewrite_engine.cpp \
+	theory/quantifiers/polymorphic_engine.h \
+	theory/quantifiers/polymorphic_engine.cpp \
 	theory/quantifiers/relevant_domain.h \
 	theory/quantifiers/relevant_domain.cpp \
 	theory/quantifiers/symmetry_breaking.h \

--- a/src/expr/expr_manager_template.cpp
+++ b/src/expr/expr_manager_template.cpp
@@ -19,6 +19,7 @@
 #include "expr/variable_type_map.h"
 #include "options/options.h"
 #include "util/statistics_registry.h"
+#include "expr/node_manager_attributes.h"
 
 #include <map>
 
@@ -28,7 +29,7 @@ ${includes}
 // compiler directs the user to the template file instead of the
 // generated one.  We don't want the user to modify the generated one,
 // since it'll get overwritten on a later build.
-#line 32 "${template}"
+#line 33 "${template}"
 
 #ifdef CVC4_STATISTICS_ON
   #define INC_STAT(kind) \
@@ -1114,7 +1115,13 @@ TypeNode exportTypeInternal(TypeNode n, NodeManager* from, NodeManager* to, Expr
     children << exportTypeInternal(*i, from, to, vmap);
   }
   TypeNode out = children.constructTypeNode();// FIXME thread safety
+  // Copy constructor type name
+  string name;
+  if(from->getAttribute(n,expr::VarNameAttr(), name)){
+    to->setAttribute(out,expr::VarNameAttr(), name);
+  };
   to_t = to->toType(out);
+  Debug("export") << "+ mapped `" << from_t << "' to `" << to_t << "'" << std::endl;
   return out;
 }/* exportTypeInternal() */
 

--- a/src/expr/expr_manager_template.cpp
+++ b/src/expr/expr_manager_template.cpp
@@ -983,6 +983,10 @@ Expr ExprManager::getPolymorphicFunction(Expr n){
 Expr ExprManager::instanciatePolymorphicFunction(Expr n, FunctionType ty)
   throw(TypeCheckingException) {
   NodeManagerScope nms(d_nodeManager);
+  if (FunctionType(n.getType()).getArity() != ty.getArity()){
+    throw TypeCheckingException(n,"application arity mismatch");
+  };
+
   try {
     return Expr(this,new Node (d_nodeManager->instanciatePolymorphicFunction(n.getNode(),*ty.d_typeNode)));
   } catch (const TypeCheckingExceptionPrivate& e) {
@@ -993,7 +997,10 @@ Expr ExprManager::instanciatePolymorphicFunction(Expr n, FunctionType ty)
 Expr ExprManager::instanciatePolymorphicFunction(Expr n, std::vector<Type> tys)
   throw(TypeCheckingException) {
   NodeManagerScope nms(d_nodeManager);
-  Debug("parser") << "em tys " << tys[0] << std::endl;
+  if (FunctionType(n.getType()).getArity() != tys.size()){
+    throw TypeCheckingException(n,"arity application mismatch");
+  };
+
   std::vector<TypeNode> tys2; tys2.reserve(tys.size());
   for(size_t i=0, len = tys.size(); i < len; ++i){
     tys2.push_back(*(tys[i]).d_typeNode);

--- a/src/expr/expr_manager_template.cpp
+++ b/src/expr/expr_manager_template.cpp
@@ -1047,6 +1047,11 @@ std::vector< Type > ExprManager::getPolymorphicTypeVarsSchema(size_t nb){
   return res2;
 }
 
+Expr ExprManager::getPolymorphicConstantArg(){
+  NodeManagerScope nms(d_nodeManager);
+  return Expr(this,new Node(d_nodeManager->getPolymorphicConstantArg()));
+}
+
 
 
 unsigned ExprManager::minArity(Kind kind) {

--- a/src/expr/expr_manager_template.cpp
+++ b/src/expr/expr_manager_template.cpp
@@ -959,6 +959,89 @@ Expr ExprManager::mkAssociative(Kind kind,
   return Expr(this, d_nodeManager->mkNodePtr(kind,newChildren) );
 }
 
+
+void ExprManager::newPolymorphicFunction(Expr n){
+  NodeManagerScope nms(d_nodeManager);
+  d_nodeManager->newPolymorphicFunction(n);
+}
+
+bool ExprManager::isPolymorphicFunction(Expr n){
+  NodeManagerScope nms(d_nodeManager);
+  return d_nodeManager->isPolymorphicFunction(n);
+}
+
+bool ExprManager::isPolymorphicFunctionInstance(Expr n){
+  NodeManagerScope nms(d_nodeManager);
+  return d_nodeManager->isPolymorphicFunctionInstance(n);
+}
+
+Expr ExprManager::getPolymorphicFunction(Expr n){
+  NodeManagerScope nms(d_nodeManager);
+  return Expr(this,new Node(d_nodeManager->getPolymorphicFunction(n.getNode())));
+}
+
+Expr ExprManager::instanciatePolymorphicFunction(Expr n, FunctionType ty)
+  throw(TypeCheckingException) {
+  NodeManagerScope nms(d_nodeManager);
+  try {
+    return Expr(this,new Node (d_nodeManager->instanciatePolymorphicFunction(n.getNode(),*ty.d_typeNode)));
+  } catch (const TypeCheckingExceptionPrivate& e) {
+    throw TypeCheckingException(this, &e);
+  }
+}
+
+Expr ExprManager::instanciatePolymorphicFunction(Expr n, std::vector<Type> tys)
+  throw(TypeCheckingException) {
+  NodeManagerScope nms(d_nodeManager);
+  Debug("parser") << "em tys " << tys[0] << std::endl;
+  std::vector<TypeNode> tys2; tys2.reserve(tys.size());
+  for(size_t i=0, len = tys.size(); i < len; ++i){
+    tys2.push_back(*(tys[i]).d_typeNode);
+  };
+  try {
+    return Expr(this,new Node (d_nodeManager->instanciatePolymorphicFunction(n.getNode(),tys2)));
+  } catch (const TypeCheckingExceptionPrivate& e) {
+    throw TypeCheckingException(this, &e);
+  }
+}
+
+bool ExprManager::isPolymorphicTypeVar(Type tv){
+  NodeManagerScope nms(d_nodeManager);
+  return d_nodeManager->isPolymorphicTypeVar(*tv.d_typeNode);
+}
+
+std::vector<std::pair<Type,Expr> > ExprManager::getPolymorphicTypeVars(size_t nb){
+  NodeManagerScope nms(d_nodeManager);
+  std::vector< std::pair<TypeNode,TNode> > res = d_nodeManager->getPolymorphicTypeVars(nb);
+  std::vector< std::pair<Type,Expr> > res2;
+  res2.reserve(nb);
+  for(std::vector< std::pair<TypeNode,TNode> >::const_iterator i =
+        res.begin();
+      i != res.end(); ++i){
+    res2.push_back( std::make_pair(Type(d_nodeManager,new TypeNode(i->first)),
+                                   Expr(this,new Node(i->second))));
+  }
+  return res2;
+}
+
+bool ExprManager::isPolymorphicTypeVarSchema(Type tv){
+  NodeManagerScope nms(d_nodeManager);
+  return d_nodeManager->isPolymorphicTypeVarSchema(*tv.d_typeNode);
+}
+
+std::vector< Type > ExprManager::getPolymorphicTypeVarsSchema(size_t nb){
+  NodeManagerScope nms(d_nodeManager);
+  std::vector< TypeNode > res = d_nodeManager->getPolymorphicTypeVarsSchema(nb);
+  std::vector< Type > res2;
+  res2.reserve(nb);
+  for(std::vector< TypeNode >::const_iterator i = res.begin(); i != res.end(); ++i){
+    res2.push_back( Type(d_nodeManager,new TypeNode(*i)));
+  }
+  return res2;
+}
+
+
+
 unsigned ExprManager::minArity(Kind kind) {
   return metakind::getLowerBoundForKind(kind);
 }

--- a/src/expr/expr_manager_template.h
+++ b/src/expr/expr_manager_template.h
@@ -552,6 +552,60 @@ public:
    */
   Expr mkBoundVar(Type type);
 
+  /**
+   * Register a function as a polymorphic function;
+   */
+  void newPolymorphicFunction(Expr n);
+
+  /**
+   * Returns true if the function is a polymorphic function.
+   */
+  bool isPolymorphicFunction(Expr n);
+
+  /**
+   * Returns true if the function is an instance of a polymorphic
+   * function.
+   */
+  bool isPolymorphicFunctionInstance(Expr n);
+
+  /**
+   * Returns the original polymorphic function
+   * or null if the function is not a monomorphised function
+   */
+  Expr getPolymorphicFunction(Expr n);
+
+  /**
+   * Returns the instanciation of a polymorphic function with the given signature
+   */
+  Expr instanciatePolymorphicFunction(Expr n, FunctionType ty)
+    throw(TypeCheckingException);
+
+  /**
+   * Returns the instanciation of a polymorphic function with the given signature
+   */
+  Expr instanciatePolymorphicFunction(Expr n, std::vector< Type > tys)
+    throw(TypeCheckingException);
+
+  /**
+   * Check if the given type is used for type polymorphicity
+   */
+  bool isPolymorphicTypeVar(Type tv);
+
+  /**
+   * Return the given number of type usable for polymorphicity
+   */
+  std::vector<std::pair<Type,Expr> > getPolymorphicTypeVars(size_t nb);
+
+  /**
+   * Check if the given type is used for polymorphic function schema
+   */
+  bool isPolymorphicTypeVarSchema(Type tv);
+
+  /**
+   * Return the given number of type usable for polymorphic function schema
+   */
+  std::vector< Type > getPolymorphicTypeVarsSchema(size_t nb);
+
   /** Get a reference to the statistics registry for this ExprManager */
   Statistics getStatistics() const throw();
 

--- a/src/expr/expr_manager_template.h
+++ b/src/expr/expr_manager_template.h
@@ -606,6 +606,11 @@ public:
    */
   std::vector< Type > getPolymorphicTypeVarsSchema(size_t nb);
 
+  /**
+   * Return the expr used for making polymorphic constant a function
+   */
+  Expr getPolymorphicConstantArg();
+
   /** Get a reference to the statistics registry for this ExprManager */
   Statistics getStatistics() const throw();
 

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -127,7 +127,7 @@ private:
 public:
   ExportPrivate(ExprManager* from, ExprManager* to, ExprManagerMapCollection& vmap, uint32_t flags) : from(from), to(to), vmap(vmap), flags(flags) {}
   Node exportInternal(TNode n) {
-
+    Debug("export") << "node: " << n << " " << n.getId() << std::endl;
     if(n.isNull()) return Node::null();
     if(theory::kindToTheoryId(n.getKind()) == theory::THEORY_DATATYPES) {
       throw ExportUnsupportedException
@@ -151,7 +151,7 @@ public:
         // to_e is a ref, so this inserts from_e -> to_e
         std::string name;
         Type type = from->exportType(from_e.getType(), to, vmap);
-        if(Node::fromExpr(from_e).getAttribute(VarNameAttr(), name)) {
+        if(NodeManager::fromExprManager(from)->getAttribute(Node::fromExpr(from_e),VarNameAttr(), name)) {
           // temporarily set the node manager to NULL; this gets around
           // a check that mkVar isn't called internally
 
@@ -207,8 +207,8 @@ public:
         children.push_back(exportInternal(*i));
       }
       if(Debug.isOn("export")) {
-        ExprManagerScope ems(*to);
         Debug("export") << "children for export from " << n << std::endl;
+        ExprManagerScope ems(*to);
         for(std::vector<Node>::iterator i = children.begin(), i_end = children.end(); i != i_end; ++i) {
           Debug("export") << "  child: " << *i << std::endl;
         }

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -147,15 +147,41 @@ public:
         Debug("export") << "+ mapped `" << from_e << "' to `" << to_e << "'" << std::endl;
         return to_e.getNode();
       } else {
+        NodeManager *from_nm = NodeManager::fromExprManager(from);
+        NodeManager *to_nm =   NodeManager::fromExprManager(to);
         // construct new variable in other manager:
         // to_e is a ref, so this inserts from_e -> to_e
         std::string name;
         Type type = from->exportType(from_e.getType(), to, vmap);
-        if(NodeManager::fromExprManager(from)->getAttribute(Node::fromExpr(from_e),VarNameAttr(), name)) {
+        if(from_nm->getAttribute(Node::fromExpr(from_e),VarNameAttr(), name)) {
           // temporarily set the node manager to NULL; this gets around
           // a check that mkVar isn't called internally
 
-          if(n.getKind() == kind::BOUND_VAR_LIST || n.getKind() == kind::BOUND_VARIABLE) {
+          if (from_nm->d_parameterVariables[n.getType()] == n){
+            //It is a boundvariable to a type variable
+            //The conversion of the type created the associated bound variable
+            Assert( to->isPolymorphicTypeVar(type) );
+            to_e = to_nm->toExpr(to_nm->d_parameterVariables[TypeNode::fromType(type)]);
+          } else if(from_nm->isPolymorphicFunctionInstance(n)) {
+            Expr to_poly = to_nm->toExpr(exportInternal(from_nm->getPolymorphicFunction(n)));
+            Debug("export") << "+ inst `" << to_poly.getType() << "' to `" << type << "'" << std::endl;
+            to_e = to->instanciatePolymorphicFunction(to_poly,type);
+          } else if(from_nm->isPolymorphicFunction(n)){
+            TNode poly = from_nm->getPolymorphicFunctionFromPolymorphicInstance(n);
+            if(poly != n){ //not the original fully polymorphic function
+              Expr to_poly = to_nm->toExpr(exportInternal(poly));
+              Debug("export") << "+ poly `" << to_poly.getType() << "' to `" << type << "'" << std::endl;
+              to_e = to->instanciatePolymorphicFunction(to_poly,type);
+            } else {
+              NodeManagerScope nullScope(NULL);
+              Assert( type.isFunction() );
+              to_e = to->mkVar(name, type);
+              to->newPolymorphicFunction(to_e);
+            }
+          } else if(n == from_nm->getPolymorphicConstantArg()) {
+            to_e = to->getPolymorphicConstantArg();
+
+          } else if(n.getKind() == kind::BOUND_VAR_LIST || n.getKind() == kind::BOUND_VARIABLE) {
             NodeManagerScope nullScope(NULL);
             to_e = to->mkBoundVar(name, type);// FIXME thread safety
           } else if(n.getKind() == kind::VARIABLE) {
@@ -186,6 +212,7 @@ public:
         vmap.d_from[to_int] = from_int;
         vmap.d_to[from_int] = to_int;
         vmap.d_typeMap[to_e] = from_e;// insert other direction too
+        Assert(!to_e.isNull());
         return Node::fromExpr(to_e);
       }
     } else {

--- a/src/expr/node_manager.cpp
+++ b/src/expr/node_manager.cpp
@@ -917,6 +917,14 @@ std::vector< TypeNode > NodeManager::getPolymorphicTypeVarsSchema(size_t nb){
   return res;
 }
 
+Node NodeManager::getPolymorphicConstantArg(){
+  if (d_polymorphicConstantArg.isNull()){
+    TypeNode cst_para_type = mkSort("cst_para");
+    d_polymorphicConstantArg = mkVar("cst_para",cst_para_type);
+  }
+  return d_polymorphicConstantArg;
+}
+
 
 bool NodeManager::safeToReclaimZombies() const{
   // FIXME multithreading

--- a/src/expr/node_manager.cpp
+++ b/src/expr/node_manager.cpp
@@ -753,7 +753,7 @@ bool NodeManager::matchPolymorphicType(TypeNode t1,
   throw(TypeCheckingExceptionPrivate){
 
   if(isPolymorphicTypeVarSchema(t2)){
-    throw TypeCheckingExceptionPrivate(Node::null(),"No inference is done, you should add an (as term ty) for specifying the return type.");
+    throw TypeCheckingExceptionPrivate(Node::null(),"You should add an (as term ty) for specifying the return type.");
   };
 
   std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction>::const_iterator i = subst.find(t1);
@@ -763,7 +763,7 @@ bool NodeManager::matchPolymorphicType(TypeNode t1,
 
   if(t1 == t2) {
     if(!isCloseSchemaVar(*this,t2)){
-      throw TypeCheckingExceptionPrivate(Node::null(),"No inference is done, you should add an (as term ty) for specifying the return type.");
+      throw TypeCheckingExceptionPrivate(Node::null(),"You should add an (as term ty) for specifying the return type.");
     }
     subst[t1] = t2;
     return true;

--- a/src/expr/node_manager.cpp
+++ b/src/expr/node_manager.cpp
@@ -145,6 +145,16 @@ NodeManager::~NodeManager() {
 
   NodeManagerScope nms(this);
 
+  // Empty all the information about polymorphic types.
+  // It is done early before all cleaning, instead of during
+  // the default destructors which run after all this code.
+  d_polymorphicFunction.clear();
+  d_instanceFunction.clear();
+  d_functionMonomorphization.clear();
+  d_parameterVariables.clear();
+  d_schemaVariables.clear();
+  d_polymorphicConstantArg = Node::null();
+
   {
     ScopedBool dontGC(d_inReclaimZombies);
     // hopefully by this point all SmtEngines have been deleted
@@ -934,6 +944,7 @@ Node NodeManager::getPolymorphicConstantArg(){
 
 bool NodeManager::safeToReclaimZombies() const{
   // FIXME multithreading
+  Assert(d_attrManager != NULL, "Attribute manager NULL in NodeManager");
   return !d_inReclaimZombies && !d_attrManager->inGarbageCollection();
 }
 

--- a/src/expr/node_manager.cpp
+++ b/src/expr/node_manager.cpp
@@ -906,7 +906,7 @@ std::vector<std::pair<TypeNode,TNode> > NodeManager::getPolymorphicTypeVars(size
   }
   while(nb > 0){
     TypeNode ty = mkSort("cvc4_tyvar");
-    Node n = mkBoundVar(ty);
+    Node n = mkBoundVar("cvc4_bvvar",ty);
     d_parameterVariables[ty] = n;
     res.push_back( std::make_pair(ty,n) );
     --nb;

--- a/src/expr/node_manager.cpp
+++ b/src/expr/node_manager.cpp
@@ -809,7 +809,10 @@ TNode NodeManager::instanciatePolymorphicFunction(TNode n,
     Node ni;
     string name;
     if(n.getAttribute(expr::VarNameAttr(), name)) {
-      ni = mkVar(name,ty);
+      std::stringstream ss;
+      ss << name << "_";
+      ss << d_instanceFunction.size() + d_polymorphicFunction.size();
+      ni = mkVar(ss.str(),ty);
     } else {
       ni = mkVar(ty);
     };

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -159,7 +159,36 @@ class NodeManager {
   /**
    * A map of tuple and record types to their corresponding datatype.
    */
-  std::hash_map<TypeNode, TypeNode, TypeNodeHashFunction> d_tupleAndRecordTypes;
+  std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction> d_tupleAndRecordTypes;
+
+
+  /**
+   * A map of polymorphic function symbols to the original polymorphic function
+   * The signature of these function is still a schema that contain type variables
+   * They should not appear in final terms
+   */
+  std::hash_map<Node, Node, NodeHashFunction> d_polymorphicFunction;
+
+  /**
+   * A map of function symbols to the original polymorphic function
+   */
+  std::hash_map<Node, Node, NodeHashFunction> d_instanceFunction;
+
+  /**
+   * A map of polymorphic function symbols to map of monomorphization
+   * according to the signature
+   */
+  std::hash_map<Node, std::hash_map<TypeNode, Node, TypeNode::HashFunction>, NodeHashFunction > d_functionMonomorphization;
+
+  /**
+   * The set of type used for polymorphic axioms with their corresponding term variable
+   */
+  std::hash_map<TypeNode, Node, TypeNode::HashFunction> d_parameterVariables;
+
+  /**
+   * The set of type used for polymorphic function schema
+   */
+  std::hash_set<TypeNode, TypeNode::HashFunction> d_schemaVariables;
 
   /**
    * Keep a count of all abstract values produced by this NodeManager.
@@ -862,6 +891,72 @@ public:
    */
   TypeNode getType(TNode n, bool check = false)
     throw(TypeCheckingExceptionPrivate, AssertionException);
+
+  /**
+   * Register a function as a polymorphic function;
+   */
+  void newPolymorphicFunction(TNode n);
+
+  /**
+   * Returns true if the function is a polymorphic function.
+   */
+  bool isPolymorphicFunction(TNode n);
+
+  /**
+   * Returns true if the function is an instance of a polymorphic
+   * function.
+   */
+  bool isPolymorphicFunctionInstance(TNode n);
+
+  /**
+   * Returns the original polymorphic function
+   * or null if the function is not a monomorphised function
+   */
+  TNode getPolymorphicFunction(TNode n);
+
+  /**
+   * Returns the instanciation of a polymorphic function with the given signature
+   */
+  TNode instanciatePolymorphicFunction(TNode n, TypeNode ty)
+    throw(TypeCheckingExceptionPrivate);
+
+  /**
+   * Returns the instanciation of a polymorphic function with the given type arguments.
+   * The return type is instanciated accordingly but type variable can remains
+   */
+  TNode instanciatePolymorphicFunction(TNode n, std::vector< TypeNode >& args)
+    throw(TypeCheckingExceptionPrivate);
+
+  /**
+   * Complete the given substitution with the substitution that
+   * instanciated the given polymorphic type to the ground type given
+   * Return false if a type variable is already associated with an incompatible type;
+   * in that case the given subtitution is already modified
+   */
+  bool matchPolymorphicType(TypeNode t1, TypeNode t2,
+                           std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction>& subst);
+
+
+  /**
+   * Check if the given type is used as type variable
+   */
+  bool isPolymorphicTypeVar(TypeNode tv);
+
+
+  /**
+   * Check if the given type is used as type variable in schema
+   */
+  bool isPolymorphicTypeVarSchema(TypeNode tv);
+
+  /**
+   * Return the given number of type usable for polymorphicity
+   */
+  std::vector<std::pair<TypeNode,TNode> > getPolymorphicTypeVars(size_t nb);
+
+  /**
+   * Return the given number of type usable for polymorphic function schema
+   */
+  std::vector< TypeNode > getPolymorphicTypeVarsSchema(size_t nb);
 
   /**
    * Convert a node to an expression.  Uses the ExprManager

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -340,6 +340,9 @@ class NodeManager {
   Node mkVar(const TypeNode& type, uint32_t flags = ExprManager::VAR_FLAG_NONE);
   Node* mkVarPtr(const TypeNode& type, uint32_t flags = ExprManager::VAR_FLAG_NONE);
 
+  /** Notify all the type constructor instantiation in the given type */
+  void registerTypeNode(TypeNode n, uint32_t flags = ExprManager::SORT_FLAG_NONE);
+
 public:
 
   explicit NodeManager(ExprManager* exprManager);

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -920,7 +920,7 @@ public:
   /**
    * Returns the instanciation of a polymorphic function with the given signature
    */
-  TNode instanciatePolymorphicFunction(TNode n, TypeNode ty)
+  TNode instanciatePolymorphicFunction(TNode n, TypeNode ty, bool check = true)
     throw(TypeCheckingExceptionPrivate);
 
   /**
@@ -935,9 +935,11 @@ public:
    * instanciated the given polymorphic type to the ground type given
    * Return false if a type variable is already associated with an incompatible type;
    * in that case the given subtitution is already modified
+   * Throw TypeCheckingExceptionPrivate if t2 contains schema variable
    */
   bool matchPolymorphicType(TypeNode t1, TypeNode t2,
-                           std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction>& subst);
+                           std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction>& subst)
+    throw(TypeCheckingExceptionPrivate);
 
 
   /**

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -191,6 +191,11 @@ class NodeManager {
   std::hash_set<TypeNode, TypeNode::HashFunction> d_schemaVariables;
 
   /**
+   * The Node used for making polymorphic constant a function
+   */
+  Node d_polymorphicConstantArg;
+
+  /**
    * Keep a count of all abstract values produced by this NodeManager.
    * Abstract values have a type attribute, so if multiple SmtEngines
    * are attached to this NodeManager, we don't want their abstract
@@ -962,6 +967,11 @@ public:
    * Return the given number of type usable for polymorphic function schema
    */
   std::vector< TypeNode > getPolymorphicTypeVarsSchema(size_t nb);
+
+  /**
+   * Return the expr used for making polymorphic constant a function
+   */
+  Node getPolymorphicConstantArg();
 
   /**
    * Convert a node to an expression.  Uses the ExprManager

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -85,6 +85,10 @@ class NodeManager {
 
   // friend so it can access NodeManager's d_listeners and notify clients
   friend std::vector<DatatypeType> ExprManager::mkMutualDatatypeTypes(const std::vector<Datatype>&, const std::set<Type>&);
+  friend class expr::ExportPrivate;
+
+  // friend so it can add types variable used for polymorphism
+  friend TypeNode expr::exportTypeInternal(TypeNode n, NodeManager* from, NodeManager* to, ExprManagerMapCollection& vmap);
 
   /** Predicate for use with STL algorithms */
   struct NodeValueReferenceCountNonZero {
@@ -921,6 +925,12 @@ public:
    * or null if the function is not a monomorphised function
    */
   TNode getPolymorphicFunction(TNode n);
+
+  /**
+   * Returns the original polymorphic function
+   * or null if the function is not a polymorphic instance
+   */
+  TNode getPolymorphicFunctionFromPolymorphicInstance(TNode n);
 
   /**
    * Returns the instanciation of a polymorphic function with the given signature

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -58,6 +58,35 @@ TypeNode TypeNode::substitute(const TypeNode& type,
   return tn;
 }
 
+TypeNode TypeNode::substitute(std::hash_map<TypeNode, TypeNode, HashFunction>& cache) const {
+  // in cache?
+  std::hash_map<TypeNode, TypeNode, HashFunction>::const_iterator i = cache.find(*this);
+  if(i != cache.end()) {
+    return (*i).second;
+  }
+
+  /* arity 0 */
+  if(getNumChildren() == 0) {
+    cache[*this] = *this;
+    return *this;
+  } else { /* arity n */
+    NodeBuilder<> nb(getKind());
+    if(getMetaKind() == kind::metakind::PARAMETERIZED) {
+      // push the operator
+      nb << TypeNode(d_nv->d_children[0]);
+    }
+    for(TypeNode::const_iterator i = begin(),
+          iend = end();
+        i != iend;
+        ++i) {
+      nb << (*i).substitute(cache);
+    }
+    TypeNode tn = nb.constructTypeNode();
+    cache[*this] = tn;
+    return tn;
+  }
+}
+
 Cardinality TypeNode::getCardinality() const {
   return kind::getCardinality(*this);
 }

--- a/src/expr/type_node.h
+++ b/src/expr/type_node.h
@@ -151,6 +151,12 @@ public:
              Iterator2 replacementsBegin, Iterator2 replacementsEnd) const;
 
   /**
+   * Simultaneous substitution of TypeNodes using the cache as
+   * representation of the substitution
+   */
+  TypeNode substitute(std::hash_map<TypeNode, TypeNode, HashFunction>& cache) const;
+
+  /**
    * Structural comparison operator for expressions.
    *
    * @param typeNode the type node to compare to

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1463,8 +1463,11 @@ term[CVC4::Expr& expr, CVC4::Expr& expr2]
         expr = MK_CONST( ::CVC4::EmptySet(type) );
       } else {
         if(f.getType() != type) {
+          Debug("parser") << "Type " << f.getType() << " and "
+                          << type << " not equal." <<  std::endl;
           PARSER_STATE->parseError("Type ascription not satisfied.");
         }
+        expr = f;
       }
     }
   | LPAREN_TOK quantOp[kind]

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2186,7 +2186,7 @@ polymorphicAssert[std::vector<std::string>& pars, CVC4::Expr& expr, CVC4::Expr& 
   std::vector< Expr > args;
 }
   :
-  | LPAREN_TOK PAR_TOK
+    LPAREN_TOK PAR_TOK
     {
       if(PARSER_STATE->strictModeEnabled()) {
         PARSER_STATE->parseError("Polymorphic functions are not permitted while operating in strict compliance mode.");

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -283,10 +283,25 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
 
   if(n.getKind() == kind::SORT_TYPE) {
     string name;
-    if(n.getAttribute(expr::VarNameAttr(), name)) {
+    if(!n.getAttribute(expr::VarNameAttr(), name)){
+      name = "???";
+    };
+
+    if (n.getNumChildren() == 0) {
       out << maybeQuoteSymbol(name);
-      return;
+    } else { /* n-arity */
+      out << "(" << maybeQuoteSymbol(name);
+      for(size_t i = 0; i < n.getNumChildren(); ++i) {
+        out << " ";
+        if(toDepth != 0) {
+          toStream(out, n[i], toDepth < 0 ? toDepth : toDepth - 1, types);
+        } else {
+          out << "(...)";
+        }
+      }
+      out << ")";
     }
+    return;
   }
 
   bool stillNeedToPrintParams = true;

--- a/src/theory/quantifiers/polymorphic_engine.cpp
+++ b/src/theory/quantifiers/polymorphic_engine.cpp
@@ -62,7 +62,8 @@ Node substituteAll(TNode n,
     };
     subst[n] = n2;
     return n2;
-  } else if (n.getType().isFunction() && NodeManager::currentNM()->isPolymorphicFunctionInstance(n)){
+  } else if (n.getType().isFunction() &&
+             NodeManager::currentNM()->isPolymorphicFunctionInstance(n)){
     TypeNode sig = n.getType().substitute(ty_subst);
     Node n2 = n;
     if(sig != n.getType() ){
@@ -72,6 +73,10 @@ Node substituteAll(TNode n,
     Trace("para-substitute") << "PolymorphicFunction " << n << " becomes " << n2 << std::endl;
     subst[n] = n2;
     return n2;
+  } else if ( n.getNumChildren() == 0 ){
+    subst[n] = n;
+    Trace("para-substitute") << "Constant " << n << " stays as " << n << std::endl;
+    return n;
   } else {
 
     Kind kind = n.getKind();
@@ -132,7 +137,10 @@ void PolymorphicEngine::check( Theory::Effort e, unsigned quant_e ){
                 std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction> ty_subst2 = ty_subst;
                 std::hash_map<TNode, TNode, TNodeHashFunction> subst;
 
-                d_quantEngine->addLemma(substituteAll(body,ty_subst2,subst));
+                Node lem = substituteAll(body,ty_subst2,subst);
+                Trace("para") << "  -instantiated to:" << lem << std::endl;
+                lem = NodeManager::currentNM()->mkNode( OR, (*lemma).negate(), lem );
+                d_quantEngine->addLemma(lem);
               } else {
                 ++v_id;
                 next_ty[v_id] = type_map.begin();

--- a/src/theory/quantifiers/polymorphic_engine.cpp
+++ b/src/theory/quantifiers/polymorphic_engine.cpp
@@ -1,0 +1,155 @@
+/*********************                                                        */
+/*! \file rewrite_engine.cpp
+ ** \verbatim
+ ** Original author: Andrew Reynolds
+ ** Major contributors: Morgan Deters
+ ** Minor contributors (to current version): none
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2014  New York University and The University of Iowa
+ ** See the file COPYING in the top-level source directory for licensing
+ ** information.\endverbatim
+ **
+ ** \brief Rewrite engine module
+ **
+ ** This class manages rewrite rules for quantifiers
+ **/
+
+#include "theory/quantifiers/polymorphic_engine.h"
+#include "theory/quantifiers/quant_util.h"
+#include "theory/quantifiers/first_order_model.h"
+#include "theory/quantifiers/model_engine.h"
+#include "theory/quantifiers/options.h"
+#include "theory/quantifiers/inst_match_generator.h"
+#include "theory/theory_engine.h"
+#include "theory/quantifiers/term_database.h"
+#include "expr/node_manager_attributes.h"
+
+using namespace CVC4;
+using namespace std;
+using namespace CVC4::theory;
+using namespace CVC4::theory::quantifiers;
+using namespace CVC4::kind;
+
+PolymorphicEngine::PolymorphicEngine( context::Context* c, QuantifiersEngine* qe ) : QuantifiersModule(qe) {
+}
+
+bool PolymorphicEngine::needsCheck( Theory::Effort e ) { return e>=Theory::EFFORT_LAST_CALL; }
+
+Node substituteAll(TNode n,
+                   std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction>& ty_subst,
+                   std::hash_map<TNode, TNode, TNodeHashFunction>& subst){
+
+  Trace("para-substitute") << "substitute:" << n << std::endl;
+
+  // in cache?
+  typename std::hash_map<TNode, TNode, TNodeHashFunction>::const_iterator i = subst.find(n);
+  if(i != subst.end()) {
+    return (*i).second;
+  }
+
+  // otherwise compute
+  if(n.getKind() == kind::BOUND_VARIABLE){
+    TypeNode ty = n.getType().substitute(ty_subst);
+    Node n2 = n;
+    if(ty != n.getType() ){
+      string name;
+      if(n.getAttribute(expr::VarNameAttr(), name)) {
+        n2 = NodeManager::currentNM()->mkBoundVar(name,ty);
+      } else {
+        n2 = NodeManager::currentNM()->mkBoundVar(ty);
+      };
+      Trace("para-substitute") << "BoundVar " << n << " becomes " << n2 << std::endl;
+    };
+    subst[n] = n2;
+    return n2;
+  } else if (n.getType().isFunction() && NodeManager::currentNM()->isPolymorphicFunctionInstance(n)){
+    TypeNode sig = n.getType().substitute(ty_subst);
+    Node n2 = n;
+    if(sig != n.getType() ){
+      n2 = NodeManager::currentNM()->instanciatePolymorphicFunction(
+                                                                   NodeManager::currentNM()->getPolymorphicFunction(n),sig);
+    }
+    Trace("para-substitute") << "PolymorphicFunction " << n << " becomes " << n2 << std::endl;
+    subst[n] = n2;
+    return n2;
+  } else {
+
+    Kind kind = n.getKind();
+    if(kind == kind::EQUAL && n[0].getType().substitute(ty_subst).isBoolean() ){
+      kind = kind::IFF;
+    }
+
+    NodeBuilder<> nb(kind);
+    if(n.getMetaKind() == kind::metakind::PARAMETERIZED) {
+      // push the operator
+      nb << substituteAll(n.getOperator(),ty_subst,subst);
+    }
+    for(TNode::const_iterator i = n.begin(),
+          iend = n.end();
+        i != iend;
+        ++i) {
+      nb << substituteAll(*i,ty_subst,subst);
+    }
+    Node n2 = nb;
+    Trace("para-substitute") << "Application " << n << " becomes " << n2 << std::endl;
+    subst[n] = n2;
+    return n2;
+  }
+}
+
+void PolymorphicEngine::check( Theory::Effort e, unsigned quant_e ){
+
+  std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction> ty_subst = ty_subst;
+
+  for(std::vector< Node >::const_iterator lemma = d_lemma.begin(); lemma != d_lemma.end(); ++lemma){
+          Trace("para") << "try instantiate lemma:" << *lemma << std::endl;
+          TNode bv = (*lemma)[0];
+          TNode body = (*lemma)[1];
+
+          std::map< TypeNode, std::vector< Node > >& type_map = d_quantEngine->getTermDatabase()->d_type_map;
+
+          std::vector< std::map< TypeNode, std::vector< Node > >::const_iterator > next_ty(bv.getNumChildren());
+
+          size_t v_id=0;
+          next_ty[0] = type_map.begin();
+          while (true){
+            Assert( v_id < bv.getNumChildren() );
+            if(v_id == 0){ ty_subst.clear(); }
+
+            if ( next_ty[v_id] == type_map.end () ) {
+              if(v_id == 0) break;
+              --v_id;
+            } else {
+
+              ty_subst[ bv[v_id].getType() ] = next_ty[v_id]->first;
+              Trace("para") << bv[v_id].getType() << "->" << next_ty[v_id]->first << ", ";
+
+              ++next_ty[v_id];
+
+              if ( v_id + 1 == bv.getNumChildren() ){
+                Trace("para") << std::endl;
+
+                std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction> ty_subst2 = ty_subst;
+                std::hash_map<TNode, TNode, TNodeHashFunction> subst;
+
+                d_quantEngine->addLemma(substituteAll(body,ty_subst2,subst));
+              } else {
+                ++v_id;
+                next_ty[v_id] = type_map.begin();
+              }
+            }
+
+          }
+  }
+};
+
+/* Called for new quantifiers */
+void PolymorphicEngine::registerQuantifier( Node q ){
+  if(TermDb::isPolymorphic(q)){
+      Trace("para") << "register new lemma:" << q << std::endl;
+      d_lemma.push_back(q);
+    }
+
+};
+void PolymorphicEngine::assertNode( Node n ){};
+

--- a/src/theory/quantifiers/polymorphic_engine.cpp
+++ b/src/theory/quantifiers/polymorphic_engine.cpp
@@ -289,3 +289,4 @@ void PolymorphicEngine::registerQuantifier( Node q ){
 
 void PolymorphicEngine::assertNode( Node n ){};
 
+void PolymorphicEngine::newTerm(Node n){}

--- a/src/theory/quantifiers/polymorphic_engine.h
+++ b/src/theory/quantifiers/polymorphic_engine.h
@@ -31,9 +31,28 @@ namespace quantifiers {
 
 class QuantInfo;
 
+class paralemma {
+public:
+  Node bv;
+  Node body;      /* possibly generalized */
+  Node origlemma; /* given by assert */
+  paralemma(Node lemma);
+};
+
 class PolymorphicEngine : public QuantifiersModule
 {
-  std::vector< Node > d_lemma;
+  std::vector<paralemma> d_lemma;
+  std::hash_set<TypeNode, TypeNode::HashFunction> d_doneType;
+
+  void instantiate(paralemma& lemma,
+                   std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction>& ty_subst,
+                   size_t v_id,
+                   bool todo_used,
+                   std::hash_set<TypeNode, TypeNode::HashFunction>& doneType,
+                   std::hash_set<TypeNode, TypeNode::HashFunction>& todoType
+                   );
+
+
 public:
   PolymorphicEngine( context::Context* c, QuantifiersEngine* qe );
   /** Quantifiers Module intereface */

--- a/src/theory/quantifiers/polymorphic_engine.h
+++ b/src/theory/quantifiers/polymorphic_engine.h
@@ -61,6 +61,9 @@ public:
   void registerQuantifier( Node q );
   void assertNode( Node n );
   std::string identify() const { return "PolymorphicEngine"; }
+
+  void newTerm(Node n);
+
 };
 
 }

--- a/src/theory/quantifiers/polymorphic_engine.h
+++ b/src/theory/quantifiers/polymorphic_engine.h
@@ -1,0 +1,51 @@
+/*********************                                                        */
+/*! \file polymorphic_engine.h
+ ** \verbatim
+ ** Original author: Francois Bobot
+ ** Major contributors: none
+ ** Minor contributors (to current version): none
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2014  New York University and The University of Iowa
+ ** See the file COPYING in the top-level source directory for licensing
+ ** information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+ ** \todo document this file
+**/
+
+#include "cvc4_private.h"
+
+#ifndef __CVC4__POLYMORPHIC_ENGINE_H
+#define __CVC4__POLYMORPHIC_ENGINE_H
+
+#include "theory/quantifiers_engine.h"
+#include "theory/quantifiers/trigger.h"
+
+#include "context/context.h"
+#include "context/context_mm.h"
+#include "context/cdchunk_list.h"
+
+namespace CVC4 {
+namespace theory {
+namespace quantifiers {
+
+class QuantInfo;
+
+class PolymorphicEngine : public QuantifiersModule
+{
+  std::vector< Node > d_lemma;
+public:
+  PolymorphicEngine( context::Context* c, QuantifiersEngine* qe );
+  /** Quantifiers Module intereface */
+  bool needsCheck(Theory::Effort e);
+  void check( Theory::Effort e, unsigned quant_e );
+  void registerQuantifier( Node q );
+  void assertNode( Node n );
+  std::string identify() const { return "PolymorphicEngine"; }
+};
+
+}
+}
+}
+
+#endif

--- a/src/theory/quantifiers/polymorphic_engine.h
+++ b/src/theory/quantifiers/polymorphic_engine.h
@@ -33,9 +33,13 @@ class QuantInfo;
 
 class paralemma {
 public:
-  Node bv;
-  Node body;      /* possibly generalized */
+  Node bv; /** Bound Type Variables */
+  Node body; /** Body of the polymorphic lemma */
   Node origlemma; /* given by assert */
+  /**  When there are no universal quantifiers, these polymorphic
+       constants are used as triggers */
+  std::hash_set<TNode, TNodeHashFunction> polymorphicConstants;
+
   paralemma(Node lemma);
 };
 
@@ -43,6 +47,13 @@ class PolymorphicEngine : public QuantifiersModule
 {
   std::vector<paralemma> d_lemma;
   std::hash_set<TypeNode, TypeNode::HashFunction> d_doneType;
+
+  /** map of terms that will trigger the addition of instantiated
+      polymorphic lemma. For not creating trivial matching loop with
+      polymorphic lemma without terms binding.
+      (par (a) (= (length (as nil (list a)) 0)))
+ */
+  std::hash_map<Node, std::vector<Node>, NodeHashFunction> d_csttrigger;
 
   void instantiate(paralemma& lemma,
                    std::hash_map<TypeNode, TypeNode, TypeNode::HashFunction>& ty_subst,

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -154,6 +154,12 @@ bool QuantifiersRewriter::hasArg1( Node a, Node n ) {
 }
 
 RewriteResponse QuantifiersRewriter::preRewrite(TNode in) {
+  /* polymorphic lemmas are rewritten once the types are instantiated */
+  if( TermDb::isPolymorphic(in) ) {
+    Trace("quantifiers-rewrite-debug") << "no pre-rewriting for polymorphic" << in << std::endl;
+    return RewriteResponse(REWRITE_DONE, in);
+  }
+
   if( in.getKind()==kind::EXISTS || in.getKind()==kind::FORALL ){
     Trace("quantifiers-rewrite-debug") << "pre-rewriting " << in << std::endl;
     std::vector< Node > args;
@@ -200,6 +206,12 @@ RewriteResponse QuantifiersRewriter::preRewrite(TNode in) {
 }
 
 RewriteResponse QuantifiersRewriter::postRewrite(TNode in) {
+  /* polymorphic lemmas are rewritten once the types are instantiated */
+  if( TermDb::isPolymorphic(in) ) {
+    Trace("quantifiers-rewrite-debug") << "no post-rewriting for polymorphic" << in << std::endl;
+    return RewriteResponse(REWRITE_DONE, in);
+  }
+
   Trace("quantifiers-rewrite-debug") << "post-rewriting " << in << std::endl;
   Trace("quantifiers-rewrite-debug") << "Attributes : " << std::endl;
   if( !options::quantRewriteRules() || !TermDb::isRewriteRule( in ) ){

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -131,6 +131,7 @@ void TermDb::addTerm( Node n, std::set< Node >& added, bool withinQuant, bool wi
   if( d_processed.find( n )==d_processed.end() ){
     d_processed.insert(n);
     d_type_map[ n.getType() ].push_back( n );
+    d_quantEngine->getPolymorphicEngine()->newTerm(n);
     //if this is an atomic trigger, consider adding it
     //Call the children?
     if( inst::Trigger::isAtomicTrigger( n ) ){

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -23,6 +23,7 @@
 #include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/quantifiers/ce_guided_instantiation.h"
 #include "theory/quantifiers/rewrite_engine.h"
+#include "theory/quantifiers/polymorphic_engine.h"
 
 //for sygus
 #include "theory/bv/theory_bv_utils.h"
@@ -1225,7 +1226,10 @@ Node TermDb::getFunDefBody( Node q ) {
 
 void TermDb::computeAttributes( Node q ) {
   Trace("quant-attr-debug") << "Compute attributes for " << q << std::endl;
-  if( q.getNumChildren()==3 ){
+  if( isPolymorphic( q ) ){
+    Trace("quant-attr") << "Attribute : polymorphic quantifier : " << q << std::endl;
+    d_quantEngine->setOwner( q, d_quantEngine->getPolymorphicEngine() );
+  } else if( q.getNumChildren()==3 ){
     for( unsigned i=0; i<q[2].getNumChildren(); i++ ){
       Trace("quant-attr-debug") << "Check : " << q[2][i] << " " << q[2][i].getKind() << std::endl;
       if( q[2][i].getKind()==INST_ATTRIBUTE ){
@@ -2019,4 +2023,11 @@ Node TermDbSygus::expandBuiltinTerm( Node t ){
                                                  NodeManager::currentNM()->mkNode( AND, t[0].negate(), t[1].negate() ) );
   }
   return Node::null();
+}
+
+bool TermDb::isPolymorphic( Node q ) {
+  return q.getKind()==FORALL && q.getNumChildren() >= 1 &&
+    q[0].getKind()==kind::BOUND_VAR_LIST &&
+    q[0].getNumChildren() >= 1 &&
+    NodeManager::currentNM()->isPolymorphicTypeVar(q[0][0].getType());
 }

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -175,6 +175,10 @@ void TermDb::addTerm( Node n, std::set< Node >& added, bool withinQuant, bool wi
   }
 }
 
+bool TermDb::isProcessed( Node n ){
+  return d_processed.find(n) != d_processed.end();
+}
+
 void TermDb::computeArgReps( TNode n ) {
   if( d_arg_reps.find( n )==d_arg_reps.end() ){
     eq::EqualityEngine * ee = d_quantEngine->getTheoryEngine()->getMasterEqualityEngine();

--- a/src/theory/quantifiers/term_database.h
+++ b/src/theory/quantifiers/term_database.h
@@ -371,6 +371,9 @@ public:
   /** get rewrite rule priority */
   int getQAttrRewriteRulePriority( Node q );
 
+  /** is quantifier polymorphic? */
+  static bool isPolymorphic( Node q );
+
 };/* class TermDb */
 
 class TermDbSygus {

--- a/src/theory/quantifiers/term_database.h
+++ b/src/theory/quantifiers/term_database.h
@@ -158,6 +158,8 @@ public:
   std::map< TypeNode, std::vector< Node > > d_type_map;
   /** add a term to the database */
   void addTerm( Node n, std::set< Node >& added, bool withinQuant = false, bool withinInstClosure = false );
+  /** Test if a Node have been already processed */
+  bool isProcessed( Node n);
   /** reset (calculate which terms are active) */
   void reset( Theory::Effort effort );
   /** get operator*/

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -27,6 +27,7 @@
 #include "theory/quantifiers/trigger.h"
 #include "theory/quantifiers/bounded_integers.h"
 #include "theory/quantifiers/rewrite_engine.h"
+#include "theory/quantifiers/polymorphic_engine.h"
 #include "theory/quantifiers/quant_conflict_find.h"
 #include "theory/quantifiers/conjecture_generator.h"
 #include "theory/quantifiers/ce_guided_instantiation.h"
@@ -178,6 +179,11 @@ d_lemmas_produced_c(u){
     d_builder = NULL;
   }
 
+  d_para_engine = new quantifiers::PolymorphicEngine( c, this );
+  d_modules.push_back(d_para_engine);
+
+
+  //options
   d_total_inst_count_debug = 0;
   d_ierCounter = 0;
   d_ierCounter_lc = 0;
@@ -186,6 +192,7 @@ d_lemmas_produced_c(u){
 QuantifiersEngine::~QuantifiersEngine(){
   delete d_builder;
   delete d_rr_engine;
+  delete d_para_engine;
   delete d_bint;
   delete d_model_engine;
   delete d_inst_engine;

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -86,6 +86,7 @@ namespace quantifiers {
   class BoundedIntegers;
   class QuantConflictFind;
   class RewriteEngine;
+  class PolymorphicEngine;
   class RelevantDomain;
   class QModelBuilder;
   class ConjectureGenerator;
@@ -138,6 +139,8 @@ private:
   quantifiers::CegInstantiation * d_ceg_inst;
   /** lte partial instantiation */
   quantifiers::LtePartialInst * d_lte_part_inst;
+  /** polymorphic engine  */
+  quantifiers::PolymorphicEngine * d_para_engine;
 public: //effort levels
   enum {
     QEFFORT_CONFLICT,
@@ -215,6 +218,8 @@ public:  //modules
   quantifiers::QuantConflictFind* getConflictFind() { return d_qcf; }
   /** rewrite rules utility */
   quantifiers::RewriteEngine * getRewriteEngine() { return d_rr_engine; }
+  /** polymorphic quantifier utility */
+  quantifiers::PolymorphicEngine * getPolymorphicEngine() { return d_para_engine; }
   /** subgoal generator */
   quantifiers::ConjectureGenerator * getConjectureGenerator() { return d_sg_gen; }
   /** ceg instantiation */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -59,6 +59,7 @@ subdirs_to_check = \
 	regress/regress0/sets \
 	regress/regress0/parser \
 	regress/regress0/sygus \
+	regress/regress0/polymorphic \
 	regress/regress1 \
 	regress/regress1/arith \
 	regress/regress2 \

--- a/test/regress/regress0/Makefile.am
+++ b/test/regress/regress0/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = . arith precedence uf uflra uflia bv arrays aufbv auflia datatypes quantifiers rewriterules lemmas push-pop preprocess tptp unconstrained decision fmf strings sets parser sygus
+SUBDIRS = . arith precedence uf uflra uflia bv arrays aufbv auflia datatypes quantifiers rewriterules lemmas push-pop preprocess tptp unconstrained decision fmf strings sets parser sygus polymorphic
 DIST_SUBDIRS = $(SUBDIRS)
 
 # don't override a BINARY imported from a personal.mk

--- a/test/regress/regress0/parser/Makefile.am
+++ b/test/regress/regress0/parser/Makefile.am
@@ -22,7 +22,8 @@ TESTS =	\
 	declarefun-emptyset-uf.smt2 \
 	constraint.smt2 \
 	strings20.smt2 \
-	strings25.smt2
+	strings25.smt2 \
+	as.smt2
 
 EXTRA_DIST = $(TESTS)
 

--- a/test/regress/regress0/parser/as.smt2
+++ b/test/regress/regress0/parser/as.smt2
@@ -1,0 +1,14 @@
+(set-logic QF_UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status sat)
+(declare-sort I 0)
+(declare-fun e0 () I)
+
+;; as was badly parsed in default case
+;; no specialization (emptyset) just dumb type-checking
+
+(assert (= (as e0 I) (as e0 I)))
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -23,6 +23,8 @@ TESTS =	\
 	parsing2.smt2 \
 	parsing3.smt2 \
 	parsing4.smt2 \
+	parsing5.smt2 \
+	parsing6.smt2 \
 	typing_bad1.smt2 \
 	typing_bad2.smt2 \
 	typing_bad3.smt2 \

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -22,6 +22,7 @@ TESTS =	\
 	parsing.smt2 \
 	parsing2.smt2 \
 	parsing3.smt2 \
+	parsing4.smt2 \
 	typing_bad1.smt2 \
 	typing_bad2.smt2 \
 	typing_bad3.smt2 \

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -28,6 +28,7 @@ TESTS =	\
 	parsing7.smt2 \
 	parsing8.smt2 \
 	parsing9.smt2 \
+	parsing10.smt2 \
 	typing_bad1.smt2 \
 	typing_bad2.smt2 \
 	typing_bad3.smt2 \

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -25,6 +25,8 @@ TESTS =	\
 	parsing4.smt2 \
 	parsing5.smt2 \
 	parsing6.smt2 \
+	parsing7.smt2 \
+	parsing8.smt2 \
 	typing_bad1.smt2 \
 	typing_bad2.smt2 \
 	typing_bad3.smt2 \

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -27,6 +27,7 @@ TESTS =	\
 	parsing6.smt2 \
 	parsing7.smt2 \
 	parsing8.smt2 \
+	parsing9.smt2 \
 	typing_bad1.smt2 \
 	typing_bad2.smt2 \
 	typing_bad3.smt2 \

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -31,7 +31,8 @@ TESTS =	\
 	typing_bad4.smt2 \
 	typing_bad5.smt2 \
 	typing_bad6.smt2 \
-	typing_bad7.smt2
+	typing_bad7.smt2 \
+	typing_bad8.smt2
 
 EXTRA_DIST = $(TESTS)
 

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -1,0 +1,44 @@
+# don't override a BINARY imported from a personal.mk
+@mk_if@eq ($(BINARY),)
+@mk_empty@BINARY = cvc4
+end@mk_if@
+
+LOG_COMPILER = @srcdir@/../../run_regression
+AM_LOG_FLAGS = $(RUN_REGRESSION_ARGS) @top_builddir@/src/main/$(BINARY)$(EXEEXT)
+
+if AUTOMAKE_1_11
+# old-style (pre-automake 1.12) test harness
+TESTS_ENVIRONMENT = \
+	$(LOG_COMPILER) \
+	$(AM_LOG_FLAGS) $(LOG_FLAGS)
+endif
+
+MAKEFLAGS = -k
+
+# These are run for all build profiles.
+# If a test shouldn't be run in e.g. competition mode,
+# put it below in "TESTS +="
+TESTS =	\
+	parsing.smt2 \
+	parsing2.smt2 \
+	parsing3.smt2
+
+EXTRA_DIST = $(TESTS)
+
+#if CVC4_BUILD_PROFILE_COMPETITION
+#else
+#TESTS += \
+#	error.cvc
+#endif
+
+# disabled tests, yet distribute
+#EXTRA_DIST += \
+#	setofsets-disequal.smt2
+
+# synonyms for "check"
+.PHONY: regress regress0 test
+regress regress0 test: check
+
+# do nothing in this subdir
+.PHONY: regress1 regress2 regress3
+regress1 regress2 regress3:

--- a/test/regress/regress0/polymorphic/Makefile.am
+++ b/test/regress/regress0/polymorphic/Makefile.am
@@ -21,7 +21,14 @@ MAKEFLAGS = -k
 TESTS =	\
 	parsing.smt2 \
 	parsing2.smt2 \
-	parsing3.smt2
+	parsing3.smt2 \
+	typing_bad1.smt2 \
+	typing_bad2.smt2 \
+	typing_bad3.smt2 \
+	typing_bad4.smt2 \
+	typing_bad5.smt2 \
+	typing_bad6.smt2 \
+	typing_bad7.smt2
 
 EXTRA_DIST = $(TESTS)
 

--- a/test/regress/regress0/polymorphic/parsing.smt2
+++ b/test/regress/regress0/polymorphic/parsing.smt2
@@ -1,0 +1,18 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-sort A 1)
+(declare-sort I1 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((A a)) a))
+
+(assert (forall ((x I1)) (= x (as (get (as (mk x) (A I1))) I1))))
+(assert (not (= i1 (as (get (as (mk i1) (A I1))) I1))))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing10.smt2
+++ b/test/regress/regress0/polymorphic/parsing10.smt2
@@ -1,0 +1,30 @@
+; EXPECT: unknown
+(set-logic UFDTLRA)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unknown)
+
+(declare-datatypes (a) (
+  ( List
+    (Cons (hd a) (tail (List a)))
+    (Nil)
+   )
+))
+
+
+(declare-fun length (par (a) ((List a)) Real))
+
+(assert (par (a) (= (length (as Nil (List a))) 0)))
+(assert (par (a) (forall ((x a)(l (List a))) (= (length (Cons x l)) (+ 1 (length l))))))
+
+(declare-sort I1 0)
+(declare-fun y1 () I1)
+(declare-fun y2 () I1)
+
+
+(assert (not (= (length (Cons y1 (Cons y2 (as Nil (List I1))))) 3)))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing2.smt2
+++ b/test/regress/regress0/polymorphic/parsing2.smt2
@@ -1,0 +1,18 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-sort A 1)
+(declare-sort I1 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((A a)) a))
+
+(assert (forall ((x I1)) (= x (get (mk x)))))
+(assert (not (= i1 (get (mk i1)))))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing3.smt2
+++ b/test/regress/regress0/polymorphic/parsing3.smt2
@@ -1,0 +1,18 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-sort A 2)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a b) (a) (A a b)))
+(declare-fun get (par (a b) ((A a b)) a))
+
+
+(assert (forall ((x I1)) (= x (as (get (as (mk x) (A I1 I2))) I1))) )
+(assert (not (= i1 (as (get (as (mk i1) (A I1 I2))) I1))))
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing4.smt2
+++ b/test/regress/regress0/polymorphic/parsing4.smt2
@@ -1,0 +1,18 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-sort A 1)
+(declare-sort I1 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((A a)) a))
+
+(assert (par (a) (forall ((x a)) (= x (as (get (as (mk x) (A a))) a)))))
+(assert (not (= i1 (as (get (as (mk i1) (A I1))) I1))))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing5.smt2
+++ b/test/regress/regress0/polymorphic/parsing5.smt2
@@ -1,0 +1,24 @@
+(set-logic UFLRA)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-sort list 1)
+
+(declare-sort unit 0)
+(declare-fun  u    () unit)
+
+(declare-fun nil (par (a) (unit) (list a)))
+(declare-fun cons (par (a) (a (list a)) (list a)))
+
+(assert (par (a) (forall ((x a)(l (list a))) (not (= (as (nil u) (list a)) (cons x l))))))
+
+(declare-sort I1 0)
+(declare-fun y1 () I1)
+(declare-fun y2 () I1)
+(declare-fun l2 () (list I1))
+
+(assert (= (as (nil u) (list I1)) (cons y1 (cons y2 l2))))
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing6.smt2
+++ b/test/regress/regress0/polymorphic/parsing6.smt2
@@ -1,0 +1,22 @@
+(set-logic UFLRA)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-sort list 1)
+
+(declare-fun nil (par (a) () (list a)))
+(declare-fun cons (par (a) (a (list a)) (list a)))
+
+(assert (par (a) (forall ((x a)(l (list a))) (not (= (as nil (list a)) (cons x l))))))
+
+(declare-sort I1 0)
+(declare-fun y1 () I1)
+(declare-fun y2 () I1)
+(declare-fun l2 () (list I1))
+
+(assert (= (as nil (list I1)) (cons y1 (cons y2 l2))))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing7.smt2
+++ b/test/regress/regress0/polymorphic/parsing7.smt2
@@ -1,0 +1,24 @@
+(set-logic UFLRA)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-sort list 1)
+
+(declare-fun nil (par (a) () (list a)))
+(declare-fun cons (par (a) (a (list a)) (list a)))
+(declare-fun length (par (a) ((list a)) Real))
+
+(assert (par (a) (= (length (as nil (list a))) 0)))
+(assert (par (a) (forall ((x a)(l (list a))) (= (length (cons x l)) (+ 1 (length l))))))
+
+(declare-sort I1 0)
+(declare-fun y1 () I1)
+(declare-fun y2 () I1)
+
+
+(assert (not (= (length (cons y1 (cons y2 (as nil (list I1))))) 2)))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing8.smt2
+++ b/test/regress/regress0/polymorphic/parsing8.smt2
@@ -1,0 +1,29 @@
+(set-logic UFDTLRA)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+
+(declare-datatypes (a) (
+  ( List
+    (Cons (hd a) (tail (List a)))
+    (Nil)
+   )
+))
+
+
+(declare-fun length (par (a) ((List a)) Real))
+
+(assert (par (a) (= (length (as Nil (List a))) 0)))
+(assert (par (a) (forall ((x a)(l (List a))) (= (length (Cons x l)) (+ 1 (length l))))))
+
+(declare-sort I1 0)
+(declare-fun y1 () I1)
+(declare-fun y2 () I1)
+
+
+(assert (not (= (length (Cons y1 (Cons y2 (as Nil (List I1))))) 2)))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/parsing9.smt2
+++ b/test/regress/regress0/polymorphic/parsing9.smt2
@@ -1,0 +1,36 @@
+; EXPECT: unknown
+(set-logic UFDTLRA)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unknown)
+
+(declare-datatypes () (
+   ( Unit
+     (U)
+   )
+))
+
+(declare-datatypes (a) (
+  ( List
+    (Cons (hd a) (tail (List a)))
+    (Nil (punit Unit))
+   )
+))
+
+
+(declare-fun length (par (a) ((List a)) Real))
+
+(assert (par (a) (forall ((u Unit)) (= (length (as (Nil u) (List a))) 0))))
+(assert (par (a) (forall ((x a)(l (List a))) (= (length (Cons x l)) (+ 1 (length l))))))
+
+(declare-sort I1 0)
+(declare-fun y1 () I1)
+(declare-fun y2 () I1)
+
+
+(assert (not (= (length (Cons y1 (Cons y2 (as (Nil U) (List I1))))) 3)))
+
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/polymorphic/typing_bad0.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad0.smt2
@@ -20,7 +20,7 @@
 ; EXPECT-ERROR:   (assert (forall ((x I1)(y I2)) (= x (get (mk y)))))
 ; EXPECT-ERROR:                                                ^
 ; EXPECT-ERROR: 
-; EXPECT-ERROR: Equation: (= x (get (mk y)))
+; EXPECT-ERROR: Equation: (= x (get_3 (mk_2 y)))
 ; EXPECT-ERROR: Type 1: I1
 ; EXPECT-ERROR: Type 2: I2
 ; EXPECT-ERROR: ")

--- a/test/regress/regress0/polymorphic/typing_bad0.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad0.smt2
@@ -1,0 +1,27 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(declare-sort A 1)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((A a)) a))
+
+(assert (forall ((x I1)(y I2)) (= x (get (mk y)))))
+(assert (not (= i1 (get (mk i1)))))
+
+(check-sat)
+(exit)
+
+; EXPECT-ERROR: (error "Parse Error: typing_bad0.smt2:12.49: Subexpressions must have a common base type:
+; EXPECT-ERROR: 
+; EXPECT-ERROR:   (assert (forall ((x I1)(y I2)) (= x (get (mk y)))))
+; EXPECT-ERROR:                                                ^
+; EXPECT-ERROR: 
+; EXPECT-ERROR: Equation: (= x (get (mk y)))
+; EXPECT-ERROR: Type 1: I1
+; EXPECT-ERROR: Type 2: I2
+; EXPECT-ERROR: ")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad1.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad1.smt2
@@ -1,0 +1,19 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(declare-sort A 1)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((A a)) a))
+
+(assert (forall ((x I1)) (= x (get (as (mk x) (A I2))))))
+(assert (not (= i1 (get (mk i1)))))
+
+(check-sat)
+(exit)
+
+; EXPECT-ERROR: (error "Parse Error: typing_bad1.smt2:12.53: Type ascription not satisfied.")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad2.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad2.smt2
@@ -1,0 +1,20 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+
+(declare-sort A 2)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a b) (a) (A a b)))
+(declare-fun get (par (a b) ((A a b)) a))
+
+
+(assert (forall ((x I1)) (= x (as (get (as (mk x) (A I2 I2))) I1))) )
+(assert (not (= i1 (as (get (as (mk i1) (A I1 I2))) I1))))
+
+(check-sat)
+(exit)
+; EXPECT-ERROR: (error "Parse Error: typing_bad2.smt2:14.60: cannot apply this polymorphic function on these arguments and return value")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad3.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad3.smt2
@@ -1,0 +1,20 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+
+(declare-sort A 2)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a b) (a) (A a b)))
+(declare-fun get (par (a) ((A a a)) a))
+
+
+(assert (forall ((x I1)) (= x (as (get (as (mk x) (A I1 I2))) I1))) )
+(assert (not (= i1 (as (get (as (mk i1) (A I1 I2))) I1))))
+
+(check-sat)
+(exit)
+; EXPECT-ERROR: (error "Parse Error: typing_bad3.smt2:14.61: cannot apply this polymorphic function on these arguments")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad4.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad4.smt2
@@ -16,5 +16,5 @@
 
 (check-sat)
 (exit)
-; EXPECT-ERROR: (error "Parse Error: typing_bad4.smt2:14.42: No inference is done, you should add an (as term ty) for specifying the return type.")
+; EXPECT-ERROR: (error "Parse Error: typing_bad4.smt2:14.42: You should add an (as term ty) for specifying the return type.")
 ; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad4.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad4.smt2
@@ -1,0 +1,20 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+
+(declare-sort A 2)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a b) (a) (A a b)))
+(declare-fun get (par (a b) ((A a b)) a))
+
+
+(assert (forall ((x I1)) (= x (get (mk x)))) )
+(assert (not (= i1 (as (get (as (mk i1) (A I1 I2))) I1))))
+
+(check-sat)
+(exit)
+; EXPECT-ERROR: (error "Parse Error: typing_bad4.smt2:14.42: No inference is done, you should add an (as term ty) for specifying the return type.")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad5.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad5.smt2
@@ -1,0 +1,20 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(declare-sort A 1)
+(declare-sort B 1)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((B a)) a))
+
+(assert (forall ((x I1)) (= x (get (mk x)))))
+(assert (not (= i1 (get (mk i1)))))
+
+(check-sat)
+(exit)
+
+; EXPECT-ERROR: (error "Parse Error: typing_bad5.smt2:13.42: cannot apply this polymorphic function on these arguments")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad6.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad6.smt2
@@ -1,0 +1,20 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(declare-sort A 1)
+(declare-sort B 1)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((A a) a) a))
+
+(assert (forall ((x I1)(y (A I1))) (= x (get (mk y) x))))
+(assert (not (= i1 (get (mk i1)))))
+
+(check-sat)
+(exit)
+
+; EXPECT-ERROR: (error "Parse Error: typing_bad6.smt2:13.54: cannot apply this polymorphic function on these arguments")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad7.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad7.smt2
@@ -1,0 +1,20 @@
+(set-logic UF)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(declare-sort A 1)
+(declare-sort B 1)
+(declare-sort I1 0)
+(declare-sort I2 0)
+(declare-fun i1 () I1)
+
+(declare-fun mk  (par (a) (a) (A a)))
+(declare-fun get (par (a) ((A a)) a))
+
+(assert (forall ((x I1)) (= x (get (mk x) x))))
+(assert (not (= i1 (get (mk i1)))))
+
+(check-sat)
+(exit)
+
+; EXPECT-ERROR: (error "Parse Error: typing_bad7.smt2:13.44: arity application mismatch")
+; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad8.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad8.smt2
@@ -18,5 +18,5 @@
 (check-sat)
 (exit)
 
-; EXPECT-ERROR: (error "Parse Error: typing_bad8.smt2:14.28: No inference is done, you should add an (as term ty) for specifying the return type.")
+; EXPECT-ERROR: (error "Parse Error: typing_bad8.smt2:14.28: You should add an (as term ty) for specifying the return type.")
 ; EXIT: 1

--- a/test/regress/regress0/polymorphic/typing_bad8.smt2
+++ b/test/regress/regress0/polymorphic/typing_bad8.smt2
@@ -1,0 +1,22 @@
+(set-logic UFLRA)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(declare-sort list 1)
+
+(declare-fun nil (par (a) () (list a)))
+(declare-fun cons (par (a) (a (list a)) (list a)))
+(declare-fun length (par (a) ((list a)) Real))
+
+(declare-sort I1 0)
+
+(assert (= (length (as nil (list I1))) 0))
+
+(assert (not (= (length nil) 0)))
+
+
+
+(check-sat)
+(exit)
+
+; EXPECT-ERROR: (error "Parse Error: typing_bad8.smt2:14.28: No inference is done, you should add an (as term ty) for specifying the return type.")
+; EXIT: 1


### PR DESCRIPTION
This merge-request is a work in progress, used to discuss choices made in the implementation.

The basic idea is to change nothing (APPLY_UF, type-checking, ...) by working with instantiated function symbol. Global datastructures (`NodeManager::d_instanceFunction` and `NodeManager::d_parametricFunction` ) keep track of which function symbol is an instantiation of which polymorphic function. Type variable are usual type sort but registered in (`NodeManager::d_parameterVariables` for axioms, and `NodeManager::d_schemaVariables` for function schema).

Progress:
- [x] polymorphic function declaration parsing
- [x] polymorphic axiom parsing
- [ ] polymorphic function definition parsing
- [x] polymorphic function application parsing (with/without as)
- [x] type checking of requested polymorphic instance
- [x] type checking of polymorphic application (usual application of the instantiated function)
- [x] type checking of polymorphic lemmas
- [x] Core infrastructure dealing with polymorphic function, function instantiations, type "variable".
- [ ] printing of polymorphic function/axiom definition, application
- [x] quantifier handling

The two first commits are fixes separately requested for merge #50.

[Examples](https://github.com/bobot/CVC4/tree/feature/parametric/test/regress/regress0/parametric) of files.
