### PR TITLE
Fix segfault by making unit conflict CDMaybe

### DIFF
--- a/src/proof/sat_proof.h
+++ b/src/proof/sat_proof.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "context/cdhashmap.h"
+#include "context/cdmaybe.h"
 #include "expr/expr.h"
 #include "proof/clause_id.h"
 #include "proof/proof_manager.h"
@@ -349,8 +350,7 @@ class TSatProof {
   IdCRefMap d_temp_idClause;
 
   // unit conflict
-  ClauseId d_unitConflictId;
-  bool d_storedUnitConflict;
+  context::CDMaybe<ClauseId> d_unitConflictId;
 
   ClauseId d_trueLit;
   ClauseId d_falseLit;

--- a/test/regress/regress0/push-pop/Makefile.am
+++ b/test/regress/regress0/push-pop/Makefile.am
@@ -48,7 +48,8 @@ BUG_TESTS = \
   inc-define.smt2 \
   bug765.smt2 \
   bug691.smt2 \
-  bug694-Unapply1.scala-0.smt2
+  bug694-Unapply1.scala-0.smt2 \
+  simple_unsat_cores.smt2
 
 TESTS =	$(SMT_TESTS) $(SMT2_TESTS) $(CVC_TESTS) $(BUG_TESTS)
 

--- a/test/regress/regress0/push-pop/simple_unsat_cores.smt2
+++ b/test/regress/regress0/push-pop/simple_unsat_cores.smt2
@@ -1,7 +1,6 @@
 ; COMMAND-LINE: --incremental
 ; EXPECT: unsat
 ; EXPECT: unsat
-(set-option :produce-unsat-cores true)
 (set-logic UF)
 (push 1)
 (assert false)

--- a/test/regress/regress0/push-pop/simple_unsat_cores.smt2
+++ b/test/regress/regress0/push-pop/simple_unsat_cores.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --incremental
+; EXPECT: unsat
+; EXPECT: unsat
+(set-option :produce-unsat-cores true)
+(set-logic UF)
+(push 1)
+(assert false)
+(check-sat)
+(pop 1)
+(assert false)
+(check-sat)


### PR DESCRIPTION
This commit fixes bug 819 by making d_unitConflictId context dependent.