### PR TITLE
Fix out-of-bounds access in test

### DIFF
--- a/test/unit/util/stats_black.h
+++ b/test/unit/util/stats_black.h
@@ -172,7 +172,6 @@ public:
         "true\n"
         "[(0 : 1), (5 : 2), (6 : 1), (10 : 2)]\n"
         "<unsupported>";
-    std::cout << buf << std::endl;
     TS_ASSERT(strncmp(expected, buf, file_size) == 0);
     delete[] buf;
 


### PR DESCRIPTION
This should fix the ASAN failure that occurred during the nightly testing. The issue was that `buf` is (most likely) not `\0` terminated.