### PR TITLE
Fix dependency tracing for fewerPreprocessingHoles

### DIFF
--- a/src/smt/ite_removal.cpp
+++ b/src/smt/ite_removal.cpp
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#include "options/proof_options.h"
 #include "proof/proof_manager.h"
 #include "theory/ite_utilities.h"
 
@@ -55,7 +56,8 @@ void RemoveITE::run(std::vector<Node>& output, IteSkolemMap& iteSkolemMap, bool 
     // fixes the bug on clang on Mac OS
     Node itesRemoved = run(output[i], output, iteSkolemMap, false);
     // In some calling contexts, not necessary to report dependence information.
-    if(reportDeps && options::unsatCores()) {
+    if (reportDeps &&
+        (options::unsatCores() || options::fewerPreprocessingHoles())) {
       // new assertions have a dependence on the node
       PROOF( ProofManager::currentPM()->addDependence(itesRemoved, output[i]); )
       while(n < output.size()) {

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -25,6 +25,7 @@
 #include "expr/node_builder.h"
 #include "options/bv_options.h"
 #include "options/options.h"
+#include "options/proof_options.h"
 #include "options/quantifiers_options.h"
 #include "proof/cnf_proof.h"
 #include "proof/lemma_proof.h"
@@ -1945,7 +1946,7 @@ bool TheoryEngine::donePPSimpITE(std::vector<Node>& assertions){
   // This pass does not support dependency tracking yet
   // (learns substitutions from all assertions so just
   // adding addDependence is not enough)
-  if (options::unsatCores()) {
+  if (options::unsatCores() || options::fewerPreprocessingHoles()) {
     return true;
   }
   bool result = true;

--- a/test/regress/regress0/bv/Makefile.am
+++ b/test/regress/regress0/bv/Makefile.am
@@ -100,7 +100,8 @@ SMT_TESTS = \
 	bv2nat-simp-range.smt2 \
 	bv-int-collapse1.smt2 \
 	bv-int-collapse2.smt2 \
-	bv-int-collapse2-sat.smt2
+	bv-int-collapse2-sat.smt2 \
+	bench_38.delta.smt2
 
 # Regression tests for SMT2 inputs
 SMT2_TESTS = divtest.smt2

--- a/test/regress/regress0/bv/bench_38.delta.smt2
+++ b/test/regress/regress0/bv/bench_38.delta.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --fewer-preprocessing-holes --check-proof --quiet
+; EXPECT: unsat
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+(assert (and (= (bvudiv (_ bv2 4) x) (_ bv2 4)) (= (_ bv0 4) x) (= (_ bv1 4) x)))
+(check-sat)
+(exit)


### PR DESCRIPTION
Previously, dependency tracing in `ite_removal.cpp` was only done with
the `unsatCores` option but `fewerPreprocessingHoles` requires
dependencies, too. This lead to errors during proof construction when
`fewerPreprocessingHoles` was active. This commit fixes the condition
and includes a test case that previously failed.  Additionally, it fixes
a similar issue in the theory engine.

NOTE: this commit might not fix all instances of this problem.
`smt_engine.cpp` turns certain flags off with `unsatCores`.
Compatibility between those flags and `fewerPreprocessingHoles` needs to
be checked separately.