### PR TITLE
Higher-order prep

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -287,36 +287,54 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
     }
     return;
   }
-  
-  if( !force_nt.isNull() ){
-    if( n.getType()!=force_nt ){
-      if( force_nt.isReal() ){
-        out << "(" << smtKindString( force_nt.isInteger() ? kind::TO_INTEGER : kind::TO_REAL) << " ";
+
+  if (!force_nt.isNull())
+  {
+    if (n.getType() != force_nt)
+    {
+      if (force_nt.isReal())
+      {
+        out << "(" << smtKindString(force_nt.isInteger() ? kind::TO_INTEGER
+                                                         : kind::TO_REAL)
+            << " ";
         toStream(out, n, toDepth, types, TypeNode::null());
         out << ")";
-      }else{            
-        Node nn = NodeManager::currentNM()->mkNode(kind::APPLY_TYPE_ASCRIPTION,
-                                                   NodeManager::currentNM()->mkConst(AscriptionType(force_nt.toType())), n );
-        toStream(out, nn, toDepth, types, TypeNode::null());                                 
       }
-      return;  
+      else
+      {
+        Node nn = NodeManager::currentNM()->mkNode(
+            kind::APPLY_TYPE_ASCRIPTION,
+            NodeManager::currentNM()->mkConst(
+                AscriptionType(force_nt.toType())),
+            n);
+        toStream(out, nn, toDepth, types, TypeNode::null());
+      }
+      return;
     }
   }
 
   // variable
-  if(n.isVar()) {
+  if (n.isVar())
+  {
     string s;
-    if(n.getAttribute(expr::VarNameAttr(), s)) {
+    if (n.getAttribute(expr::VarNameAttr(), s))
+    {
       out << maybeQuoteSymbol(s);
-    } else {
-      if(n.getKind() == kind::VARIABLE) {
+    }
+    else
+    {
+      if (n.getKind() == kind::VARIABLE)
+      {
         out << "var_";
-      } else {
+      }
+      else
+      {
         out << n.getKind() << '_';
       }
       out << n.getId();
     }
-    if(types) {
+    if (types)
+    {
       // print the whole type, but not *its* type
       out << ":";
       n.getType().toStream(out, language::output::LANG_SMTLIB_V2_5);

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -116,43 +116,6 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
     return;
   }
 
-  if( !force_nt.isNull() && n.getKind()!=kind::CONST_RATIONAL ){
-    if( n.getType()!=force_nt ){
-      if( force_nt.isReal() ){
-        out << "(" << smtKindString( force_nt.isInteger() ? kind::TO_INTEGER : kind::TO_REAL) << " ";
-        toStream(out, n, toDepth, types, TypeNode::null());
-        out << ")";
-      }else{            
-        Node nn = NodeManager::currentNM()->mkNode(kind::APPLY_TYPE_ASCRIPTION,
-                                                   NodeManager::currentNM()->mkConst(AscriptionType(force_nt.toType())), n );
-        toStream(out, nn, toDepth, types, TypeNode::null());                                 
-      }
-      return;  
-    }
-  }
-
-  // variable
-  if(n.isVar()) {
-    string s;
-    if(n.getAttribute(expr::VarNameAttr(), s)) {
-      out << maybeQuoteSymbol(s);
-    } else {
-      if(n.getKind() == kind::VARIABLE) {
-        out << "var_";
-      } else {
-        out << n.getKind() << '_';
-      }
-      out << n.getId();
-    }
-    if(types) {
-      // print the whole type, but not *its* type
-      out << ":";
-      n.getType().toStream(out, language::output::LANG_SMTLIB_V2_5);
-    }
-
-    return;
-  }
-
   // constant
   if(n.getMetaKind() == kind::metakind::CONSTANT) {
     switch(n.getKind()) {
@@ -322,6 +285,43 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
       }
       out << ')';
     }
+    return;
+  }
+  
+  if( !force_nt.isNull() ){
+    if( n.getType()!=force_nt ){
+      if( force_nt.isReal() ){
+        out << "(" << smtKindString( force_nt.isInteger() ? kind::TO_INTEGER : kind::TO_REAL) << " ";
+        toStream(out, n, toDepth, types, TypeNode::null());
+        out << ")";
+      }else{            
+        Node nn = NodeManager::currentNM()->mkNode(kind::APPLY_TYPE_ASCRIPTION,
+                                                   NodeManager::currentNM()->mkConst(AscriptionType(force_nt.toType())), n );
+        toStream(out, nn, toDepth, types, TypeNode::null());                                 
+      }
+      return;  
+    }
+  }
+
+  // variable
+  if(n.isVar()) {
+    string s;
+    if(n.getAttribute(expr::VarNameAttr(), s)) {
+      out << maybeQuoteSymbol(s);
+    } else {
+      if(n.getKind() == kind::VARIABLE) {
+        out << "var_";
+      } else {
+        out << n.getKind() << '_';
+      }
+      out << n.getId();
+    }
+    if(types) {
+      // print the whole type, but not *its* type
+      out << ":";
+      n.getType().toStream(out, language::output::LANG_SMTLIB_V2_5);
+    }
+
     return;
   }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2425,7 +2425,7 @@ Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, Node
         }
 
         Node instance = fm.substitute(formals.begin(), formals.end(),
-                                      n.begin(), n.end());
+                                      n.begin(), n.begin()+formals.size());
         Debug("expand") << "made : " << instance << endl;
 
         Node expanded = expandDefinitions(instance, cache, expandOnly);

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2424,8 +2424,10 @@ Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, Node
           fm = def.getFormula();
         }
 
-        Node instance = fm.substitute(formals.begin(), formals.end(),
-                                      n.begin(), n.begin()+formals.size());
+        Node instance = fm.substitute(formals.begin(),
+                                      formals.end(),
+                                      n.begin(),
+                                      n.begin() + formals.size());
         Debug("expand") << "made : " << instance << endl;
 
         Node expanded = expandDefinitions(instance, cache, expandOnly);

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -105,6 +105,9 @@ void QuantifiersRewriter::computeArgs( std::vector< Node >& args, std::map< Node
         activeMap[ n ] = true;
       }
     }else{
+      if( n.hasOperator() ){
+        computeArgs( args, activeMap, n.getOperator(), visited );
+      }
       for( int i=0; i<(int)n.getNumChildren(); i++ ){
         computeArgs( args, activeMap, n[i], visited );
       }

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -105,8 +105,9 @@ void QuantifiersRewriter::computeArgs( std::vector< Node >& args, std::map< Node
         activeMap[ n ] = true;
       }
     }else{
-      if( n.hasOperator() ){
-        computeArgs( args, activeMap, n.getOperator(), visited );
+      if (n.hasOperator())
+      {
+        computeArgs(args, activeMap, n.getOperator(), visited);
       }
       for( int i=0; i<(int)n.getNumChildren(); i++ ){
         computeArgs( args, activeMap, n[i], visited );


### PR DESCRIPTION
Minor preparation for the final states of the higher-order merge, this fixes a few bugs found by some preemptive testing of the next stage of the merge of https://github.com/CVC4/CVC4/tree/ho-smt

This pull request:

- Rearranges printing of variables in the smt2 printer to come after printing of constants.  In particular, this allows the type ascription case (!force_nt.isNull()) to not be checked for type constants, which led to problems on the ho-smt branch.

- Variables are collected in operators in the quantifiers rewriter,

- Makes definition expansion robust to partial function application, e.g. when we have a term:
(APPLY (lambda ((x Int) (y Int)) (P x y)) a)
this should be expanded to:
(lambda ((y Int)) (P a y))
Previously this assumed all lambdas were fully applied.