### PR TITLE
[Competition] Fix ABC, fix CryptoMiniSat req

### DIFF
--- a/config/cryptominisat.m4
+++ b/config/cryptominisat.m4
@@ -37,8 +37,8 @@ elif test -n "$with_cryptominisat"; then
 
   dnl TODO FIXME:
   dnl For some reason the CVC4_TRY_CRYPTOMINISAT is not working correctly
-  CVC4_TRY_CRYPTOMINISAT_WITH([])
-  CVC4_TRY_CRYPTOMINISAT_WITH([-lm4ri])
+  CVC4_TRY_CRYPTOMINISAT_WITH([-pthread])
+  CVC4_TRY_CRYPTOMINISAT_WITH([-pthread -lm4ri])
 
   if test -z "$CRYPTOMINISAT_LIBS"; then
     AC_MSG_FAILURE([cannot link against libcryptominisat!])
@@ -48,7 +48,6 @@ elif test -n "$with_cryptominisat"; then
   fi
 
   CRYPTOMINISAT_LDFLAGS="-L$CRYPTOMINISAT_HOME/install/lib"
-  CRYPTOMINISAT_LIBS="-lcryptominisat4 -lm4ri"
 
 else
   AC_MSG_RESULT([no, user didn't request cryptominisat])
@@ -71,10 +70,9 @@ if test -z "$CRYPTOMINISAT_LIBS"; then
   LDFLAGS="-L$CRYPTOMINISAT_HOME/install/lib"
   LIBS="-lcryptominisat4 $1"
 
-
   AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM([#include <cryptominisat4/cryptominisat.h>],
-      [CMSat::SATSolver test()])], [CRYPTOMINISAT_LIBS="-lcryptominisat4 $1"],
+    [AC_LANG_PROGRAM([[#include <cryptominisat4/cryptominisat.h>]],
+      [[CMSat::SATSolver test()]])], [CRYPTOMINISAT_LIBS="-lcryptominisat4 $1"],
     [CRYPTOMINISAT_LIBS=])
 
   LDFLAGS="$cvc4_save_LDFLAGS"

--- a/contrib/get-abc
+++ b/contrib/get-abc
@@ -2,7 +2,7 @@
 #
 set -e
 
-commit=3c5d3319120b
+commit=53f39c11b58d
 
 cd "$(dirname "$0")/.."
 
@@ -39,9 +39,6 @@ gunzip -f abc-$commit.tar.gz
 tar xfv abc-$commit.tar
 cd alanmi-abc-$commit
 
-cp src/base/main/main.c src/base/main/main.c.orig
-sed 's,^// *#define ABC_LIB *$,#define ABC_LIB,' src/base/main/main.c.orig > src/base/main/main.c
-
 # Strip out libSupport.c, it is in charge of loading extensions and we
 # don't want different behavior based on ABC_LIB_PATH, or based on what
 # .so is in the current directory!
@@ -52,10 +49,10 @@ sed 's,\( *\)\(.*Libs_Init(\),\1//\2,;s,\( *\)\(.*Libs_End(\),\1//\2,' src/base/
 
 # Build optimized, without readline, without pthreads.
 # These aren't necessary for our usage and we don't want the dependencies.
-make libabc.a OPTFLAGS=-O READLINE=0 PTHREADS=0
+make libabc.a OPTFLAGS=-O ABC_USE_NO_READLINE=1 ABC_USE_NO_PTHREADS=1
 mv libabc.a libabc-static.a
 make clean
-make libabc.a OPTFLAGS='-O -fPIC' READLINE=0 PTHREADS=0
+make libabc.a OPTFLAGS='-O -fPIC' ABC_USE_NO_READLINE=1 ABC_USE_NO_PTHREADS=1
 
 echo
 echo ===================== Now configure CVC4 with =====================


### PR DESCRIPTION
#This commit fixes two issues that caused the competition configuration to fail on the cluster machines:

We used an ancient version of ABC that declared a function (factorial()
luckySimple.c) in a source file as inline but not static. This issue was fixed
in the following commit:

https://bitbucket.org/alanmi/abc/commits/e0aa7af0d73538fb786c4dcc72745578f0068a38

The issue with non-static inline functions in source files is described in the
following Stackoverflow post:

https://stackoverflow.com/questions/16740515/simple-c-inline-linker-error

This commit updates ABC to a much newer version (commit tagged as abc20160717),
which fixes the issue. One of the modifications previously performed by
contrib/get-abc does not need to be necessary anymore.

CryptoMiniSat was always linked against m4ri, even though it was not getting
compiled with it (-DNOM4RI="ON" in contrib/get-cryptominisat4). This commit
removes the part of config/cryptominisat.m4 that explicitly sets the libraries
linked to and instead uses the result of CVC4_TRY_CRYPTOMINISAT_WITH (which
seems to work even though there is comment indicating otherwise). Further, it
adds -pthread to the libraries required by CryptoMiniSat because it is required
by the version of CryptoMiniSat that we use (a newer version supports disabling
that behavior, so it might be a good idea to update). Previously, this would
lead to linker errors.

Tested with the following configuration:

```
./configure competition --with-antlr-dir=`pwd`/antlr-3.4 ANTLR=`pwd`/antlr-3.4/bin/antlr3 --enable-static-binary --enable-gpl --with-cln --with-glpk --with-glpk-dir=`pwd`/glpk-cut-log --with-abc --with-abc-dir=`pwd`/abc/alanmi-abc-53f39c11b58d --disable-thread-support --without-readline --disable-shared --with-cryptominisat --with-cryptominisat-dir=`pwd`/cryptominisat4
```