### PR TITLE
Adds required steps to contrib/mac-build.

### DIFF
--- a/contrib/get-antlr-3.4
+++ b/contrib/get-antlr-3.4
@@ -27,11 +27,17 @@ function webget {
 
 if [ -z "${MACHINE_TYPE}" ]; then
   if ! [ -e config/config.guess ]; then
-   echo "$(basename $0): I need the file config/config.guess to tell MACHINE_TYPE" >&2
-   echo "Try running ./autogen.sh, or set the MACHINE_TYPE environment variable." >&2
-   exit 1
+    # Attempt to download once
+    webget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' config/config.guess
+   if [ -e config/config.guess ]; then
+     chmod +x config/config.guess
+        else
+     echo "$(basename $0): I need the file config/config.guess to tell MACHINE_TYPE" >&2
+     echo "Try running ./autogen.sh, or set the MACHINE_TYPE environment variable" >&2
+     echo "(e.g., \"export MACHINE_TYPE=x86_64\")." >&2
+     exit 1
+    fi
   fi
-
   # get first nibble from config.guess (x86_64, i686, ...)
   MACHINE_TYPE=`config/config.guess | sed 's,-.*,,'`
 fi

--- a/contrib/mac-build
+++ b/contrib/mac-build
@@ -44,11 +44,6 @@ fi
 echo
 echo =============================================================================
 echo
-echo "running: ./autogen.sh"
-./autogen.sh || reporterror
-echo
-echo =============================================================================
-echo
 contrib/get-antlr-3.4 | grep -v 'Now configure CVC4 with' | grep -v '\./configure --with-antlr-dir='
 [ ${PIPESTATUS[0]} -eq 0 ] || reporterror
 echo

--- a/contrib/mac-build
+++ b/contrib/mac-build
@@ -5,7 +5,7 @@
 # Tue, 25 Sep 2012 15:44:27 -0400
 #
 
-macports_prereq="boost gmp gtime readline"
+macports_prereq="autoconf automake boost gmp gtime libtool readline"
 
 export PATH="/opt/local/bin:$PATH"
 
@@ -41,6 +41,11 @@ else
   echo "ERROR: See http://www.macports.org/"
   reporterror
 fi
+echo
+echo =============================================================================
+echo
+echo "running: ./autogen.sh"
+./autogen.sh || reporterror
 echo
 echo =============================================================================
 echo


### PR DESCRIPTION
autogen.sh must be run before get-antlr-3.4 or it fails with

    I need the file config/config.guess to tell MACHINE_TYPE

autogen.sh can't run unless the autoconf, automake and libtools
MacPorts packages are installed.