### PR TITLE
Initial support for solving bit-vector inequalities

### DIFF
--- a/src/theory/quantifiers/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_instantiator.cpp
@@ -284,6 +284,7 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
       if( vinst->hasProcessAssertion( this, sf, pv, effort ) ){
         Trace("cbqi-inst-debug") << "[4] try based on assertions." << std::endl;
         std::vector< Node > lits;
+        std::vector< Node > alits;
         //unsigned rmax = Theory::theoryOf( pv )==Theory::theoryOf( pv.getType() ) ? 1 : 2;
         for( unsigned r=0; r<2; r++ ){
           TheoryId tid = r==0 ? Theory::theoryOf( pvtn ) : THEORY_UF;
@@ -293,17 +294,23 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
             for (unsigned j = 0; j<ita->second.size(); j++) {
               Node lit = ita->second[j];
               if( std::find( lits.begin(), lits.end(), lit )==lits.end() ){
-                lits.push_back( lit );
-                if( vinst->hasProcessAssertion( this, sf, pv, lit, effort ) ){  
-                  Trace("cbqi-inst-debug2") << "  look at " << lit << std::endl;
+                Node plit = vinst->hasProcessAssertion( this, sf, pv, lit, effort );
+                if( !plit.isNull() ){  
+                  Trace("cbqi-inst-debug2") << "  look at " << lit;
+                  if( plit!=lit ){
+                    Trace("cbqi-inst-debug2") << "...processed to : " << plit;
+                  }
+                  Trace("cbqi-inst-debug2") << std::endl;
                   // apply substitutions
-                  Node slit = applySubstitutionToLiteral( lit, sf );
+                  Node slit = applySubstitutionToLiteral( plit, sf );
                   if( !slit.isNull() ){
                     Trace("cbqi-inst-debug") << "...try based on literal " << slit << std::endl;
                     // check if contains pv
                     if( hasVariable( slit, pv ) ){
-                      if( vinst->processAssertion( this, sf, pv, slit, effort ) ){
-                       return true;
+                      lits.push_back( slit );
+                      alits.push_back( lit );
+                      if( vinst->processAssertion( this, sf, pv, slit, lit, effort ) ){
+                        return true;
                       }
                     }
                   }
@@ -312,7 +319,7 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
             }
           }
         }
-        if( vinst->processAssertions( this, sf, pv, lits, effort ) ){
+        if( vinst->processAssertions( this, sf, pv, lits, alits, effort ) ){
           return true;
         }
       }

--- a/src/theory/quantifiers/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_instantiator.cpp
@@ -283,8 +283,7 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
       //[4] directly look at assertions
       if( vinst->hasProcessAssertion( this, sf, pv, effort ) ){
         Trace("cbqi-inst-debug") << "[4] try based on assertions." << std::endl;
-        std::vector< Node > lits;
-        std::vector<Node> alits;
+        std::unordered_set< Node, NodeHashFunction > lits;
         //unsigned rmax = Theory::theoryOf( pv )==Theory::theoryOf( pv.getType() ) ? 1 : 2;
         for( unsigned r=0; r<2; r++ ){
           TheoryId tid = r==0 ? Theory::theoryOf( pvtn ) : THEORY_UF;
@@ -293,7 +292,8 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
           if( ita!=d_curr_asserts.end() ){
             for (unsigned j = 0; j<ita->second.size(); j++) {
               Node lit = ita->second[j];
-              if( std::find( lits.begin(), lits.end(), lit )==lits.end() ){
+              if( lits.find(lit)==lits.end() ){
+                lits.insert(lit);
                 Node plit =
                     vinst->hasProcessAssertion(this, sf, pv, lit, effort);
                 if (!plit.isNull()) {
@@ -308,8 +308,6 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
                     Trace("cbqi-inst-debug") << "...try based on literal " << slit << std::endl;
                     // check if contains pv
                     if( hasVariable( slit, pv ) ){
-                      lits.push_back(slit);
-                      alits.push_back(lit);
                       if (vinst->processAssertion(this, sf, pv, slit, lit,
                                                   effort)) {
                         return true;
@@ -321,7 +319,7 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
             }
           }
         }
-        if (vinst->processAssertions(this, sf, pv, lits, alits, effort)) {
+        if (vinst->processAssertions(this, sf, pv, effort)) {
           return true;
         }
       }

--- a/src/theory/quantifiers/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_instantiator.cpp
@@ -284,7 +284,7 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
       if( vinst->hasProcessAssertion( this, sf, pv, effort ) ){
         Trace("cbqi-inst-debug") << "[4] try based on assertions." << std::endl;
         std::vector< Node > lits;
-        std::vector< Node > alits;
+        std::vector<Node> alits;
         //unsigned rmax = Theory::theoryOf( pv )==Theory::theoryOf( pv.getType() ) ? 1 : 2;
         for( unsigned r=0; r<2; r++ ){
           TheoryId tid = r==0 ? Theory::theoryOf( pvtn ) : THEORY_UF;
@@ -294,22 +294,24 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
             for (unsigned j = 0; j<ita->second.size(); j++) {
               Node lit = ita->second[j];
               if( std::find( lits.begin(), lits.end(), lit )==lits.end() ){
-                Node plit = vinst->hasProcessAssertion( this, sf, pv, lit, effort );
-                if( !plit.isNull() ){  
+                Node plit =
+                    vinst->hasProcessAssertion(this, sf, pv, lit, effort);
+                if (!plit.isNull()) {
                   Trace("cbqi-inst-debug2") << "  look at " << lit;
-                  if( plit!=lit ){
+                  if (plit != lit) {
                     Trace("cbqi-inst-debug2") << "...processed to : " << plit;
                   }
                   Trace("cbqi-inst-debug2") << std::endl;
                   // apply substitutions
-                  Node slit = applySubstitutionToLiteral( plit, sf );
+                  Node slit = applySubstitutionToLiteral(plit, sf);
                   if( !slit.isNull() ){
                     Trace("cbqi-inst-debug") << "...try based on literal " << slit << std::endl;
                     // check if contains pv
                     if( hasVariable( slit, pv ) ){
-                      lits.push_back( slit );
-                      alits.push_back( lit );
-                      if( vinst->processAssertion( this, sf, pv, slit, lit, effort ) ){
+                      lits.push_back(slit);
+                      alits.push_back(lit);
+                      if (vinst->processAssertion(this, sf, pv, slit, lit,
+                                                  effort)) {
                         return true;
                       }
                     }
@@ -319,7 +321,7 @@ bool CegInstantiator::doAddInstantiation( SolvedForm& sf, unsigned i, unsigned e
             }
           }
         }
-        if( vinst->processAssertions( this, sf, pv, lits, alits, effort ) ){
+        if (vinst->processAssertions(this, sf, pv, lits, alits, effort)) {
           return true;
         }
       }

--- a/src/theory/quantifiers/ceg_instantiator.h
+++ b/src/theory/quantifiers/ceg_instantiator.h
@@ -272,15 +272,36 @@ public:
 
   // whether the instantiator implements processAssertion for any literal
   virtual bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return false; }
-  // whether the instantiator implements processAssertion for literal lit
-  virtual bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort ) { return false; }
-  // Called when the entailment:
-  //   E |= lit 
-  // holds in current context E. Typically, lit belongs to the list of current assertions.
-  // Returns true if an instantiation was successfully added via a recursive call
-  virtual bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort ) { return false; }
-  // Called after processAssertion is called for each literal asserted to the instantiator.
-  virtual bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, unsigned effort ) { return false; }
+  /** has process assertion
+  *
+  * Called when the entailment:
+  *   E |= lit 
+  * holds in current context E. Typically, lit belongs to the list of current assertions.
+  *
+  * This function is used to determine whether the instantiator implements processAssertion for literal lit.
+  *   If this function returns null, then this intantiator does not handle the literal lit
+  *   Otherwise, this function returns a literal lit' with the properties:
+  *   (1) lit' is true in the current model,
+  *   (2) lit' implies lit.
+  *   where typically lit' = lit.
+  */
+  virtual Node hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort ) { return Node::null(); }
+  /** process assertion
+  * Processes the assertion slit for variable pv
+  *
+  * lit is the substituted form (under sf) of a literal returned by hasProcessAssertion
+  * alit is the asserted literal, given as input to hasProcessAssertion
+  *
+  * Returns true if an instantiation was successfully added via a recursive call
+  */
+  virtual bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort ) { return false; }
+  /** process assertions
+  * Called after processAssertion is called for each literal asserted to the instantiator.
+  * lits contains all literals that were given as input to processAssertion with argument lit,
+  * alits contains all literals that were given as input to processAssertion with argument alit
+  */
+  virtual bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, 
+                                  std::vector< Node >& alits, unsigned effort ) { return false; }
 
   //do we use the model value as instantiation for pv
   virtual bool useModelValue( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return false; }

--- a/src/theory/quantifiers/ceg_instantiator.h
+++ b/src/theory/quantifiers/ceg_instantiator.h
@@ -308,14 +308,9 @@ public:
   /** process assertions
   * Called after processAssertion is called for each literal asserted to the
   * instantiator.
-  * lits contains all literals that were given as input to processAssertion with
-  * argument lit,
-  * alits contains all literals that were given as input to processAssertion
-  * with argument alit
   */
   virtual bool processAssertions(CegInstantiator* ci, SolvedForm& sf, Node pv,
-                                 std::vector<Node>& lits,
-                                 std::vector<Node>& alits, unsigned effort) {
+                                 unsigned effort) {
     return false;
   }
 

--- a/src/theory/quantifiers/ceg_instantiator.h
+++ b/src/theory/quantifiers/ceg_instantiator.h
@@ -275,33 +275,49 @@ public:
   /** has process assertion
   *
   * Called when the entailment:
-  *   E |= lit 
-  * holds in current context E. Typically, lit belongs to the list of current assertions.
+  *   E |= lit
+  * holds in current context E. Typically, lit belongs to the list of current
+  * assertions.
   *
-  * This function is used to determine whether the instantiator implements processAssertion for literal lit.
-  *   If this function returns null, then this intantiator does not handle the literal lit
+  * This function is used to determine whether the instantiator implements
+  * processAssertion for literal lit.
+  *   If this function returns null, then this intantiator does not handle the
+  * literal lit
   *   Otherwise, this function returns a literal lit' with the properties:
   *   (1) lit' is true in the current model,
   *   (2) lit' implies lit.
   *   where typically lit' = lit.
   */
-  virtual Node hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort ) { return Node::null(); }
+  virtual Node hasProcessAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv,
+                                   Node lit, unsigned effort) {
+    return Node::null();
+  }
   /** process assertion
   * Processes the assertion slit for variable pv
   *
-  * lit is the substituted form (under sf) of a literal returned by hasProcessAssertion
+  * lit is the substituted form (under sf) of a literal returned by
+  * hasProcessAssertion
   * alit is the asserted literal, given as input to hasProcessAssertion
   *
   * Returns true if an instantiation was successfully added via a recursive call
   */
-  virtual bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort ) { return false; }
+  virtual bool processAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv,
+                                Node lit, Node alit, unsigned effort) {
+    return false;
+  }
   /** process assertions
-  * Called after processAssertion is called for each literal asserted to the instantiator.
-  * lits contains all literals that were given as input to processAssertion with argument lit,
-  * alits contains all literals that were given as input to processAssertion with argument alit
+  * Called after processAssertion is called for each literal asserted to the
+  * instantiator.
+  * lits contains all literals that were given as input to processAssertion with
+  * argument lit,
+  * alits contains all literals that were given as input to processAssertion
+  * with argument alit
   */
-  virtual bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, 
-                                  std::vector< Node >& alits, unsigned effort ) { return false; }
+  virtual bool processAssertions(CegInstantiator* ci, SolvedForm& sf, Node pv,
+                                 std::vector<Node>& lits,
+                                 std::vector<Node>& alits, unsigned effort) {
+    return false;
+  }
 
   //do we use the model value as instantiation for pv
   virtual bool useModelValue( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return false; }

--- a/src/theory/quantifiers/ceg_t_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_t_instantiator.cpp
@@ -395,9 +395,7 @@ bool ArithInstantiator::processAssertion(CegInstantiator* ci, SolvedForm& sf,
 }
 
 bool ArithInstantiator::processAssertions(CegInstantiator* ci, SolvedForm& sf,
-                                          Node pv, std::vector<Node>& lits,
-                                          std::vector<Node>& alits,
-                                          unsigned effort) {
+                                          Node pv, unsigned effort) {
   if (options::cbqiModel()) {
     bool use_inf = ci->useVtsInfinity() && ( d_type.isInteger() ? options::cbqiUseInfInt() : options::cbqiUseInfReal() );
     bool upper_first = false;
@@ -974,9 +972,7 @@ bool BvInstantiator::processAssertion(CegInstantiator* ci, SolvedForm& sf,
 }
 
 bool BvInstantiator::processAssertions(CegInstantiator* ci, SolvedForm& sf,
-                                       Node pv, std::vector<Node>& lits,
-                                       std::vector<Node>& alits,
-                                       unsigned effort) {
+                                       Node pv, unsigned effort) {
   std::unordered_map< Node, std::vector< unsigned >, NodeHashFunction >::iterator iti = d_var_to_inst_id.find( pv );
   if( iti!=d_var_to_inst_id.end() ){
     Trace("cegqi-bv") << "BvInstantiator::processAssertions for " << pv << std::endl;

--- a/src/theory/quantifiers/ceg_t_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_t_instantiator.cpp
@@ -263,18 +263,23 @@ bool ArithInstantiator::processEquality( CegInstantiator * ci, SolvedForm& sf, N
   return false;
 }
 
-Node ArithInstantiator::hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort ) {
+Node ArithInstantiator::hasProcessAssertion(CegInstantiator* ci, SolvedForm& sf,
+                                            Node pv, Node lit,
+                                            unsigned effort) {
   Node atom = lit.getKind()==NOT ? lit[0] : lit;
   bool pol = lit.getKind()!=NOT;
   //arithmetic inequalities and disequalities
-  if( atom.getKind()==GEQ || ( atom.getKind()==EQUAL && !pol && atom[0].getType().isReal() ) ){
+  if (atom.getKind() == GEQ ||
+      (atom.getKind() == EQUAL && !pol && atom[0].getType().isReal())) {
     return lit;
-  }else{
+  } else {
     return Node::null();
   }
 }
 
-bool ArithInstantiator::processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort ) {
+bool ArithInstantiator::processAssertion(CegInstantiator* ci, SolvedForm& sf,
+                                         Node pv, Node lit, Node alit,
+                                         unsigned effort) {
   Node atom = lit.getKind()==NOT ? lit[0] : lit;
   bool pol = lit.getKind()!=NOT;
   //arithmetic inequalities and disequalities
@@ -389,8 +394,11 @@ bool ArithInstantiator::processAssertion( CegInstantiator * ci, SolvedForm& sf, 
   return false;
 }
 
-bool ArithInstantiator::processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, std::vector< Node >& alits, unsigned effort ) {
- if( options::cbqiModel() ){
+bool ArithInstantiator::processAssertions(CegInstantiator* ci, SolvedForm& sf,
+                                          Node pv, std::vector<Node>& lits,
+                                          std::vector<Node>& alits,
+                                          unsigned effort) {
+  if (options::cbqiModel()) {
     bool use_inf = ci->useVtsInfinity() && ( d_type.isInteger() ? options::cbqiUseInfInt() : options::cbqiUseInfReal() );
     bool upper_first = false;
     if( options::cbqiMinBounds() ){
@@ -877,8 +885,9 @@ void BvInstantiator::reset( CegInstantiator * ci, SolvedForm& sf, Node pv, unsig
   d_alit_to_model_slack.clear();
 }
 
-
-void BvInstantiator::processLiteral( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort ) {
+void BvInstantiator::processLiteral(CegInstantiator* ci, SolvedForm& sf,
+                                    Node pv, Node lit, Node alit,
+                                    unsigned effort) {
   Assert( d_inverter!=NULL );
   // find path to pv
   std::vector< unsigned > path;
@@ -902,44 +911,52 @@ void BvInstantiator::processLiteral( CegInstantiator * ci, SolvedForm& sf, Node 
   }
 }
 
-Node BvInstantiator::hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort ) {
-  Node atom = lit.getKind()==NOT ? lit[0] : lit;
-  bool pol = lit.getKind()!=NOT;
+Node BvInstantiator::hasProcessAssertion(CegInstantiator* ci, SolvedForm& sf,
+                                         Node pv, Node lit, unsigned effort) {
+  Node atom = lit.getKind() == NOT ? lit[0] : lit;
+  bool pol = lit.getKind() != NOT;
   Kind k = atom.getKind();
-  if( pol && k==EQUAL ){
+  if (pol && k == EQUAL) {
     // positively asserted equalities between bitvector terms we leave unmodifed
-    if( atom[0].getType().isBitVector() ){
+    if (atom[0].getType().isBitVector()) {
       return lit;
     }
-  }else{
-    // for all other predicates, we convert them to a positive equality based on the current model M, e.g.:
+  } else {
+    // for all other predicates, we convert them to a positive equality based on
+    // the current model M, e.g.:
     //   (not) s ~ t  --->  s = t + ( s^M - t^M )
-    if (k==EQUAL || k == BITVECTOR_ULT || k == BITVECTOR_ULE || k == BITVECTOR_SLT || k == BITVECTOR_SLE) {
+    if (k == EQUAL || k == BITVECTOR_ULT || k == BITVECTOR_ULE ||
+        k == BITVECTOR_SLT || k == BITVECTOR_SLE) {
       Node s = atom[0];
       Node t = atom[1];
       // only handle equalities between bitvectors
-      if( s.getType().isBitVector() ){
+      if (s.getType().isBitVector()) {
         NodeManager* nm = NodeManager::currentNM();
-        Node sm = ci->getModelValue( s );
-        Assert( !sm.isNull() && sm.isConst() );
-        Node tm = ci->getModelValue( t );
-        Assert( !tm.isNull() && tm.isConst() );
-        if( sm!=tm ){
-          Node slack = Rewriter::rewrite( nm->mkNode( kind::BITVECTOR_SUB, sm, tm ) );
-          Assert( slack.isConst() );
+        Node sm = ci->getModelValue(s);
+        Assert(!sm.isNull() && sm.isConst());
+        Node tm = ci->getModelValue(t);
+        Assert(!tm.isNull() && tm.isConst());
+        if (sm != tm) {
+          Node slack =
+              Rewriter::rewrite(nm->mkNode(kind::BITVECTOR_SUB, sm, tm));
+          Assert(slack.isConst());
           // remember the slack value for the asserted literal
           d_alit_to_model_slack[lit] = slack;
-          Node ret = nm->mkNode( kind::EQUAL, s, nm->mkNode( kind::BITVECTOR_PLUS, t, slack ) );
-          Trace("cegqi-bv") << "Process " << lit << " as " << ret << ", slack is " << slack << std::endl;
+          Node ret = nm->mkNode(kind::EQUAL, s,
+                                nm->mkNode(kind::BITVECTOR_PLUS, t, slack));
+          Trace("cegqi-bv") << "Process " << lit << " as " << ret
+                            << ", slack is " << slack << std::endl;
           return ret;
         }
-      }    
+      }
     }
   }
   return Node::null();
 }
 
-bool BvInstantiator::processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort ) {
+bool BvInstantiator::processAssertion(CegInstantiator* ci, SolvedForm& sf,
+                                      Node pv, Node lit, Node alit,
+                                      unsigned effort) {
   // if option enabled, use approach for word-level inversion for BV instantiation
   if( options::cbqiBv() ){
     // get the best rewritten form of lit for solving for pv 
@@ -951,12 +968,15 @@ bool BvInstantiator::processAssertion( CegInstantiator * ci, SolvedForm& sf, Nod
         Trace("cegqi-bv") << "...rewritten to " << rlit << std::endl;
       }
     }
-    processLiteral( ci, sf, pv, rlit, alit, effort );
+    processLiteral(ci, sf, pv, rlit, alit, effort);
   }
   return false;
 }
 
-bool BvInstantiator::processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, std::vector< Node >& alits, unsigned effort ) {
+bool BvInstantiator::processAssertions(CegInstantiator* ci, SolvedForm& sf,
+                                       Node pv, std::vector<Node>& lits,
+                                       std::vector<Node>& alits,
+                                       unsigned effort) {
   std::unordered_map< Node, std::vector< unsigned >, NodeHashFunction >::iterator iti = d_var_to_inst_id.find( pv );
   if( iti!=d_var_to_inst_id.end() ){
     Trace("cegqi-bv") << "BvInstantiator::processAssertions for " << pv << std::endl;
@@ -968,28 +988,29 @@ bool BvInstantiator::processAssertions( CegInstantiator * ci, SolvedForm& sf, No
     // hence we randomize the list
     // this helps robustness, since picking the same literal every time may be lead to a stream of value instantiations
     std::random_shuffle( iti->second.begin(), iti->second.end() );
-    Node min_slack_val;
-    
+
     for( unsigned j=0; j<iti->second.size(); j++ ){
       unsigned inst_id = iti->second[j];
       Assert( d_inst_id_to_term.find(inst_id)!=d_inst_id_to_term.end() );
       Node inst_term = d_inst_id_to_term[inst_id];
-      Assert( d_inst_id_to_alit.find(inst_id)!=d_inst_id_to_alit.end() );
+      Assert(d_inst_id_to_alit.find(inst_id) != d_inst_id_to_alit.end());
       Node alit = d_inst_id_to_alit[inst_id];
-      
+
       // get the slack value introduced for the asserted literal
       Node curr_slack_val;
-      std::unordered_map< Node, Node, NodeHashFunction >::iterator itms = d_alit_to_model_slack.find(alit);
-      if( itms!=d_alit_to_model_slack.end() ){
+      std::unordered_map<Node, Node, NodeHashFunction>::iterator itms =
+          d_alit_to_model_slack.find(alit);
+      if (itms != d_alit_to_model_slack.end()) {
         curr_slack_val = itms->second;
       }
-      
+
       // debug printing
       if( Trace.isOn("cegqi-bv") ){
         Trace("cegqi-bv") << "   [" << j << "] : ";
         Trace("cegqi-bv") << inst_term << std::endl;
-        if( !curr_slack_val.isNull() ){
-          Trace("cegqi-bv") << "   ...with slack value : " << curr_slack_val << std::endl;
+        if (!curr_slack_val.isNull()) {
+          Trace("cegqi-bv") << "   ...with slack value : " << curr_slack_val
+                            << std::endl;
         }
         // process information about solved status
         std::unordered_map< unsigned, BvInverterStatus >::iterator its = d_inst_id_to_status.find( inst_id );
@@ -1003,24 +1024,15 @@ bool BvInstantiator::processAssertions( CegInstantiator * ci, SolvedForm& sf, No
         }
         Trace("cegqi-bv") << std::endl;
       }
-      
 
-      // currently we take select the literal with the minimal slack
+      // currently we take select the first literal
       if( inst_ids_try.empty() ){
         // try the first one
         inst_ids_try.push_back( inst_id );
-        min_slack_val = curr_slack_val;
-      }else{
+      } else {
         // selection criteria across multiple literals goes here
-        
-        // if no slack value for this, and previously we had one, replace
-        if( !min_slack_val.isNull() && curr_slack_val.isNull() ){
-          inst_ids_try.clear();
-          inst_ids_try.push_back( inst_id );
-          min_slack_val = curr_slack_val;
-        }else{
-          //minimize slack value?
-        }
+
+
       }
     }
     

--- a/src/theory/quantifiers/ceg_t_instantiator.h
+++ b/src/theory/quantifiers/ceg_t_instantiator.h
@@ -43,9 +43,9 @@ public:
   bool hasProcessEquality( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }
   bool processEquality( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< TermProperties >& term_props, std::vector< Node >& terms, unsigned effort );
   bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }
-  bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
-  bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
-  bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, unsigned effort );
+  Node hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
+  bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort );
+  bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, std::vector< Node >& alits, unsigned effort );
   bool needsPostProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool postProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort, std::vector< Node >& lemmas );
   std::string identify() const { return "Arith"; }
@@ -86,25 +86,32 @@ private:
   // point to the bv inverter class
   BvInverter * d_inverter;
   unsigned d_inst_id_counter;
+  /** information about solved forms */
   std::unordered_map< Node, std::vector< unsigned >, NodeHashFunction > d_var_to_inst_id;
   std::unordered_map< unsigned, Node > d_inst_id_to_term;
   std::unordered_map< unsigned, BvInverterStatus > d_inst_id_to_status;
+  std::unordered_map< unsigned, Node > d_inst_id_to_alit;
   // variable to current id we are processing
   std::unordered_map< Node, unsigned, NodeHashFunction > d_var_to_curr_inst_id;
+  /** the amount of slack we added for asserted literals */
+  std::unordered_map< Node, Node, NodeHashFunction > d_alit_to_model_slack;
   /** rewrite assertion for solve pv
   * returns a literal that is equivalent to lit that leads to best solved form for pv
   */
   Node rewriteAssertionForSolvePv( Node pv, Node lit );
-private:
-  void processLiteral( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
+  /** process literal, called from processAssertion
+  * lit is the literal to solve for pv that has been rewritten according to internal rules here.
+  * alit is the asserted literal that lit is derived from.
+  */
+  void processLiteral( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort );
 public:
   BvInstantiator( QuantifiersEngine * qe, TypeNode tn );
   virtual ~BvInstantiator();
   void reset( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }
-  bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
-  bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
-  bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, unsigned effort );
+  Node hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
+  bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort );
+  bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, std::vector< Node >& alits, unsigned effort );
   bool needsPostProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool postProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort, std::vector< Node >& lemmas );
   bool useModelValue( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }

--- a/src/theory/quantifiers/ceg_t_instantiator.h
+++ b/src/theory/quantifiers/ceg_t_instantiator.h
@@ -48,7 +48,6 @@ public:
   bool processAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv, Node lit,
                         Node alit, unsigned effort);
   bool processAssertions(CegInstantiator* ci, SolvedForm& sf, Node pv,
-                         std::vector<Node>& lits, std::vector<Node>& alits,
                          unsigned effort);
   bool needsPostProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool postProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort, std::vector< Node >& lemmas );
@@ -121,7 +120,6 @@ private:
   bool processAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv, Node lit,
                         Node alit, unsigned effort);
   bool processAssertions(CegInstantiator* ci, SolvedForm& sf, Node pv,
-                         std::vector<Node>& lits, std::vector<Node>& alits,
                          unsigned effort);
   bool needsPostProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool postProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort, std::vector< Node >& lemmas );

--- a/src/theory/quantifiers/ceg_t_instantiator.h
+++ b/src/theory/quantifiers/ceg_t_instantiator.h
@@ -43,9 +43,13 @@ public:
   bool hasProcessEquality( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }
   bool processEquality( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< TermProperties >& term_props, std::vector< Node >& terms, unsigned effort );
   bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }
-  Node hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
-  bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort );
-  bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, std::vector< Node >& alits, unsigned effort );
+  Node hasProcessAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv,
+                           Node lit, unsigned effort);
+  bool processAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv, Node lit,
+                        Node alit, unsigned effort);
+  bool processAssertions(CegInstantiator* ci, SolvedForm& sf, Node pv,
+                         std::vector<Node>& lits, std::vector<Node>& alits,
+                         unsigned effort);
   bool needsPostProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool postProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort, std::vector< Node >& lemmas );
   std::string identify() const { return "Arith"; }
@@ -90,28 +94,35 @@ private:
   std::unordered_map< Node, std::vector< unsigned >, NodeHashFunction > d_var_to_inst_id;
   std::unordered_map< unsigned, Node > d_inst_id_to_term;
   std::unordered_map< unsigned, BvInverterStatus > d_inst_id_to_status;
-  std::unordered_map< unsigned, Node > d_inst_id_to_alit;
+  std::unordered_map<unsigned, Node> d_inst_id_to_alit;
   // variable to current id we are processing
   std::unordered_map< Node, unsigned, NodeHashFunction > d_var_to_curr_inst_id;
   /** the amount of slack we added for asserted literals */
-  std::unordered_map< Node, Node, NodeHashFunction > d_alit_to_model_slack;
+  std::unordered_map<Node, Node, NodeHashFunction> d_alit_to_model_slack;
   /** rewrite assertion for solve pv
   * returns a literal that is equivalent to lit that leads to best solved form for pv
   */
   Node rewriteAssertionForSolvePv( Node pv, Node lit );
   /** process literal, called from processAssertion
-  * lit is the literal to solve for pv that has been rewritten according to internal rules here.
+  * lit is the literal to solve for pv that has been rewritten according to
+  * internal rules here.
   * alit is the asserted literal that lit is derived from.
   */
-  void processLiteral( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort );
-public:
+  void processLiteral(CegInstantiator* ci, SolvedForm& sf, Node pv, Node lit,
+                      Node alit, unsigned effort);
+
+ public:
   BvInstantiator( QuantifiersEngine * qe, TypeNode tn );
   virtual ~BvInstantiator();
   void reset( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }
-  Node hasProcessAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, unsigned effort );
-  bool processAssertion( CegInstantiator * ci, SolvedForm& sf, Node pv, Node lit, Node alit, unsigned effort );
-  bool processAssertions( CegInstantiator * ci, SolvedForm& sf, Node pv, std::vector< Node >& lits, std::vector< Node >& alits, unsigned effort );
+  Node hasProcessAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv,
+                           Node lit, unsigned effort);
+  bool processAssertion(CegInstantiator* ci, SolvedForm& sf, Node pv, Node lit,
+                        Node alit, unsigned effort);
+  bool processAssertions(CegInstantiator* ci, SolvedForm& sf, Node pv,
+                         std::vector<Node>& lits, std::vector<Node>& alits,
+                         unsigned effort);
   bool needsPostProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort );
   bool postProcessInstantiationForVariable( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort, std::vector< Node >& lemmas );
   bool useModelValue( CegInstantiator * ci, SolvedForm& sf, Node pv, unsigned effort ) { return true; }

--- a/test/regress/regress0/quantifiers/Makefile.am
+++ b/test/regress/regress0/quantifiers/Makefile.am
@@ -92,7 +92,8 @@ TESTS =	\
 	bug822.smt2 \
 	qbv-test-invert-mul.smt2 \
 	qbv-simple-2vars-vo.smt2 \
-	qbv-test-urem-rewrite.smt2
+	qbv-test-urem-rewrite.smt2 \
+	qbv-inequality2.smt2
 
 # regression can be solved with --finite-model-find --fmf-inst-engine
 # set3.smt2

--- a/test/regress/regress0/quantifiers/Makefile.am
+++ b/test/regress/regress0/quantifiers/Makefile.am
@@ -100,9 +100,10 @@ TESTS =	\
 	qbv-test-invert-shl.smt2 \
 	qbv-test-invert-udiv-0.smt2 \
 	qbv-test-invert-udiv-1.smt2 \
-  qbv-simple-2vars-vo.smt2 \
+	qbv-simple-2vars-vo.smt2 \
 	qbv-test-urem-rewrite.smt2 \
-	qbv-inequality2.smt2
+	qbv-inequality2.smt2 \
+	qbv-test-invert-bvult-1.smt2
  
 
 # regression can be solved with --finite-model-find --fmf-inst-engine

--- a/test/regress/regress0/quantifiers/qbv-inequality2.smt2
+++ b/test/regress/regress0/quantifiers/qbv-inequality2.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --cbqi-bv
+; EXPECT: sat
+(set-logic BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 32))
+(declare-fun b () (_ BitVec 32))
+
+
+(assert (forall ((x (_ BitVec 32))) (or (bvuge x (bvadd a b)) (bvule x b))))
+
+(check-sat)

--- a/test/regress/regress0/quantifiers/qbv-multi-lit-uge.smt2
+++ b/test/regress/regress0/quantifiers/qbv-multi-lit-uge.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --cbqi-bv
+; EXPECT: sat
+(set-logic BV)
+(set-info :status sat)
+(declare-fun a () (_ BitVec 3))
+(declare-fun b () (_ BitVec 3))
+(declare-fun c () (_ BitVec 3))
+
+(assert (forall ((x (_ BitVec 3))) (or (not (= (bvmul x a) b)) (bvuge x c))))
+
+(check-sat)


### PR DESCRIPTION
This commit:
- Adds initial support for solving bit-vector inequalities in cegqi-bv using conversion to positive equality + model value slack.
Currently we convert inequalities s > t ----> s = t + ( s^M - t^M ), where "( s^M - t^M )" is referred to as the slack for literal s > t.

- Adds a regression (qbv-multi-lit-uge.smt2) that demonstrates a case where an instantiation with a side condition is repeated, where we resort to model value instantiation.

- Extends the interface of CegInstantiator objects for the required functionality.

- Adds a working regression (qbv-inequality2.smt2).
