### PR TITLE
Fix typo in Makefile that makes distcheck fail

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -270,7 +270,7 @@ libcvc4_la_SOURCES = \
 	theory/sets/theory_sets_type_rules.h \
 	theory/sets/theory_sets_rels.cpp \
 	theory/sets/theory_sets_rels.h \
-	theory/sets/rel_utils.h \
+	theory/sets/rels_utils.h \
 	theory/strings/theory_strings.h \
 	theory/strings/theory_strings.cpp \
 	theory/strings/theory_strings_rewriter.h \


### PR DESCRIPTION
Commit 031722bee8682005bd4c8700ef78b5f893fc48fe broke distcheck again (see https://s3.amazonaws.com/archive.travis-ci.org/jobs/170932048/log.txt). Note: This is a different issue from the one solved in commit fb2f690c235470c8ec72d207eaa97213b1cdc446. All tests should pass now.