### PR TITLE
Fix Python API with Preprocessor Directives

### DIFF
--- a/src/expr/expr.i
+++ b/src/expr/expr.i
@@ -134,14 +134,18 @@ namespace CVC4 {
 /* The python bindings on Mac OS X have trouble with this one - leave it
  * out for now. */
 //%template(getConstTypeConstant) CVC4::Expr::getConst<CVC4::TypeConstant>;
+
+ /* This one also causes problems for the python api */
+ //%template(getConstSubrangeBounds) CVC4::Expr::getConst<CVC4::SubrangeBounds>;
 #else
 %template(getConstTypeConstant) CVC4::Expr::getConst<CVC4::TypeConstant>;
-#endif
+%template(getConstSubrangeBounds) CVC4::Expr::getConst<CVC4::SubrangeBounds>;
+#endif /* SWIGPYTHON */
+
 %template(getConstArrayStoreAll) CVC4::Expr::getConst<CVC4::ArrayStoreAll>;
 %template(getConstBitVectorSize) CVC4::Expr::getConst<CVC4::BitVectorSize>;
 %template(getConstAscriptionType) CVC4::Expr::getConst<CVC4::AscriptionType>;
 %template(getConstBitVectorBitOf) CVC4::Expr::getConst<CVC4::BitVectorBitOf>;
-%template(getConstSubrangeBounds) CVC4::Expr::getConst<CVC4::SubrangeBounds>;
 %template(getConstBitVectorRepeat) CVC4::Expr::getConst<CVC4::BitVectorRepeat>;
 %template(getConstBitVectorExtract) CVC4::Expr::getConst<CVC4::BitVectorExtract>;
 %template(getConstBitVectorRotateLeft) CVC4::Expr::getConst<CVC4::BitVectorRotateLeft>;

--- a/src/expr/expr_manager.i
+++ b/src/expr/expr_manager.i
@@ -40,11 +40,17 @@
 
 %include "expr/expr_manager.h"
 
+#ifdef SWIGPYTHON
+  /* This line causes problems in the python API -- leave it out for now */
+  //%template(mkConst) CVC4::ExprManager::mkConst<CVC4::SubrangeBounds>;
+#else
+  %template(mkConst) CVC4::ExprManager::mkConst<CVC4::SubrangeBounds>;
+#endif /* SWIGPYTHON */
+
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::ArrayStoreAll>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::BitVectorSize>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::AscriptionType>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::BitVectorBitOf>;
-%template(mkConst) CVC4::ExprManager::mkConst<CVC4::SubrangeBounds>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::BitVectorRepeat>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::BitVectorExtract>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::BitVectorRotateLeft>;


### PR DESCRIPTION
The SWIG Python API has been broken due to (supposedly) undefined symbols getConstSubrangeBounds and mkConstSubrangeBounds. The simple fix is to omit them if python is enabled in the build.

I tried to find a better/more permanent solution but haven't come up with anything yet, so I thought I'd submit this fix.