### PR TITLE
Fix bug related to sort inference + subtypes.

### DIFF
--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -540,7 +540,8 @@ TypeNode SortInference::getTypeForId( int t ){
 }
 
 Node SortInference::getNewSymbol( Node old, TypeNode tn ){
-  if( tn.isNull() || tn==old.getType() ){
+  // if no sort was inferred for this node, return original
+  if( tn.isNull() || tn.isComparableTo( old.getType() ) ){
     return old;
   }else if( old.isConst() ){
     //must make constant of type tn

--- a/test/regress/regress0/Makefile.am
+++ b/test/regress/regress0/Makefile.am
@@ -70,7 +70,8 @@ SMT2_TESTS = \
 	hung13sdk_output2.smt2 \
 	declare-funs.smt2 \
 	declare-fun-is-match.smt2 \
-	non-fatal-errors.smt2
+	non-fatal-errors.smt2 \
+	sqrt2-sort-inf-unk.smt2
 
 # Regression tests for PL inputs
 CVC_TESTS = \

--- a/test/regress/regress0/sqrt2-sort-inf-unk.smt2
+++ b/test/regress/regress0/sqrt2-sort-inf-unk.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --sort-inference
+; EXPECT: unknown
+(set-logic QF_NRA)
+(declare-fun x () Real)
+(assert (= (* x x) 2.0))
+(check-sat)


### PR DESCRIPTION
This was reported by Geoff Sutcliffe when running 2017 CASC CVC4 for FOF non-theorems (satisfiable quantified UF problems) on TFA problems (quantified UFLIRA problems).

The bug is related to not taking into account subtypes in a corner case of sort inference where an Int constant is equal to a real-valued term.