### PR TITLE
CID 1459592: Always checking whether rd is null or not.

### DIFF
--- a/src/theory/quantifiers/inst_strategy_enumerative.cpp
+++ b/src/theory/quantifiers/inst_strategy_enumerative.cpp
@@ -135,7 +135,7 @@ bool InstStrategyEnum::process(Node f, bool fullEffort)
         Trace("inst-alg") << "-> Ground term instantiate " << f << "..."
                           << std::endl;
       }
-      Assert(rd != NULL);
+      AlwaysAssert(rd);
       Trace("inst-alg-debug") << "Compute relevant domain..." << std::endl;
       rd->compute();
       Trace("inst-alg-debug") << "...finished" << std::endl;


### PR DESCRIPTION
One possible conservative way to address CID 1459592. Not sure what the best long term fix is.

Coverity Scan Summary:
> 1459592 Dereference after null check
> Either the check against null is unnecessary, or there may be a null pointer dereference.
> In CVC4::​theory::​quantifiers::​InstStrategyEnum::​process(CVC4::​NodeTemplate<true>, bool): 
> Pointer is checked against null but then dereferenced anyway (CWE-476)