### PR TITLE
Refactor check function in last call effort of non-linear extension.

### DIFF
--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -85,9 +85,10 @@ class NonlinearExtension {
 
   // Check assertions for consistency in the effort LAST_CALL with a subset of
   // the assertions, false_asserts, evaluate to false in the current model.
-  void checkLastCall(const std::vector<Node>& assertions,
-                     const std::set<Node>& false_asserts,
-                     const std::vector<Node>& xts);
+  // Returns the number of lemmas added on the output channel.
+  int checkLastCall(const std::vector<Node>& assertions,
+                    const std::set<Node>& false_asserts,
+                    const std::vector<Node>& xts);
 
   static bool isArithKind(Kind k);
   static Node mkLit(Node a, Node b, int status, int orderType = 0);
@@ -203,7 +204,7 @@ class NonlinearExtension {
   std::map<Node, unsigned> d_order_vars;
   std::vector<Node> d_order_points;
   
-  //transcendent functions
+  //transcendental functions
   std::map<Node, Node> d_trig_base;
   std::map<Node, bool> d_trig_is_base;
   std::map< Node, bool > d_tf_initial_refine;

--- a/test/regress/regress0/nl/Makefile.am
+++ b/test/regress/regress0/nl/Makefile.am
@@ -65,7 +65,8 @@ TESTS =	\
   nta/tan-rewrite2.smt2 \
   nta/tan-rewrite.smt2 \
   nta/arrowsmith-050317.smt2 \
-  nta/sin-init-tangents.smt2
+  nta/sin-init-tangents.smt2 \
+  nta/cos1-tc.smt2
 
 # unsolved : garbage_collect.cvc
 

--- a/test/regress/regress0/nl/nta/cos1-tc.smt2
+++ b/test/regress/regress0/nl/nta/cos1-tc.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --nl-ext
+; EXPECT: unknown
+(set-logic UFNRA)
+(declare-fun f (Real) Real)
+
+(assert (= (f 0.0) (cos 1)))
+
+(check-sat)


### PR DESCRIPTION
This refactors the last effort check call for non-linear.

This makes it so that check is called if there are false assertions *or* a shared term has a model value that is not accurate (this is required in some corner cases).  Additionally a single point catches when to set incomplete now instead of two places.