### PR TITLE
Fix assertion failure due to missing clause id (clean PR)

### DIFF
--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -428,7 +428,10 @@ bool Solver::addClause_(vec<Lit>& ps, bool removable, ClauseId& id)
             }
           }
           return ok;
-        } else return ok;
+        } else {
+          PROOF(id = ClauseIdUndef;);
+          return ok;
+        }
       }
     }
 

--- a/test/regress/regress0/push-pop/Makefile.am
+++ b/test/regress/regress0/push-pop/Makefile.am
@@ -49,7 +49,8 @@ BUG_TESTS = \
   bug765.smt2 \
   bug691.smt2 \
   bug694-Unapply1.scala-0.smt2 \
-  simple_unsat_cores.smt2
+  simple_unsat_cores.smt2 \
+  bug821.smt2
 
 TESTS =	$(SMT_TESTS) $(SMT2_TESTS) $(CVC_TESTS) $(BUG_TESTS)
 

--- a/test/regress/regress0/push-pop/bug821.smt2
+++ b/test/regress/regress0/push-pop/bug821.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --incremental
+; EXPECT: sat
+(set-logic UF)
+(push 1)
+(declare-fun _substvar_4_ () Bool)
+(assert _substvar_4_)
+(assert _substvar_4_)
+(check-sat)


### PR DESCRIPTION
This commit fixes bug 821. As written in the description of the bug, the issue
is that `id` is not being set on one of the paths in addClause(), specifically
in the case where all but one literal are assigned false and the remaining
literal is assigned true. In that case, we are not actually adding anything and
set the `id` to `ClauseIdUndef`.