### PR TITLE
Simplify representation of inversion Skolems for bv cegqi

### DIFF
--- a/src/theory/quantifiers/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_instantiator.cpp
@@ -55,7 +55,6 @@ void CegInstantiator::computeProgVars( Node n ){
       computeProgVars( n[i] );
       if( d_inelig.find( n[i] )!=d_inelig.end() ){
         d_inelig[n] = true;
-        return;
       }
       for( std::map< Node, bool >::iterator it = d_prog_var[n[i]].begin(); it != d_prog_var[n[i]].end(); ++it ){
         d_prog_var[n][it->first] = true;
@@ -126,7 +125,6 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
     if( needsPostprocess ){
       //must make copy so that backtracking reverts sf
       SolvedForm sf_tmp = sf;
-      unsigned prev_var_size = sf.d_vars.size();
       bool postProcessSuccess = true;
       for( std::map< Instantiator *, Node >::iterator itp = pp_inst_to_var.begin(); itp != pp_inst_to_var.end(); ++itp ){
         if( !itp->first->postProcessInstantiationForVariable( this, sf_tmp, itp->second, effort, lemmas ) ){
@@ -134,17 +132,6 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
           break;
         }
       }
-      if( sf_tmp.d_vars.size()>prev_var_size ){
-        // if we added substitutions during postprocess, process these now
-        std::vector< Node > new_vars;
-        std::vector< Node > new_subs;
-        for( unsigned i=0; i<prev_var_size; i++ ){
-          Node subs = sf_tmp.d_subs[i];
-          sf_tmp.d_subs[i] = subs.substitute( sf_tmp.d_vars.begin() + prev_var_size, sf_tmp.d_vars.end(),
-                                              sf_tmp.d_subs.begin() + prev_var_size, sf_tmp.d_subs.end() );
-        }
-      }
-
       if( postProcessSuccess ){
         return doAddInstantiation( sf_tmp.d_vars, sf_tmp.d_subs, lemmas );
       }else{

--- a/src/theory/quantifiers/ceg_t_instantiator.h
+++ b/src/theory/quantifiers/ceg_t_instantiator.h
@@ -94,43 +94,85 @@ public:
   BvInverterStatus() : d_status(0) {}
   ~BvInverterStatus(){}
   int d_status;
+  // TODO : may not need this (conditions are now appear explicitly in solved forms)
   // side conditions 
   std::vector< Node > d_conds;
-  // conditions regarding the skolems in d_conds
-  std::unordered_map< Node, Node, NodeHashFunction > d_sk_inv;
 };
 
 // inverter class
 // TODO : move to theory/bv/ if generally useful?
 class BvInverter {
 private:
+  /** dummy variables for each type */
   std::map< TypeNode, Node > d_solve_var;
-  Node getPathToPv( Node lit, Node pv, Node sv, std::vector< unsigned >& path, std::unordered_set< TNode, TNodeHashFunction >& visited );
-  // stores the inversion skolems
+  /** stores the inversion skolems, for each condition */
   std::unordered_map< Node, Node, NodeHashFunction > d_inversion_skolem_cache;
+  /** helper function for getPathToPv */
+  Node getPathToPv( Node lit, Node pv, Node sv, std::vector< unsigned >& path, std::unordered_set< TNode, TNodeHashFunction >& visited );
+  /** helper function for eliminateSkolemFunctions */
+  Node eliminateSkolemFunctions( TNode n, std::vector< Node >& side_conditions, std::unordered_map< TNode, Node, TNodeHashFunction >& visited ); 
+  // is operator k invertible?
+  bool isInvertible( Kind k );
+  /** get inversion skolem for condition
+  * precondition : exists x. cond( x ) is a tautology in BV,
+  *               where x is getSolveVariable( tn ).
+  * returns fresh skolem k of type tn, where we may assume cond( k ).
+  */
+  Node getInversionSkolemFor( Node cond, TypeNode tn );
+  /** get inversion skolem function for type tn.
+  *   This is a function of type ( Bool -> tn ) that is used for explicitly storing side conditions
+  *   inside terms. For all ( cond, tn ), if :
+  *
+  *   f = getInversionSkolemFunctionFor( tn )
+  *   k = getInversionSkolemFor( cond, tn )
+  *   then:
+  *   f( cond ) is a placeholder for k.
+  *
+  * In the call eliminateSkolemFunctions, we replace all f( cond ) with k and add cond{ x -> k } to side_conditions.
+  * The advantage is that f( cond ) explicitly contains the side condition so it automatically
+  * updates with substitutions.
+  */
+  Node getInversionSkolemFunctionFor( TypeNode tn );
 public:
   BvInverter(){}
   ~BvInverter(){}
-  // get dummy fresh variable of type tn, used as argument for sv 
+  /** get dummy fresh variable of type tn, used as argument for sv */
   Node getSolveVariable( TypeNode tn );
-  // get inversion skolem for condition
-  // precondition : exists x. cond( x ) is a tautology in BV,
-  //                where x is getSolveVariable( tn ).
-  // returns fresh skolem k, where we may assume cond( k ).
-  Node getInversionSkolemFor( Node cond, TypeNode tn );
-  // Get path to pv in lit, replace that occurrence by sv and all others by pvs.
-  // e.g. if return value R is non-null, then:
-  //   lit.path = pv
-  //   R.path = sv
-  //   R.path' = pvs for all lit.path' = pv, where path' != path
+  /** get inversion node, if :
+  *
+  *   f = getInversionSkolemFunctionFor( tn )
+  *
+  * This returns f( cond ).
+  */
+  Node getInversionNode( Node cond, TypeNode tn );
+  /** Get path to pv in lit, replace that occurrence by sv and all others by pvs.
+  * If return value R is non-null, then :
+  *   lit.path = pv
+  *   R.path = sv
+  *   R.path' = pvs for all lit.path' = pv, where path' != path
+  */
   Node getPathToPv( Node lit, Node pv, Node sv, Node pvs, std::vector< unsigned >& path );
-public:
-  // solve for sv in constraint ( (pol ? _ : not) sv_t <rk> t ), where sv_t.path = sv
-  // status accumulates side conditions
+  /** eliminate skolem functions in node n
+  *
+  * This eliminates all Skolem functions from Node n and replaces them with finalized 
+  * Skolem variables. 
+  * 
+  * For each skolem variable we introduce, we ensure its associated side condition is
+  * added to side_conditions.
+  *
+  * Apart from Skolem functions, all subterms of n should be eligible for instantiation.
+  */
+  Node eliminateSkolemFunctions( TNode n, std::vector< Node >& side_conditions );
+  /** solve_bv_constraint
+  * solve for sv in constraint ( (pol ? _ : not) sv_t <rk> t ), where sv_t.path = sv
+  * status accumulates side conditions
+  */
   Node solve_bv_constraint( Node sv, Node sv_t, Node t, Kind rk, bool pol, std::vector< unsigned >& path,
                             BvInverterModelQuery * m, BvInverterStatus& status );
-  // solve for sv in lit, where lit.path = sv
-  // status accumulates side conditions
+  /** solve_bv_lit
+  * solve for sv in lit, where lit.path = sv
+  * status accumulates side conditions
+  */
   Node solve_bv_lit( Node sv, Node lit, bool pol, std::vector< unsigned >& path,
                      BvInverterModelQuery * m, BvInverterStatus& status );
 };

--- a/src/theory/quantifiers/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/inst_strategy_cbqi.cpp
@@ -746,7 +746,8 @@ bool InstStrategyCegqi::addLemma( Node lem ) {
 
 bool InstStrategyCegqi::isEligibleForInstantiation( Node n ) {
   if( n.getKind()==INST_CONSTANT || n.getKind()==SKOLEM ){
-    if( n.getKind()==SKOLEM && d_quantEngine->getTermDatabase()->containsVtsTerm( n ) ){
+    if( n.getAttribute(VirtualTermSkolemAttribute()) ){
+      // virtual terms are allowed
       return true;
     }else{
       TypeNode tn = n.getType();

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -1656,6 +1656,9 @@ Node TermDb::getVtsDelta( bool isFree, bool create ) {
     }
     if( d_vts_delta.isNull() ){
       d_vts_delta = NodeManager::currentNM()->mkSkolem( "delta", NodeManager::currentNM()->realType(), "delta for virtual term substitution" );
+      //mark as a virtual term
+      VirtualTermSkolemAttribute vtsa;
+      d_vts_delta.setAttribute(vtsa,true);
     }
   }
   return isFree ? d_vts_delta_free : d_vts_delta;
@@ -1668,6 +1671,9 @@ Node TermDb::getVtsInfinity( TypeNode tn, bool isFree, bool create ) {
     }
     if( d_vts_inf[tn].isNull() ){
       d_vts_inf[tn] = NodeManager::currentNM()->mkSkolem( "inf", tn, "infinity for virtual term substitution" );
+      //mark as a virtual term
+      VirtualTermSkolemAttribute vtsa;
+      d_vts_inf[tn].setAttribute(vtsa,true);
     }
   }
   return isFree ? d_vts_inf_free[tn] : d_vts_inf[tn];

--- a/src/theory/quantifiers/term_database.h
+++ b/src/theory/quantifiers/term_database.h
@@ -123,6 +123,9 @@ typedef expr::Attribute< QuantIdNumAttributeId, uint64_t > QuantIdNumAttribute;
 struct SygusVarNumAttributeId {};
 typedef expr::Attribute<SygusVarNumAttributeId, uint64_t> SygusVarNumAttribute;
 
+/** Attribute to mark Skolems as virtual terms */
+struct VirtualTermSkolemAttributeId {};
+typedef expr::Attribute< VirtualTermSkolemAttributeId, bool > VirtualTermSkolemAttribute;
 
 
 class QuantifiersEngine;

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -24,6 +24,7 @@
 #include "theory/quantifiers/ambqi_builder.h"
 #include "theory/quantifiers/bounded_integers.h"
 #include "theory/quantifiers/ce_guided_instantiation.h"
+#include "theory/quantifiers/ceg_t_instantiator.h"
 #include "theory/quantifiers/conjecture_generator.h"
 #include "theory/quantifiers/first_order_model.h"
 #include "theory/quantifiers/full_model_check.h"
@@ -130,6 +131,7 @@ QuantifiersEngine::QuantifiersEngine(context::Context* c, context::UserContext* 
   d_uee = NULL;
   d_fs = NULL;
   d_rel_dom = NULL;
+  d_bv_invert = NULL;
   d_builder = NULL;
 
   d_total_inst_count_debug = 0;
@@ -160,6 +162,7 @@ QuantifiersEngine::~QuantifiersEngine(){
   delete d_qcf;
   delete d_quant_rel;
   delete d_rel_dom;
+  delete d_bv_invert;
   delete d_model;
   delete d_tr_trie;
   delete d_term_db;
@@ -217,9 +220,10 @@ void QuantifiersEngine::finishInit(){
   if( options::cbqi() ){
     d_i_cbqi = new quantifiers::InstStrategyCegqi( this );
     d_modules.push_back( d_i_cbqi );
-    //if( options::cbqiModel() ){
-    //  needsBuilder = true;
-    //}
+    if( options::cbqiBv() ){
+      // if doing instantiation for BV, need the inverter class
+      d_bv_invert = new quantifiers::BvInverter;
+    }
   }
   if( options::ceGuidedInst() ){
     d_ceg_inst = new quantifiers::CegInstantiation( this, c );

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -48,16 +48,20 @@ public:
 };
 
 namespace quantifiers {
+  //TODO: organize this more/review this, github issue #1163
+  //utilities
   class TermDb;
   class TermDbSygus;
   class FirstOrderModel;
-  //modules
+  class RelevantDomain;
+  class BvInverter;
+  class InstPropagator;
+  //modules, these are "subsolvers" of the quantifiers theory.
   class InstantiationEngine;
   class ModelEngine;
   class BoundedIntegers;
   class QuantConflictFind;
   class RewriteEngine;
-  class RelevantDomain;
   class QModelBuilder;
   class ConjectureGenerator;
   class CegInstantiation;
@@ -71,7 +75,6 @@ namespace quantifiers {
   class QuantDSplit;
   class QuantAntiSkolem;
   class EqualityInference;
-  class InstPropagator;
 }/* CVC4::theory::quantifiers */
 
 namespace inst {
@@ -108,6 +111,8 @@ private:
   QuantRelevance * d_quant_rel;
   /** relevant domain */
   quantifiers::RelevantDomain* d_rel_dom;
+  /** inversion utility for BV instantiation */
+  quantifiers::BvInverter * d_bv_invert;
   /** alpha equivalence */
   quantifiers::AlphaEquivalence * d_alpha_equiv;
   /** model builder */
@@ -225,6 +230,8 @@ public:
   Valuation& getValuation();
   /** get relevant domain */
   quantifiers::RelevantDomain* getRelevantDomain() { return d_rel_dom; }
+  /** get the BV inverter utility */
+  quantifiers::BvInverter * getBvInverter() { return d_bv_invert; }
   /** get quantifier relevance */
   QuantRelevance* getQuantifierRelevance() { return d_quant_rel; }
   /** get the model builder */

--- a/test/regress/regress0/quantifiers/Makefile.am
+++ b/test/regress/regress0/quantifiers/Makefile.am
@@ -89,10 +89,10 @@ TESTS =	\
 	cbqi-sdlx-fixpoint-3-dd.smt2 \
 	qbv-simp.smt2 \
 	psyco-001-bv.smt2 \
-	bug822.smt2 
+	bug822.smt2 \
+	qbv-test-invert-mul.smt2 
 
 # FIXME: solvable with --cbqi-bv
-#qbv-test-invert-mul.smt2 
 #qbv-simple-2vars-vo.smt2
 
 # regression can be solved with --finite-model-find --fmf-inst-engine

--- a/test/regress/regress0/quantifiers/Makefile.am
+++ b/test/regress/regress0/quantifiers/Makefile.am
@@ -90,10 +90,8 @@ TESTS =	\
 	qbv-simp.smt2 \
 	psyco-001-bv.smt2 \
 	bug822.smt2 \
-	qbv-test-invert-mul.smt2 
-
-# FIXME: solvable with --cbqi-bv
-#qbv-simple-2vars-vo.smt2
+	qbv-test-invert-mul.smt2 \
+	qbv-simple-2vars-vo.smt2
 
 # regression can be solved with --finite-model-find --fmf-inst-engine
 # set3.smt2

--- a/test/regress/regress0/quantifiers/qbv-simple-2vars-vo.smt2
+++ b/test/regress/regress0/quantifiers/qbv-simple-2vars-vo.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --cbqi-bv
+; EXPECT: sat
 (set-logic BV)
 (set-info :status sat)
 (declare-fun a () (_ BitVec 32))

--- a/test/regress/regress0/quantifiers/qbv-simple-2vars-vo.smt2
+++ b/test/regress/regress0/quantifiers/qbv-simple-2vars-vo.smt2
@@ -8,7 +8,6 @@
 
 (assert (not (= a #x00000000)))
 
-; this is sensitive to variable ordering (try changing x and y)
 (assert (forall ((x (_ BitVec 32)) (y (_ BitVec 32))) (or 
 (not (= (bvmul x y) #x0000000A))
 (not (= (bvadd y a) #x00000010))

--- a/test/regress/regress0/quantifiers/qbv-test-invert-mul.smt2
+++ b/test/regress/regress0/quantifiers/qbv-test-invert-mul.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --cbqi-bv
+; EXPECT: sat
 (set-logic BV)
 (set-info :status sat)
 (declare-fun a () (_ BitVec 32))


### PR DESCRIPTION
This commit:
- Simplifies the intermediate representation of inversion Skolems for cegqi bit-vectors so that side conditions are part of the term structure and hence are updated automatically with substitutions.  This means several data structures for bookkeeping are no longer necessary.
- Moves bv inverter utility to QuantifierEngine so that we cache things globally
- Generalizes the policy for virtual term substitution for eligible instantiation terms to bit-vectors
- Enables a quantified bit-vector regression.
- Adds infrastructure for avoiding paths that are non-invertible (such as paths that go inside applications of Skolem functions)


