### PR TITLE
Disabling out of memory tests unit tests when ASAN is enabled. ASAN f…

### DIFF
--- a/test/unit/context/cdlist_black.h
+++ b/test/unit/context/cdlist_black.h
@@ -16,18 +16,17 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include <iostream>
 #include <limits.h>
+#include <iostream>
 #include <vector>
 
 #include "base/exception.h"
-#include "context/context.h"
 #include "context/cdlist.h"
+#include "context/context.h"
 #include "memory.h"
 
 using namespace std;
 using namespace CVC4::context;
-using namespace CVC4::test;
 using namespace CVC4;
 
 struct DtorSensitiveObject {
@@ -37,19 +36,13 @@ struct DtorSensitiveObject {
 };
 
 class CDListBlack : public CxxTest::TestSuite {
-private:
-
+ private:
   Context* d_context;
 
-public:
+ public:
+  void setUp() { d_context = new Context(); }
 
-  void setUp() {
-    d_context = new Context();
-  }
-
-  void tearDown() {
-    delete d_context;
-  }
+  void tearDown() { delete d_context; }
 
   // test at different sizes.  this triggers grow() behavior differently.
   // grow() was completely broken in revision 256
@@ -69,21 +62,19 @@ public:
     CDList<int> list(d_context, callDestructor);
 
     TS_ASSERT(list.empty());
-    for(int i = 0; i < N; ++i) {
+    for (int i = 0; i < N; ++i) {
       TS_ASSERT_EQUALS(list.size(), unsigned(i));
       list.push_back(i);
       TS_ASSERT(!list.empty());
       TS_ASSERT_EQUALS(list.back(), i);
       int i2 = 0;
-      for(CDList<int>::const_iterator j = list.begin();
-          j != list.end();
-          ++j) {
+      for (CDList<int>::const_iterator j = list.begin(); j != list.end(); ++j) {
         TS_ASSERT_EQUALS(*j, i2++);
       }
     }
     TS_ASSERT_EQUALS(list.size(), unsigned(N));
 
-    for(int i = 0; i < N; ++i) {
+    for (int i = 0; i < N; ++i) {
       TS_ASSERT_EQUALS(list[i], i);
     }
   }
@@ -132,30 +123,31 @@ public:
   }
 
   void testEmptyIterator() {
-    CDList<int>* list = new(true) CDList<int>(d_context);
+    CDList<int>* list = new (true) CDList<int>(d_context);
     TS_ASSERT_EQUALS(list->begin(), list->end());
     list->deleteSelf();
   }
 
-  /* setrlimit() totally broken on Mac OS X */
   void testOutOfMemory() {
-#ifdef __APPLE__
+#ifdef CVC4_MEMORY_LIMITING_DISABLED
 
-    TS_WARN("can't run memory tests on Mac OS X");
+    test::WarnWithLimitedMemoryDisabledReason();
 
-#else /* __APPLE__ */
+#else /* CVC4_MEMORY_LIMITING_DISABLED */
 
     CDList<unsigned> list(d_context);
-    WithLimitedMemory wlm(1);
+    test::WithLimitedMemory wlm(1);
 
-    TS_ASSERT_THROWS({
-        // We cap it at UINT_MAX, preferring to terminate with a
-        // failure than run indefinitely.
-        for(unsigned i = 0; i < UINT_MAX; ++i) {
-          list.push_back(i);
-        }
-      }, bad_alloc);
+    TS_ASSERT_THROWS(
+        {
+          // We cap it at UINT_MAX, preferring to terminate with a
+          // failure than run indefinitely.
+          for (unsigned i = 0; i < UINT_MAX; ++i) {
+            list.push_back(i);
+          }
+        },
+        bad_alloc);
 
-#endif /* __APPLE__ */
+#endif /* CVC4_MEMORY_LIMITING_DISABLED */
   }
 };

--- a/test/unit/context/cdvector_black.h
+++ b/test/unit/context/cdvector_black.h
@@ -22,14 +22,11 @@
 
 #include <limits.h>
 
-#include "memory.h"
-
 #include "context/context.h"
 #include "context/cdvector.h"
 
 using namespace std;
 using namespace CVC4::context;
-using namespace CVC4::test;
 
 struct DtorSensitiveObject {
   bool& d_dtorCalled;

--- a/test/unit/memory.h
+++ b/test/unit/memory.h
@@ -19,6 +19,12 @@
  **   TS_ASSERT_THROWS( foo(), bad_alloc );
  **
  ** The WithLimitedMemory destructor will re-establish the previous limit.
+ **
+ ** This class does not exist in CVC4_MEMORY_LIMITING_DISABLED is defined.
+ ** This can be disabled for a variety of reasons.
+ ** If this is disabled, there will be a function:
+ **   void WarnWithLimitedMemoryDisabledReason()
+ ** uses TS_WARN to alert users that these tests are disabled.
  **/
 
 #include <cxxtest/TestSuite.h>
@@ -26,47 +32,52 @@
 #ifndef __CVC4__TEST__MEMORY_H
 #define __CVC4__TEST__MEMORY_H
 
-#include <sys/time.h>
+#include <string>
 #include <sys/resource.h>
+#include <sys/time.h>
 
 #include "base/cvc4_assert.h"
+
+// Conditionally define CVC4_MEMORY_LIMITING_DISABLED.
+#ifdef __APPLE__
+#  define CVC4_MEMORY_LIMITING_DISABLED 1
+#  define CVC4_MEMORY_LIMITING_DISABLED_REASON "setrlimit() is broken on Mac."
+#else /* __APPLE__ */
+#  if defined(__has_feature)
+#    if __has_feature(address_sanitizer)
+// Tests cannot expect bad_alloc to be thrown due to limit memory using
+// setrlimit when ASAN is enable. ASAN instead aborts on mmap failures.
+#      define CVC4_MEMORY_LIMITING_DISABLED 1
+#      define CVC4_MEMORY_LIMITING_DISABLED_REASON "ASAN's mmap failures abort."
+#    endif /* __has_feature(address_sanitizer) */
+#  endif /* defined(__has_feature) */
+#endif
+
+
 
 namespace CVC4 {
 namespace test {
 
+#ifdef CVC4_MEMORY_LIMITING_DISABLED
+
+inline void WarnWithLimitedMemoryDisabledReason() {
+  const std::string reason = std::string("WithLimitedMemory is disabled: ") +
+      std::string(CVC4_MEMORY_LIMITING_DISABLED_REASON);
+  TS_WARN(reason.c_str());
+}
+
+#else /* CVC4_MEMORY_LIMITING_DISABLED */
+
 class WithLimitedMemory {
-  rlim_t d_prevAmount;
-
-  void remember() {
-    struct rlimit rlim;
-    TS_ASSERT_EQUALS(getrlimit(RLIMIT_AS, &rlim), 0);
-    d_prevAmount = rlim.rlim_cur;
-  }
-
-public:
-
-  WithLimitedMemory() {
-#ifdef __APPLE__
-    TS_FAIL("setrlimit() is broken on Mac, can't run memory tests.");
-    AlwaysAssert(false,
-                 "setrlimit() is broken on Mac, can't run memory tests.");
-#endif /* __APPLE__ */
-    remember();
-  }
+ public:
+  WithLimitedMemory() { remember(); }
 
   WithLimitedMemory(rlim_t amount) {
-#ifdef __APPLE__
-    TS_FAIL("setrlimit() is broken on Mac, can't run memory tests.");
-    AlwaysAssert(false,
-                 "setrlimit() is broken on Mac, can't run memory tests.");
-#endif /* __APPLE__ */
     remember();
     set(amount);
   }
 
-  ~WithLimitedMemory() {
-    set(d_prevAmount);
-  }
+  ~WithLimitedMemory() { set(d_prevAmount); }
 
   void set(rlim_t amount) {
     struct rlimit rlim;
@@ -74,9 +85,26 @@ public:
     rlim.rlim_max = RLIM_INFINITY;
     TS_ASSERT_EQUALS(setrlimit(RLIMIT_AS, &rlim), 0);
   }
-};
 
-}/* CVC4::test namespace */
-}/* CVC4 namespace */
+ private:
+  void remember() {
+    struct rlimit rlim;
+    TS_ASSERT_EQUALS(getrlimit(RLIMIT_AS, &rlim), 0);
+    d_prevAmount = rlim.rlim_cur;
+  }
+
+  rlim_t d_prevAmount;
+}; /* class WithLimitedMemory */
+
+#endif /* CVC4_MEMORY_LIMITING_DISABLED */
+
+} /* CVC4::test namespace */
+} /* CVC4 namespace */
+
+
+// Remove CVC4_MEMORY_LIMITING_DISABLED_REASON if it is defined.
+#ifdef CVC4_MEMORY_LIMITING_DISABLED_REASON
+#undef CVC4_MEMORY_LIMITING_DISABLED_REASON
+#endif /* CVC4_MEMORY_LIMITING_DISABLED_REASON */
 
 #endif /* __CVC4__TEST__MEMORY_H */


### PR DESCRIPTION
…ailures are too hard for the unit testing framework.