### PR TITLE
Fix memory leak in symbol table

### DIFF
--- a/src/expr/symbol_table.cpp
+++ b/src/expr/symbol_table.cpp
@@ -49,6 +49,12 @@ class SymbolTable::Implementation {
         d_typeMap(new (true) TypeMap(&d_context)),
         d_functions(new (true) CDHashSet<Expr, ExprHashFunction>(&d_context)) {}
 
+  ~Implementation() {
+    d_exprMap->deleteSelf();
+    d_typeMap->deleteSelf();
+    d_functions->deleteSelf();
+  }
+
   void bind(const string& name, Expr obj, bool levelZero) throw();
   void bindDefinedFunction(const string& name, Expr obj,
                            bool levelZero) throw();


### PR DESCRIPTION
Commit 4cab39bd4f166716cd3d357a175c346afb838137 moved d_exprMap, d_typeMap,
and d_functions into SymbolTable::Implementation but did not move the deletion
of those objects from SymbolTable to the SymbolTable::Implementation
desconstructor, resulting in a memory leak. This commit fixes the issue.