### PR TITLE
Fix minor bug in sets rewriter

### DIFF
--- a/src/theory/sets/theory_sets_rewriter.cpp
+++ b/src/theory/sets/theory_sets_rewriter.cpp
@@ -328,6 +328,7 @@ RewriteResponse TheorySetsRewriter::postRewrite(TNode node) {
                    NodeManager::currentNM()->mkNode( kind::CARD, NodeManager::currentNM()->mkNode( kind::INTERSECTION, node[0][0], node[0][1] ) ) );                                      
       return RewriteResponse(REWRITE_DONE, ret );
     }
+    break;
   }
   case kind::TRANSPOSE: {
     if(node[0].getKind() == kind::TRANSPOSE) {

--- a/test/regress/regress0/rels/Makefile.am
+++ b/test/regress/regress0/rels/Makefile.am
@@ -112,7 +112,8 @@ TESTS =	\
   joinImg_1_1.cvc \
   joinImg_1.cvc \
   joinImg_2_1.cvc \
-  joinImg_2.cvc  
+  joinImg_2.cvc \
+  card_transpose.cvc
 
 # unsolved : garbage_collect.cvc
 

--- a/test/regress/regress0/rels/card_transpose.cvc
+++ b/test/regress/regress0/rels/card_transpose.cvc
@@ -1,0 +1,6 @@
+% EXPECT: unknown (INCOMPLETE)
+OPTION "logic" "ALL_SUPPORTED";
+IntPair: TYPE = [INT, INT];
+x : SET OF IntPair;
+ASSERT (CARD(TRANSPOSE(x)) > 0);
+CHECKSAT;


### PR DESCRIPTION
As reported by Coverity, one of the switches in the sets rewriter had a missing
break. This could lead to an assertion failure when rewriting the cardinality
of a transpose as in the test case included in this commit.