### PR TITLE
Operator overloading

### DIFF
--- a/src/expr/symbol_table.cpp
+++ b/src/expr/symbol_table.cpp
@@ -57,9 +57,9 @@ class SymbolTable::Implementation {
     d_functions->deleteSelf();
   }
 
-  void bind(const string& name, Expr obj, bool levelZero) throw();
+  void bind(const string& name, Expr obj, bool levelZero, bool doOverload) throw();
   void bindDefinedFunction(const string& name, Expr obj,
-                           bool levelZero) throw();
+                           bool levelZero, bool doOverload) throw();
   void bindType(const string& name, Type t, bool levelZero = false) throw();
   void bindType(const string& name, const vector<Type>& params, Type t,
                 bool levelZero = false) throw();
@@ -135,13 +135,13 @@ class SymbolTable::Implementation {
 }; /* SymbolTable::Implementation */
 
 void SymbolTable::Implementation::bind(const string& name, Expr obj,
-                                       bool levelZero) throw() {
+                                       bool levelZero, bool doOverload) throw() {
   PrettyCheckArgument(!obj.isNull(), obj, "cannot bind to a null Expr");
   ExprManagerScope ems(obj);
-  if (levelZero) {
-    // we only bind symbols to overload at top level  
-    // things like bound variables in scopes are assumed to shadow previous definitions
+  if (doOverload) {
     bindWithOverloading(name, obj);
+  }
+  if (levelZero) {
     d_exprMap->insertAtContextLevelZero(name, obj);
   } else {
     d_exprMap->insert(name, obj);
@@ -150,13 +150,14 @@ void SymbolTable::Implementation::bind(const string& name, Expr obj,
 
 void SymbolTable::Implementation::bindDefinedFunction(const string& name,
                                                       Expr obj,
-                                                      bool levelZero) throw() {
+                                                      bool levelZero, 
+                                                      bool doOverload) throw() {
   PrettyCheckArgument(!obj.isNull(), obj, "cannot bind to a null Expr");
   ExprManagerScope ems(obj);
-  if (levelZero) {
-    // we only bind symbols to overload at top level
-    // things like bound variables in scopes are assumed to shadow previous definitions
+  if (doOverload) {
     bindWithOverloading(name, obj);
+  }
+  if (levelZero) {
     d_exprMap->insertAtContextLevelZero(name, obj);
     d_functions->insertAtContextLevelZero(obj);
   } else {
@@ -409,13 +410,13 @@ SymbolTable::SymbolTable()
 
 SymbolTable::~SymbolTable() {}
 
-void SymbolTable::bind(const string& name, Expr obj, bool levelZero) throw() {
-  d_implementation->bind(name, obj, levelZero);
+void SymbolTable::bind(const string& name, Expr obj, bool levelZero, bool doOverload) throw() {
+  d_implementation->bind(name, obj, levelZero, doOverload);
 }
 
 void SymbolTable::bindDefinedFunction(const string& name, Expr obj,
-                                      bool levelZero) throw() {
-  d_implementation->bindDefinedFunction(name, obj, levelZero);
+                                      bool levelZero, bool doOverload) throw() {
+  d_implementation->bindDefinedFunction(name, obj, levelZero, doOverload);
 }
 
 void SymbolTable::bindType(const string& name, Type t, bool levelZero) throw() {

--- a/src/expr/symbol_table.cpp
+++ b/src/expr/symbol_table.cpp
@@ -42,20 +42,160 @@ using ::std::pair;
 using ::std::string;
 using ::std::vector;
 
+// This data structure stores a trie of expressions with
+// the same name, and must be distinguished by their argument types.
+// It is context-dependent.
+class OverloadedTypeTrie
+{
+public:
+  OverloadedTypeTrie(Context * c ) :
+    d_overloaded_symbols(new (true) CDHashSet<Expr, ExprHashFunction>(c)) {
+  }  
+  ~OverloadedTypeTrie() {
+    d_overloaded_symbols->deleteSelf();
+  }
+  /** is this function overloaded? */
+  bool isOverloadedFunction(Expr fun) const;
+  
+  /** Get overloaded constant for type.
+   * If possible, it returns a defined symbol with name
+   * that has type t. Otherwise returns null expression.
+  */
+  Expr getOverloadedConstantForType(const std::string& name, Type t) const;
+  
+  /**
+   * If possible, returns a defined function for a name
+   * and a vector of expected argument types. Otherwise returns
+   * null expression.
+   */
+  Expr getOverloadedFunctionForTypes(const std::string& name, const std::vector< Type >& argTypes) const;
+  /** called when obj is bound to name, and prev_bound_obj was already bound to name */
+  void bind(const string& name, Expr prev_bound_obj, Expr obj);
+private:
+  /** Marks expression obj with name as overloaded. 
+   * Adds relevant information to the type arg trie data structure.
+  */
+  void markOverloaded(const string& name, Expr obj);
+  /** the null expression */
+  Expr d_nullExpr;
+  // The (context-independent) trie storing that maps expected argument
+  // vectors to symbols. All expressions stored in d_symbols are only 
+  // interpreted as active if they also appear in the context-dependent
+  // set d_overloaded_symbols.
+  class TypeArgTrie {
+  public:
+    // children of this node
+    std::map< Type, TypeArgTrie > d_children;
+    // symbols at this node
+    std::map< Type, Expr > d_symbols;
+  };
+  /** for each string with operator overloading, this stores the data structure above. */
+  std::unordered_map< std::string, TypeArgTrie > d_overload_type_arg_trie;
+  /** The set of overloaded symbols. */
+  CDHashSet<Expr, ExprHashFunction>* d_overloaded_symbols;
+};
+
+bool OverloadedTypeTrie::isOverloadedFunction(Expr fun) const {
+  return d_overloaded_symbols->find(fun)!=d_overloaded_symbols->end();
+}
+
+Expr OverloadedTypeTrie::getOverloadedConstantForType(const std::string& name, Type t) const {
+  std::unordered_map< std::string, TypeArgTrie >::const_iterator it = d_overload_type_arg_trie.find(name);
+  if(it!=d_overload_type_arg_trie.end()) {
+    std::map< Type, Expr >::const_iterator its = it->second.d_symbols.find(t);
+    if(its!=it->second.d_symbols.end()) {
+      return its->second;
+    }
+  }
+  return d_nullExpr;
+}
+
+Expr OverloadedTypeTrie::getOverloadedFunctionForTypes(const std::string& name, 
+                                                       const std::vector< Type >& argTypes) const {
+  std::unordered_map< std::string, TypeArgTrie >::const_iterator it = d_overload_type_arg_trie.find(name);
+  if(it!=d_overload_type_arg_trie.end()) {
+    const TypeArgTrie * tat = &it->second;
+    for(unsigned i=0; i<argTypes.size(); i++) {
+      std::map< Type, TypeArgTrie >::const_iterator itc = tat->d_children.find(argTypes[i]);
+      if(itc!=tat->d_children.end()) {
+        tat = &itc->second;
+      }else{
+        // no functions match 
+        return d_nullExpr;
+      }
+    }
+    // now, we must ensure that there is one and only one active symbol at this node
+    Expr retExpr;
+    for(std::map< Type, Expr >::const_iterator its = tat->d_symbols.begin(); its != tat->d_symbols.end(); ++its) {
+      Expr expr = its->second;
+      if(isOverloadedFunction(expr)) {
+        if(retExpr.isNull()) {
+          retExpr = expr;
+        }else{
+          // multiple functions match
+          return d_nullExpr;
+        }
+      }
+    }
+    return retExpr;
+  }
+  return d_nullExpr;
+}
+
+void OverloadedTypeTrie::bind(const string& name, Expr prev_bound_obj, Expr obj) {
+  if(!isOverloadedFunction(prev_bound_obj)) {
+    // mark previous as overloaded
+    markOverloaded(name, prev_bound_obj);
+  }
+  // mark this as overloaded
+  markOverloaded(name, obj);
+}
+
+void OverloadedTypeTrie::markOverloaded(const string& name, Expr obj) {
+  Trace("parser-overloading") << "Overloaded function : " << name;
+  Trace("parser-overloading") << " with type " << obj.getType() << std::endl;
+  d_overloaded_symbols->insert(obj);
+  // get the argument types
+  Type t = obj.getType();
+  Type rangeType = t;
+  std::vector< Type > argTypes;
+  if(t.isFunction()) {
+    argTypes = ((FunctionType)t).getArgTypes();
+    rangeType = ((FunctionType)t).getRangeType();
+  }else if(t.isConstructor()) {
+    argTypes = ((ConstructorType)t).getArgTypes();
+    rangeType = ((ConstructorType)t).getRangeType();
+  }else if(t.isTester()) {
+    argTypes.push_back( ((TesterType)t).getDomain() );
+    rangeType = ((TesterType)t).getRangeType();
+  }else if(t.isSelector()) {
+    argTypes.push_back( ((SelectorType)t).getDomain() );
+    rangeType = ((SelectorType)t).getRangeType();
+  }
+  // add to the trie
+  TypeArgTrie * tat = &d_overload_type_arg_trie[name];
+  for(unsigned i=0; i<argTypes.size(); i++) {
+    tat = &(tat->d_children[argTypes[i]]);
+  }
+  tat->d_symbols[rangeType] = obj;
+}
+
+
 class SymbolTable::Implementation {
  public:
   Implementation()
       : d_context(),
         d_exprMap(new (true) CDHashMap<string, Expr>(&d_context)),
         d_typeMap(new (true) TypeMap(&d_context)),
-        d_functions(new (true) CDHashSet<Expr, ExprHashFunction>(&d_context)),
-        d_overloaded_symbols(new (true) CDHashSet<Expr, ExprHashFunction>(&d_context)) {}
+        d_functions(new (true) CDHashSet<Expr, ExprHashFunction>(&d_context)){
+    d_overload_trie = new OverloadedTypeTrie(&d_context);
+  }
 
   ~Implementation() {
     d_exprMap->deleteSelf();
     d_typeMap->deleteSelf();
     d_functions->deleteSelf();
-    d_overloaded_symbols->deleteSelf();
+    delete d_overload_trie;
   }
 
   void bind(const string& name, Expr obj, bool levelZero, bool doOverload) throw();
@@ -77,20 +217,13 @@ class SymbolTable::Implementation {
   size_t getLevel() const throw();
   void reset();
   //------------------------ operator overloading
-  /** is this function overloaded? */
+  /** implementation of function from header */
   bool isOverloadedFunction(Expr fun) const;
   
-  /** Get overloaded constant for type.
-   * If possible, it returns a defined symbol with name
-   * that has type t. Otherwise returns null expression.
-  */
+  /** implementation of function from header */
   Expr getOverloadedConstantForType(const std::string& name, Type t) const;
   
-  /**
-   * If possible, returns a defined function for a name
-   * and a vector of expected argument types. Otherwise returns
-   * null expression.
-   */
+  /** implementation of function from header */
   Expr getOverloadedFunctionForTypes(const std::string& name, const std::vector< Type >& argTypes) const;
   //------------------------ end operator overloading
  private:
@@ -106,33 +239,17 @@ class SymbolTable::Implementation {
 
   /** A set of defined functions. */
   CDHashSet<Expr, ExprHashFunction>* d_functions;
+  
   //------------------------ operator overloading
   // the null expression
   Expr d_nullExpr;
-  // This data structure stores a trie of expressions with
-  // the same name, and must be distinguished by their argument types.
-  // For simplicity, it is context-independent.
-  class TypeArgTrie {
-  public:
-    // children of this node
-    std::map< Type, TypeArgTrie > d_children;
-    // symbols at this node
-    std::map< Type, Expr > d_symbols;
-  };
-  // for each string with operator overloading, this stores the data
-  // structure above.
-  std::unordered_map< std::string, TypeArgTrie > d_overload_type_arg_trie;
+  // overloaded type trie, stores all information regarding overloading
+  OverloadedTypeTrie * d_overload_trie;
   /** bind with overloading
    * This is called whenever obj is bound to name where overloading symbols is allowed.
    * If a symbol is previously bound to that name, it marks both as overloaded.
   */
   void bindWithOverloading(const string& name, Expr obj);
-  /** Marks expression obj with name as overloaded. 
-   * Adds relevant information to the type arg trie data structure.
-  */
-  void markOverloaded(const string& name, Expr obj);
-  /** The set of overloaded symbols. */
-  CDHashSet<Expr, ExprHashFunction>* d_overloaded_symbols;
   //------------------------ end operator overloading
 }; /* SymbolTable::Implementation */
 
@@ -314,95 +431,27 @@ void SymbolTable::Implementation::reset() {
   new (this) SymbolTable::Implementation();
 }
 
-void SymbolTable::Implementation::bindWithOverloading(const string& name, Expr obj) {
-  CDHashMap<string, Expr>::const_iterator it = d_exprMap->find(name);
-  if(it != d_exprMap->end()) {
-    const Expr& prev_bound_expr = (*it).second;
-    if(prev_bound_expr!=obj) {
-      if(!isOverloadedFunction(prev_bound_expr)) {
-        // mark previous as overloaded
-        markOverloaded(name, prev_bound_expr);
-      }
-      // mark this as overloaded
-      markOverloaded(name, obj);
-    }
-  }
-}
-
-void SymbolTable::Implementation::markOverloaded(const string& name, Expr obj) {
-  Trace("parser-overloading") << "Overloaded function : " << name;
-  Trace("parser-overloading") << " with type " << obj.getType() << std::endl;
-  d_overloaded_symbols->insert(obj);
-  // get the argument types
-  Type t = obj.getType();
-  Type rangeType = t;
-  std::vector< Type > argTypes;
-  if(t.isFunction()) {
-    argTypes = ((FunctionType)t).getArgTypes();
-    rangeType = ((FunctionType)t).getRangeType();
-  }else if(t.isConstructor()) {
-    argTypes = ((ConstructorType)t).getArgTypes();
-    rangeType = ((ConstructorType)t).getRangeType();
-  }else if(t.isTester()) {
-    argTypes.push_back( ((TesterType)t).getDomain() );
-    rangeType = ((TesterType)t).getRangeType();
-  }else if(t.isSelector()) {
-    argTypes.push_back( ((SelectorType)t).getDomain() );
-    rangeType = ((SelectorType)t).getRangeType();
-  }
-  // add to the trie
-  TypeArgTrie * tat = &d_overload_type_arg_trie[name];
-  for(unsigned i=0; i<argTypes.size(); i++) {
-    tat = &(tat->d_children[argTypes[i]]);
-  }
-  tat->d_symbols[rangeType] = obj;
-}
-  
 bool SymbolTable::Implementation::isOverloadedFunction(Expr fun) const {
-  return d_overloaded_symbols->find(fun)!=d_overloaded_symbols->end();
+  return d_overload_trie->isOverloadedFunction(fun);
 }
 
 Expr SymbolTable::Implementation::getOverloadedConstantForType(const std::string& name, Type t) const {
-  std::unordered_map< std::string, TypeArgTrie >::const_iterator it = d_overload_type_arg_trie.find(name);
-  if(it!=d_overload_type_arg_trie.end()) {
-    std::map< Type, Expr >::const_iterator its = it->second.d_symbols.find(t);
-    if(its!=it->second.d_symbols.end()) {
-      return its->second;
-    }
-  }
-  return d_nullExpr;
+  return d_overload_trie->getOverloadedConstantForType(name, t);
 }
 
 Expr SymbolTable::Implementation::getOverloadedFunctionForTypes(const std::string& name, 
                                                                 const std::vector< Type >& argTypes) const {
-  std::unordered_map< std::string, TypeArgTrie >::const_iterator it = d_overload_type_arg_trie.find(name);
-  if(it!=d_overload_type_arg_trie.end()) {
-    const TypeArgTrie * tat = &it->second;
-    for(unsigned i=0; i<argTypes.size(); i++) {
-      std::map< Type, TypeArgTrie >::const_iterator itc = tat->d_children.find(argTypes[i]);
-      if(itc!=tat->d_children.end()) {
-        tat = &itc->second;
-      }else{
-        // no functions match 
-        return d_nullExpr;
-      }
+  return d_overload_trie->getOverloadedFunctionForTypes(name, argTypes);
+}
+
+void SymbolTable::Implementation::bindWithOverloading(const string& name, Expr obj){
+  CDHashMap<string, Expr>::const_iterator it = d_exprMap->find(name);
+  if(it != d_exprMap->end()) {
+    const Expr& prev_bound_obj = (*it).second;
+    if(prev_bound_obj!=obj) {
+      d_overload_trie->bind(name, prev_bound_obj, obj);
     }
-    // now, we must ensure that there is one and only one active symbol at this node
-    Expr retExpr;
-    for(std::map< Type, Expr >::const_iterator its = tat->d_symbols.begin(); its != tat->d_symbols.end(); ++its) {
-      Expr expr = its->second;
-      if(isOverloadedFunction(expr)) {
-        if(retExpr.isNull()) {
-          retExpr = expr;
-        }else{
-          // multiple functions match
-          return d_nullExpr;
-        }
-      }
-    }
-    return retExpr;
   }
-  return d_nullExpr;
 }
 
 bool SymbolTable::isOverloadedFunction(Expr fun) const {

--- a/src/expr/symbol_table.cpp
+++ b/src/expr/symbol_table.cpp
@@ -317,10 +317,11 @@ void SymbolTable::Implementation::reset() {
 void SymbolTable::Implementation::bindWithOverloading(const string& name, Expr obj) {
   CDHashMap<string, Expr>::const_iterator it = d_exprMap->find(name);
   if(it != d_exprMap->end()) {
-    if((*it).second!=obj) {
-      if(!isOverloadedFunction((*it).second)) {
+    const Expr& prev_bound_expr = (*it).second;
+    if(prev_bound_expr!=obj) {
+      if(!isOverloadedFunction(prev_bound_expr)) {
         // mark previous as overloaded
-        markOverloaded(name, (*it).second);
+        markOverloaded(name, prev_bound_expr);
       }
       // mark this as overloaded
       markOverloaded(name, obj);

--- a/src/expr/symbol_table.cpp
+++ b/src/expr/symbol_table.cpp
@@ -76,6 +76,23 @@ class SymbolTable::Implementation {
   void pushScope() throw();
   size_t getLevel() const throw();
   void reset();
+  //------------------------ operator overloading
+  /** is this function overloaded? */
+  bool isOverloadedFunction(Expr fun) const;
+  
+  /** Get overloaded constant for type.
+   * If possible, it returns a defined symbol with name
+   * that has type t. Otherwise returns null expression.
+  */
+  Expr getOverloadedConstantForType(const std::string& name, Type t) const;
+  
+  /**
+   * If possible, returns a defined function for a name
+   * and a vector of expected argument types. Otherwise returns
+   * null expression.
+   */
+  Expr getOverloadedFunctionForTypes(const std::string& name, const std::vector< Type >& argTypes) const;
+  //------------------------ end operator overloading
  private:
   /** The context manager for the scope maps. */
   Context d_context;
@@ -89,8 +106,7 @@ class SymbolTable::Implementation {
 
   /** A set of defined functions. */
   CDHashSet<Expr, ExprHashFunction>* d_functions;
- // for operator overloading
- private:
+  //------------------------ operator overloading
   // the null expression
   Expr d_nullExpr;
   // This data structure stores a trie of expressions with
@@ -117,22 +133,7 @@ class SymbolTable::Implementation {
   void markOverloaded(const string& name, Expr obj);
   /** The set of overloaded symbols. */
   CDHashSet<Expr, ExprHashFunction>* d_overloaded_symbols;
- public:
-   /** is this function overloaded? */
-  bool isOverloadedFunction(Expr fun) const;
-  
-  /** Get overloaded constant for type.
-   * If possible, it returns a defined symbol with name
-   * that has type t. Otherwise returns null expression.
-  */
-  Expr getOverloadedConstantForType(const std::string& name, Type t) const;
-  
-  /**
-   * If possible, returns a defined function for a name
-   * and a vector of expected argument types. Otherwise returns
-   * null expression.
-   */
-  Expr getOverloadedFunctionForTypes(const std::string& name, const std::vector< Type >& argTypes) const;
+  //------------------------ end operator overloading
 }; /* SymbolTable::Implementation */
 
 void SymbolTable::Implementation::bind(const string& name, Expr obj,

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -22,7 +22,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <unordered_map>
 
 #include "base/exception.h"
 #include "expr/expr.h"
@@ -189,20 +188,20 @@ class CVC4_PUBLIC SymbolTable {
  
  public:  // the following functions are for operator overloading
   /** is this function overloaded? */
-  bool isOverloadedFunction(Expr fun);
+  bool isOverloadedFunction(Expr fun) const;
   
   /** Get overloaded constant for type.
    * If possible, it returns a defined symbol with name
    * that has type t. Otherwise returns null expression.
   */
-  Expr getOverloadedConstantForType(const std::string& name, Type t);
+  Expr getOverloadedConstantForType(const std::string& name, Type t) const;
   
   /**
    * If possible, returns a defined function for a name
    * and a vector of expected argument types. Otherwise returns
    * null expression.
    */
-  Expr getOverloadedFunctionForTypes(const std::string& name, std::vector< Type >& argTypes);
+  Expr getOverloadedFunctionForTypes(const std::string& name, const std::vector< Type >& argTypes) const;
   
  private:
   // Copying and assignment have not yet been implemented.

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -43,28 +43,43 @@ class CVC4_PUBLIC SymbolTable {
   ~SymbolTable();
 
   /**
-   * Bind an expression to a name in the current scope level.  If
-   * <code>name</code> is already bound to an expression in the current
+   * Bind an expression to a name in the current scope level.  
+   *
+   * When doOverload is false:
+   * if <code>name</code> is already bound to an expression in the current
    * level, then the binding is replaced. If <code>name</code> is bound
    * in a previous level, then the binding is "covered" by this one
-   * until the current scope is popped when doOverload is false. 
+   * until the current scope is popped. 
    * If levelZero is true the name shouldn't be already bound.
+   *
+   * When doOverload is true:
+   * if <code>name</code> is already bound to an expression in the current
+   * level, then we mark the previous bound expression and obj as overloaded
+   * functions.
    *
    * @param name an identifier
    * @param obj the expression to bind to <code>name</code>
    * @param levelZero set if the binding must be done at level 0
    * @param doOverload set if the binding can overload the function name.
-   *        if this is not set, the name is "covered" in the sense above.
    */
   void bind(const std::string& name, Expr obj, bool levelZero = false, 
             bool doOverload = false) throw();
 
   /**
-   * Bind a function body to a name in the current scope.  If
-   * <code>name</code> is already bound to an expression in the current
+   * Bind a function body to a name in the current scope.  
+   *
+   * When doOverload is false:
+   * if <code>name</code> is already bound to an expression in the current
    * level, then the binding is replaced. If <code>name</code> is bound
    * in a previous level, then the binding is "covered" by this one
-   * until the current scope is popped when doOverload is false.  
+   * until the current scope is popped. 
+   * If levelZero is true the name shouldn't be already bound.
+   *
+   * When doOverload is true:
+   * if <code>name</code> is already bound to an expression in the current
+   * level, then we mark the previous bound expression and obj as overloaded
+   * functions.
+   *
    * Same as bind() but registers this as a function (so that 
    * isBoundDefinedFunction() returns true).
    *
@@ -72,7 +87,6 @@ class CVC4_PUBLIC SymbolTable {
    * @param obj the expression to bind to <code>name</code>
    * @param levelZero set if the binding must be done at level 0
    * @param doOverload set if the binding can overload the function name.
-   *        if this is not set, the name is "covered" in the sense above.
    */
   void bindDefinedFunction(const std::string& name, Expr obj,
                            bool levelZero = false, 
@@ -191,15 +205,21 @@ class CVC4_PUBLIC SymbolTable {
   bool isOverloadedFunction(Expr fun) const;
   
   /** Get overloaded constant for type.
-   * If possible, it returns a defined symbol with name
+   * If possible, it returns the defined symbol with name
    * that has type t. Otherwise returns null expression.
   */
   Expr getOverloadedConstantForType(const std::string& name, Type t) const;
   
   /**
-   * If possible, returns a defined function for a name
-   * and a vector of expected argument types. Otherwise returns
-   * null expression.
+   * If possible, returns the unique defined function for a name
+   * that expects arguments with types "argTypes".
+   * For example, if argTypes = ( T1, ..., Tn ), then this may return 
+   * an expression with type function( T1, ..., Tn ), or constructor( T1, ...., Tn ).
+   * 
+   * If there is not a unique defined function for the name and argTypes,
+   * this returns the null expression. This can happen either if there are
+   * no functions with name and expected argTypes, or alternatively there are
+   * more than one functions with name and expected argTypes.
    */
   Expr getOverloadedFunctionForTypes(const std::string& name, const std::vector< Type >& argTypes) const;
   //------------------------ end operator overloading

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -185,8 +185,8 @@ class CVC4_PUBLIC SymbolTable {
 
   /** Reset everything. */
   void reset();
- 
- public:  // the following functions are for operator overloading
+  
+  //------------------------ operator overloading
   /** is this function overloaded? */
   bool isOverloadedFunction(Expr fun) const;
   
@@ -202,6 +202,7 @@ class CVC4_PUBLIC SymbolTable {
    * null expression.
    */
   Expr getOverloadedFunctionForTypes(const std::string& name, const std::vector< Type >& argTypes) const;
+  //------------------------ end operator overloading
   
  private:
   // Copying and assignment have not yet been implemented.

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "base/exception.h"
 #include "expr/expr.h"

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -154,7 +154,9 @@ class CVC4_PUBLIC SymbolTable {
    * Lookup a bound expression.
    *
    * @param name the identifier to lookup
-   * @returns the expression bound to <code>name</code> in the current scope.
+   * @returns the unique expression bound to <code>name</code> in the current scope.
+   * It returns the null expression if there is not a unique expression bound to 
+   * <code>name</code> in the current scope (i.e. if there is not exactly one).
    */
   Expr lookup(const std::string& name) const throw();
 

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -48,29 +48,36 @@ class CVC4_PUBLIC SymbolTable {
    * <code>name</code> is already bound to an expression in the current
    * level, then the binding is replaced. If <code>name</code> is bound
    * in a previous level, then the binding is "covered" by this one
-   * until the current scope is popped. If levelZero is true the name
-   * shouldn't be already bound.
+   * until the current scope is popped when doOverload is false. 
+   * If levelZero is true the name shouldn't be already bound.
    *
    * @param name an identifier
    * @param obj the expression to bind to <code>name</code>
    * @param levelZero set if the binding must be done at level 0
+   * @param doOverload set if the binding can overload the function name.
+   *        if this is not set, the name is "covered" in the sense above.
    */
-  void bind(const std::string& name, Expr obj, bool levelZero = false) throw();
+  void bind(const std::string& name, Expr obj, bool levelZero = false, 
+            bool doOverload = false) throw();
 
   /**
    * Bind a function body to a name in the current scope.  If
    * <code>name</code> is already bound to an expression in the current
    * level, then the binding is replaced. If <code>name</code> is bound
    * in a previous level, then the binding is "covered" by this one
-   * until the current scope is popped.  Same as bind() but registers
-   * this as a function (so that isBoundDefinedFunction() returns true).
+   * until the current scope is popped when doOverload is false.  
+   * Same as bind() but registers this as a function (so that 
+   * isBoundDefinedFunction() returns true).
    *
    * @param name an identifier
    * @param obj the expression to bind to <code>name</code>
    * @param levelZero set if the binding must be done at level 0
+   * @param doOverload set if the binding can overload the function name.
+   *        if this is not set, the name is "covered" in the sense above.
    */
   void bindDefinedFunction(const std::string& name, Expr obj,
-                           bool levelZero = false) throw();
+                           bool levelZero = false, 
+                           bool doOverload = false) throw();
 
   /**
    * Bind a type to a name in the current scope.  If <code>name</code>

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -178,7 +178,24 @@ class CVC4_PUBLIC SymbolTable {
 
   /** Reset everything. */
   void reset();
-
+ 
+ public:  // the following functions are for operator overloading
+  /** is this function overloaded? */
+  bool isOverloadedFunction(Expr fun);
+  
+  /** Get overloaded constant for type.
+   * If possible, it returns a defined symbol with name
+   * that has type t. Otherwise returns null expression.
+  */
+  Expr getOverloadedConstantForType(const std::string& name, Type t);
+  
+  /**
+   * If possible, returns a defined function for a name
+   * and a vector of expected argument types. Otherwise returns
+   * null expression.
+   */
+  Expr getOverloadedFunctionForTypes(const std::string& name, std::vector< Type >& argTypes);
+  
  private:
   // Copying and assignment have not yet been implemented.
   SymbolTable(const SymbolTable&);

--- a/src/parser/cvc/Cvc.g
+++ b/src/parser/cvc/Cvc.g
@@ -1047,7 +1047,7 @@ declareVariables[std::unique_ptr<CVC4::Command>* cmd, CVC4::Type& t,
             i != i_end;
             ++i) {
           if(PARSER_STATE->isDeclared(*i, SYM_VARIABLE)) {
-            Type oldType = PARSER_STATE->getType(*i);
+            Type oldType = PARSER_STATE->getVariable(*i).getType();
             Debug("parser") << "  " << *i << " was declared previously "
                             << "with type " << oldType << std::endl;
             if(oldType != t) {
@@ -2139,7 +2139,7 @@ simpleTerm[CVC4::Expr& f]
     /* ascriptions will be required for parameterized zero-ary constructors */
     { f = PARSER_STATE->getVariable(name); }
     { // datatypes: zero-ary constructors
-      Type t2 = PARSER_STATE->getType(name);
+      Type t2 = f.getType();
       if(t2.isConstructor() && ConstructorType(t2).getArity() == 0) {
         // don't require parentheses, immediately turn it into an apply
         f = MK_EXPR(CVC4::kind::APPLY_CONSTRUCTOR, f);

--- a/src/parser/cvc/Cvc.g
+++ b/src/parser/cvc/Cvc.g
@@ -1745,22 +1745,10 @@ postfixTerm[CVC4::Expr& f]
       formula[f] { args.push_back(f); }
       ( COMMA formula[f] { args.push_back(f); } )* RPAREN
       // TODO: check arity
-      { Type t = args.front().getType();
-        Debug("parser") << "type is " << t << std::endl;
+      { Kind k = PARSER_STATE->getKindForFunction(args.front());
         Debug("parser") << "expr is " << args.front() << std::endl;
-        if(PARSER_STATE->isDefinedFunction(args.front())) {
-          f = MK_EXPR(CVC4::kind::APPLY, args);
-        } else if(t.isFunction()) {
-          f = MK_EXPR(CVC4::kind::APPLY_UF, args);
-        } else if(t.isConstructor()) {
-          f = MK_EXPR(CVC4::kind::APPLY_CONSTRUCTOR, args);
-        } else if(t.isSelector()) {
-          f = MK_EXPR(CVC4::kind::APPLY_SELECTOR, args);
-        } else if(t.isTester()) {
-          f = MK_EXPR(CVC4::kind::APPLY_TESTER, args);
-        } else {
-          PARSER_STATE->parseError("internal error: unhandled function application kind");
-        }
+        Debug("parser") << "kind is " << k << std::endl;
+        f = MK_EXPR(k, args);
       }
 
       /* record / tuple select */

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -351,7 +351,7 @@ bool Parser::isUnresolvedType(const std::string& name) {
 }
 
 std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
-    std::vector<Datatype>& datatypes) {
+    std::vector<Datatype>& datatypes, bool doOverload) {
   try {
     std::vector<DatatypeType> types =
         d_exprManager->mkMutualDatatypeTypes(datatypes, d_unresolved);
@@ -382,7 +382,7 @@ std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
         Debug("parser-idt") << "+ define " << constructor << std::endl;
         string constructorName = ctor.getName();
         if(consNames.find(constructorName)==consNames.end()) {
-          defineVar(constructorName, constructor, false, true);
+          defineVar(constructorName, constructor, false, doOverload);
           consNames.insert(constructorName);
         }else{
           throw ParserException(constructorName + " already declared in this datatype");
@@ -390,7 +390,7 @@ std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
         Expr tester = ctor.getTester();
         Debug("parser-idt") << "+ define " << tester << std::endl;
         string testerName = ctor.getTesterName();
-        defineVar(testerName, tester, false, true);
+        defineVar(testerName, tester, false, doOverload);
         for (DatatypeConstructor::const_iterator k = ctor.begin(),
                                                  k_end = ctor.end();
              k != k_end; ++k) {
@@ -398,7 +398,7 @@ std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
           Debug("parser-idt") << "+++ define " << selector << std::endl;
           string selectorName = (*k).getName();
           if(selNames.find(selectorName)==selNames.end()) {
-            defineVar(selectorName, selector, false, true);
+            defineVar(selectorName, selector, false, doOverload);
             selNames.insert(selectorName);
           }else{
             throw ParserException(selectorName + " already declared in this datatype");

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -123,6 +123,25 @@ Expr Parser::getVariableExpressionForType(const std::string& name, Type t) {
   return expr;
 }
 
+Kind Parser::getKindForFunction(Expr fun) {
+  if(isDefinedFunction(fun)) {
+    return APPLY;
+  }
+  Type t = fun.getType();
+  if(t.isConstructor()) {
+    return APPLY_CONSTRUCTOR;
+  } else if(t.isSelector()) {
+    return APPLY_SELECTOR;
+  } else if(t.isTester()) {
+    return APPLY_TESTER;
+  } else if(t.isFunction()) {
+    return APPLY_UF;
+  }else{
+    parseError("internal error: unhandled function application kind");
+    return UNDEFINED_KIND;
+  }
+}
+
 Type Parser::getSort(const std::string& name) {
   checkDeclaration(name, CHECK_DECLARED, SYM_SORT);
   assert(isDeclared(name, SYM_SORT));

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -210,10 +210,10 @@ Expr Parser::mkVar(const std::string& name, const Type& type, uint32_t flags, bo
   return expr;
 }
 
-Expr Parser::mkBoundVar(const std::string& name, const Type& type, bool doOverload) {
+Expr Parser::mkBoundVar(const std::string& name, const Type& type) {
   Debug("parser") << "mkVar(" << name << ", " << type << ")" << std::endl;
   Expr expr = d_exprManager->mkBoundVar(name, type);
-  defineVar(name, expr, false, doOverload);
+  defineVar(name, expr, false);
   return expr;
 }
 
@@ -251,10 +251,10 @@ std::vector<Expr> Parser::mkVars(const std::vector<std::string> names,
 }
 
 std::vector<Expr> Parser::mkBoundVars(const std::vector<std::string> names,
-                                      const Type& type, bool doOverload) {
+                                      const Type& type) {
   std::vector<Expr> vars;
   for (unsigned i = 0; i < names.size(); ++i) {
-    vars.push_back(mkBoundVar(names[i], type, doOverload));
+    vars.push_back(mkBoundVar(names[i], type));
   }
   return vars;
 }
@@ -382,6 +382,9 @@ std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
         Debug("parser-idt") << "+ define " << constructor << std::endl;
         string constructorName = ctor.getName();
         if(consNames.find(constructorName)==consNames.end()) {
+          if(!doOverload) {
+            checkDeclaration(constructorName, CHECK_UNDECLARED);
+          }
           defineVar(constructorName, constructor, false, doOverload);
           consNames.insert(constructorName);
         }else{
@@ -390,6 +393,9 @@ std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
         Expr tester = ctor.getTester();
         Debug("parser-idt") << "+ define " << tester << std::endl;
         string testerName = ctor.getTesterName();
+        if(!doOverload) {
+          checkDeclaration(testerName, CHECK_UNDECLARED);
+        }
         defineVar(testerName, tester, false, doOverload);
         for (DatatypeConstructor::const_iterator k = ctor.begin(),
                                                  k_end = ctor.end();
@@ -398,6 +404,9 @@ std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
           Debug("parser-idt") << "+++ define " << selector << std::endl;
           string selectorName = (*k).getName();
           if(selNames.find(selectorName)==selNames.end()) {
+            if(!doOverload) {
+              checkDeclaration(selectorName, CHECK_UNDECLARED);
+            }
             defineVar(selectorName, selector, false, doOverload);
             selNames.insert(selectorName);
           }else{

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -702,7 +702,7 @@ public:
     Expr nextExpr() { return d_parser->nextExpression(); }
   };/* class Parser::ExprStream */
   
-public:
+  //------------------------ operator overloading
   /** is this function overloaded? */
   bool isOverloadedFunction(Expr fun) {
     return d_symtab->isOverloadedFunction(fun);
@@ -724,6 +724,7 @@ public:
   Expr getOverloadedFunctionForTypes(const std::string& name, std::vector< Type >& argTypes) {
     return d_symtab->getOverloadedFunctionForTypes(name, argTypes);
   }
+  //------------------------ end operator overloading
 };/* class Parser */
 
 }/* CVC4::parser namespace */

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -134,7 +134,7 @@ inline std::ostream& operator<<(std::ostream& out, SymbolType type) {
  */
 class CVC4_PUBLIC Parser {
   friend class ParserBuilder;
-
+protected:
   /** The expression manager */
   ExprManager *d_exprManager;
   /** The resource manager associated with this expr manager */
@@ -235,7 +235,9 @@ class CVC4_PUBLIC Parser {
    */
   std::list<Command*> d_commandQueue;
 
-  /** Lookup a symbol in the given namespace. */
+  /** Lookup a symbol in the given namespace. 
+   * Only returns a symbol if it is not overloaded.
+   */
   Expr getSymbol(const std::string& var_name, SymbolType type);
 
 protected:
@@ -322,6 +324,7 @@ public:
    *
    * @param name the name of the variable
    * @return the variable expression
+   * Only returns a variable if its name is not overloaded.
    */
   Expr getVariable(const std::string& name);
 
@@ -330,9 +333,21 @@ public:
    *
    * @param name the name of the variable
    * @return the variable expression
+   * Only returns a function if its name is not overloaded.
    */
   Expr getFunction(const std::string& name);
 
+  /**
+   * Returns a expression, given a name.
+   * Only returns an expression if its name is not overloaded.
+   */
+  virtual Expr getVariableExpression(const std::string& name);  
+  
+  /**
+   * Returns a expression, given a name and a type.
+   */
+  virtual Expr getVariableExpressionForType(const std::string& name, Type t);
+  
   /**
    * Returns a sort, given a name.
    * @param sort_name the name to look up
@@ -404,14 +419,6 @@ public:
    * operator <code>kind</code> has not been enabled
    */
   void checkOperator(Kind kind, unsigned numArgs) throw(ParserException);
-
-  /**
-   * Returns the type for the variable with the given name.
-   *
-   * @param var_name the symbol to lookup
-   * @param type the (namespace) type of the symbol
-   */
-  Type getType(const std::string& var_name, SymbolType type = SYM_VARIABLE);
 
   /** Create a new CVC4 variable expression of the given type. */
   Expr mkVar(const std::string& name, const Type& type,
@@ -663,6 +670,29 @@ public:
     ~ExprStream() { delete d_parser; }
     Expr nextExpr() { return d_parser->nextExpression(); }
   };/* class Parser::ExprStream */
+  
+public:
+  /** is this function overloaded? */
+  bool isOverloadedFunction(Expr fun) {
+    return d_symtab->isOverloadedFunction(fun);
+  }
+  
+  /** Get overloaded constant for type.
+   * If possible, it returns a defined symbol with name
+   * that has type t. Otherwise returns null expression.
+  */
+  Expr getOverloadedConstantForType(const std::string& name, Type t) {
+    return d_symtab->getOverloadedConstantForType(name, t);
+  }
+  
+  /**
+   * If possible, returns a defined function for a name
+   * and a vector of expected argument types. Otherwise returns
+   * null expression.
+   */
+  Expr getOverloadedFunctionForTypes(const std::string& name, std::vector< Type >& argTypes) {
+    return d_symtab->getOverloadedFunctionForTypes(name, argTypes);
+  }
 };/* class Parser */
 
 }/* CVC4::parser namespace */

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -536,9 +536,12 @@ public:
 
   /**
    * Create sorts of mutually-recursive datatypes.
+   * For each symbol defined by the datatype, if a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, we overwrite name with val in the current context.
    */
   std::vector<DatatypeType>
-  mkMutualDatatypeTypes(std::vector<Datatype>& datatypes);
+  mkMutualDatatypeTypes(std::vector<Datatype>& datatypes, bool doOverload=false);
 
   /**
    * Add an operator to the current legal set.

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -448,7 +448,7 @@ public:
            bool doOverload = false);
 
   /** Create a new CVC4 bound variable expression of the given type. */
-  Expr mkBoundVar(const std::string& name, const Type& type, bool doOverload=false);
+  Expr mkBoundVar(const std::string& name, const Type& type);
 
   /**
    * Create a set of new CVC4 bound variable expressions of the given type.
@@ -456,8 +456,7 @@ public:
    *  then if doOverload is true, we create overloaded operators.
    *  else if doOverload is false, we overwrite name with val in the current context.
    */
-  std::vector<Expr> mkBoundVars(const std::vector<std::string> names, const Type& type, 
-                                bool doOverload=false);
+  std::vector<Expr> mkBoundVars(const std::vector<std::string> names, const Type& type);
 
   /** Create a new CVC4 function expression of the given type. */
   Expr mkFunction(const std::string& name, const Type& type,

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -134,7 +134,7 @@ inline std::ostream& operator<<(std::ostream& out, SymbolType type) {
  */
 class CVC4_PUBLIC Parser {
   friend class ParserBuilder;
-protected:
+private:
   /** The expression manager */
   ExprManager *d_exprManager;
   /** The resource manager associated with this expr manager */

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -399,12 +399,12 @@ public:
   void reserveSymbolAtAssertionLevel(const std::string& name);
 
   /**
-   * Checks whether the given name is bound to a function.
-   * @param name the name to check
-   * @throws ParserException if checks are enabled and name is not
-   * bound to a function
+   * Checks whether the given expression is a function.
+   * @param fun the expression to check
+   * @throws ParserException if checks are enabled and fun is not
+   * a function
    */
-  void checkFunctionLike(const std::string& name) throw(ParserException);
+  void checkFunctionLike(Expr fun) throw(ParserException);
 
   /**
    * Check that <code>kind</code> can accept <code>numArgs</code> arguments.
@@ -427,28 +427,42 @@ public:
    */
   void checkOperator(Kind kind, unsigned numArgs) throw(ParserException);
 
-  /** Create a new CVC4 variable expression of the given type. */
+  /** Create a new CVC4 variable expression of the given type. 
+   * If a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, we overwrite name with val in the current context.  
+   */
   Expr mkVar(const std::string& name, const Type& type,
-             uint32_t flags = ExprManager::VAR_FLAG_NONE);
+             uint32_t flags = ExprManager::VAR_FLAG_NONE, 
+             bool doOverload = false);
 
   /**
    * Create a set of new CVC4 variable expressions of the given type.
+   * For each name, if a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, we overwrite name with val in the current context.
    */
   std::vector<Expr>
     mkVars(const std::vector<std::string> names, const Type& type,
-           uint32_t flags = ExprManager::VAR_FLAG_NONE);
+           uint32_t flags = ExprManager::VAR_FLAG_NONE, 
+           bool doOverload = false);
 
   /** Create a new CVC4 bound variable expression of the given type. */
-  Expr mkBoundVar(const std::string& name, const Type& type);
+  Expr mkBoundVar(const std::string& name, const Type& type, bool doOverload=false);
 
   /**
    * Create a set of new CVC4 bound variable expressions of the given type.
+   * For each name, if a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, we overwrite name with val in the current context.
    */
-  std::vector<Expr> mkBoundVars(const std::vector<std::string> names, const Type& type);
+  std::vector<Expr> mkBoundVars(const std::vector<std::string> names, const Type& type, 
+                                bool doOverload=false);
 
   /** Create a new CVC4 function expression of the given type. */
   Expr mkFunction(const std::string& name, const Type& type,
-                  uint32_t flags = ExprManager::VAR_FLAG_NONE);
+                  uint32_t flags = ExprManager::VAR_FLAG_NONE, 
+                  bool doOverload=false);
 
   /**
    * Create a new CVC4 function expression of the given type,
@@ -458,13 +472,21 @@ public:
   Expr mkAnonymousFunction(const std::string& prefix, const Type& type,
                            uint32_t flags = ExprManager::VAR_FLAG_NONE);
 
-  /** Create a new variable definition (e.g., from a let binding). */
+  /** Create a new variable definition (e.g., from a let binding). 
+   * If a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, we overwrite name with val in the current context.
+   */
   void defineVar(const std::string& name, const Expr& val,
-                 bool levelZero = false);
+                 bool levelZero = false, bool doOverload = false);
 
-  /** Create a new function definition (e.g., from a define-fun). */
+  /** Create a new function definition (e.g., from a define-fun). 
+   * If a symbol with name already exists,
+   *  then if doOverload is true, we create overloaded operators.
+   *  else if doOverload is false, we overwrite name with val in the current context.
+   */
   void defineFunction(const std::string& name, const Expr& val,
-                      bool levelZero = false);
+                      bool levelZero = false, bool doOverload = false);
 
   /** Create a new type definition. */
   void defineType(const std::string& name, const Type& type);
@@ -536,8 +558,8 @@ public:
   /** Is the symbol bound to a boolean variable? */
   bool isBoolean(const std::string& name);
 
-  /** Is the symbol bound to a function (or function-like thing)? */
-  bool isFunctionLike(const std::string& name);
+  /** Is fun a function (or function-like thing)? */
+  bool isFunctionLike(Expr fun);
 
   /** Is the symbol bound to a defined function? */
   bool isDefinedFunction(const std::string& name);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -349,6 +349,13 @@ public:
   virtual Expr getVariableExpressionForType(const std::string& name, Type t);
   
   /**
+   * Returns the kind that should be used for function fun. For example,
+   * returns APPLY_UF if fun is a function, APPLY_CONSTRUCTOR if fun
+   * is a constructor.
+   */
+  Kind getKindForFunction(Expr fun);
+  
+  /**
    * Returns a sort, given a name.
    * @param sort_name the name to look up
    */

--- a/src/parser/smt1/Smt1.g
+++ b/src/parser/smt1/Smt1.g
@@ -483,8 +483,8 @@ functionSymbol[CVC4::Expr& fun]
 	std::string name;
 }
   : functionName[name,CHECK_DECLARED]
-    { PARSER_STATE->checkFunctionLike(name);
-      fun = PARSER_STATE->getVariable(name); }
+    { fun = PARSER_STATE->getVariable(name);
+      PARSER_STATE->checkFunctionLike(fun); }
   ;
 
 /**

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -1521,7 +1521,7 @@ datatypes_2_5_DefCommand[bool isCo, std::unique_ptr<CVC4::Command>* cmd]
   RPAREN_TOK
   LPAREN_TOK ( LPAREN_TOK datatypeDef[isCo, dts, sorts] RPAREN_TOK )+ RPAREN_TOK
   { PARSER_STATE->popScope();
-    cmd->reset(new DatatypeDeclarationCommand(PARSER_STATE->mkMutualDatatypeTypes(dts)));
+    cmd->reset(new DatatypeDeclarationCommand(PARSER_STATE->mkMutualDatatypeTypes(dts, true)));
   }
   ;
   
@@ -1537,7 +1537,7 @@ datatypeDefCommand[bool isCo, std::unique_ptr<CVC4::Command>* cmd]
  }
  ( LPAREN_TOK constructorDef[dts.back()] RPAREN_TOK )+
  RPAREN_TOK
- { cmd->reset(new DatatypeDeclarationCommand(PARSER_STATE->mkMutualDatatypeTypes(dts))); }
+ { cmd->reset(new DatatypeDeclarationCommand(PARSER_STATE->mkMutualDatatypeTypes(dts, true))); }
  ;
   
 datatypesDefCommand[bool isCo, std::unique_ptr<CVC4::Command>* cmd]
@@ -1599,7 +1599,7 @@ datatypesDefCommand[bool isCo, std::unique_ptr<CVC4::Command>* cmd]
     )+
   RPAREN_TOK
   { PARSER_STATE->popScope();
-    cmd->reset(new DatatypeDeclarationCommand(PARSER_STATE->mkMutualDatatypeTypes(dts))); 
+    cmd->reset(new DatatypeDeclarationCommand(PARSER_STATE->mkMutualDatatypeTypes(dts, true))); 
   }
   ;
 

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -337,6 +337,18 @@ bool Smt2::logicIsSet() {
   return d_logicSet;
 }
 
+Expr Smt2::getVariableExpressionForType(const std::string& name, Type t) {
+  if(sygus() && name[0]=='-' && 
+    name.find_first_not_of("0123456789", 1) == std::string::npos) {
+    //allow unary minus in sygus
+    return d_exprManager->mkConst(Rational(name));
+  }else if(isAbstractValue(name)) {
+    return mkAbstractValue(name);
+  }else{
+    return Parser::getVariableExpressionForType(name, t);
+  }
+}
+
 void Smt2::reset() {
   d_logicSet = false;
   d_logic = LogicInfo();

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -341,7 +341,7 @@ Expr Smt2::getVariableExpressionForType(const std::string& name, Type t) {
   if(sygus() && name[0]=='-' && 
     name.find_first_not_of("0123456789", 1) == std::string::npos) {
     //allow unary minus in sygus
-    return d_exprManager->mkConst(Rational(name));
+    return getExprManager()->mkConst(Rational(name));
   }else if(isAbstractValue(name)) {
     return mkAbstractValue(name);
   }else{

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -87,6 +87,11 @@ public:
   bool isTheoryEnabled(Theory theory) const;
 
   bool logicIsSet();
+  
+  /**
+   * Returns a expression, given a name and a type.
+   */
+  virtual Expr getVariableExpressionForType(const std::string& name, Type t);
 
   void reset();
 

--- a/test/regress/regress0/Makefile.am
+++ b/test/regress/regress0/Makefile.am
@@ -69,7 +69,10 @@ SMT2_TESTS = \
 	hung10_itesdk_output1.smt2 \
 	hung13sdk_output2.smt2 \
 	declare-funs.smt2 \
-	declare-fun-is-match.smt2
+	declare-fun-is-match.smt2 \
+	issue1063-overloading-dt-cons.smt2 \
+	issue1063-overloading-dt-sel.smt2 \
+	issue1063-overloading-dt-fun.smt2
 
 # Regression tests for PL inputs
 CVC_TESTS = \

--- a/test/regress/regress0/Makefile.am
+++ b/test/regress/regress0/Makefile.am
@@ -73,6 +73,7 @@ SMT2_TESTS = \
 	issue1063-overloading-dt-cons.smt2 \
 	issue1063-overloading-dt-sel.smt2 \
 	issue1063-overloading-dt-fun.smt2 \
+	non-fatal-errors.smt2 \
 	sqrt2-sort-inf-unk.smt2
 
 

--- a/test/regress/regress0/datatypes/error.cvc
+++ b/test/regress/regress0/datatypes/error.cvc
@@ -1,7 +1,7 @@
 % EXPECT-ERROR: CVC4 Error:
-% EXPECT-ERROR: Parse Error: foo already declared
+% EXPECT-ERROR: Parse Error: foo already declared in this datatype
 % EXIT: 1
 
-DATATYPE single_ctor = foo(bar:REAL) END;
+DATATYPE single_ctor = foo(bar:REAL) | foo(bar2:REAL) END;
 DATATYPE double_ctor = foo(bar:REAL) END;
 

--- a/test/regress/regress0/issue1063-overloading-dt-cons.smt2
+++ b/test/regress/regress0/issue1063-overloading-dt-cons.smt2
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --lang=smt2.5
+; EXPECT: sat
+(set-logic ALL)
+(set-info :status sat)
+(declare-datatypes () ((Enum0 (In_Air) (On_Ground) (None))))
+(declare-datatypes () ((Enum1 (True) (False) (None))))
+(declare-fun var_0 (Int) Enum0)
+(declare-fun var_1 (Int) Enum1)
+(assert (= (var_0 0) (as None Enum0)))
+(assert (= (var_1 1) (as None Enum1)))
+(assert (not (is-In_Air (var_0 0))))
+(declare-fun var_2 () Enum1)
+(assert (is-None var_2))
+(check-sat)

--- a/test/regress/regress0/issue1063-overloading-dt-fun.smt2
+++ b/test/regress/regress0/issue1063-overloading-dt-fun.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --lang=smt2.5
+; EXPECT: sat
+(set-logic ALL)
+(set-info :status sat)
+(declare-datatypes () ((Enum (cons (val Int)) (On_Ground) (None))))
+(declare-fun cons (Int Int) Int)
+(declare-fun cons (Enum) Bool)
+(declare-fun cons (Bool) Int)
+(assert (cons (cons 0)))
+(assert (= (cons (cons true) (cons false)) 4))
+(check-sat)

--- a/test/regress/regress0/issue1063-overloading-dt-sel.smt2
+++ b/test/regress/regress0/issue1063-overloading-dt-sel.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --lang=smt2.5
+; EXPECT: sat
+(set-logic ALL)
+(set-info :status sat)
+(declare-datatypes () ((Enum0 (cons (data Int)) (None))))
+(declare-datatypes () ((Enum1 (cons (data Bool)) (None))))
+(declare-fun var_0 () Enum0)
+(declare-fun var_1 () Enum1)
+(assert (= (data var_0) 5))
+(assert (data var_1))
+(check-sat)


### PR DESCRIPTION
This adds support for operator overloading in the Smt2 parser. It addresses github issue #1063.

The changes required:

- The Smt2 grammar for term had to be split into term and termNonVariable to accommodate reading variable expressions with type casts via AS_TOK.

- The commit required some refactoring of the Parser class so that some query functions take expressions instead of names as arguments.

- The symbol table class is extended with a data structure to remember a trie of functions for each 

- We have to distinguish when we allow for symbols to be overloaded (see argument "doOverload" throughout).  Currently, top-level declarations (including datatype declarations) and definitions with name clashes are treated as overloaded symbols.  Other things like local variable declarations are not treated as overloaded.  This is to accommodate cases like this:

(declare-fun x () Int)
(declare-fun y () Int)
(assert (= x (let ((x 15)) (+ x y))))

or

(assert (forall ((x T1)) (or (P x) (forall ((x T2)) (Q x))))

which commonly occur (about 10 of our regressions rely on locally scoped variables that shadow other symbols).