### PR TITLE
Change remaining hash_set -> unordered_set

### DIFF
--- a/proofs/lfsc_checker/.gitignore
+++ b/proofs/lfsc_checker/.gitignore
@@ -12,5 +12,4 @@ Makefile.in
 /aclocal.m4
 *~
 \#*\#
-/config/
 *.swp

--- a/proofs/lfsc_checker/config/ax_cxx_compile_stdcxx.m4
+++ b/proofs/lfsc_checker/config/ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,1 @@
+../../../config/ax_cxx_compile_stdcxx.m4

--- a/proofs/lfsc_checker/config/ax_cxx_compile_stdcxx_11.m4
+++ b/proofs/lfsc_checker/config/ax_cxx_compile_stdcxx_11.m4
@@ -1,0 +1,1 @@
+../../../config/ax_cxx_compile_stdcxx_11.m4

--- a/proofs/lfsc_checker/configure.ac
+++ b/proofs/lfsc_checker/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.61])
 AC_INIT([lfsc-checker], [1.0], [cvc-bugs@cs.nyu.edu])
 AC_CONFIG_SRCDIR([libwriter.h])
 AC_CONFIG_AUX_DIR([config])
-AC_CONFIG_MACRO_DIR([config])
+AC_CONFIG_MACRO_DIR([../../config])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([1.11 foreign no-define tar-pax])
 LT_INIT
@@ -26,6 +26,10 @@ AC_DISABLE_STATIC
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC
+
+# C++11 support in the compiler is now mandatory. Check for support and add
+# switches if necessary.
+AX_CXX_COMPILE_STDCXX_11([ext], [mandatory])
 
 # Checks for libraries.
 # FIXME: Replace `main' with a function in `-lgmp':

--- a/proofs/lfsc_checker/configure.ac
+++ b/proofs/lfsc_checker/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.61])
 AC_INIT([lfsc-checker], [1.0], [cvc-bugs@cs.nyu.edu])
 AC_CONFIG_SRCDIR([libwriter.h])
 AC_CONFIG_AUX_DIR([config])
-AC_CONFIG_MACRO_DIR([../../config])
+AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([1.11 foreign no-define tar-pax])
 LT_INIT

--- a/proofs/lfsc_checker/expr.h
+++ b/proofs/lfsc_checker/expr.h
@@ -2,11 +2,12 @@
 #define sc2__expr_h
 
 #include <stdint.h>
-#include <ext/hash_set>
 #include <iostream>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <vector>
+
 #include "chunking_memory_management.h"
 #include "gmp.h"
 
@@ -57,21 +58,17 @@ enum { NOT_CEXPR = 0, // for INT_EXPR, HOLE_EXPR, SYM_EXPR, SYMS_EXPR
 class Expr;
 class SymExpr;
 
-namespace __gnu_cxx {
-template <>
-struct hash<Expr *> {
+struct hashExprPtr {
   size_t operator()(const Expr *x) const {
     return reinterpret_cast<uintptr_t>(x);
   }
 };
-}
 
 struct eqExprPtr {
   bool operator()(const Expr *e1, const Expr *e2) const { return e1 == e2; }
 };
 
-typedef __gnu_cxx::hash_set<Expr *, __gnu_cxx::hash<Expr *>, eqExprPtr>
-    expr_ptr_set_t;
+typedef std::unordered_set<Expr *, hashExprPtr, eqExprPtr> expr_ptr_set_t;
 
 class Expr {
 protected:

--- a/src/theory/arith/approx_simplex.cpp
+++ b/src/theory/arith/approx_simplex.cpp
@@ -16,10 +16,10 @@
  **/
 #include "theory/arith/approx_simplex.h"
 
+#include <math.h>
 #include <cfloat>
 #include <cmath>
-#include <map>
-#include <math.h>
+#include <unordered_set>
 
 #include "base/output.h"
 #include "cvc4autoconfig.h"
@@ -2043,7 +2043,7 @@ bool ApproxGLPK::checkCutOnPad(int nid, const CutInfo& cut) const{
 
   const DenseMap<Rational>& constructedLhs = d_pad.d_cut.lhs;
   const Rational& constructedRhs = d_pad.d_cut.rhs;
-  hash_set<ArithVar> visited;
+  std::unordered_set<ArithVar> visited;
 
   if(constructedLhs.empty()){
     Debug("approx::checkCutOnPad") << "its empty?" <<endl;


### PR DESCRIPTION
The nighlty competition build has been failing due to a remaining use of
hash_set in approx_simplex.cpp. This commit changes the remaining uses
of hash_set to unordered_set.