### PR TITLE
Add Mac build to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
  apt: true
  directories:
   - $HOME/cxxtest
+  - $HOME/Library/Caches/Homebrew
 
 sudo: required
 dist: trusty
@@ -139,6 +140,25 @@ matrix:
           branch_pattern: coverity_scan
       after_failure:
         - cat /home/travis/build/CVC4/CVC4/cov-int/build-log.txt
+    - os: osx
+      jdk: openjdk-7-jdk
+      before_install:
+      - |
+        contrib/mac-build
+        brew install swig
+      install: # Duplicated here because osx does not support `cp -T`
+      - |
+        wget http://sourceforge.net/projects/cxxtest/files/cxxtest/4.3/cxxtest-4.3.tar.gz
+        tar -xzvf cxxtest-4.3.tar.gz
+        cp -vR cxxtest-4.3/ $HOME/cxxtest
+      env:
+      - JAVA_HOME=`/Library/Java/JavaVirtualMachines/jdk1.*/Contents/Home`
+      - TRAVIS_CVC4=yes
+      - TRAVIS_CVC4_CHECK_PORTFOLIO=yes
+      - TRAVIS_CVC4_CONFIG="debug --enable-language-bindings=java --with-antlr-dir=`pwd`/antlr-3.4"
+      - LDFLAGS=-L/opt/local/lib
+      - CPPFLAGS='-I/opt/local/include -I/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers'
+      - ANTLR=`pwd`/antlr-3.4/bin/antlr3
 notifications:
   email:
     on_success: change

--- a/contrib/mac-build
+++ b/contrib/mac-build
@@ -6,6 +6,7 @@
 #
 
 macports_prereq="autoconf automake boost gmp gtime libtool readline"
+homebrew_prereq="autoconf automake boost gmp gnu-time libtool readline"
 
 export PATH="/opt/local/bin:$PATH"
 
@@ -13,8 +14,8 @@ if [ $# -ne 0 ]; then
   echo "usage: `basename $0`" >&2
   echo >&2
   echo "This script attempts to set up the build requirements for CVC4 for Mac OS X." >&2
-  echo "MacPorts must be installed (but this script installs prerequisite port" >&2
-  echo "packages for CVC4).  If this script is successful, it prints a configure" >&2
+  echo "MacPorts or Homebrew must be installed (but this script installs prerequisite" >&2
+  echo "port packages for CVC4).  If this script is successful, it prints a configure" >&2
   echo "line that you can use to configure CVC4." >&2
   exit 1
 fi
@@ -30,11 +31,15 @@ function reporterror {
 
 echo =============================================================================
 echo
-echo "running: sudo port install $macports_prereq"
 if which port &>/dev/null; then
+  echo "running: sudo port install $macports_prereq"
   echo "You may be asked for your password to install these packages."
   echo
   sudo port install $macports_prereq || reporterror
+elif which brew &>/dev/null; then
+  for package in $homebrew_prereq; do
+      brew list $package &>/dev/null || brew install $package || reporterror
+  done
 else
   echo
   echo "ERROR: You must have MacPorts installed for Mac builds of CVC4."


### PR DESCRIPTION
This PR adds one Mac build to Travis CI.

In order to install dependencies on Travis, I added [Homebrew](https://brew.sh) support to `contrib/mac-build`. If `port` in available, the script will still try to use that first. If it is not available (as on Travis), it will fallback to using `brew`.

Test is currently not passing. I'm working to debug:

```text
FAIL: CVC4JavaTest
==================
java -classpath .:/Users/travis/build/pathawks/CVC4/builds/x86_64-apple-darwin15.6.0/debug/src/bindings/CVC4.jar -Djava.library.path=/Users/travis/build/pathawks/CVC4/builds/x86_64-apple-darwin15.6.0/debug/src/bindings/java/.libs:/Users/travis/build/pathawks/CVC4/builds/x86_64-apple-darwin15.6.0/debug/src/.libs:/Users/travis/build/pathawks/CVC4/builds/x86_64-apple-darwin15.6.0/debug/src/parser/.libs CVC4JavaTest
Exception in thread "main" java.lang.UnsatisfiedLinkError: /Users/travis/build/pathawks/CVC4/builds/x86_64-apple-darwin15.6.0/debug/src/bindings/java/.libs/libcvc4jni.3.dylib: dlopen(/Users/travis/build/pathawks/CVC4/builds/x86_64-apple-darwin15.6.0/debug/src/bindings/java/.libs/libcvc4jni.3.dylib, 1): Library not loaded: /usr/local/lib/libcvc4.3.dylib
  Referenced from: /Users/travis/build/pathawks/CVC4/builds/x86_64-apple-darwin15.6.0/debug/src/bindings/java/.libs/libcvc4jni.3.dylib
  Reason: image not found
	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
	at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1857)
	at java.lang.Runtime.loadLibrary0(Runtime.java:870)
	at java.lang.System.loadLibrary(System.java:1122)
	at CVC4JavaTest.main(CVC4JavaTest.java:36)
FAIL CVC4JavaTest.class (exit status: 1)
```