### PR TITLE
Use antlr-3.4 directory if already present in CVC4 root directory

### DIFF
--- a/config/antlr.m4
+++ b/config/antlr.m4
@@ -21,8 +21,8 @@ AC_DEFUN([AC_PROG_ANTLR], [
     fi
   fi
   # Check if antlr-3.4 was installed via contrib/get-antlr3.4
-  if test -e "../../../antlr-3.4/bin/antlr3"; then
-    ANTLR="`realpath ../../../antlr-3.4/bin/antlr3`"
+  if test -e "$ac_abs_confdir/antlr-3.4/bin/antlr3"; then
+    ANTLR="$ac_abs_confdir/antlr-3.4/bin/antlr3"
   fi
   if test "x$ANTLR" = "x"; then
     AC_MSG_WARN(
@@ -60,8 +60,8 @@ AC_DEFUN([AC_LIB_ANTLR],[
   )
 
   # Check if antlr-3.4 was installed via contrib/get-antlr3.4
-  if test -e "../../../antlr-3.4"; then
-    ANTLR_PREFIXES="`realpath ../../../antlr-3.4`"
+  if test -e "$ac_abs_confdir/antlr-3.4"; then
+    ANTLR_PREFIXES="$ac_abs_confdir/antlr-3.4"
   fi
 
   AC_MSG_CHECKING(for ANTLR3 C runtime library)

--- a/config/antlr.m4
+++ b/config/antlr.m4
@@ -20,6 +20,10 @@ AC_DEFUN([AC_PROG_ANTLR], [
       AC_MSG_RESULT([OK])
     fi
   fi
+  # Check if antlr-3.4 was installed via contrib/get-antlr3.4
+  if test -e "../../../antlr-3.4/bin/antlr3"; then
+    ANTLR="`realpath ../../../antlr-3.4/bin/antlr3`"
+  fi
   if test "x$ANTLR" = "x"; then
     AC_MSG_WARN(
 [No usable antlr3 script found. Make sure that the parser code has
@@ -54,6 +58,11 @@ AC_DEFUN([AC_LIB_ANTLR],[
     ANTLR_PREFIXES="$withval",
     ANTLR_PREFIXES="$ANTLR_HOME /usr/local /usr /opt/local /opt"
   )
+
+  # Check if antlr-3.4 was installed via contrib/get-antlr3.4
+  if test -e "../../../antlr-3.4"; then
+    ANTLR_PREFIXES="`realpath ../../../antlr-3.4`"
+  fi
 
   AC_MSG_CHECKING(for ANTLR3 C runtime library)
 

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -136,7 +136,7 @@ public:
       d_scope(d_context->getTopScope()) {
       d_context->push();
     }
-    ~ScopedPush() {
+    ~ScopedPush() noexcept(false) {
       d_context->pop();
       AlwaysAssert(d_context->getTopScope() == d_scope,
                    "Context::ScopedPush observed an uneven Context (at pop, "

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -136,7 +136,7 @@ public:
       d_scope(d_context->getTopScope()) {
       d_context->push();
     }
-    ~ScopedPush() noexcept(false) {
+    ~ScopedPush() {
       d_context->pop();
       AlwaysAssert(d_context->getTopScope() == d_scope,
                    "Context::ScopedPush observed an uneven Context (at pop, "


### PR DESCRIPTION
./configure automatically finds the antlr-3.4 directory if installed via contrib/antlr-3.4.