### PR TITLE
Properly handle user cardinality constraints for uf-ss=none.

### DIFF
--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -125,13 +125,18 @@ void TheoryUF::check(Effort level) {
       d_equalityEngine.assertEquality(atom, polarity, fact);
     } else if (atom.getKind() == kind::CARDINALITY_CONSTRAINT || atom.getKind() == kind::COMBINED_CARDINALITY_CONSTRAINT) {
       if( d_thss == NULL ){
-        std::stringstream ss;
-        ss << "Cardinality constraint " << atom << " was asserted, but the logic does not allow it." << std::endl;
-        ss << "Try using a logic containing \"UFC\"." << std::endl;
-        throw Exception( ss.str() );
+        if( !getLogicInfo().hasCardinalityConstraints() ){
+          std::stringstream ss;
+          ss << "Cardinality constraint " << atom << " was asserted, but the logic does not allow it." << std::endl;
+          ss << "Try using a logic containing \"UFC\"." << std::endl;
+          throw Exception( ss.str() );
+        }else{
+          // support for cardinality constraints is not enabled, set incomplete
+          d_out->setIncomplete();
+        } 
       }
       //needed for models
-      if( options::produceModels() && ( atom.getKind() == kind::COMBINED_CARDINALITY_CONSTRAINT || options::ufssMode()!=UF_SS_FULL ) ){
+      if( options::produceModels() ){
         d_equalityEngine.assertPredicate(atom, polarity, fact);
       }
     } else {


### PR DESCRIPTION
This is a followup to #1060 that ensures uf-ss=none and user-provided cardinality constraints are properly combined.
Previously, a spurious LogicException was thrown when combining these two features, now we set incomplete.