### PR TITLE
Fix stream parsing

### DIFF
--- a/src/parser/Makefile.am
+++ b/src/parser/Makefile.am
@@ -52,7 +52,9 @@ libcvc4parser_la_SOURCES = \
 	parser.h \
 	parser_builder.cpp \
 	parser_builder.h \
-	parser_exception.h
+	parser_exception.h \
+	line_buffer.h \
+	line_buffer.cpp
 
 EXTRA_DIST = \
 	Makefile.antlr_tracing \

--- a/src/parser/Makefile.am
+++ b/src/parser/Makefile.am
@@ -46,15 +46,15 @@ libcvc4parser_la_SOURCES = \
 	bounded_token_factory.h \
 	input.cpp \
 	input.h \
+	line_buffer.cpp \
+	line_buffer.h \
 	memory_mapped_input_buffer.cpp \
 	memory_mapped_input_buffer.h \
 	parser.cpp \
 	parser.h \
 	parser_builder.cpp \
 	parser_builder.h \
-	parser_exception.h \
-	line_buffer.h \
-	line_buffer.cpp
+	parser_exception.h
 
 EXTRA_DIST = \
 	Makefile.antlr_tracing \

--- a/src/parser/antlr_input.cpp
+++ b/src/parser/antlr_input.cpp
@@ -127,6 +127,9 @@ AntlrInputStream::~AntlrInputStream() {
   if(d_inputString != NULL){
     free(d_inputString);
   }
+  if (d_line_buffer != NULL) {
+    delete d_line_buffer;
+  }
 }
 
 pANTLR3_INPUT_STREAM AntlrInputStream::getAntlr3InputStream() const {

--- a/src/parser/antlr_input.h
+++ b/src/parser/antlr_input.h
@@ -35,11 +35,11 @@
 #include "base/output.h"
 #include "parser/bounded_token_buffer.h"
 #include "parser/input.h"
+#include "parser/line_buffer.h"
 #include "parser/parser_exception.h"
 #include "util/bitvector.h"
 #include "util/integer.h"
 #include "util/rational.h"
-
 
 namespace CVC4 {
 
@@ -62,10 +62,11 @@ private:
    */
   pANTLR3_UINT8 d_inputString;
 
-  AntlrInputStream(std::string name,
-                   pANTLR3_INPUT_STREAM input,
-                   bool fileIsTemporary,
-                   pANTLR3_UINT8 inputString);
+  LineBuffer* d_line_buffer;
+
+  AntlrInputStream(std::string name, pANTLR3_INPUT_STREAM input,
+                   bool fileIsTemporary, pANTLR3_UINT8 inputString,
+                   LineBuffer* line_buffer);
 
   /* This is private and unimplemented, because you should never use it. */
   AntlrInputStream(const AntlrInputStream& inputStream) CVC4_UNDEFINED;

--- a/src/parser/antlr_input.h
+++ b/src/parser/antlr_input.h
@@ -202,9 +202,6 @@ public:
   /** Get a bitvector constant from the text of the number and the size token */
   static BitVector tokenToBitvector(pANTLR3_COMMON_TOKEN number, pANTLR3_COMMON_TOKEN size);
 
-  /** Retrieve the remaining text in this input. */
-  std::string getUnparsedText();
-
   /** Get the ANTLR3 lexer for this input. */
   pANTLR3_LEXER getAntlr3Lexer() { return d_lexer; }
 
@@ -243,14 +240,6 @@ protected:
   /** Set the Parser object for this input. */
   virtual void setParser(Parser& parser);
 };/* class AntlrInput */
-
-inline std::string AntlrInput::getUnparsedText() {
-  const char *base = (const char *)d_antlr3InputStream->data;
-  const char *cur = (const char *)d_antlr3InputStream->nextChar;
-
-  return std::string(cur, d_antlr3InputStream->sizeBuf - (cur - base));
-}
-
 
 inline std::string AntlrInput::tokenText(pANTLR3_COMMON_TOKEN token) {
   if( token->type == ANTLR3_TOKEN_EOF ) {

--- a/src/parser/antlr_line_buffered_input.cpp
+++ b/src/parser/antlr_line_buffered_input.cpp
@@ -224,7 +224,7 @@ static ANTLR3_UCHAR myLA(pANTLR3_INT_STREAM is, ANTLR3_INT32 la) {
   pANTLR3_INPUT_STREAM input = ((pANTLR3_INPUT_STREAM)(is->super));
   CVC4::parser::pANTLR3_LINE_BUFFERED_INPUT_STREAM line_buffered_input =
       (CVC4::parser::pANTLR3_LINE_BUFFERED_INPUT_STREAM)input;
-  char* result = line_buffered_input->line_buffer->getPtrWithOffset(
+  uint8_t* result = line_buffered_input->line_buffer->getPtrWithOffset(
       input->line, input->charPositionInLine, la - 1);
   return (result != NULL) ? *result : ANTLR3_CHARSTREAM_EOF;
 }
@@ -234,12 +234,12 @@ static void myConsume(pANTLR3_INT_STREAM is) {
   CVC4::parser::pANTLR3_LINE_BUFFERED_INPUT_STREAM line_buffered_input =
       (CVC4::parser::pANTLR3_LINE_BUFFERED_INPUT_STREAM)input;
 
-  char* current = line_buffered_input->line_buffer->getPtr(
+  uint8_t* current = line_buffered_input->line_buffer->getPtr(
       input->line, input->charPositionInLine);
   if (current != NULL) {
     input->charPositionInLine++;
 
-    if (reinterpret_cast<unsigned char&>(*current) == input->newlineChar) {
+    if (*current == input->newlineChar) {
       // Reset for start of a new line of input
       input->line++;
       input->charPositionInLine = 0;
@@ -323,7 +323,7 @@ static pANTLR3_INPUT_STREAM antlr3CreateLineBufferedStream(
 
   // Structure was allocated correctly, now we can install the pointer
   //
-  input->data = malloc(1024);
+  input->data = NULL;
   input->isAllocated = ANTLR3_FALSE;
 
   ((pANTLR3_LINE_BUFFERED_INPUT_STREAM)input)->in = &in;

--- a/src/parser/antlr_line_buffered_input.cpp
+++ b/src/parser/antlr_line_buffered_input.cpp
@@ -267,7 +267,7 @@ static void bufferedInputConsume(pANTLR3_INT_STREAM is) {
   if (current != NULL) {
     input->charPositionInLine++;
 
-    if (*current == input->newlineChar) {
+    if (*current == LineBuffer::NewLineChar) {
       // Reset for start of a new line of input
       input->line++;
       input->charPositionInLine = 0;
@@ -307,6 +307,12 @@ static ANTLR3_UINT32 bufferedInputSize(pANTLR3_INPUT_STREAM input) {
   return 0;
 }
 
+static void bufferedInputSetNewLineChar(pANTLR3_INPUT_STREAM input,
+                                        ANTLR3_UINT32 newlineChar) {
+  // Not supported for this type of stream
+  assert(false);
+}
+
 static void bufferedInputSetUcaseLA(pANTLR3_INPUT_STREAM input,
                                     ANTLR3_BOOLEAN flag) {
   // Not supported for this type of stream
@@ -339,8 +345,8 @@ pANTLR3_INPUT_STREAM antlr3LineBufferedStreamNew(std::istream& in,
   input->istream->seek = bufferedInputSeek;
   input->istream->rewind = bufferedInputRewind;
   input->size = bufferedInputSize;
+  input->SetNewLineChar = bufferedInputSetNewLineChar;
   input->setUcaseLA = bufferedInputSetUcaseLA;
-  input->sizeBuf = 0;
 
 #ifndef CVC4_ANTLR3_OLD_INPUT_STREAM
     // We have the data in memory now so we can deal with it according to
@@ -393,19 +399,23 @@ static pANTLR3_INPUT_STREAM antlr3CreateLineBufferedStream(
 // initialization.
 //
 #ifdef CVC4_ANTLR3_OLD_INPUT_STREAM
-	antlr3AsciiSetupStream(input, ANTLR3_CHARSTREAM);
+  antlr3AsciiSetupStream(input, ANTLR3_CHARSTREAM);
 #else /* CVC4_ANTLR3_OLD_INPUT_STREAM */
-	antlr38BitSetupStream(input);
-        // In some libantlr3c 3.4-beta versions, this call is not included in the above.
-        // This is probably an erroneously-deleted line in the libantlr3c source since 3.2.
-	antlr3GenericSetupStream(input);
+  antlr38BitSetupStream(input);
+  // In some libantlr3c 3.4-beta versions, this call is not included in the
+  // above.
+  // This is probably an erroneously-deleted line in the libantlr3c source since
+  // 3.2.
+  antlr3GenericSetupStream(input);
 #endif /* CVC4_ANTLR3_OLD_INPUT_STREAM */
 
-        input->charPositionInLine = 0;
-        input->line = 0;
-        input->nextChar = line_buffer->getPtr(0, 0);
-        input->currentLine = line_buffer->getPtr(0, 0);
-        return  input;
+  input->sizeBuf = 0;
+  input->newlineChar = LineBuffer::NewLineChar;
+  input->charPositionInLine = 0;
+  input->line = 0;
+  input->nextChar = line_buffer->getPtr(0, 0);
+  input->currentLine = line_buffer->getPtr(0, 0);
+  return input;
 }
 
 }/* CVC4::parser namespace */

--- a/src/parser/antlr_line_buffered_input.h
+++ b/src/parser/antlr_line_buffered_input.h
@@ -31,7 +31,6 @@
 #define __CVC4__PARSER__ANTLR_LINE_BUFFERED_INPUT_H
 
 #include <istream>
-#include <vector>
 
 #include "parser/line_buffer.h"
 

--- a/src/parser/antlr_line_buffered_input.h
+++ b/src/parser/antlr_line_buffered_input.h
@@ -2,17 +2,22 @@
 /*! \file antlr_line_buffered_input.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Morgan Deters, Tim King
+ **   Morgan Deters, Tim King, Andres Noetzli
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2016 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief [[ Add one-line brief description here ]]
+ ** \brief A custom ANTLR input stream that reads from the input stream lazily
  **
- ** [[ Add lengthier description here ]]
- ** \todo document this file
+ ** By default, ANTLR expects the whole input to be in a single, consecutive
+ ** buffer. When doing incremental solving and the input is coming from the
+ ** standard input, this is problematic because CVC4 might receive new input
+ ** based on the result of solving the existing input.
+ **
+ ** This file overwrites the _LA and the consume functions of the input streamto
+ ** achieve that and stores the lines received so far in a LineBuffer.
  **/
 
 // These headers should be the first two included.
@@ -26,6 +31,9 @@
 #define __CVC4__PARSER__ANTLR_LINE_BUFFERED_INPUT_H
 
 #include <istream>
+#include <vector>
+
+#include "parser/line_buffer.h"
 
 namespace CVC4 {
 namespace parser {
@@ -33,10 +41,13 @@ namespace parser {
 typedef struct ANTLR3_LINE_BUFFERED_INPUT_STREAM {
   ANTLR3_INPUT_STREAM antlr;
   std::istream* in;
+  LineBuffer* line_buffer;
 } *pANTLR3_LINE_BUFFERED_INPUT_STREAM;
 
-pANTLR3_INPUT_STREAM
-antlr3LineBufferedStreamNew(std::istream& in, ANTLR3_UINT32 encoding, pANTLR3_UINT8 name);
+pANTLR3_INPUT_STREAM antlr3LineBufferedStreamNew(std::istream& in,
+                                                 ANTLR3_UINT32 encoding,
+                                                 pANTLR3_UINT8 name,
+                                                 LineBuffer* line_buffer);
 
 }/* CVC4::parser namespace */
 }/* CVC4 namespace */

--- a/src/parser/input.h
+++ b/src/parser/input.h
@@ -140,9 +140,6 @@ public:
   /** Destructor. Frees the input stream and closes the input. */
   virtual ~Input();
 
-  /** Retrieve the remaining text in this input. */
-  virtual std::string getUnparsedText() = 0;
-
   /** Get the language that this Input is reading. */
   virtual InputLanguage getLanguage() const throw() = 0;
 

--- a/src/parser/line_buffer.cpp
+++ b/src/parser/line_buffer.cpp
@@ -1,0 +1,70 @@
+/*********************                                                        */
+/*! \file line_buffer.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andres Noetzli
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2016 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The LineBuffer class stores lines from an input stream
+ **
+ ** For each line, the class allocates a separate buffer.
+ **/
+
+#include "parser/line_buffer.h"
+
+#include <cstring>
+#include <string>
+
+namespace CVC4 {
+namespace parser {
+
+LineBuffer::LineBuffer(std::istream* stream) : d_stream(stream) {}
+
+LineBuffer::~LineBuffer() {
+  for (size_t i = 0; i < d_lines.size(); i++) {
+    delete[] d_lines[i];
+  }
+}
+
+char* LineBuffer::getPtr(size_t line, size_t pos_in_line) {
+  if (!readToLine(line)) {
+    return NULL;
+  }
+  return d_lines[line] + pos_in_line;
+}
+
+char* LineBuffer::getPtrWithOffset(size_t line, size_t pos_in_line,
+                                   size_t offset) {
+  if (!readToLine(line)) {
+    return NULL;
+  }
+  if (pos_in_line + offset >= d_sizes[line]) {
+    return getPtrWithOffset(line + 1, 0,
+                            offset - (d_sizes[line] - pos_in_line - 1));
+  }
+  return d_lines[line] + pos_in_line + offset;
+}
+
+bool LineBuffer::readToLine(size_t line) {
+  while (line >= d_lines.size()) {
+    if (!(*d_stream)) {
+      return false;
+    }
+
+    std::string line;
+    std::getline(*d_stream, line);
+    char* segment = new char[line.size() + 1];
+    std::memcpy(segment, line.c_str(), line.size());
+    segment[line.size()] = '\n';
+    d_lines.push_back(segment);
+    d_sizes.push_back(line.size() + 1);
+  }
+  return true;
+}
+
+}  // namespace parser
+}  // namespace CVC4

--- a/src/parser/line_buffer.cpp
+++ b/src/parser/line_buffer.cpp
@@ -30,14 +30,14 @@ LineBuffer::~LineBuffer() {
   }
 }
 
-char* LineBuffer::getPtr(size_t line, size_t pos_in_line) {
+uint8_t* LineBuffer::getPtr(size_t line, size_t pos_in_line) {
   if (!readToLine(line)) {
     return NULL;
   }
   return d_lines[line] + pos_in_line;
 }
 
-char* LineBuffer::getPtrWithOffset(size_t line, size_t pos_in_line,
+uint8_t* LineBuffer::getPtrWithOffset(size_t line, size_t pos_in_line,
                                    size_t offset) {
   if (!readToLine(line)) {
     return NULL;
@@ -57,7 +57,7 @@ bool LineBuffer::readToLine(size_t line) {
 
     std::string line;
     std::getline(*d_stream, line);
-    char* segment = new char[line.size() + 1];
+    uint8_t* segment = new uint8_t[line.size() + 1];
     std::memcpy(segment, line.c_str(), line.size());
     segment[line.size()] = '\n';
     d_lines.push_back(segment);

--- a/src/parser/line_buffer.cpp
+++ b/src/parser/line_buffer.cpp
@@ -77,7 +77,7 @@ bool LineBuffer::readToLine(size_t line) {
     std::getline(*d_stream, line);
     uint8_t* segment = new uint8_t[line.size() + 1];
     std::memcpy(segment, line.c_str(), line.size());
-    segment[line.size()] = '\n';
+    segment[line.size()] = LineBuffer::NewLineChar;
     d_lines.push_back(segment);
     d_sizes.push_back(line.size() + 1);
   }

--- a/src/parser/line_buffer.h
+++ b/src/parser/line_buffer.h
@@ -1,0 +1,68 @@
+/*********************                                                        */
+/*! \file line_buffer.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andres Noetzli
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2016 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The LineBuffer class stores lines from an input stream
+ **
+ ** Each line is guaranteed to be consecutive in memory. The content in
+ ** the line buffer can be addressed using line number and the position
+ ** within the line.
+ **/
+
+#include "cvc4parser_private.h"
+
+#ifndef __CVC4__PARSER__SEGMENTED_BUFFER_H
+#define __CVC4__PARSER__SEGMENTED_BUFFER_H
+
+#include <cstdlib>
+#include <istream>
+#include <vector>
+
+namespace CVC4 {
+namespace parser {
+
+class LineBuffer {
+ public:
+  LineBuffer(std::istream* stream);
+  ~LineBuffer();
+
+  /**
+    * Gets a pointer to a char at a specific line and position within that
+    * line.
+    */
+  char* getPtr(size_t line, size_t pos_in_line);
+
+  /**
+    * Gets a pointer to a char at an offset relative to a  specific line and
+    * position within that line.
+    */
+  char* getPtrWithOffset(size_t line, size_t pos_in_line, size_t offset);
+
+ private:
+  /**
+    * Reads lines up to a line number from the input if needed (it does
+    * nothing for the lines that were already read). Returns false if the end
+    * of the input stream has been reached and not all lines could be read.
+    */
+  bool readToLine(size_t line);
+
+  std::istream* d_stream;
+  // Each element in this vector corresponds to a line from the input stream.
+  // WARNING: not null-terminated.
+  std::vector<char*> d_lines;
+  // Each element in this vector corresponds to the length of a line from the
+  // input stream.
+  std::vector<size_t> d_sizes;
+};
+
+}  // namespace parser
+}  // namespace CVC4
+
+#endif /* __CVC4__PARSER__SEGMENTED_BUFFER_H */

--- a/src/parser/line_buffer.h
+++ b/src/parser/line_buffer.h
@@ -18,8 +18,8 @@
 
 #include "cvc4parser_private.h"
 
-#ifndef __CVC4__PARSER__SEGMENTED_BUFFER_H
-#define __CVC4__PARSER__SEGMENTED_BUFFER_H
+#ifndef __CVC4__PARSER__LINE_BUFFER_H
+#define __CVC4__PARSER__LINE_BUFFER_H
 
 #include <cstdlib>
 #include <istream>
@@ -37,13 +37,13 @@ class LineBuffer {
     * Gets a pointer to a char at a specific line and position within that
     * line.
     */
-  char* getPtr(size_t line, size_t pos_in_line);
+  uint8_t* getPtr(size_t line, size_t pos_in_line);
 
   /**
     * Gets a pointer to a char at an offset relative to a  specific line and
     * position within that line.
     */
-  char* getPtrWithOffset(size_t line, size_t pos_in_line, size_t offset);
+  uint8_t* getPtrWithOffset(size_t line, size_t pos_in_line, size_t offset);
 
  private:
   /**
@@ -56,7 +56,7 @@ class LineBuffer {
   std::istream* d_stream;
   // Each element in this vector corresponds to a line from the input stream.
   // WARNING: not null-terminated.
-  std::vector<char*> d_lines;
+  std::vector<uint8_t*> d_lines;
   // Each element in this vector corresponds to the length of a line from the
   // input stream.
   std::vector<size_t> d_sizes;
@@ -65,4 +65,4 @@ class LineBuffer {
 }  // namespace parser
 }  // namespace CVC4
 
-#endif /* __CVC4__PARSER__SEGMENTED_BUFFER_H */
+#endif /* __CVC4__PARSER__LINE_BUFFER_H */

--- a/src/parser/line_buffer.h
+++ b/src/parser/line_buffer.h
@@ -45,6 +45,12 @@ class LineBuffer {
     */
   uint8_t* getPtrWithOffset(size_t line, size_t pos_in_line, size_t offset);
 
+  /**
+    * Tests whether a given pointer points to a location before a given
+    * line and position within that line.
+    */
+  bool isPtrBefore(uint8_t* ptr, size_t line, size_t pos_in_line);
+
  private:
   /**
     * Reads lines up to a line number from the input if needed (it does

--- a/src/parser/line_buffer.h
+++ b/src/parser/line_buffer.h
@@ -30,6 +30,8 @@ namespace parser {
 
 class LineBuffer {
  public:
+  static const uint8_t NewLineChar = '\n';
+
   LineBuffer(std::istream* stream);
   ~LineBuffer();
 


### PR DESCRIPTION
This commit fixes bug 811. Bug 811 was caused because tokens were referring to
a buffer that was reallocated and thus the pointers were not valid anymore.

Background:
The buffered input stream avoids copying the whole input stream before handing
it to ANTLR (in contrast to the non-buffered input stream that first copies
everything into a buffer). This enables interactivity (e.g. with kind2) and may
save memory.
CVC4 uses it when reading from stdin in competition mode for the application
track (the incremental benchmarks) and in non-competition mode. To set the
CVC4_SMTCOMP_APPLICATION_TRACK flag, the {C,CXX}FLAGS have to be modified at
configure time.

Solution:
This commit fixes the issue by changing how a stream gets buffered. Instead of
storing the stream into a single buffer, CVC4 now stores each line in a
separate buffer, making sure that they do not have to move, keeping tokens
valid. The commit adds the LineBuffer class for managing those buffers. It
further modifies CVC4's LA and consume functions to use line number and
position within a line to index into the line buffer. This allows us to use the
standard mark()/rewind()/etc. functions because they automatically store and
restore that state. The solution also (arguably) simplifies the code.

Disadvantages:
Tokens split across lines would cause problems (seems reasonable to me). One
allocation per line.

Alternatives considered:
Pull request 162 by Tim was a first attempt to solve the problem. The issues
with this solution are: memory usage (old versions of the buffer do not get
deleted), tokens split across buffers would be problematic, and
mark()/rewind()/etc. would have to be overwritten for the approach to work.
I had a partially working fix that used indexes into the stream instead of
pointers to memory. The solution stored the content of the stream into a
segmented buffer (lines were not guaranteed to be consecutive in memory. This
approach was working for basic use cases but had the following issues: ugly
casting (the solution requires casting the index to a pointer and storing it in
the input stream's nextChar because that's where ANTLR is taking the location
information from when creating a token), more modifications (not only would
this solution require overwriting more functions of the input stream such as
substr, it also requires changes to the use of GETCHARINDEX() in the Smt2
parser and AntlrInput::tokenText() for example), more complex code.