### PR TITLE
Fix three leaks in unit tests

### DIFF
--- a/test/unit/main/interactive_shell_black.h
+++ b/test/unit/main/interactive_shell_black.h
@@ -47,8 +47,12 @@ private:
   void countCommands(InteractiveShell& shell, 
                      int minCommands, 
                      int maxCommands) {
+    Command* cmd;
     int n = 0;
-    while( n <= maxCommands && shell.readCommand() != NULL ) { ++n; }
+    while( n <= maxCommands && (cmd = shell.readCommand()) != NULL ) {
+      ++n;
+      delete cmd;
+    }
     TS_ASSERT( n <= maxCommands );
     TS_ASSERT( n >= minCommands );
   }

--- a/test/unit/parser/parser_builder_black.h
+++ b/test/unit/parser/parser_builder_black.h
@@ -99,6 +99,7 @@ public:
 
     remove(filename);
     //    mkfifo(ptr, S_IWUSR | s_IRUSR);
+    delete filename;
   }
 
   void testSimpleFileInput() {
@@ -114,6 +115,7 @@ public:
                    );
 
     remove(filename);
+    delete filename;
   }
 
   void testEmptyStringInput() {

--- a/test/unit/util/listener_black.h
+++ b/test/unit/util/listener_black.h
@@ -100,6 +100,7 @@ public:
     TS_ASSERT(collection->empty());
     std::string expected[4] = {"a", "b", "c", "c"};
     TS_ASSERT_EQUALS(d_events, mkMultiset(expected, 4));
+    TS_ASSERT_THROWS_NOTHING( delete collection );
   }
 
   void testRegisterMiddleTearDown() {


### PR DESCRIPTION
The `testMultipleCollection` test case was allocating a
ListenerCollection without deleting it. The helper function
`countCommands` was not deleting the `Command`s returned from
`InteractiveShell::readCommand`. In the `testEmptyFileInput` and
`testSimpleFileInput` tests, the `filename` string was not deleted. This
commit fixes all issues.