### PR TITLE
Fix SIGILL handler

### DIFF
--- a/src/main/util.cpp
+++ b/src/main/util.cpp
@@ -307,7 +307,7 @@ void cvc4_init() throw(Exception) {
   }
 
   struct sigaction act4;
-  act4.sa_sigaction = segv_handler;
+  act4.sa_sigaction = ill_handler;
   act4.sa_flags = SA_SIGINFO;
   sigemptyset(&act4.sa_mask);
   if(sigaction(SIGILL, &act4, NULL)) {


### PR DESCRIPTION
As pointed out by @cpitclaudel in pull request #172, we are using the same
handler for SIGSEGV and SIGILL and ill_handler() is unused. This commit changes
the SIGILL handler to ill_handler().