### PR TITLE
Fix unsat cores script for SMT-COMP

### DIFF
--- a/contrib/run-script-smtcomp2017-unsat-cores
+++ b/contrib/run-script-smtcomp2017-unsat-cores
@@ -17,8 +17,7 @@ QF_LRA)
   finishwith --no-restrict-pivots --use-soi --new-prop --unconstrained-simp
   ;;
 QF_LIA)
-  # same as QF_LRA but add --pb-rewrites
-  finishwith --enable-miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi --pb-rewrites
+  finishwith --enable-miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi
   ;;
 QF_NIA)
   finishwith --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cryptominisat
@@ -46,13 +45,13 @@ QF_AUFBV)
   finishwith --decision=justification-stoponly
   ;;
 QF_ABV)
-  finishwith --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
+  finishwith --ite-simp --simp-with-care --arrays-weak-equiv
   ;;
 QF_UFBV)
   finishwith --bitblast=eager --bv-sat-solver=cryptominisat
   ;;
 QF_BV)
-  finishwith --unconstrained-simp --bv-div-zero-const --bv-intro-pow2 --bv-eq-slicer=auto --no-bv-abstraction
+  finishwith --bv-div-zero-const --bv-eq-slicer=auto --no-bv-abstraction
   ;;
 QF_AUFLIA)
   finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification

--- a/contrib/run-script-smtcomp2017-unsat-cores
+++ b/contrib/run-script-smtcomp2017-unsat-cores
@@ -5,18 +5,6 @@ bench="$1"
 
 logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
 
-# use: trywith [params..]
-# to attempt a run.  Only thing printed on stdout is "sat" or "unsat", in
-# which case this run script terminates immediately.  Otherwise, this
-# function returns normally.
-function trywith {
-  limit=$1; shift;
-  result="$(ulimit -S -t "$limit";$cvc4 -L smt2.6 --no-incremental --no-checking --no-interactive "$@" $bench)"
-  case "$result" in
-    sat|unsat) echo "$result"; exit 0;;
-  esac
-}
-
 # use: finishwith [params..]
 # to run cvc4 and let it output whatever it will to stdout.
 function finishwith {
@@ -26,7 +14,6 @@ function finishwith {
 case "$logic" in
 
 QF_LRA)
-  trywith 200 --enable-miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi
   finishwith --no-restrict-pivots --use-soi --new-prop --unconstrained-simp
   ;;
 QF_LIA)
@@ -34,97 +21,38 @@ QF_LIA)
   finishwith --enable-miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi --pb-rewrites
   ;;
 QF_NIA)
-  trywith 300 --nl-ext --nl-ext-tplanes --decision=internal
-  trywith 1800 --solve-int-as-bv=2 --bitblast=eager --bv-sat-solver=cryptominisat
-  trywith 1800 --solve-int-as-bv=4 --bitblast=eager --bv-sat-solver=cryptominisat
-  trywith 1800 --solve-int-as-bv=8 --bitblast=eager --bv-sat-solver=cryptominisat
-  trywith 1800 --solve-int-as-bv=16 --bitblast=eager --bv-sat-solver=cryptominisat
   finishwith --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cryptominisat
   ;;
 QF_NRA)
-  trywith 300 --nl-ext --nl-ext-tplanes --decision=justification
   finishwith --nl-ext --nl-ext-tplanes
   ;;
 # all logics with UF + quantifiers should either fall under this or special cases below
 ALIA|AUFLIA|AUFLIRA|AUFNIRA|UF|UFIDL|UFLIA|UFLRA|UFNIA|UFDT|UFDTLIA|AUFDTLIA|AUFBVDTLIA)
-  # the following is designed for a run time of 2400s (40 min).
-  # initial runs 1min
-  trywith 20 --simplification=none --full-saturate-quant
-  trywith 20 --no-e-matching --full-saturate-quant
-  trywith 20 --fs-inst --decision=internal --full-saturate-quant
-  # trigger selections 3min
-  trywith 30 --relevant-triggers --full-saturate-quant
-  trywith 30 --trigger-sel=max --full-saturate-quant
-  trywith 30 --multi-trigger-when-single --full-saturate-quant
-  trywith 30 --multi-trigger-when-single --multi-trigger-priority --full-saturate-quant
-  trywith 30 --multi-trigger-cache --full-saturate-quant
-  trywith 30 --no-multi-trigger-linear --full-saturate-quant
-  # other 3min
-  trywith 30 --pre-skolem-quant --full-saturate-quant
-  trywith 30 --inst-when=full --full-saturate-quant
-  trywith 30 --no-e-matching --no-quant-cf --full-saturate-quant
-  trywith 30 --nl-ext --full-saturate-quant
-  trywith 30 --full-saturate-quant --quant-ind
-  trywith 60 --decision=internal --simplification=none --no-inst-no-entail --no-quant-cf --full-saturate-quant
-  # finite model find 2min
-  trywith 20 --finite-model-find --mbqi=none
-  trywith 20 --finite-model-find
-  trywith 20 --finite-model-find --uf-ss=no-minimal
-  trywith 60 --finite-model-find --fmf-inst-engine
-  # long runs 20min
-  trywith 200 --decision=internal --full-saturate-quant
-  trywith 200 --term-db-mode=relevant --full-saturate-quant
-  trywith 200 --fs-inst --full-saturate-quant
-  trywith 600 --finite-model-find --decision=internal
-  # finite model find 1min
-  trywith 30 --finite-model-find --fmf-bound-int
-  trywith 30 --finite-model-find --sort-inference
-  # finish 10min
   finishwith --full-saturate-quant
   ;;
 UFBV)
-  # most problems in UFBV are essentially BV
-  trywith 300 --full-saturate-quant
-  trywith 300 --full-saturate-quant --no-cbqi
-  trywith 300 --full-saturate-quant --cbqi --decision=internal
   finishwith --finite-model-find
   ;;
 BV)
-  trywith 300 --full-saturate-quant
-  trywith 300 --full-saturate-quant --no-cbqi
   finishwith --full-saturate-quant --cbqi --decision=internal
   ;;
 LIA|LRA)
-  trywith 30 --full-saturate-quant
-  trywith 300 --full-saturate-quant --cbqi-midpoint
-  trywith 300 --full-saturate-quant --cbqi-nested-qe
   finishwith --full-saturate-quant --cbqi --cbqi-nested-qe --decision=internal
   ;;
 NIA|NRA)
-  trywith 30 --full-saturate-quant
-  trywith 300 --full-saturate-quant --nl-ext
-  trywith 300 --full-saturate-quant --cbqi-nested-qe
   finishwith --full-saturate-quant --cbqi --cbqi-nested-qe --decision=internal
   ;;
 QF_AUFBV)
-  trywith 600
   finishwith --decision=justification-stoponly
   ;;
 QF_ABV)
-  trywith 50 --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
-  trywith 500 --arrays-weak-equiv
   finishwith --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
   ;;
 QF_UFBV)
   finishwith --bitblast=eager --bv-sat-solver=cryptominisat
   ;;
 QF_BV)
-  trywith 300 --unconstrained-simp --bv-div-zero-const --bv-intro-pow2 --bitblast=eager  --bv-sat-solver=cryptominisat --bitblast-aig --no-bv-abstraction
   finishwith --unconstrained-simp --bv-div-zero-const --bv-intro-pow2 --bv-eq-slicer=auto --no-bv-abstraction
-  #trywith 10 --bv-eq-slicer=auto --decision=justification
-  #trywith 60 --decision=justification
-  #trywith 600 --decision=internal --bitblast-eager
-  #finishwith --decision=justification --decision-use-weight --decision-weight-internal=usr1
   ;;
 QF_AUFLIA)
   finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification
@@ -136,7 +64,6 @@ QF_AUFNIA)
   finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
   ;;
 QF_ALIA)
-  trywith 70 --decision=justification --arrays-weak-equiv
   finishwith --decision=justification-stoponly --no-arrays-eager-index --arrays-eager-lemmas
   ;;
 *)


### PR DESCRIPTION
This commit fixes the unsat cores script for the SMT-COMP by removing all trywith steps and flags that do not work in combination with unsat cores.