### PR TITLE
Moving the CVC4_PUBLIC attribute to the beginning of operator++.

### DIFF
--- a/src/expr/kind_template.h
+++ b/src/expr/kind_template.h
@@ -92,8 +92,8 @@ ${theory_enum}
 const TheoryId THEORY_FIRST = static_cast<TheoryId>(0);
 const TheoryId THEORY_SAT_SOLVER = THEORY_LAST;
 
-inline TheoryId& CVC4_PUBLIC operator ++ (TheoryId& id) {
-  return id = static_cast<TheoryId>(((int)id) + 1);
+CVC4_PUBLIC inline TheoryId& operator++(TheoryId& id) {
+  return id = static_cast<TheoryId>(static_cast<int>(id) + 1);
 }
 
 std::ostream& operator<<(std::ostream& out, TheoryId theoryId);


### PR DESCRIPTION
Removes the following warning when compiling with gcc version 4.8.4 :

../../../../../src/expr/kind_template.h:95:55: warning: '__visibility__' attribute ignored on non-class types [-Wattributes]

Tested with clang-3.5.