### PR TITLE
Remove Coverity SSL certificate workaround from Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ matrix:
           notification_email: timothy.alan.king@gmail.com
           build_command_prepend: "./autogen.sh; ./configure --enable-unit-testing --enable-proof"
           build_command: "make V=1 -j4"
-          branch_pattern: coverity_scan
+          branch_pattern: rem_coverity_ssl_cert_workaround
       after_failure:
         - cat /home/travis/build/CVC4/CVC4/cov-int/build-log.txt
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 cache:
  apt: true
 
-sudo: required
+sudo: false
 dist: trusty
 
 compiler:
@@ -104,7 +104,6 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      before_install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
       env:
         - TRAVIS_COVERITY=yes CVC4_REGRESSION_ARGS='--no-early-exit'
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: cpp
 cache:
  apt: true
 
-sudo: false
+# We need more than 4G memory for compiling CVC4. Hence, we cannot switch
+# to container-based virtualization environments since they only provide 4G of
+# memory. We will stick with the VM-based environments for now.
+sudo: required
 dist: trusty
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ matrix:
           notification_email: timothy.alan.king@gmail.com
           build_command_prepend: "./autogen.sh; ./configure --enable-unit-testing --enable-proof"
           build_command: "make V=1 -j4"
-          branch_pattern: rem_coverity_ssl_cert_workaround
+          branch_pattern: coverity_scan
       after_failure:
         - cat /home/travis/build/CVC4/CVC4/cov-int/build-log.txt
 notifications:


### PR DESCRIPTION
The SSL certificate workaround is not needed anymore since Ubuntu Trusty can handle the new ciphers used for the Coverity SSL certificate. This also removes the requirement for sudo, however, we still have to use the VM-based virtualization environment since the container-based one only provides 4G of memory instead of 7.5G. With 4G memory clang fails and gcc gets slower since it has to swap. 