### PR TITLE
Fix build for old GMP version

### DIFF
--- a/src/util/gmp_util.h
+++ b/src/util/gmp_util.h
@@ -20,7 +20,13 @@
 #ifndef __CVC4__GMP_UTIL_H
 #define __CVC4__GMP_UTIL_H
 
+/*
+ * Older versions of GMP in combination with newer versions of GCC and C++11
+ * cause errors: https://gcc.gnu.org/gcc-4.9/porting_to.html
+ * Including <cstddef> is a workaround for this issue.
+ */
 #include <cstddef>
+
 #include <gmpxx.h>
 
 namespace CVC4 {

--- a/src/util/gmp_util.h
+++ b/src/util/gmp_util.h
@@ -20,6 +20,7 @@
 #ifndef __CVC4__GMP_UTIL_H
 #define __CVC4__GMP_UTIL_H
 
+#include <cstddef>
 #include <gmpxx.h>
 
 namespace CVC4 {

--- a/src/util/rational_gmp_imp.h
+++ b/src/util/rational_gmp_imp.h
@@ -20,7 +20,13 @@
 #ifndef __CVC4__RATIONAL_H
 #define __CVC4__RATIONAL_H
 
+/*
+ * Older versions of GMP in combination with newer versions of GCC and C++11
+ * cause errors: https://gcc.gnu.org/gcc-4.9/porting_to.html
+ * Including <cstddef> is a workaround for this issue.
+ */
 #include <cstddef>
+
 #include <gmp.h>
 #include <string>
 

--- a/src/util/rational_gmp_imp.h
+++ b/src/util/rational_gmp_imp.h
@@ -20,6 +20,7 @@
 #ifndef __CVC4__RATIONAL_H
 #define __CVC4__RATIONAL_H
 
+#include <cstddef>
 #include <gmp.h>
 #include <string>
 


### PR DESCRIPTION
Older versions of GMP in combination with newer versions of GCC and
C++11 cause errors [0]. This commit adds the necessary includes of
<cstddef>.

[0] https://gcc.gnu.org/gcc-4.9/porting_to.html