### PR TITLE
Coverage fix

### DIFF
--- a/src/expr/Makefile.am
+++ b/src/expr/Makefile.am
@@ -1,6 +1,19 @@
+# Forcing some make variables to be actual absolute paths to fix Coverage
+# lcov does not support relative paths and src/options and src/expr
+# in particular were breaking it
+# Note: variable declarations may be moved in generated Makefile
+# see src/expr/Makefile.am
+
+VPATH = $(realpath @srcdir@)
+srcdir = $(realpath @srcdir@)
+abs_srcdir = $(realpath @abs_srcdir@)
+abs_top_srcdir = $(realpath @abs_top_srcdir@)
+top_srcdir = $(realpath @top_srcdir@)
+
+
 AM_CPPFLAGS = \
 	-D__BUILDING_CVC4LIB \
-	-I@builddir@/.. -I@srcdir@/../include -I@srcdir@/..
+	-I$(realpath @builddir@/..) -I$(realpath @srcdir@/../include) -I$(realpath @srcdir@/..)
 AM_CXXFLAGS = -Wall -Wno-unknown-pragmas $(FLAG_VISIBILITY_HIDDEN)
 
 noinst_LTLIBRARIES = libexpr.la

--- a/src/options/Makefile.am
+++ b/src/options/Makefile.am
@@ -12,6 +12,18 @@
 #   This stage also waits for X_options.h as otherwise it cannot compile.
 #
 
+# Forcing some make variables to be actual absolute paths to fix Coverage
+# lcov does not support relative paths and src/options and src/expr
+# in particular were breaking it
+# Note: variable declarations may be moved in generated Makefile
+# see src/options/Makefile.am
+
+VPATH = $(realpath @srcdir@)
+srcdir = $(realpath @srcdir@)
+abs_srcdir = $(realpath @abs_srcdir@)
+abs_top_srcdir = $(realpath @abs_top_srcdir@)
+top_srcdir = $(realpath @top_srcdir@)
+
 OPTIONS_SRC_FILES = \
 	arith_options \
 	arrays_options \
@@ -200,7 +212,7 @@ DOCUMENTATION_TEMPLATE_SEDS = \
 
 AM_CPPFLAGS = \
 	-D__BUILDING_CVC4LIB \
-	-I@builddir@/.. -I@srcdir@/../include -I@srcdir@/..
+	-I$(realpath @builddir@/..) -I$(realpath @srcdir@/../include) -I$(realpath @srcdir@/..)
 AM_CXXFLAGS = -Wall $(FLAG_VISIBILITY_HIDDEN)
 
 noinst_LTLIBRARIES = liboptions.la
@@ -308,7 +320,7 @@ arith_options arrays_options base_options booleans_options builtin_options bv_op
 # Make is happier being listed explictly. Not sure why.
 arith_options.tmp arrays_options.tmp base_options.tmp booleans_options.tmp builtin_options.tmp bv_options.tmp datatypes_options.tmp decision_options.tmp expr_options.tmp fp_options.tmp idl_options.tmp main_options.tmp parser_options.tmp printer_options.tmp proof_options.tmp prop_options.tmp quantifiers_options.tmp sep_options.tmp sets_options.tmp smt_options.tmp strings_options.tmp theory_options.tmp uf_options.tmp:
 	echo "$@" "$(@:.tmp=)"
-	$(AM_V_GEN)(cp "@srcdir@/$(@:.tmp=)" "$@" || true)
+	$(AM_V_GEN)(cp "$(realpath @srcdir@/$(@:.tmp=))" "$@" || true)
 #TIM:
 #The (... || true) here is to make distcheck not fail.
 
@@ -321,38 +333,38 @@ arith_options.tmp arrays_options.tmp base_options.tmp booleans_options.tmp built
 # We use the updating of %_options.options to signal that the options file updated.
 # However, we use the original file in src to generate the file.
 %_options.sed: %_options.options mkoptions
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions module-sed "@srcdir@/$(@:.sed=)" ) > "$@"
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) module-sed "$(realpath @srcdir@/$(@:.sed=))" ) > "$@"
 
 
 $(CPP_TEMPLATE_SEDS): %.sed : % mkoptions
 #	echo "template seds"
 #	echo "$@"
 #	echo $(TEMPLATE_SEDS)
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions template-sed "$<" ) > "$@"
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) template-sed "$<" ) > "$@"
 
 $(DOCUMENTATION_TEMPLATE_SEDS): %.sed : % mkoptions
 #	echo "template seds"
 #	echo "$@"
 #	echo $(TEMPLATE_SEDS)
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions template-sed "$<" ) > "$@"
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) template-sed "$<" ) > "$@"
 
 %_options.h : %_options.sed mkoptions base_options_template.h base_options_template.h.sed
 #	echo heads
 #	echo "$@"
 #	echo $(OPTIONS_HEADS)
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions apply-sed-files-to-template \
-		@srcdir@/base_options_template.h \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) apply-sed-files-to-template \
+		$(realpath @srcdir@/base_options_template.h) \
 		base_options_template.h.sed \
 		"$<" \
 	) > "$@"
 
 summary.sed : mkoptions $(OPTIONS_OPTIONS_FILES)
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions summary-sed \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) summary-sed \
 		$(OPTIONS_OPTIONS_FILES) \
 	) > summary.sed
 
@@ -360,18 +372,18 @@ summary.sed : mkoptions $(OPTIONS_OPTIONS_FILES)
 
 #   mkoptions apply-sed-to-template sed-file template-file
 options_holder.h : options_holder_template.h options_holder_template.h.sed summary.sed mkoptions $(OPTIONS_HEADS)
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions apply-sed-files-to-template \
-		@srcdir@/options_holder_template.h \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) apply-sed-files-to-template \
+		$(realpath @srcdir@/options_holder_template.h) \
 		@builddir@/options_holder_template.h.sed \
 		summary.sed \
 	) > "$@"
 
 # Make sure not to match with "options.cpp" too.
 %_options.cpp: %_options.sed %_options.h mkoptions options_holder.h base_options_template.cpp base_options_template.cpp.sed
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions apply-sed-files-to-template \
-		@srcdir@/base_options_template.cpp \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) apply-sed-files-to-template \
+		$(realpath @srcdir@/base_options_template.cpp) \
 		base_options_template.cpp.sed \
 		"$<" \
 	) > "$@"
@@ -381,9 +393,9 @@ options_holder.h : options_holder_template.h options_holder_template.h.sed summa
 
 #   mkoptions apply-sed-to-template sed-file template-file
 options.cpp : options_template.cpp options_template.cpp.sed mkoptions summary.sed $(OPTIONS_HEADS) options_holder.h
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions apply-sed-files-to-template \
-		@srcdir@/options_template.cpp \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) apply-sed-files-to-template \
+		$(realpath @srcdir@/options_template.cpp) \
 		@builddir@/options_template.cpp.sed \
 		summary.sed \
 	) > "$@"
@@ -391,17 +403,17 @@ options.cpp : options_template.cpp options_template.cpp.sed mkoptions summary.se
 
 #   mkoptions apply-sed-to-template sed-file template-file
 options_get_option.cpp : options_get_option_template.cpp options_get_option_template.cpp.sed mkoptions summary.sed $(OPTIONS_HEADS)
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions apply-sed-files-to-template \
-		@srcdir@/options_get_option_template.cpp \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) apply-sed-files-to-template \
+		$(realpath @srcdir@/options_get_option_template.cpp) \
 		@builddir@/options_get_option_template.cpp.sed \
 		summary.sed \
 	) > "$@"
 
 options_set_option.cpp : options_set_option_template.cpp options_set_option_template.cpp.sed mkoptions summary.sed $(OPTIONS_HEADS)
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions apply-sed-files-to-template \
-		@srcdir@/options_set_option_template.cpp \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) apply-sed-files-to-template \
+		$(realpath @srcdir@/options_set_option_template.cpp) \
 		@builddir@/options_set_option_template.cpp.sed \
 		summary.sed \
 	) > "$@"
@@ -411,8 +423,8 @@ options_set_option.cpp : options_set_option_template.cpp options_set_option_temp
 $(DOCUMENTATION_FILES) : % : %_template %_template.sed mkoptions summary.sed
 #	echo "$<"
 #	echo "$@"
-	$(AM_V_at)chmod +x @srcdir@/mkoptions
-	$(AM_V_GEN)(@srcdir@/mkoptions apply-sed-files-to-template \
+	$(AM_V_at)chmod +x $(realpath @srcdir@/mkoptions)
+	$(AM_V_GEN)($(realpath @srcdir@/mkoptions) apply-sed-files-to-template \
 		"$<" \
 		"$<".sed \
 		@builddir@/summary.sed \


### PR DESCRIPTION
Forcing some make variables to be absolute paths
lcov does not (officially) support relative paths
src/expr and src/options in particular were breaking it