### PR TITLE
 Decouple sygus term database and term database.

### DIFF
--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -14,20 +14,12 @@
 
 #include "theory/quantifiers/term_database.h"
 
-#include "expr/datatype.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
-#include "options/datatypes_options.h"
 #include "options/uf_options.h"
-#include "theory/quantifiers/ce_guided_instantiation.h"
-#include "theory/quantifiers/first_order_model.h"
-#include "theory/quantifiers/fun_def_engine.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
-#include "theory/quantifiers/rewrite_engine.h"
-#include "theory/quantifiers/theory_quantifiers.h"
-#include "theory/quantifiers/trigger.h"
-#include "theory/quantifiers/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/quantifiers/trigger.h"
 #include "theory/quantifiers_engine.h"
 #include "theory/theory_engine.h"
 
@@ -250,10 +242,6 @@ void TermDb::addTerm( Node n, std::set< Node >& added, bool withinQuant, bool wi
           d_ops.push_back(op);
           d_op_map[op].push_back( n );
           added.insert( n );
-          
-          if( d_quantEngine->getTermDatabaseSygus() ){
-            d_quantEngine->getTermDatabaseSygus()->registerEvalTerm( n );
-          }
         }
       }else{
         setTermInactive( n );

--- a/src/theory/quantifiers/term_database_sygus.cpp
+++ b/src/theory/quantifiers/term_database_sygus.cpp
@@ -1912,32 +1912,34 @@ unsigned TermDbSygus::getAnchorDepth( Node n ) {
 void TermDbSygus::registerEvalTerm( Node n ) {
   if( options::sygusDirectEval() ){
     if( n.getKind()==APPLY_UF && !n.getType().isBoolean() ){
-      Trace("sygus-eager") << "TermDbSygus::eager: Register eval term : " << n
-                           << std::endl;
       TypeNode tn = n[0].getType();
       if( tn.isDatatype() ){
         const Datatype& dt = ((DatatypeType)(tn).toType()).getDatatype();
         if( dt.isSygus() ){
           Node f = n.getOperator();
-          Trace("sygus-eager") << "...the evaluation function is : " << f << std::endl;
           if( n[0].getKind()!=APPLY_CONSTRUCTOR ){
-            d_evals[n[0]].push_back( n );
-            TypeNode tn = n[0].getType();
-            Assert( tn.isDatatype() );
-            const Datatype& dt = ((DatatypeType)(tn).toType()).getDatatype();
-            Node var_list = Node::fromExpr( dt.getSygusVarList() );
-            Assert( dt.isSygus() );
-            d_eval_args[n[0]].push_back( std::vector< Node >() );
-            bool isConst = true;
-            for( unsigned j=1; j<n.getNumChildren(); j++ ){
-              d_eval_args[n[0]].back().push_back( n[j] );
-              if( !n[j].isConst() ){
-                isConst = false;
+            if( d_eval_processed.find(n)==d_eval_processed.end() ){
+              Trace("sygus-eager") << "TermDbSygus::eager: Register eval term : " << n
+                                   << std::endl;
+              d_eval_processed.insert(n);
+              d_evals[n[0]].push_back( n );
+              TypeNode tn = n[0].getType();
+              Assert( tn.isDatatype() );
+              const Datatype& dt = ((DatatypeType)(tn).toType()).getDatatype();
+              Node var_list = Node::fromExpr( dt.getSygusVarList() );
+              Assert( dt.isSygus() );
+              d_eval_args[n[0]].push_back( std::vector< Node >() );
+              bool isConst = true;
+              for( unsigned j=1; j<n.getNumChildren(); j++ ){
+                d_eval_args[n[0]].back().push_back( n[j] );
+                if( !n[j].isConst() ){
+                  isConst = false;
+                }
               }
+              d_eval_args_const[n[0]].push_back( isConst );
+              Node a = getAnchor( n[0] );
+              d_subterms[a][n[0]] = true;
             }
-            d_eval_args_const[n[0]].push_back( isConst );
-            Node a = getAnchor( n[0] );
-            d_subterms[a][n[0]] = true;
           }
         }
       }    

--- a/src/theory/quantifiers/term_database_sygus.cpp
+++ b/src/theory/quantifiers/term_database_sygus.cpp
@@ -1918,26 +1918,30 @@ void TermDbSygus::registerEvalTerm( Node n ) {
         if( dt.isSygus() ){
           Node f = n.getOperator();
           if( n[0].getKind()!=APPLY_CONSTRUCTOR ){
-            if( d_eval_processed.find(n)==d_eval_processed.end() ){
-              Trace("sygus-eager") << "TermDbSygus::eager: Register eval term : " << n
-                                   << std::endl;
+            if (d_eval_processed.find(n) == d_eval_processed.end())
+            {
+              Trace("sygus-eager")
+                  << "TermDbSygus::eager: Register eval term : " << n
+                  << std::endl;
               d_eval_processed.insert(n);
-              d_evals[n[0]].push_back( n );
+              d_evals[n[0]].push_back(n);
               TypeNode tn = n[0].getType();
-              Assert( tn.isDatatype() );
+              Assert(tn.isDatatype());
               const Datatype& dt = ((DatatypeType)(tn).toType()).getDatatype();
-              Node var_list = Node::fromExpr( dt.getSygusVarList() );
-              Assert( dt.isSygus() );
-              d_eval_args[n[0]].push_back( std::vector< Node >() );
+              Node var_list = Node::fromExpr(dt.getSygusVarList());
+              Assert(dt.isSygus());
+              d_eval_args[n[0]].push_back(std::vector<Node>());
               bool isConst = true;
-              for( unsigned j=1; j<n.getNumChildren(); j++ ){
-                d_eval_args[n[0]].back().push_back( n[j] );
-                if( !n[j].isConst() ){
+              for (unsigned j = 1; j < n.getNumChildren(); j++)
+              {
+                d_eval_args[n[0]].back().push_back(n[j]);
+                if (!n[j].isConst())
+                {
                   isConst = false;
                 }
               }
-              d_eval_args_const[n[0]].push_back( isConst );
-              Node a = getAnchor( n[0] );
+              d_eval_args_const[n[0]].push_back(isConst);
+              Node a = getAnchor(n[0]);
               d_subterms[a][n[0]] = true;
             }
           }

--- a/src/theory/quantifiers/term_database_sygus.h
+++ b/src/theory/quantifiers/term_database_sygus.h
@@ -17,7 +17,7 @@
 #ifndef __CVC4__THEORY__QUANTIFIERS__TERM_DATABASE_SYGUS_H
 #define __CVC4__THEORY__QUANTIFIERS__TERM_DATABASE_SYGUS_H
 
-#include <unordered_map>
+#include <unordered_set>
 
 #include "theory/quantifiers/sygus_explain.h"
 #include "theory/quantifiers/term_database.h"

--- a/src/theory/quantifiers/term_database_sygus.h
+++ b/src/theory/quantifiers/term_database_sygus.h
@@ -17,6 +17,8 @@
 #ifndef __CVC4__THEORY__QUANTIFIERS__TERM_DATABASE_SYGUS_H
 #define __CVC4__THEORY__QUANTIFIERS__TERM_DATABASE_SYGUS_H
 
+#include <unordered_map>
+
 #include "theory/quantifiers/sygus_explain.h"
 #include "theory/quantifiers/term_database.h"
 
@@ -243,6 +245,8 @@ public: // for symmetry breaking
 //for eager instantiation
   // TODO (as part of #1235) move some of these functions to sygus_explain.h
  private:
+  /** the set of evaluation terms we have already processed */
+  std::unordered_set< Node, NodeHashFunction > d_eval_processed;
   std::map< Node, std::map< Node, bool > > d_subterms;
   std::map< Node, std::vector< Node > > d_evals;
   std::map< Node, std::vector< std::vector< Node > > > d_eval_args;

--- a/src/theory/quantifiers/term_database_sygus.h
+++ b/src/theory/quantifiers/term_database_sygus.h
@@ -246,7 +246,7 @@ public: // for symmetry breaking
   // TODO (as part of #1235) move some of these functions to sygus_explain.h
  private:
   /** the set of evaluation terms we have already processed */
-  std::unordered_set< Node, NodeHashFunction > d_eval_processed;
+  std::unordered_set<Node, NodeHashFunction> d_eval_processed;
   std::map< Node, std::map< Node, bool > > d_subterms;
   std::map< Node, std::vector< Node > > d_evals;
   std::map< Node, std::vector< std::vector< Node > > > d_eval_args;

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -853,15 +853,22 @@ void QuantifiersEngine::addTermToDatabase( Node n, bool withinQuant, bool within
   if( !d_presolve || !options::incrementalSolving() ){
     std::set< Node > added;
     d_term_db->addTerm(n, added, withinQuant, withinInstClosure);
-    
-    if( !withinQuant ){
-      if( d_sygus_tdb ){
-        d_sygus_tdb->registerEvalTerm( n );
+
+    if (!withinQuant)
+    {
+      if (d_sygus_tdb)
+      {
+        d_sygus_tdb->registerEvalTerm(n);
       }
-    
-      //added contains also the Node that just have been asserted in this branch
-      if( d_quant_rel ){
-        for( std::set< Node >::iterator i=added.begin(), end=added.end(); i!=end; i++ ){
+
+      // added contains also the Node that just have been asserted in this
+      // branch
+      if (d_quant_rel)
+      {
+        for (std::set<Node>::iterator i = added.begin(), end = added.end();
+             i != end;
+             i++)
+        {
           d_quant_rel->setRelevance( i->getOperator(), 0 );
         }
       }

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -853,11 +853,15 @@ void QuantifiersEngine::addTermToDatabase( Node n, bool withinQuant, bool within
   if( !d_presolve || !options::incrementalSolving() ){
     std::set< Node > added;
     d_term_db->addTerm(n, added, withinQuant, withinInstClosure);
-
-    //added contains also the Node that just have been asserted in this branch
-    if( d_quant_rel ){
-      for( std::set< Node >::iterator i=added.begin(), end=added.end(); i!=end; i++ ){
-        if( !withinQuant ){
+    
+    if( !withinQuant ){
+      if( d_sygus_tdb ){
+        d_sygus_tdb->registerEvalTerm( n );
+      }
+    
+      //added contains also the Node that just have been asserted in this branch
+      if( d_quant_rel ){
+        for( std::set< Node >::iterator i=added.begin(), end=added.end(); i!=end; i++ ){
           d_quant_rel->setRelevance( i->getOperator(), 0 );
         }
       }


### PR DESCRIPTION
This moves a call to term database sygus from TermDb to QuantifiersEngine, thus decoupling term database and term database sygus.
It applies clang format to a function in sygus term database.