### PR TITLE
Fix win-build script to use MinGW-w64 by default

### DIFF
--- a/contrib/win-build
+++ b/contrib/win-build
@@ -13,7 +13,7 @@ if [ $# -ne 0 ]; then
 fi
 
 if [ -z "$HOST" ]; then
-  HOST=i586-mingw32msvc
+  HOST=i686-w64-mingw32
   echo "WARNING:"
   echo "WARNING: Using default HOST value: $HOST"
   echo "WARNING: You should probably run this script like this:"


### PR DESCRIPTION
Previous changes to the win-build script left the script in an
inconsistent state: the script was updated to refer to MinGW-w64 but the
default host was still referring to MinGW.