### PR TITLE
Travis: Package instead of download for cxxtest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: cpp
 cache:
  apt: true
- directories:
-  - $HOME/cxxtest
 
 sudo: required
 dist: trusty
@@ -26,7 +24,7 @@ addons:
  apt:
   sources:
   - ubuntu-toolchain-r-test
-  packages:
+  packages: &common_deps
   - libgmp-dev
   - libboost-dev
   - libboost-thread-dev
@@ -36,11 +34,7 @@ addons:
   - antlr3
   - libantlr3c-dev
   - ant-optional
-install:
-# Download and cache a copy of cxxtest until it appears officially in quantal.
- - wget http://sourceforge.net/projects/cxxtest/files/cxxtest/4.3/cxxtest-4.3.tar.gz
- - tar -xzvf cxxtest-4.3.tar.gz
- - cp -vRT cxxtest-4.3 $HOME/cxxtest
+  - cxxtest
 before_script:
  - export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
  - export PATH=$PATH:$JAVA_HOME/bin
@@ -52,7 +46,7 @@ script:
    normal="$(echo -e '\033[0m')" red="$normal$(echo -e '\033[01;31m')" green="$normal$(echo -e '\033[01;32m')"
    configureCVC4() {
      echo "CVC4 config - $TRAVIS_CVC4_CONFIG";
-     ./configure --enable-unit-testing $TRAVIS_CVC4_CONFIG  CXXTEST=$HOME/cxxtest ||
+     ./configure --enable-unit-testing $TRAVIS_CVC4_CONFIG ||
        (echo; echo "Trying to print config.log"; cat builds/config.log; error "CONFIGURE FAILED");
    }
    error() {
@@ -62,7 +56,7 @@ script:
      exit 1;
    }
    makeDistcheck() {
-     make V=1 -j2 distcheck CVC4_REGRESSION_ARGS='--no-early-exit' DISTCHECK_CONFIGURE_FLAGS="CXXTEST=$HOME/cxxtest" ||
+     make V=1 -j2 distcheck CVC4_REGRESSION_ARGS='--no-early-exit' ||
        error "DISTCHECK (WITH NEWTHEORY TESTS) FAILED";
    }
    makeCheck() {
@@ -112,21 +106,14 @@ matrix:
       compiler: gcc
       before_install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
       env:
-        - TRAVIS_COVERITY=yes CVC4_REGRESSION_ARGS='--no-early-exit'  CXXTEST="$HOME/cxxtest"
+        - TRAVIS_COVERITY=yes CVC4_REGRESSION_ARGS='--no-early-exit'
       addons:
         # Need to duplicate as addons will be over written.
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - libgmp-dev
-            - libboost-dev
-            - libboost-thread-dev
-            - swig
-            - libcln-dev
-            - openjdk-7-jdk
-            - antlr3
-            - libantlr3c-dev
+            - *common_deps
         coverity_scan:
           project:
             name: "CVC4/CVC4"


### PR DESCRIPTION
Before this commit, we were downloading cxxtest from Sourceforge. This commit
instead installs the Ubuntu package, which is easier and more reliable. Instead
of adding the package to the list of packages for Coverity and the common list
of packages, this commit changes the Coverity package list to just refer to the
common list of packages.