### PR TITLE
Rewrite BV assertion for solve

### DIFF
--- a/src/theory/quantifiers/ceg_t_instantiator.h
+++ b/src/theory/quantifiers/ceg_t_instantiator.h
@@ -91,6 +91,10 @@ private:
   std::unordered_map< unsigned, BvInverterStatus > d_inst_id_to_status;
   // variable to current id we are processing
   std::unordered_map< Node, unsigned, NodeHashFunction > d_var_to_curr_inst_id;
+  /** rewrite assertion for solve pv
+  * returns a literal that is equivalent to lit that leads to best solved form for pv
+  */
+  Node rewriteAssertionForSolvePv( Node pv, Node lit );
 private:
   void processLiteral( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
 public:

--- a/test/regress/regress0/quantifiers/Makefile.am
+++ b/test/regress/regress0/quantifiers/Makefile.am
@@ -91,7 +91,8 @@ TESTS =	\
 	psyco-001-bv.smt2 \
 	bug822.smt2 \
 	qbv-test-invert-mul.smt2 \
-	qbv-simple-2vars-vo.smt2
+	qbv-simple-2vars-vo.smt2 \
+	qbv-test-urem-rewrite.smt2
 
 # regression can be solved with --finite-model-find --fmf-inst-engine
 # set3.smt2

--- a/test/regress/regress0/quantifiers/qbv-test-urem-rewrite.smt2
+++ b/test/regress/regress0/quantifiers/qbv-test-urem-rewrite.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --cbqi-bv --bv-div-zero-const
+; EXPECT: sat
+(set-logic BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 4))
+(declare-fun b () (_ BitVec 4))
+
+(assert (forall ((x (_ BitVec 4))) (not (= (bvurem x a) b))))
+
+(check-sat)


### PR DESCRIPTION
Adds infrastructure for a rewriting pass in BvInstantiator::processAssertion to remove non-invertible operators. Add regression.