### PR TITLE
Fix seeking for buffered input

### DIFF
--- a/src/parser/antlr_line_buffered_input.cpp
+++ b/src/parser/antlr_line_buffered_input.cpp
@@ -294,10 +294,8 @@ static void bufferedInputSeek(pANTLR3_INT_STREAM is, ANTLR3_MARKER seekPoint) {
   assert(!line_buffered_input->line_buffer->isPtrBefore(
       (uint8_t*)seekPoint, input->line, input->charPositionInLine));
 
-  ssize_t count = (ssize_t)(seekPoint - (ANTLR3_MARKER)(input->nextChar));
-  while (count > 0) {
+  while ((ANTLR3_MARKER)(input->nextChar) != seekPoint) {
     is->consume(is);
-    count--;
   }
 }
 


### PR DESCRIPTION
CVC4's implementation of seek was calculating the pointer difference
between the current position in the input and the seek point to
determine how many characters to consume. This was causing problems when
ANTLR was seeking to a pointer on a line after the current line because
it would result in a big number of characters to consume because each
line is allocated separately.  This resulted in issue #1113, where CVC4
was computing a large number of characters to consume and would block
until it received all of them.  This commit fixes and simplifies the
code by simply consuming characters until the seek point is reached
without computing a count beforehand.