### PR TITLE
Minor fix in safe_print function

### DIFF
--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -61,7 +61,7 @@ namespace CVC4 {
     const char *progPath;
 
     /** Just the basename component of argv[0] */
-    const char *progName;
+    const std::string *progName;
 
     /** A pointer to the CommandExecutor (the signal handlers need it) */
     CVC4::main::CommandExecutor* pExecutor = NULL;
@@ -112,7 +112,8 @@ int runCvc4(int argc, char* argv[], Options& opts) {
   }
 # endif
 
-  progName = opts.getBinaryName().c_str();
+  string progNameStr = opts.getBinaryName();
+  progName = &progNameStr;
 
   if( opts.getHelp() ) {
     printUsage(opts, true);

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -38,7 +38,7 @@ class CommandExecutor;
 extern const char* progPath;
 
 /** Just the basename component of argv[0] */
-extern const char* progName;
+extern const std::string* progName;
 
 /** A reference for use by the signal handlers to print statistics */
 extern CVC4::main::CommandExecutor* pExecutor;

--- a/src/main/util.cpp
+++ b/src/main/util.cpp
@@ -112,14 +112,14 @@ void segv_handler(int sig, siginfo_t* info, void* c) {
     safe_print(STDERR_FILENO,
                "Spinning so that a debugger can be connected.\n");
     safe_print(STDERR_FILENO, "Try:  gdb ");
-    safe_print(STDERR_FILENO, progName);
+    safe_print(STDERR_FILENO, *progName);
     safe_print(STDERR_FILENO, " ");
     safe_print<int64_t>(STDERR_FILENO, getpid());
     safe_print(STDERR_FILENO, "\n");
     safe_print(STDERR_FILENO, " or:  gdb --pid=");
     safe_print<int64_t>(STDERR_FILENO, getpid());
     safe_print(STDERR_FILENO, " ");
-    safe_print(STDERR_FILENO, progName);
+    safe_print(STDERR_FILENO, *progName);
     safe_print(STDERR_FILENO, "\n");
     for(;;) {
       sleep(60);
@@ -156,14 +156,14 @@ void ill_handler(int sig, siginfo_t* info, void*) {
     safe_print(STDERR_FILENO,
                "Spinning so that a debugger can be connected.\n");
     safe_print(STDERR_FILENO, "Try:  gdb ");
-    safe_print(STDERR_FILENO, progName);
+    safe_print(STDERR_FILENO, *progName);
     safe_print(STDERR_FILENO, " ");
     safe_print<int64_t>(STDERR_FILENO, getpid());
     safe_print(STDERR_FILENO, "\n");
     safe_print(STDERR_FILENO, " or:  gdb --pid=");
     safe_print<int64_t>(STDERR_FILENO, getpid());
     safe_print(STDERR_FILENO, " ");
-    safe_print(STDERR_FILENO, progName);
+    safe_print(STDERR_FILENO, *progName);
     safe_print(STDERR_FILENO, "\n");
     for(;;) {
       sleep(60);
@@ -206,14 +206,14 @@ void cvc4unexpected() {
     safe_print(STDERR_FILENO,
                "Spinning so that a debugger can be connected.\n");
     safe_print(STDERR_FILENO, "Try:  gdb ");
-    safe_print(STDERR_FILENO, progName);
+    safe_print(STDERR_FILENO, *progName);
     safe_print(STDERR_FILENO, " ");
     safe_print<int64_t>(STDERR_FILENO, getpid());
     safe_print(STDERR_FILENO, "\n");
     safe_print(STDERR_FILENO, " or:  gdb --pid=");
     safe_print<int64_t>(STDERR_FILENO, getpid());
     safe_print(STDERR_FILENO, " ");
-    safe_print(STDERR_FILENO, progName);
+    safe_print(STDERR_FILENO, *progName);
     safe_print(STDERR_FILENO, "\n");
     for(;;) {
       sleep(60);

--- a/src/util/safe_print.cpp
+++ b/src/util/safe_print.cpp
@@ -128,9 +128,8 @@ void safe_print(int fd, const double& _d) {
     d -= c;
     i++;
   }
-  if (i == 0) {
-    safe_print(fd, "0");
-  } else if (write(fd, buf, i) != i) {
+
+  if (write(fd, buf, i) != i) {
     abort();
   }
 }
@@ -172,7 +171,7 @@ void safe_print_hex(int fd, uint64_t i) {
 
   // This loop fills the buffer from the end. The number of elements in the
   // buffer is BUFER_SIZE - idx - 1 and they start at position idx + 1.
-  size_t idx = BUFFER_SIZE - 1;
+  ssize_t idx = BUFFER_SIZE - 1;
   while (i != 0 && idx >= 0) {
     char current = i % 16;
     if (current <= 9) {

--- a/src/util/statistics.cpp
+++ b/src/util/statistics.cpp
@@ -122,8 +122,8 @@ void StatisticsBase::safeFlushInformation(int fd) const {
   for (StatSet::iterator i = d_stats.begin(); i != d_stats.end(); ++i) {
     Stat* s = *i;
     if (d_prefix.size() != 0) {
-      safe_print(fd, d_prefix.c_str());
-      safe_print(fd, s_regDelim.c_str());
+      safe_print(fd, d_prefix);
+      safe_print(fd, s_regDelim);
     }
     s->safeFlushStat(fd);
     safe_print(fd, "\n");

--- a/src/util/statistics_registry.h
+++ b/src/util/statistics_registry.h
@@ -137,7 +137,7 @@ public:
    */
   virtual void safeFlushStat(int fd) const {
     if (__CVC4_USE_STATISTICS) {
-      safe_print(fd, d_name.c_str());
+      safe_print(fd, d_name);
       safe_print(fd, ", ");
       safeFlushInformation(fd);
     }


### PR DESCRIPTION
This commit fixes two issues reported by Coverity:

- Fixes the check whether the buffer is full in safe_print_hex
- Removes dead code in safe_print for floating-point values