### PR TITLE
Tptp unsat core

### DIFF
--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -27,6 +27,19 @@
 namespace CVC4 {
 namespace main {
 
+/** 
+ * Command context class 
+ * This virtual class contains required functions when executing commands with
+ * the CommandExecutor class below.
+*/
+class CommandContext {
+public:
+  CommandContext(){}
+  virtual ~CommandContext(){}
+  /** get the unsat core names */
+  virtual std::map<Expr, std::string> getUnsatCoreNames() = 0;
+};
+
 class CommandExecutor {
 private:
   std::string d_lastStatistics;
@@ -54,7 +67,7 @@ public:
    * sequence.  Eventually uses doCommandSingleton (which can be
    * overridden by a derived class).
    */
-  bool doCommand(CVC4::Command* cmd);
+  bool doCommand(CVC4::Command* cmd, CommandContext * cc = NULL);
 
   Result getResult() const { return d_result; }
   void reset();
@@ -88,7 +101,7 @@ public:
 
 protected:
   /** Executes treating cmd as a singleton */
-  virtual bool doCommandSingleton(CVC4::Command* cmd);
+  virtual bool doCommandSingleton(CVC4::Command* cmd, CommandContext * cc);
 
 private:
   CommandExecutor();

--- a/src/main/command_executor_portfolio.cpp
+++ b/src/main/command_executor_portfolio.cpp
@@ -398,7 +398,12 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd, CommandContext *
         status = doCommandSingleton(gi, cc);
       } else if( d_options.getDumpUnsatCores() &&
                  d_result.asSatisfiabilityResult() == Result::UNSAT ) {
-        Command* guc = new GetUnsatCoreCommand();
+        Command* guc;
+        if( cc ) {
+          guc = new GetUnsatCoreCommand(cc->getUnsatCoreNames());
+        }else{
+          guc  = new GetUnsatCoreCommand();
+        }
         status = doCommandSingleton(guc, cc);
       }
     }

--- a/src/main/command_executor_portfolio.cpp
+++ b/src/main/command_executor_portfolio.cpp
@@ -181,7 +181,7 @@ void CommandExecutorPortfolio::lemmaSharingCleanup()
 }/* CommandExecutorPortfolio::lemmaSharingCleanup() */
 
 
-bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
+bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd, CommandContext * cc)
 {
   /**
    * save the command and if check sat or query command, run a
@@ -199,7 +199,7 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
 
   if( dynamic_cast<CheckSynthCommand*>(cmd) != NULL ){
     // sygus not supported in portfolio : FIXME: can support once datatypes exportTo is supported
-    return CommandExecutor::doCommandSingleton(cmd);
+    return CommandExecutor::doCommandSingleton(cmd, cc);
   }
 
   if(dynamic_cast<CheckSatCommand*>(cmd) != NULL ||
@@ -265,7 +265,7 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
         if(d_options.getFallbackSequential()) {
           Notice() << "Unsupported theory encountered."
                    << "Switching to sequential mode.";
-          return CommandExecutor::doCommandSingleton(cmd);
+          return CommandExecutor::doCommandSingleton(cmd, cc);
         }
         else
           throw Exception("Certain theories (e.g., datatypes) are (currently)"
@@ -378,12 +378,12 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
              d_result.whyUnknown() == Result::INCOMPLETE) ) )
       {
         Command* gm = new GetModelCommand();
-        status = doCommandSingleton(gm);
+        status = doCommandSingleton(gm, cc);
       } else if( d_options.getProof() &&
                  d_options.getDumpProofs() &&
                  d_result.asSatisfiabilityResult() == Result::UNSAT ) {
         Command* gp = new GetProofCommand();
-        status = doCommandSingleton(gp);
+        status = doCommandSingleton(gp, cc);
       } else if( d_options.getDumpInstantiations() &&
                  ( ( d_options.getInstFormatMode() != INST_FORMAT_MODE_SZS &&
                    ( d_result.asSatisfiabilityResult() == Result::SAT ||
@@ -391,15 +391,15 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
                       d_result.whyUnknown() == Result::INCOMPLETE) ) ) ||
                    d_result.asSatisfiabilityResult() == Result::UNSAT ) ) {
         Command* gi = new GetInstantiationsCommand();
-        status = doCommandSingleton(gi);
+        status = doCommandSingleton(gi, cc);
       } else if( d_options.getDumpSynth() &&
                  d_result.asSatisfiabilityResult() == Result::UNSAT ){
         Command* gi = new GetSynthSolutionCommand();
-        status = doCommandSingleton(gi);
+        status = doCommandSingleton(gi, cc);
       } else if( d_options.getDumpUnsatCores() &&
                  d_result.asSatisfiabilityResult() == Result::UNSAT ) {
         Command* guc = new GetUnsatCoreCommand();
-        status = doCommandSingleton(guc);
+        status = doCommandSingleton(guc, cc);
       }
     }
 

--- a/src/main/command_executor_portfolio.h
+++ b/src/main/command_executor_portfolio.h
@@ -66,7 +66,7 @@ public:
   void flushStatistics(std::ostream& out) const;
 
 protected:
-  bool doCommandSingleton(Command* cmd);
+  bool doCommandSingleton(Command* cmd, CommandContext * cc);
 private:
   CommandExecutorPortfolio();
   void lemmaSharingInit();

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -59,6 +59,7 @@ Parser::Parser(ExprManager* exprManager, Input* input, bool strictMode,
       d_logicIsForced(false),
       d_forcedLogic() {
   d_input->setParser(*this);
+  d_unsatCoreNames.push(std::map<Expr, std::string>());
 }
 
 Parser::~Parser() {

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -36,7 +36,6 @@ namespace parser {
 Smt2::Smt2(ExprManager* exprManager, Input* input, bool strictMode, bool parseOnly) :
   Parser(exprManager,input,strictMode,parseOnly),
   d_logicSet(false) {
-  d_unsatCoreNames.push(std::map<Expr, std::string>());
   if( !strictModeEnabled() ) {
     addTheory(Smt2::THEORY_CORE);
   }
@@ -342,10 +341,8 @@ void Smt2::reset() {
   d_logic = LogicInfo();
   operatorKindMap.clear();
   d_lastNamedTerm = std::pair<Expr, std::string>();
-  d_unsatCoreNames = std::stack< std::map<Expr, std::string> >();
   this->Parser::reset();
 
-  d_unsatCoreNames.push(std::map<Expr, std::string>());
   if( !strictModeEnabled() ) {
     addTheory(Smt2::THEORY_CORE);
   }

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -61,8 +61,6 @@ private:
   LogicInfo d_logic;
   std::unordered_map<std::string, Kind> operatorKindMap;
   std::pair<Expr, std::string> d_lastNamedTerm;
-  // this is a user-context stack
-  std::stack< std::map<Expr, std::string> > d_unsatCoreNames;
   // for sygus
   std::vector<Expr> d_sygusVars, d_sygusConstraints, d_sygusFunSymbols;
   std::map< Expr, bool > d_sygusVarPrimed;
@@ -149,22 +147,6 @@ public:
 
   std::pair<Expr, std::string> lastNamedTerm() {
     return d_lastNamedTerm;
-  }
-
-  void pushUnsatCoreNameScope() {
-    d_unsatCoreNames.push(d_unsatCoreNames.top());
-  }
-
-  void popUnsatCoreNameScope() {
-    d_unsatCoreNames.pop();
-  }
-
-  void registerUnsatCoreName(std::pair<Expr, std::string> name) {
-    d_unsatCoreNames.top().insert(name);
-  }
-
-  std::map<Expr, std::string> getUnsatCoreNames() {
-    return d_unsatCoreNames.top();
   }
 
   bool isAbstractValue(const std::string& name) {

--- a/src/parser/tptp/Tptp.g
+++ b/src/parser/tptp/Tptp.g
@@ -169,9 +169,8 @@ parseCommand returns [CVC4::Command* cmd = NULL]
     (COMMA_TOK anything*)? RPAREN_TOK DOT_TOK
     {
       PARSER_STATE->pushScope();
-      Expr func = PARSER_STATE->getNameDefinitionExpr(expr, name);
+      PARSER_STATE->setUnsatCoreName(fr, expr, name);
       cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ true, true);
-      //PARSER_STATE->registerUnsatCoreName(func);
       PARSER_STATE->popScope();
     }
   | FOF_TOK LPAREN_TOK nameN[name] COMMA_TOK formulaRole[fr] COMMA_TOK
@@ -179,9 +178,8 @@ parseCommand returns [CVC4::Command* cmd = NULL]
     fofFormula[expr] (COMMA_TOK anything*)? RPAREN_TOK DOT_TOK
     {
       PARSER_STATE->pushScope();
-      Expr func = PARSER_STATE->getNameDefinitionExpr(expr, name);
+      PARSER_STATE->setUnsatCoreName(fr, expr, name);
       cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ false, true);
-      //PARSER_STATE->registerUnsatCoreName(func);
       PARSER_STATE->popScope();
     }
   | TFF_TOK LPAREN_TOK nameN[name] COMMA_TOK
@@ -191,9 +189,8 @@ parseCommand returns [CVC4::Command* cmd = NULL]
       tffFormula[expr] (COMMA_TOK anything*)?
       {
         PARSER_STATE->pushScope();
-        Expr func = PARSER_STATE->getNameDefinitionExpr(expr, name);
+        PARSER_STATE->setUnsatCoreName(fr, expr, name);
         cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ false, true);
-        //PARSER_STATE->registerUnsatCoreName(func);
         PARSER_STATE->popScope();
       }
     ) RPAREN_TOK DOT_TOK

--- a/src/parser/tptp/Tptp.g
+++ b/src/parser/tptp/Tptp.g
@@ -168,13 +168,21 @@ parseCommand returns [CVC4::Command* cmd = NULL]
   }
     (COMMA_TOK anything*)? RPAREN_TOK DOT_TOK
     {
-      cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ true);
+      PARSER_STATE->pushScope();
+      Expr func = PARSER_STATE->getNameDefinitionExpr(expr, name);
+      cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ true, true);
+      //PARSER_STATE->registerUnsatCoreName(func);
+      PARSER_STATE->popScope();
     }
   | FOF_TOK LPAREN_TOK nameN[name] COMMA_TOK formulaRole[fr] COMMA_TOK
     { PARSER_STATE->cnf = false; PARSER_STATE->fof = true; }
     fofFormula[expr] (COMMA_TOK anything*)? RPAREN_TOK DOT_TOK
     {
-      cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ false);
+      PARSER_STATE->pushScope();
+      Expr func = PARSER_STATE->getNameDefinitionExpr(expr, name);
+      cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ false, true);
+      //PARSER_STATE->registerUnsatCoreName(func);
+      PARSER_STATE->popScope();
     }
   | TFF_TOK LPAREN_TOK nameN[name] COMMA_TOK
     ( TYPE_TOK COMMA_TOK tffTypedAtom[cmd]
@@ -182,7 +190,11 @@ parseCommand returns [CVC4::Command* cmd = NULL]
       { PARSER_STATE->cnf = false; PARSER_STATE->fof = false; }
       tffFormula[expr] (COMMA_TOK anything*)?
       {
-        cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ false);
+        PARSER_STATE->pushScope();
+        Expr func = PARSER_STATE->getNameDefinitionExpr(expr, name);
+        cmd = PARSER_STATE->makeCommand(fr, expr, /* cnf == */ false, true);
+        //PARSER_STATE->registerUnsatCoreName(func);
+        PARSER_STATE->popScope();
       }
     ) RPAREN_TOK DOT_TOK
   | INCLUDE_TOK LPAREN_TOK unquotedFileName[name]

--- a/src/parser/tptp/tptp.h
+++ b/src/parser/tptp/tptp.h
@@ -161,10 +161,9 @@ public:
       the formula is a CNF formula, inUnsatCore is whether expr is considered by unsat cores. */
   inline Command* makeCommand(FormulaRole fr, Expr& expr, bool cnf, bool inUnsatCore);
   
-  /** get name definition expression, where expr is named "name" for unsat core generation. 
-      This adds a define named 
+  /** set that the formula corresponding to expr is named "name" for unsat core generation
   */
-  inline Expr getNameDefinitionExpr(Expr& expr, std::string name);
+  inline void setUnsatCoreName(FormulaRole fr, Expr& expr, std::string name);
 
   /** Ugly hack because I don't know how to return an expression from a
       token */
@@ -245,12 +244,16 @@ inline Command* Tptp::makeCommand(FormulaRole fr, Expr& expr, bool cnf, bool inU
   return NULL;
 }
 
-inline Expr Tptp::getNameDefinitionExpr(Expr& expr, std::string name){
-  Expr func = mkFunction(name,expr.getType());
-  Command* c = new DefineNamedFunctionCommand(name, func, std::vector<Expr>(), expr);
+inline void Tptp::setUnsatCoreName(FormulaRole fr, Expr& expr, std::string name){
+  Expr cexpr = expr;
+  if(fr == FR_CONJECTURE) {
+    cexpr = getExprManager()->mkExpr(kind::NOT,cexpr);
+  }
+  Expr func = mkFunction(name,cexpr.getType());
+  Command* c = new DefineNamedFunctionCommand(name, func, std::vector<Expr>(), cexpr);
   c->setMuted(true);
   preemptCommand(c);
-  return func;
+  registerUnsatCoreName(std::pair<Expr, std::string>(cexpr,name));
 }
 
 namespace tptp {

--- a/src/printer/tptp/tptp_printer.cpp
+++ b/src/printer/tptp/tptp_printer.cpp
@@ -23,6 +23,7 @@
 #include "expr/expr.h" // for ExprSetDepth etc..
 #include "expr/node_manager.h" // for VarNameAttr
 #include "options/language.h" // for LANG_AST
+#include "options/smt_options.h" // for unsat cores
 #include "smt/command.h"
 
 using namespace std;
@@ -59,6 +60,20 @@ void TptpPrinter::toStream(std::ostream& out, const Model& m, const Command* c) 
   Unreachable();
 }
 
+void TptpPrinter::toStream(std::ostream& out, const UnsatCore& core, const std::map<Expr, std::string>& names) const throw() {
+  out << "% SZS output start UnsatCore " << std::endl;
+  for(UnsatCore::const_iterator i = core.begin(); i != core.end(); ++i) {
+    map<Expr, string>::const_iterator j = names.find(*i);
+    if (j != names.end()) {
+      // Named assertions always get printed
+      out << (*j).second << endl;
+    } else if (options::dumpUnsatCoresFull()) {
+      // Unnamed assertions only get printed if the option is set
+      out << *i << endl;
+    }
+  }
+  out << "% SZS output end UnsatCore " << std::endl;
+}
 
 }/* CVC4::printer::tptp namespace */
 }/* CVC4::printer namespace */

--- a/src/printer/tptp/tptp_printer.h
+++ b/src/printer/tptp/tptp_printer.h
@@ -35,6 +35,7 @@ public:
   void toStream(std::ostream& out, const Command* c, int toDepth, bool types, size_t dag) const throw();
   void toStream(std::ostream& out, const CommandStatus* s) const throw();
   void toStream(std::ostream& out, const Model& m) const throw();
+  void toStream(std::ostream& out, const UnsatCore& core, const std::map<Expr, std::string>& names) const throw();
 };/* class TptpPrinter */
 
 }/* CVC4::printer::tptp namespace */


### PR DESCRIPTION
This pull request enables the parser and command executor properly carry names for unsat cores independent of parser.  It also adds support for unsat core name bookkeeping for TPTP.

This leads to two improvements:

(1) cvc4 --dump-unsat-cores and --dump-unsat-cores-full now take unsat core names into account
(2) These commands also work as expected with the TPTP parser, where all assertions are named based on the TPTP input format.