### PR TITLE
Disable separate gnu++11 tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
   #   via the "travis encrypt" command using the project repo's public key
   - secure: "fRfdzYwV10VeW5tVSvy5qpR8ZlkXepR7XWzCulzlHs9SRI2YY20BpzWRjyMBiGu2t7IeJKT7qdjq/CJOQEM8WS76ON7QJ1iymKaRDewDs3OhyPJ71fsFKEGgLky9blk7I9qZh23hnRVECj1oJAVry9IK04bc2zyIEjUYpjRkUAQ="
  matrix:
-  - TRAVIS_CVC4=yes CXXFLAGS='-std=gnu++11' TRAVIS_CVC4_CONFIG='--enable-proof'
   - TRAVIS_CVC4=yes TRAVIS_CVC4_CHECK_PORTFOLIO=yes TRAVIS_CVC4_CONFIG='production --enable-language-bindings=java,c --enable-proof --with-portfolio'
   - TRAVIS_CVC4=yes TRAVIS_CVC4_CHECK_PORTFOLIO=yes TRAVIS_CVC4_CONFIG='debug --enable-language-bindings=java,c --enable-proof --with-portfolio'
   - TRAVIS_CVC4=yes TRAVIS_CVC4_CONFIG='--disable-proof'


### PR DESCRIPTION
Given that we are now always compiling with gnu++11, we don't need
separate tests anymore.