### PR TITLE
Bug 679 fix

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -254,7 +254,9 @@ void CommandExecutor::printStatsFilterZeros(std::ostream& out,
     std::getline(iss, statValue, '\n');
 
     double curFloat;
-    bool isFloat = static_cast<bool>(std::istringstream(statValue) >> curFloat);
+    std::istringstream iss_stat_value (statValue);
+    iss_stat_value >> curFloat;
+    bool isFloat = iss_stat_value.good();
 
     if( (isFloat && curFloat == 0) ||
         statValue == " \"0\"" ||


### PR DESCRIPTION
With reference to Bug 679, this commit integrates part of the proposed patch, and it fixes the usage of std::istringstream when checking the correct float parsing.
    
The compilation issue in Bug 679 does not apply anymore with gcc6.3.1