### PR TITLE
Fix output of --show-config for readline.

### DIFF
--- a/src/base/configuration_private.h
+++ b/src/base/configuration_private.h
@@ -126,7 +126,7 @@ namespace CVC4 {
 #define IS_LFSC_BUILD false
 #endif /* CVC4_USE_LFSC */
 
-#ifdef HAVE_LIBREADLINE
+#if HAVE_LIBREADLINE
 #  define IS_READLINE_BUILD true
 #else /* HAVE_LIBREADLINE */
 #  define IS_READLINE_BUILD false


### PR DESCRIPTION
cvc4 --show-config reported the wrong configuration for readline since
HAVE_LIBREADLINE is set to 0 or 1 but was checked with #ifdef.