### PR TITLE
Fix compilation issue on MinGW64

### DIFF
--- a/src/util/sexpr.cpp
+++ b/src/util/sexpr.cpp
@@ -124,6 +124,22 @@ SExpr::SExpr(unsigned long int value)
       d_stringValue(""),
       d_children(NULL) {}
 
+#ifdef CVC4_NEED_INT64_T_OVERLOADS
+SExpr::SExpr(int64_t value)
+    : d_sexprType(SEXPR_INTEGER),
+      d_integerValue(value),
+      d_rationalValue(0),
+      d_stringValue(""),
+      d_children(NULL) {}
+	  
+SExpr::SExpr(uint64_t value)
+    : d_sexprType(SEXPR_INTEGER),
+      d_integerValue(value),
+      d_rationalValue(0),
+      d_stringValue(""),
+      d_children(NULL) {}
+#endif /* CVC4_NEED_INT64_T_OVERLOADS */
+  
 SExpr::SExpr(const CVC4::Rational& value)
     : d_sexprType(SEXPR_RATIONAL),
       d_integerValue(0),

--- a/src/util/sexpr.h
+++ b/src/util/sexpr.h
@@ -67,6 +67,11 @@ class CVC4_PUBLIC SExpr {
   SExpr(unsigned int value);
   SExpr(unsigned long int value);
 
+ #ifdef CVC4_NEED_INT64_T_OVERLOADS
+  SExpr(int64_t  value);
+  SExpr(uint64_t value);
+#endif /* CVC4_NEED_INT64_T_OVERLOADS */
+
   SExpr(const CVC4::Rational& value);
 
   SExpr(const std::string& value);


### PR DESCRIPTION
  CXX      smt/smt_engine.lo
../../../../src/smt/smt_engine.cpp: In member function 'CVC4::SExpr CVC4::SmtEngine::getInfo(const string&) const':
../../../../src/smt/smt_engine.cpp:2154:0: error: call of overloaded 'SExpr(std::vector<int>::size_type)' is ambiguous
     return SExpr(d_userLevels.size());