### PR TITLE
Fix non-idempotent rewrite in Array rewriter

### DIFF
--- a/src/theory/arrays/theory_arrays_rewriter.h
+++ b/src/theory/arrays/theory_arrays_rewriter.h
@@ -370,8 +370,9 @@ public:
               indices.pop_back();
               elements.pop_back();
             }
+            Assert(n != node);
             Trace("arrays-postrewrite") << "Arrays::postRewrite returning " << n << std::endl;
-            return RewriteResponse(REWRITE_DONE, n);
+            return RewriteResponse(REWRITE_AGAIN, n);
           }
         }
         break;

--- a/test/regress/regress0/arrays/Makefile.am
+++ b/test/regress/regress0/arrays/Makefile.am
@@ -48,7 +48,8 @@ TESTS =	\
 	constarr.cvc \
 	constarr2.cvc \
 	constarr3.cvc \
-	parsing_ringer.cvc
+	parsing_ringer.cvc \
+	bug637.delta.smt2
 
 EXTRA_DIST = $(TESTS)
 

--- a/test/regress/regress0/arrays/bug637.delta.smt2
+++ b/test/regress/regress0/arrays/bug637.delta.smt2
@@ -1,0 +1,14 @@
+(set-logic QF_ABV)
+(set-info :status unsat)
+(declare-fun x2 () (_ BitVec 32))
+(declare-fun a () (Array (_ BitVec 32) (_ BitVec 8)))
+(declare-fun x3 () (_ BitVec 32))
+
+(assert (not (=
+(store (store (store a x2 (select a (bvadd x2 (_ bv1 32))))
+	      (bvadd x2 (_ bv1 32)) (select a (bvadd x2 (_ bv1 32))))
+       x2 (select a x2))
+
+       a)))
+(check-sat)
+(exit)


### PR DESCRIPTION
This commit fixes bug 637 (
http://church.cims.nyu.edu/bugzilla3/show_bug.cgi?id=637 ) as
proposed in Bugzilla and adds the minified test case to the
regression tests.