### PR TITLE
Remove decl. of getStatisticsRegistry(SmtEngine*)

### DIFF
--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -105,10 +105,6 @@ namespace theory {
   class TheoryModel;
 }/* CVC4::theory namespace */
 
-namespace stats {
-  StatisticsRegistry* getStatisticsRegistry(SmtEngine*);
-}/* CVC4::stats namespace */
-
 // TODO: SAT layer (esp. CNF- versus non-clausal solvers under the
 // hood): use a type parameter and have check() delegate, or subclass
 // SmtEngine and override check()?
@@ -356,7 +352,6 @@ class CVC4_PUBLIC SmtEngine {
   friend class ::CVC4::smt::SmtEnginePrivate;
   friend class ::CVC4::smt::SmtScope;
   friend class ::CVC4::smt::BooleanTermConverter;
-  friend ::CVC4::StatisticsRegistry* ::CVC4::stats::getStatisticsRegistry(SmtEngine*);
   friend ProofManager* ::CVC4::smt::currentProofManager();
   friend class ::CVC4::LogicRequest;
   // to access d_modelCommands

--- a/src/smt/smt_engine.i
+++ b/src/smt/smt_engine.i
@@ -45,7 +45,6 @@ SWIGEXPORT void JNICALL Java_edu_nyu_acsys_CVC4_SmtEngine_dlRef(JNIEnv* jenv, jc
 #endif // SWIGJAVA
 
 %ignore CVC4::SmtEngine::setLogic(const char*);
-%ignore CVC4::stats::getStatisticsRegistry(SmtEngine*);
 %ignore CVC4::smt::currentProofManager();
 
 %include "smt/smt_engine.h"


### PR DESCRIPTION
Commit f4ef7af0a2295691f281ee1604dfeb4082fe229c removed the definition
of getStatisticsRegistry(SmtEngine*) but not the declaration.