### PR TITLE
Revert "Removing the CVC4_NEEDS_REPLACEMENT_FUNCTIONS guard to have a…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1004,11 +1004,11 @@ AC_SEARCH_LIBS([clock_gettime], [rt],
                           [Defined to 1 if clock_gettime() is supported by the platform.])],
                [AC_LIBOBJ([clock_gettime])])
 AC_CHECK_FUNC([strtok_r], [AC_DEFINE([HAVE_STRTOK_R], [1],
-                                     [Defined to 1 if strtok_r() is supported by the platform.])],
-                          [AC_LIBOBJ([strtok_r])])
+                                     [Defined to 1 if strtok_r() is supported by the platform.])])
 AC_CHECK_FUNC([ffs], [AC_DEFINE([HAVE_FFS], [1],
-                                [Defined to 1 if ffs() is supported by the platform.])],
-                     [AC_LIBOBJ([ffs])])
+                                [Defined to 1 if ffs() is supported by the platform.])])
+
+AC_LIBOBJ([strtok_r ffs])
 
 # Check for antlr C++ runtime (defined in config/antlr.m4)
 AC_LIB_ANTLR
@@ -1337,8 +1337,6 @@ else
   AM_CONDITIONAL([CVC4_HAS_THREADS], [false])
   AC_SUBST([CVC4_HAS_THREADS], 0)
 fi
-
-AM_CONDITIONAL([CVC4_NEEDS_REPLACEMENT_FUNCTIONS], [test -n "$LIBOBJS"])
 
 # Final information to the user
 gpl=no

--- a/src/lib/ffs.c
+++ b/src/lib/ffs.c
@@ -21,6 +21,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+#ifndef HAVE_FFS
 
 int ffs(int i) {
   long mask = 0x1;
@@ -35,6 +36,7 @@ int ffs(int i) {
   return 0;
 }
 
+#endif /* ifndef HAVE_FFS */
 #ifdef __cplusplus
 }/* extern "C" */
 #endif /* __cplusplus */


### PR DESCRIPTION
… simpler build process."

This reverts commit 06e266745d3621a11da7860de45b6533de96f55c and makes
CVC4 build on macOS Sierra. Otherwise the build dies with `ar: no
archive members specified` when linking the empty `libreplacements.la`.
