### PR TITLE
Added missing LogicException to throws in method lemma.

### DIFF
--- a/src/theory/output_channel.h
+++ b/src/theory/output_channel.h
@@ -22,6 +22,7 @@
 #include "util/cvc4_assert.h"
 #include "theory/interrupted.h"
 #include "util/resource_manager.h"
+#include "smt/logic_exception.h"
 
 namespace CVC4 {
 namespace theory {
@@ -120,7 +121,7 @@ public:
    */
   virtual LemmaStatus lemma(TNode n, bool removable = false,
                             bool preprocess = false)
-    throw(TypeCheckingExceptionPrivate, AssertionException, UnsafeInterruptException) = 0;
+    throw(TypeCheckingExceptionPrivate, AssertionException, UnsafeInterruptException, LogicException) = 0;
 
   /**
    * Request a split on a new theory atom.  This is equivalent to

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -303,7 +303,7 @@ class TheoryEngine {
       return d_engine->propagate(literal, d_theory);
     }
 
-    theory::LemmaStatus lemma(TNode lemma, bool removable = false, bool preprocess = false) throw(TypeCheckingExceptionPrivate, AssertionException, UnsafeInterruptException) {
+    theory::LemmaStatus lemma(TNode lemma, bool removable = false, bool preprocess = false) throw(TypeCheckingExceptionPrivate, AssertionException, UnsafeInterruptException, LogicException) {
       Trace("theory::lemma") << "EngineOutputChannel<" << d_theory << ">::lemma(" << lemma << ")" << std::endl;
       ++ d_statistics.lemmas;
       d_engine->d_outputChannelUsed = true;


### PR DESCRIPTION
This would cause CVC4 to sometimes raise uncatchable exceptions (even with catch(...)) when complex non-linear predicates were asserted.
I could not reproduce this crash on a simple benchmark but this fixes it.