### PR TITLE
Floating point symfpu support 3

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -899,6 +899,8 @@ static string smtKindString(Kind k) throw() {
   case kind::FLOATINGPOINT_RTI: return "fp.roundToIntegral";
   case kind::FLOATINGPOINT_MIN: return "fp.min";
   case kind::FLOATINGPOINT_MAX: return "fp.max";
+  case kind::FLOATINGPOINT_MIN_TOTAL: return "fp.min_total";
+  case kind::FLOATINGPOINT_MAX_TOTAL: return "fp.max_total";
 
   case kind::FLOATINGPOINT_LEQ: return "fp.leq";
   case kind::FLOATINGPOINT_LT: return "fp.lt";
@@ -920,8 +922,11 @@ static string smtKindString(Kind k) throw() {
   case kind::FLOATINGPOINT_TO_FP_UNSIGNED_BITVECTOR: return "to_fp_unsigned";
   case kind::FLOATINGPOINT_TO_FP_GENERIC: return "to_fp_unsigned";
   case kind::FLOATINGPOINT_TO_UBV: return "fp.to_ubv";
+  case kind::FLOATINGPOINT_TO_UBV_TOTAL: return "fp.to_ubv_total";
   case kind::FLOATINGPOINT_TO_SBV: return "fp.to_sbv";
+  case kind::FLOATINGPOINT_TO_SBV_TOTAL: return "fp.to_sbv_total";
   case kind::FLOATINGPOINT_TO_REAL: return "fp.to_real";
+  case kind::FLOATINGPOINT_TO_REAL_TOTAL: return "fp.to_real_total";
 
   //string theory
   case kind::STRING_CONCAT: return "str.++";
@@ -1042,6 +1047,14 @@ static void printFpParameterizedOp(std::ostream& out, TNode n) throw() {
   case kind::FLOATINGPOINT_TO_SBV:
     out << "fp.to_sbv "
         << n.getOperator().getConst<FloatingPointToSBV>().bvs.size;
+    break;
+  case kind::FLOATINGPOINT_TO_UBV_TOTAL:
+    out << "fp.to_ubv_total "
+        << n.getOperator().getConst<FloatingPointToUBVTotal>().bvs.size;
+    break;
+  case kind::FLOATINGPOINT_TO_SBV_TOTAL:
+    out << "fp.to_sbv_total "
+        << n.getOperator().getConst<FloatingPointToSBVTotal>().bvs.size;
     break;
   default:
     out << n.getKind();

--- a/src/theory/fp/kinds
+++ b/src/theory/fp/kinds
@@ -110,6 +110,12 @@ typerule FLOATINGPOINT_MIN   ::CVC4::theory::fp::FloatingPointOperationTypeRule
 operator FLOATINGPOINT_MAX 2 "floating-point maximum"
 typerule FLOATINGPOINT_MAX   ::CVC4::theory::fp::FloatingPointOperationTypeRule
 
+operator FLOATINGPOINT_MIN_TOTAL 3 "floating-point minimum (defined for all inputs)"
+typerule FLOATINGPOINT_MIN_TOTAL   ::CVC4::theory::fp::FloatingPointPartialOperationTypeRule
+
+operator FLOATINGPOINT_MAX_TOTAL 3 "floating-point maximum (defined for all inputs)"
+typerule FLOATINGPOINT_MAX_TOTAL   ::CVC4::theory::fp::FloatingPointPartialOperationTypeRule
+
 
 operator FLOATINGPOINT_LEQ 2: "floating-point less than or equal"
 typerule FLOATINGPOINT_LEQ   ::CVC4::theory::fp::FloatingPointTestTypeRule
@@ -236,6 +242,17 @@ parameterized FLOATINGPOINT_TO_UBV FLOATINGPOINT_TO_UBV_OP 2 "convert a floating
 typerule FLOATINGPOINT_TO_UBV   ::CVC4::theory::fp::FloatingPointToUBVTypeRule
 
 
+constant FLOATINGPOINT_TO_UBV_TOTAL_OP \
+    ::CVC4::FloatingPointToUBVTotal \
+    "::CVC4::FloatingPointToBVHashFunction<0x4>" \
+    "util/floatingpoint.h" \
+    "operator for to_ubv_total"
+typerule FLOATINGPOINT_TO_UBV_TOTAL_OP ::CVC4::theory::fp::FloatingPointParametricOpTypeRule
+
+parameterized FLOATINGPOINT_TO_UBV_TOTAL FLOATINGPOINT_TO_UBV_TOTAL_OP 3 "convert a floating-point value to an unsigned bit vector (defined for all inputs)"
+typerule FLOATINGPOINT_TO_UBV_TOTAL   ::CVC4::theory::fp::FloatingPointToUBVTotalTypeRule
+
+
 
 constant FLOATINGPOINT_TO_SBV_OP \
     ::CVC4::FloatingPointToSBV \
@@ -248,8 +265,22 @@ parameterized FLOATINGPOINT_TO_SBV FLOATINGPOINT_TO_SBV_OP 2 "convert a floating
 typerule FLOATINGPOINT_TO_SBV   ::CVC4::theory::fp::FloatingPointToSBVTypeRule
 
 
+constant FLOATINGPOINT_TO_SBV_TOTAL_OP \
+    ::CVC4::FloatingPointToSBVTotal \
+    "::CVC4::FloatingPointToBVHashFunction<0x8>" \
+    "util/floatingpoint.h" \
+    "operator for to_sbv_total"
+typerule FLOATINGPOINT_TO_SBV_TOTAL_OP ::CVC4::theory::fp::FloatingPointParametricOpTypeRule
+
+parameterized FLOATINGPOINT_TO_SBV_TOTAL FLOATINGPOINT_TO_SBV_TOTAL_OP 3 "convert a floating-point value to a signed bit vector (defined for all inputs)"
+typerule FLOATINGPOINT_TO_SBV_TOTAL   ::CVC4::theory::fp::FloatingPointToSBVTotalTypeRule
+
+
 operator FLOATINGPOINT_TO_REAL 1 "floating-point to real"
 typerule FLOATINGPOINT_TO_REAL   ::CVC4::theory::fp::FloatingPointToRealTypeRule
+
+operator FLOATINGPOINT_TO_REAL_TOTAL 2 "floating-point to real (defined for all inputs)"
+typerule FLOATINGPOINT_TO_REAL_TOTAL   ::CVC4::theory::fp::FloatingPointToRealTotalTypeRule
 
 
 endtheory

--- a/src/theory/fp/theory_fp_type_rules.h
+++ b/src/theory/fp/theory_fp_type_rules.h
@@ -189,6 +189,42 @@ class FloatingPointRoundingOperationTypeRule {
   }
 };
 
+class FloatingPointPartialOperationTypeRule {
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
+                                     bool check) {
+    TRACE("FloatingPointOperationTypeRule");
+
+    TypeNode firstOperand = n[0].getType(check);
+
+    if (check) {
+      if (!firstOperand.isFloatingPoint()) {
+        throw TypeCheckingExceptionPrivate(
+            n, "floating-point operation applied to a non floating-point sort");
+      }
+
+      size_t children = n.getNumChildren();
+      for (size_t i = 1; i < children - 1; ++i) {
+        if (!(n[i].getType(check) == firstOperand)) {
+          throw TypeCheckingExceptionPrivate(
+              n, "floating-point partial operation applied to mixed sorts");
+        }
+      }
+
+      TypeNode UFValueType = n[children - 1].getType(check);
+
+      if (!(UFValueType.isBitVector()) ||
+	  !(UFValueType.getBitVectorSize() == 1)) {
+	throw TypeCheckingExceptionPrivate(
+	    n, "floating-point partial operation final argument must be a bit-vector of length 1");
+      }
+    }
+
+    return firstOperand;
+  }
+};
+
+
 class FloatingPointParametricOpTypeRule {
  public:
   inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
@@ -438,6 +474,86 @@ class FloatingPointToSBVTypeRule {
   }
 };
 
+class FloatingPointToUBVTotalTypeRule {
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
+                                     bool check) {
+    TRACE("FloatingPointToUBVTotalTypeRule");
+
+    FloatingPointToUBVTotal info = n.getOperator().getConst<FloatingPointToUBVTotal>();
+
+    if (check) {
+      TypeNode roundingModeType = n[0].getType(check);
+
+      if (!roundingModeType.isRoundingMode()) {
+        throw TypeCheckingExceptionPrivate(
+            n, "first argument must be a rounding mode");
+      }
+
+      TypeNode operandType = n[1].getType(check);
+
+      if (!(operandType.isFloatingPoint())) {
+        throw TypeCheckingExceptionPrivate(n,
+                                           "conversion to unsigned bit vector total"
+                                           "used with a sort other than "
+                                           "floating-point");
+      }
+
+      TypeNode defaultValueType = n[2].getType(check);
+
+      if (!(defaultValueType.isBitVector()) ||
+	  !(defaultValueType.getBitVectorSize() == info)) {
+	throw TypeCheckingExceptionPrivate(n,
+					   "conversion to unsigned bit vector total"
+					   "needs a bit vector of the same length"
+					   "as last argument");
+      }
+    }
+
+    return nodeManager->mkBitVectorType(info.bvs);
+  }
+};
+
+class FloatingPointToSBVTotalTypeRule {
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
+                                     bool check) {
+    TRACE("FloatingPointToSBVTotalTypeRule");
+
+    FloatingPointToSBVTotal info = n.getOperator().getConst<FloatingPointToSBVTotal>();
+
+    if (check) {
+      TypeNode roundingModeType = n[0].getType(check);
+
+      if (!roundingModeType.isRoundingMode()) {
+        throw TypeCheckingExceptionPrivate(
+            n, "first argument must be a rounding mode");
+      }
+
+      TypeNode operandType = n[1].getType(check);
+
+      if (!(operandType.isFloatingPoint())) {
+        throw TypeCheckingExceptionPrivate(n,
+                                           "conversion to signed bit vector "
+                                           "used with a sort other than "
+                                           "floating-point");
+      }
+
+      TypeNode defaultValueType = n[2].getType(check);
+
+      if (!(defaultValueType.isBitVector()) ||
+	  !(defaultValueType.getBitVectorSize() == info)) {
+	throw TypeCheckingExceptionPrivate(n,
+					   "conversion to signed bit vector total"
+					   "needs a bit vector of the same length"
+					   "as last argument");
+      }
+    }
+
+    return nodeManager->mkBitVectorType(info.bvs);
+  }
+};
+
 class FloatingPointToRealTypeRule {
  public:
   inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
@@ -451,6 +567,33 @@ class FloatingPointToRealTypeRule {
         throw TypeCheckingExceptionPrivate(
             n, "floating-point to real applied to a non floating-point sort");
       }
+    }
+
+    return nodeManager->realType();
+  }
+};
+
+class FloatingPointToRealTotalTypeRule {
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
+                                     bool check) {
+    TRACE("FloatingPointToRealTotalTypeRule");
+
+    if (check) {
+      TypeNode operandType = n[0].getType(check);
+
+      if (!operandType.isFloatingPoint()) {
+        throw TypeCheckingExceptionPrivate(
+            n, "floating-point to real total applied to a non floating-point sort");
+      }
+
+      TypeNode defaultValueType = n[1].getType(check);
+
+      if (!defaultValueType.isReal()) {
+        throw TypeCheckingExceptionPrivate(
+            n, "floating-point to real total needs a real second argument");
+      }
+
     }
 
     return nodeManager->realType();


### PR DESCRIPTION
(includes the previous two support commits, only depends on the first)

Adds 5 new kinds so that later code can convert partially defined functions into totally defined ones.
