### PR TITLE
Make comp script more robust

### DIFF
--- a/contrib/run-script-smtcomp2017-application
+++ b/contrib/run-script-smtcomp2017-application
@@ -2,13 +2,19 @@
 
 cvc4=./cvc4-application
 
-read line
+line=""
+while [[ -z "$line" ]]; do
+  read line
+done
 if [ "$line" != '(set-option :print-success true)' ]; then
   echo 'ERROR: first line supposed to be set-option :print-success, but got: "'"$line"'"' >&2
   exit 1
 fi
 echo success
-read line
+line=""
+while [[ -z "$line" ]]; do
+  read line
+done
 logic=$(expr "$line" : ' *(set-logic  *\([A-Z_]*\) *) *$')
 if [ -z "$logic" ]; then
   echo 'ERROR: second line supposed to be set-logic, but got: "'"$line"'"' >&2


### PR DESCRIPTION
In certain cases, the trace executor inserts empty lines, which threw off
our competition script. This commit adds code to ignores empty lines.