### PR TITLE
(Refactor) Decouple rep set iterator and quantifiers

### DIFF
--- a/src/theory/quantifiers/bounded_integers.cpp
+++ b/src/theory/quantifiers/bounded_integers.cpp
@@ -739,14 +739,8 @@ bool BoundedIntegers::getRsiSubsitution( Node q, Node v, std::vector< Node >& va
     Trace("bound-int-rsi") << "Look up the value for " << d_set[q][i] << " " << i << std::endl;
     int v = rsi->getVariableOrder( i );
     Assert( q[0][v]==d_set[q][i] );
-    Node t = rsi->getCurrentTerm( v );
+    Node t = rsi->getCurrentTerm( v, true );
     Trace("bound-int-rsi") << "term : " << t << std::endl;
-    Node tt = rsi->d_rep_set->getTermForRepresentative(t);
-    if (!tt.isNull())
-    {
-      t = tt;
-      Trace("bound-int-rsi") << "term (post-rep) : " << t << std::endl;
-    }
     vars.push_back( d_set[q][i] );
     subs.push_back( t );
   }

--- a/src/theory/quantifiers/bounded_integers.cpp
+++ b/src/theory/quantifiers/bounded_integers.cpp
@@ -739,7 +739,7 @@ bool BoundedIntegers::getRsiSubsitution( Node q, Node v, std::vector< Node >& va
     Trace("bound-int-rsi") << "Look up the value for " << d_set[q][i] << " " << i << std::endl;
     int v = rsi->getVariableOrder( i );
     Assert( q[0][v]==d_set[q][i] );
-    Node t = rsi->getCurrentTerm( v, true );
+    Node t = rsi->getCurrentTerm(v, true);
     Trace("bound-int-rsi") << "term : " << t << std::endl;
     vars.push_back( d_set[q][i] );
     subs.push_back( t );

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -223,11 +223,8 @@ bool FirstOrderModel::initializeRepresentativesForType(TypeNode tn)
       Assert(d_rep_set.hasType(tn));
       return true;
     }
-    else
-    {
-      Trace("fm-debug") << "  variable cannot be bounded." << std::endl;
-      return false;
-    }
+    Trace("fm-debug") << "  variable cannot be bounded." << std::endl;
+    return false;
   }
 }
 

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -183,7 +183,8 @@ void FirstOrderModel::initializeModelForTerm( Node n, std::map< Node, bool >& vi
 
 Node FirstOrderModel::getSomeDomainElement(TypeNode tn){
   //check if there is even any domain elements at all
-  if (!d_rep_set.hasType(tn) || d_rep_set.d_type_reps[tn].size()==0) {
+  if (!d_rep_set.hasType(tn) || d_rep_set.d_type_reps[tn].size() == 0)
+  {
     Trace("fm-debug") << "Must create domain element for " << tn << "..."
                       << std::endl;
     Node mbt = getModelBasisTerm(tn);
@@ -201,7 +202,7 @@ bool FirstOrderModel::initializeRepresentativesForType(TypeNode tn)
     if (!d_rep_set.hasType(tn))
     {
       // terms in rep_set are now constants which mapped to terms through
-      // TheoryModel. Thus, should introduce a constant and a term.  
+      // TheoryModel. Thus, should introduce a constant and a term.
       // For now, we just add an arbitrary term.
       Node var = d_qe->getModel()->getSomeDomainElement(tn);
       Trace("mkVar") << "RepSetIterator:: Make variable " << var << " : " << tn

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -183,15 +183,12 @@ void FirstOrderModel::initializeModelForTerm( Node n, std::map< Node, bool >& vi
 
 Node FirstOrderModel::getSomeDomainElement(TypeNode tn){
   //check if there is even any domain elements at all
-  if (!d_rep_set.hasType(tn)) {
+  if (!d_rep_set.hasType(tn) || d_rep_set.d_type_reps[tn].size()==0) {
     Trace("fm-debug") << "Must create domain element for " << tn << "..."
                       << std::endl;
     Node mbt = getModelBasisTerm(tn);
     Trace("fm-debug") << "Add to representative set..." << std::endl;
     d_rep_set.add(tn, mbt);
-  }else if( d_rep_set.d_type_reps[tn].size()==0 ){
-    Message() << "empty reps" << std::endl;
-    exit(0);
   }
   return d_rep_set.d_type_reps[tn][0];
 }
@@ -203,12 +200,9 @@ bool FirstOrderModel::initializeRepresentativesForType(TypeNode tn)
     // must ensure uninterpreted type is non-empty.
     if (!d_rep_set.hasType(tn))
     {
-      // FIXME:
       // terms in rep_set are now constants which mapped to terms through
-      // TheoryModel
-      // thus, should introduce a constant and a term.  for now, just a term.
-
-      // Node c = d_qe->getTermUtil()->getEnumerateTerm( tn, 0 );
+      // TheoryModel. Thus, should introduce a constant and a term.  
+      // For now, we just add an arbitrary term.
       Node var = d_qe->getModel()->getSomeDomainElement(tn);
       Trace("mkVar") << "RepSetIterator:: Make variable " << var << " : " << tn
                      << std::endl;

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -34,7 +34,7 @@ using namespace CVC4::theory::quantifiers::fmcheck;
 namespace CVC4 {
 namespace theory {
 namespace quantifiers {
-  
+
 struct sortQuantifierRelevance {
   FirstOrderModel * d_fm;
   bool operator() (Node i, Node j) {
@@ -48,16 +48,25 @@ struct sortQuantifierRelevance {
   }
 };
 
-RepSetIterator::RsiEnumType QRepBoundExt::setBound(Node owner, unsigned i, std::vector< Node >& elements ) {
-  //builtin: check if it is bound by bounded integer module
-  if( owner.getKind()==FORALL && d_qe->getBoundedIntegers() ){
-    if( d_qe->getBoundedIntegers()->isBoundVar( owner, owner[0][i] ) ){
-      unsigned bvt = d_qe->getBoundedIntegers()->getBoundVarType( owner, owner[0][i] );
-      if( bvt!=BoundedIntegers::BOUND_FINITE ){
+RepSetIterator::RsiEnumType QRepBoundExt::setBound(Node owner,
+                                                   unsigned i,
+                                                   std::vector<Node>& elements)
+{
+  // builtin: check if it is bound by bounded integer module
+  if (owner.getKind() == FORALL && d_qe->getBoundedIntegers())
+  {
+    if (d_qe->getBoundedIntegers()->isBoundVar(owner, owner[0][i]))
+    {
+      unsigned bvt =
+          d_qe->getBoundedIntegers()->getBoundVarType(owner, owner[0][i]);
+      if (bvt != BoundedIntegers::BOUND_FINITE)
+      {
         d_bound_int[i] = true;
         return RepSetIterator::ENUM_BOUND_INT;
-      }else{
-        // indicates the variable is finitely bound due to 
+      }
+      else
+      {
+        // indicates the variable is finitely bound due to
         // the (small) cardinality of its type,
         // will treat in default way
       }
@@ -66,32 +75,48 @@ RepSetIterator::RsiEnumType QRepBoundExt::setBound(Node owner, unsigned i, std::
   return RepSetIterator::ENUM_INVALID;
 }
 
-bool QRepBoundExt::resetIndex(RepSetIterator * rsi, Node owner, unsigned i, bool initial, std::vector< Node >& elements ){
-  if( d_bound_int.find( i )!=d_bound_int.end() ){
-    Assert( owner.getKind()==FORALL );
-    Assert( d_qe->getBoundedIntegers()!=nullptr );
-    if( !d_qe->getBoundedIntegers()->getBoundElements( rsi, initial, owner, owner[0][i], elements ) ){
+bool QRepBoundExt::resetIndex(RepSetIterator* rsi,
+                              Node owner,
+                              unsigned i,
+                              bool initial,
+                              std::vector<Node>& elements)
+{
+  if (d_bound_int.find(i) != d_bound_int.end())
+  {
+    Assert(owner.getKind() == FORALL);
+    Assert(d_qe->getBoundedIntegers() != nullptr);
+    if (!d_qe->getBoundedIntegers()->getBoundElements(
+            rsi, initial, owner, owner[0][i], elements))
+    {
       return false;
     }
   }
   return true;
 }
 
-bool QRepBoundExt::initializeRepresentativesForType( TypeNode tn ) {
-  return d_qe->getModel()->initializeRepresentativesForType( tn );  
+bool QRepBoundExt::initializeRepresentativesForType(TypeNode tn)
+{
+  return d_qe->getModel()->initializeRepresentativesForType(tn);
 }
 
-bool QRepBoundExt::getVariableOrder( Node owner, std::vector< unsigned >& varOrder ) {
-  //must set a variable index order based on bounded integers
-  if( owner.getKind()==FORALL && d_qe->getBoundedIntegers() ){
+bool QRepBoundExt::getVariableOrder(Node owner, std::vector<unsigned>& varOrder)
+{
+  // must set a variable index order based on bounded integers
+  if (owner.getKind() == FORALL && d_qe->getBoundedIntegers())
+  {
     Trace("bound-int-rsi") << "Calculating variable order..." << std::endl;
-    for( unsigned i=0; i<d_qe->getBoundedIntegers()->getNumBoundVars( owner ); i++ ){
-      Node v = d_qe->getBoundedIntegers()->getBoundVar( owner, i );
-      Trace("bound-int-rsi") << "  bound var #" << i << " is " << v << std::endl;
-      varOrder.push_back( d_qe->getTermUtil()->getVariableNum( owner, v ) );
+    for (unsigned i = 0; i < d_qe->getBoundedIntegers()->getNumBoundVars(owner);
+         i++)
+    {
+      Node v = d_qe->getBoundedIntegers()->getBoundVar(owner, i);
+      Trace("bound-int-rsi") << "  bound var #" << i << " is " << v
+                             << std::endl;
+      varOrder.push_back(d_qe->getTermUtil()->getVariableNum(owner, v));
     }
-    for( unsigned i=0; i<owner[0].getNumChildren(); i++) {
-      if( !d_qe->getBoundedIntegers()->isBoundVar(owner, owner[0][i])) {
+    for (unsigned i = 0; i < owner[0].getNumChildren(); i++)
+    {
+      if (!d_qe->getBoundedIntegers()->isBoundVar(owner, owner[0][i]))
+      {
         varOrder.push_back(i);
       }
     }
@@ -159,7 +184,8 @@ void FirstOrderModel::initializeModelForTerm( Node n, std::map< Node, bool >& vi
 Node FirstOrderModel::getSomeDomainElement(TypeNode tn){
   //check if there is even any domain elements at all
   if (!d_rep_set.hasType(tn)) {
-    Trace("fm-debug") << "Must create domain element for " << tn << "..." << std::endl;
+    Trace("fm-debug") << "Must create domain element for " << tn << "..."
+                      << std::endl;
     Node mbt = getModelBasisTerm(tn);
     Trace("fm-debug") << "Add to representative set..." << std::endl;
     d_rep_set.add(tn, mbt);
@@ -170,30 +196,40 @@ Node FirstOrderModel::getSomeDomainElement(TypeNode tn){
   return d_rep_set.d_type_reps[tn][0];
 }
 
-bool FirstOrderModel::initializeRepresentativesForType(TypeNode tn) {
-  if( tn.isSort() ){
-    //must ensure uninterpreted type is non-empty.
-    if( !d_rep_set.hasType( tn ) ){
-      //FIXME:
-      // terms in rep_set are now constants which mapped to terms through TheoryModel
+bool FirstOrderModel::initializeRepresentativesForType(TypeNode tn)
+{
+  if (tn.isSort())
+  {
+    // must ensure uninterpreted type is non-empty.
+    if (!d_rep_set.hasType(tn))
+    {
+      // FIXME:
+      // terms in rep_set are now constants which mapped to terms through
+      // TheoryModel
       // thus, should introduce a constant and a term.  for now, just a term.
 
-      //Node c = d_qe->getTermUtil()->getEnumerateTerm( tn, 0 );
-      Node var = d_qe->getModel()->getSomeDomainElement( tn );
-      Trace("mkVar") << "RepSetIterator:: Make variable " << var << " : " << tn << std::endl;
-      d_rep_set.add( tn, var );
+      // Node c = d_qe->getTermUtil()->getEnumerateTerm( tn, 0 );
+      Node var = d_qe->getModel()->getSomeDomainElement(tn);
+      Trace("mkVar") << "RepSetIterator:: Make variable " << var << " : " << tn
+                     << std::endl;
+      d_rep_set.add(tn, var);
     }
     return true;
-  }else{
+  }
+  else
+  {
     // can we complete it?
     if (d_qe->getTermEnumeration()->mayComplete(tn))
     {
-      Trace("fm-debug") << "  do complete, since cardinality is small (" << tn.getCardinality() << ")..." << std::endl;
-      d_rep_set.complete( tn );
-      //must have succeeded
-      Assert( d_rep_set.hasType( tn ) );
+      Trace("fm-debug") << "  do complete, since cardinality is small ("
+                        << tn.getCardinality() << ")..." << std::endl;
+      d_rep_set.complete(tn);
+      // must have succeeded
+      Assert(d_rep_set.hasType(tn));
       return true;
-    }else{
+    }
+    else
+    {
       Trace("fm-debug") << "  variable cannot be bounded." << std::endl;
       return false;
     }
@@ -1107,6 +1143,6 @@ Node FirstOrderModelAbs::getVariable( Node q, unsigned i ) {
   return q[0][d_var_order[q][i]];
 }
 
-}/* CVC4::theory::quantifiers namespace */
-}/* CVC4::theory namespace */
-}/* CVC4 namespace */
+} /* CVC4::theory::quantifiers namespace */
+} /* CVC4::theory namespace */
+} /* CVC4 namespace */

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -27,13 +27,14 @@
 #define USE_INDEX_ORDERING
 
 using namespace std;
-using namespace CVC4;
 using namespace CVC4::kind;
 using namespace CVC4::context;
-using namespace CVC4::theory;
-using namespace CVC4::theory::quantifiers;
 using namespace CVC4::theory::quantifiers::fmcheck;
 
+namespace CVC4 {
+namespace theory {
+namespace quantifiers {
+  
 struct sortQuantifierRelevance {
   FirstOrderModel * d_fm;
   bool operator() (Node i, Node j) {
@@ -1105,3 +1106,7 @@ void FirstOrderModelAbs::processInitializeQuantifier( Node q ) {
 Node FirstOrderModelAbs::getVariable( Node q, unsigned i ) {
   return q[0][d_var_order[q][i]];
 }
+
+}/* CVC4::theory::quantifiers namespace */
+}/* CVC4::theory namespace */
+}/* CVC4 namespace */

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -16,6 +16,7 @@
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "theory/quantifiers/ambqi_builder.h"
+#include "theory/quantifiers/bounded_integers.h"
 #include "theory/quantifiers/full_model_check.h"
 #include "theory/quantifiers/model_engine.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
@@ -45,6 +46,58 @@ struct sortQuantifierRelevance {
     }
   }
 };
+
+RepSetIterator::RsiEnumType QRepBoundExt::setBound(Node owner, unsigned i, std::vector< Node >& elements ) {
+  //builtin: check if it is bound by bounded integer module
+  if( owner.getKind()==FORALL && d_qe->getBoundedIntegers() ){
+    if( d_qe->getBoundedIntegers()->isBoundVar( owner, owner[0][i] ) ){
+      unsigned bvt = d_qe->getBoundedIntegers()->getBoundVarType( owner, owner[0][i] );
+      if( bvt!=BoundedIntegers::BOUND_FINITE ){
+        d_bound_int[i] = true;
+        return RepSetIterator::ENUM_BOUND_INT;
+      }else{
+        // indicates the variable is finitely bound due to 
+        // the (small) cardinality of its type,
+        // will treat in default way
+      }
+    }
+  }
+  return RepSetIterator::ENUM_INVALID;
+}
+
+bool QRepBoundExt::resetIndex(RepSetIterator * rsi, Node owner, unsigned i, bool initial, std::vector< Node >& elements ){
+  if( d_bound_int.find( i )!=d_bound_int.end() ){
+    Assert( owner.getKind()==FORALL );
+    Assert( d_qe->getBoundedIntegers()!=nullptr );
+    if( !d_qe->getBoundedIntegers()->getBoundElements( rsi, initial, owner, owner[0][i], elements ) ){
+      return false;
+    }
+  }
+  return true;
+}
+
+bool QRepBoundExt::initializeRepresentativesForType( TypeNode tn ) {
+  return d_qe->getModel()->initializeRepresentativesForType( tn );  
+}
+
+bool QRepBoundExt::getVariableOrder( Node owner, std::vector< unsigned >& varOrder ) {
+  //must set a variable index order based on bounded integers
+  if( owner.getKind()==FORALL && d_qe->getBoundedIntegers() ){
+    Trace("bound-int-rsi") << "Calculating variable order..." << std::endl;
+    for( unsigned i=0; i<d_qe->getBoundedIntegers()->getNumBoundVars( owner ); i++ ){
+      Node v = d_qe->getBoundedIntegers()->getBoundVar( owner, i );
+      Trace("bound-int-rsi") << "  bound var #" << i << " is " << v << std::endl;
+      varOrder.push_back( d_qe->getTermUtil()->getVariableNum( owner, v ) );
+    }
+    for( unsigned i=0; i<owner[0].getNumChildren(); i++) {
+      if( !d_qe->getBoundedIntegers()->isBoundVar(owner, owner[0][i])) {
+        varOrder.push_back(i);
+      }
+    }
+    return true;
+  }
+  return false;
+}
 
 FirstOrderModel::FirstOrderModel(QuantifiersEngine * qe, context::Context* c, std::string name ) :
 TheoryModel( c, name, true ),

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -109,7 +109,14 @@ class FirstOrderModel : public TheoryModel
   unsigned getModelBasisArg(Node n);
   /** get some domain element */
   Node getSomeDomainElement(TypeNode tn);
-
+  /** initialize representative set for type 
+   * 
+   * Returns true if the initialization was complete,
+   * in that the set for tn in TheoryModel::d_rep_set 
+   * has all representatives of type tn.
+   */
+  bool initializeRepresentativesForType(TypeNode tn);
+  
  protected:
   /** quant engine */
   QuantifiersEngine* d_qe;

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -54,6 +54,34 @@ class FirstOrderModelAbs;
 struct IsStarAttributeId {};
 typedef expr::Attribute<IsStarAttributeId, bool> IsStarAttribute;
 
+
+/** Quantifiers representative bound 
+ * 
+ * This class is used for computing (finite)
+ * bounds for the domain of a quantifier
+ * in the context of a RepSetIterator
+ * (see theory/rep_set.h).
+ */
+class QRepBoundExt : public RepBoundExt {
+ public:
+  QRepBoundExt( QuantifiersEngine * qe ) : d_qe( qe ){}
+  virtual ~QRepBoundExt() {}
+  /** set bound */
+  virtual RepSetIterator::RsiEnumType setBound(Node owner, unsigned i, std::vector< Node >& elements ) override;
+  /** reset index */
+  virtual bool resetIndex(RepSetIterator * rsi, Node owner, unsigned i, bool initial, std::vector< Node >& elements ) override;
+  /** initialize representative set for type */
+  virtual bool initializeRepresentativesForType( TypeNode tn ) override;
+  /** get variable order */
+  virtual bool getVariableOrder( Node owner, std::vector< unsigned >& varOrder ) override;
+ private:
+  /** quantifiers engine associated with this bound */
+  QuantifiersEngine * d_qe;
+  /** indices that are bound integer enumeration */
+  std::map< unsigned, bool > d_bound_int;
+};
+
+
 // TODO (#1301) : document and refactor this class
 class FirstOrderModel : public TheoryModel
 {
@@ -110,6 +138,15 @@ class FirstOrderModel : public TheoryModel
   /** get some domain element */
   Node getSomeDomainElement(TypeNode tn);
   /** initialize representative set for type 
+   * 
+   * This ensures that TheoryModel::d_rep_set 
+   * is initialized for type tn. In particular:
+   * (1) If tn is an uninitialized (unconstrained)
+   * uninterpreted sort, then we interpret it
+   * as a set of size one,
+   * (2) If tn is a "small" enumerable finite type,
+   * then we ensure that all its values are in 
+   * TheoryModel::d_rep_set.
    * 
    * Returns true if the initialization was complete,
    * in that the set for tn in TheoryModel::d_rep_set 

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -54,33 +54,39 @@ class FirstOrderModelAbs;
 struct IsStarAttributeId {};
 typedef expr::Attribute<IsStarAttributeId, bool> IsStarAttribute;
 
-
-/** Quantifiers representative bound 
- * 
+/** Quantifiers representative bound
+ *
  * This class is used for computing (finite)
  * bounds for the domain of a quantifier
  * in the context of a RepSetIterator
  * (see theory/rep_set.h).
  */
-class QRepBoundExt : public RepBoundExt {
+class QRepBoundExt : public RepBoundExt
+{
  public:
-  QRepBoundExt( QuantifiersEngine * qe ) : d_qe( qe ){}
+  QRepBoundExt(QuantifiersEngine* qe) : d_qe(qe) {}
   virtual ~QRepBoundExt() {}
   /** set bound */
-  virtual RepSetIterator::RsiEnumType setBound(Node owner, unsigned i, std::vector< Node >& elements ) override;
+  virtual RepSetIterator::RsiEnumType setBound(
+      Node owner, unsigned i, std::vector<Node>& elements) override;
   /** reset index */
-  virtual bool resetIndex(RepSetIterator * rsi, Node owner, unsigned i, bool initial, std::vector< Node >& elements ) override;
+  virtual bool resetIndex(RepSetIterator* rsi,
+                          Node owner,
+                          unsigned i,
+                          bool initial,
+                          std::vector<Node>& elements) override;
   /** initialize representative set for type */
-  virtual bool initializeRepresentativesForType( TypeNode tn ) override;
+  virtual bool initializeRepresentativesForType(TypeNode tn) override;
   /** get variable order */
-  virtual bool getVariableOrder( Node owner, std::vector< unsigned >& varOrder ) override;
+  virtual bool getVariableOrder(Node owner,
+                                std::vector<unsigned>& varOrder) override;
+
  private:
   /** quantifiers engine associated with this bound */
-  QuantifiersEngine * d_qe;
+  QuantifiersEngine* d_qe;
   /** indices that are bound integer enumeration */
-  std::map< unsigned, bool > d_bound_int;
+  std::map<unsigned, bool> d_bound_int;
 };
-
 
 // TODO (#1301) : document and refactor this class
 class FirstOrderModel : public TheoryModel
@@ -137,23 +143,23 @@ class FirstOrderModel : public TheoryModel
   unsigned getModelBasisArg(Node n);
   /** get some domain element */
   Node getSomeDomainElement(TypeNode tn);
-  /** initialize representative set for type 
-   * 
-   * This ensures that TheoryModel::d_rep_set 
+  /** initialize representative set for type
+   *
+   * This ensures that TheoryModel::d_rep_set
    * is initialized for type tn. In particular:
    * (1) If tn is an uninitialized (unconstrained)
    * uninterpreted sort, then we interpret it
    * as a set of size one,
    * (2) If tn is a "small" enumerable finite type,
-   * then we ensure that all its values are in 
+   * then we ensure that all its values are in
    * TheoryModel::d_rep_set.
-   * 
+   *
    * Returns true if the initialization was complete,
-   * in that the set for tn in TheoryModel::d_rep_set 
+   * in that the set for tn in TheoryModel::d_rep_set
    * has all representatives of type tn.
    */
   bool initializeRepresentativesForType(TypeNode tn);
-  
+
  protected:
   /** quant engine */
   QuantifiersEngine* d_qe;

--- a/src/theory/quantifiers/full_model_check.cpp
+++ b/src/theory/quantifiers/full_model_check.cpp
@@ -748,10 +748,10 @@ int FullModelChecker::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, i
 }
 
 /** Representative bound fmc entry
- * 
+ *
  * This bound information corresponds to one
  * entry in a term definition (see terminology in
- * Chapter 5 of Finite Model Finding for 
+ * Chapter 5 of Finite Model Finding for
  * Satisfiability Modulo Theories thesis).
  * For example, a term definition for the body
  * of a quantified formula:
@@ -763,36 +763,43 @@ int FullModelChecker::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, i
  * Indicating that the quantified formula evaluates
  * to true in the current model for x=0, y=0, z=0,
  * or y=1, z=2 for any x, and evaluates to false
- * otherwise. 
+ * otherwise.
  * This class is used if we wish
  * to iterate over all values corresponding to one
  * of these entries. For example, for the second entry:
  *   (*, 1, 2 )
- * we iterate over all values of x, but only {1} 
+ * we iterate over all values of x, but only {1}
  * for y and {2} for z.
  */
-class RepBoundFmcEntry : public QRepBoundExt {
-public:
-  RepBoundFmcEntry(QuantifiersEngine * qe, Node e, FirstOrderModelFmc * f) : QRepBoundExt(qe), d_entry(e), d_fm(f){}
-  ~RepBoundFmcEntry(){}
+class RepBoundFmcEntry : public QRepBoundExt
+{
+ public:
+  RepBoundFmcEntry(QuantifiersEngine* qe, Node e, FirstOrderModelFmc* f)
+      : QRepBoundExt(qe), d_entry(e), d_fm(f)
+  {
+  }
+  ~RepBoundFmcEntry() {}
   /** set bound */
-  virtual RepSetIterator::RsiEnumType setBound(Node owner, unsigned i, std::vector< Node >& elements ) override {
+  virtual RepSetIterator::RsiEnumType setBound(
+      Node owner, unsigned i, std::vector<Node>& elements) override
+  {
     if( d_fm->isInterval(d_entry[i]) ){
-      //explicitly add the interval?
+      // explicitly add the interval?
     }else if( d_fm->isStar(d_entry[i]) ){
-      //must add the full range
+      // must add the full range
     }else{
       //only need to consider the single point
       elements.push_back( d_entry[i] );
       return RepSetIterator::ENUM_DEFAULT;
     }
-    return QRepBoundExt::setBound( owner, i, elements );
+    return QRepBoundExt::setBound(owner, i, elements);
   }
-private:
+
+ private:
   /** the entry for this bound */
   Node d_entry;
   /** the model builder associated with this bound */
-  FirstOrderModelFmc * d_fm;
+  FirstOrderModelFmc* d_fm;
 };
 
 bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, Node c, int c_index) {
@@ -800,10 +807,11 @@ bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, No
   debugPrintCond("fmc-exh", c, true);
   Trace("fmc-exh")<< std::endl;
   RepBoundFmcEntry rbfe(d_qe, c, fm);
-  RepSetIterator riter( d_qe->getModel()->getRepSet(), &rbfe );
+  RepSetIterator riter(d_qe->getModel()->getRepSet(), &rbfe);
   Trace("fmc-exh-debug") << "Set quantifier..." << std::endl;
   //initialize
-  if( riter.setQuantifier( f ) ){
+  if (riter.setQuantifier(f))
+  {
     Trace("fmc-exh-debug") << "Set element domains..." << std::endl;
     int addedLemmas = 0;
     //now do full iteration
@@ -812,7 +820,8 @@ bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, No
       Trace("fmc-exh-debug") << "Inst : ";
       std::vector< Node > ev_inst;
       std::vector< Node > inst;
-      for( unsigned i=0; i<riter.getNumTerms(); i++ ){
+      for (unsigned i = 0; i < riter.getNumTerms(); i++)
+      {
         Node rr = riter.getCurrentTerm( i );
         Node r = rr;
         //if( r.getType().isSort() ){
@@ -849,7 +858,7 @@ bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, No
       if( !riter.isFinished() ){
         if (index>=0 && riter.d_index[index]>0 && addedLemmas>0 && riter.d_enum_type[index]==RepSetIterator::ENUM_BOUND_INT ) {
           Trace("fmc-exh-debug") << "Since this is a range enumeration, skip to the next..." << std::endl;
-          riter.incrementAtIndex( index-1 );
+          riter.incrementAtIndex(index - 1);
         }
       }
     }

--- a/src/theory/quantifiers/full_model_check.cpp
+++ b/src/theory/quantifiers/full_model_check.cpp
@@ -757,12 +757,12 @@ int FullModelChecker::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, i
  * of a quantified formula:
  *   forall xyz. P( x, y, z )
  * may be:
- *   ( 0, 0, 0 ) -> true
- *   ( *, 1, 2 ) -> true
- *   ( *, *, * ) -> false
+ *   ( 0, 0, 0 ) -> false
+ *   ( *, 1, 2 ) -> false
+ *   ( *, *, * ) -> true
  * Indicating that the quantified formula evaluates
- * to true in the current model for x=0, y=0, z=0,
- * or y=1, z=2 for any x, and evaluates to false
+ * to false in the current model for x=0, y=0, z=0,
+ * or y=1, z=2 for any x, and evaluates to true
  * otherwise.
  * This class is used if we wish
  * to iterate over all values corresponding to one
@@ -783,16 +783,16 @@ class RepBoundFmcEntry : public QRepBoundExt
   virtual RepSetIterator::RsiEnumType setBound(
       Node owner, unsigned i, std::vector<Node>& elements) override
   {
-    if( d_fm->isInterval(d_entry[i]) ){
-      // explicitly add the interval?
-    }else if( d_fm->isStar(d_entry[i]) ){
-      // must add the full range
-    }else{
-      //only need to consider the single point
-      elements.push_back( d_entry[i] );
-      return RepSetIterator::ENUM_DEFAULT;
-    }
-    return QRepBoundExt::setBound(owner, i, elements);
+  if( d_fm->isInterval(d_entry[i]) ){
+    // explicitly add the interval?
+  }else if( d_fm->isStar(d_entry[i]) ){
+    // must add the full range
+  }else{
+    //only need to consider the single point
+    elements.push_back( d_entry[i] );
+    return RepSetIterator::ENUM_DEFAULT;
+  }
+  return QRepBoundExt::setBound(owner, i, elements);
   }
 
  private:

--- a/src/theory/quantifiers/full_model_check.cpp
+++ b/src/theory/quantifiers/full_model_check.cpp
@@ -783,16 +783,21 @@ class RepBoundFmcEntry : public QRepBoundExt
   virtual RepSetIterator::RsiEnumType setBound(
       Node owner, unsigned i, std::vector<Node>& elements) override
   {
-  if( d_fm->isInterval(d_entry[i]) ){
-    // explicitly add the interval?
-  }else if( d_fm->isStar(d_entry[i]) ){
-    // must add the full range
-  }else{
-    //only need to consider the single point
-    elements.push_back( d_entry[i] );
-    return RepSetIterator::ENUM_DEFAULT;
-  }
-  return QRepBoundExt::setBound(owner, i, elements);
+    if (d_fm->isInterval(d_entry[i]))
+    {
+      // explicitly add the interval?
+    }
+    else if (d_fm->isStar(d_entry[i]))
+    {
+      // must add the full range
+    }
+    else
+    {
+      // only need to consider the single point
+      elements.push_back(d_entry[i]);
+      return RepSetIterator::ENUM_DEFAULT;
+    }
+    return QRepBoundExt::setBound(owner, i, elements);
   }
 
  private:

--- a/src/theory/quantifiers/full_model_check.cpp
+++ b/src/theory/quantifiers/full_model_check.cpp
@@ -750,8 +750,26 @@ int FullModelChecker::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, i
 /** Representative bound fmc entry
  * 
  * This bound information corresponds to one
- * entry in a definition.
- * TODO
+ * entry in a term definition (see terminology in
+ * Chapter 5 of Finite Model Finding for 
+ * Satisfiability Modulo Theories thesis).
+ * For example, a term definition for the body
+ * of a quantified formula:
+ *   forall xyz. P( x, y, z )
+ * may be:
+ *   ( 0, 0, 0 ) -> true
+ *   ( *, 1, 2 ) -> true
+ *   ( *, *, * ) -> false
+ * Indicating that the quantified formula evaluates
+ * to true in the current model for x=0, y=0, z=0,
+ * or y=1, z=2 for any x, and evaluates to false
+ * otherwise. 
+ * This class is used if we wish
+ * to iterate over all values corresponding to one
+ * of these entries. For example, for the second entry:
+ *   (*, 1, 2 )
+ * we iterate over all values of x, but only {1} 
+ * for y and {2} for z.
  */
 class RepBoundFmcEntry : public QRepBoundExt {
 public:

--- a/src/theory/quantifiers/full_model_check.cpp
+++ b/src/theory/quantifiers/full_model_check.cpp
@@ -747,36 +747,45 @@ int FullModelChecker::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, i
   }
 }
 
-class RepBoundFmcEntry : public RepBoundExt {
+/** Representative bound fmc entry
+ * 
+ * This bound information corresponds to one
+ * entry in a definition.
+ * TODO
+ */
+class RepBoundFmcEntry : public QRepBoundExt {
 public:
-  Node d_entry;
-  FirstOrderModelFmc * d_fm;
-  bool setBound( Node owner, int i, TypeNode tn, std::vector< Node >& elements ) {
+  RepBoundFmcEntry(QuantifiersEngine * qe, Node e, FirstOrderModelFmc * f) : QRepBoundExt(qe), d_entry(e), d_fm(f){}
+  ~RepBoundFmcEntry(){}
+  /** set bound */
+  virtual RepSetIterator::RsiEnumType setBound(Node owner, unsigned i, std::vector< Node >& elements ) override {
     if( d_fm->isInterval(d_entry[i]) ){
-      //explicitly add the interval TODO?
+      //explicitly add the interval?
     }else if( d_fm->isStar(d_entry[i]) ){
-      //add the full range
-      return false;
+      //must add the full range
     }else{
       //only need to consider the single point
       elements.push_back( d_entry[i] );
-      return true;
+      return RepSetIterator::ENUM_DEFAULT;
     }
-    return false;
+    return QRepBoundExt::setBound( owner, i, elements );
   }
+private:
+  /** the entry for this bound */
+  Node d_entry;
+  /** the model builder associated with this bound */
+  FirstOrderModelFmc * d_fm;
 };
 
 bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, Node c, int c_index) {
-  RepSetIterator riter( d_qe );
   Trace("fmc-exh") << "----Exhaustive instantiate based on index " << c_index << " : " << c << " ";
   debugPrintCond("fmc-exh", c, true);
   Trace("fmc-exh")<< std::endl;
-  RepBoundFmcEntry rbfe;
-  rbfe.d_entry = c;
-  rbfe.d_fm = fm;
+  RepBoundFmcEntry rbfe(d_qe, c, fm);
+  RepSetIterator riter( d_qe->getModel()->getRepSet(), &rbfe );
   Trace("fmc-exh-debug") << "Set quantifier..." << std::endl;
   //initialize
-  if( riter.setQuantifier( f, &rbfe ) ){
+  if( riter.setQuantifier( f ) ){
     Trace("fmc-exh-debug") << "Set element domains..." << std::endl;
     int addedLemmas = 0;
     //now do full iteration
@@ -785,7 +794,7 @@ bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, No
       Trace("fmc-exh-debug") << "Inst : ";
       std::vector< Node > ev_inst;
       std::vector< Node > inst;
-      for( int i=0; i<riter.getNumTerms(); i++ ){
+      for( unsigned i=0; i<riter.getNumTerms(); i++ ){
         Node rr = riter.getCurrentTerm( i );
         Node r = rr;
         //if( r.getType().isSort() ){
@@ -822,7 +831,7 @@ bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, No
       if( !riter.isFinished() ){
         if (index>=0 && riter.d_index[index]>0 && addedLemmas>0 && riter.d_enum_type[index]==RepSetIterator::ENUM_BOUND_INT ) {
           Trace("fmc-exh-debug") << "Since this is a range enumeration, skip to the next..." << std::endl;
-          riter.increment2( index-1 );
+          riter.incrementAtIndex( index-1 );
         }
       }
     }

--- a/src/theory/quantifiers/full_model_check.cpp
+++ b/src/theory/quantifiers/full_model_check.cpp
@@ -767,7 +767,7 @@ public:
 };
 
 bool FullModelChecker::exhaustiveInstantiate(FirstOrderModelFmc * fm, Node f, Node c, int c_index) {
-  RepSetIterator riter( d_qe, &(fm->d_rep_set) );
+  RepSetIterator riter( d_qe );
   Trace("fmc-exh") << "----Exhaustive instantiate based on index " << c_index << " : " << c << " ";
   debugPrintCond("fmc-exh", c, true);
   Trace("fmc-exh")<< std::endl;

--- a/src/theory/quantifiers/model_builder.cpp
+++ b/src/theory/quantifiers/model_builder.cpp
@@ -109,12 +109,13 @@ void QModelBuilder::debugModel( TheoryModel* m ){
         vars.push_back( f[0][j] );
       }
       QRepBoundExt qrbe(d_qe);
-      RepSetIterator riter(d_qe->getModel()->getRepSet(),&qrbe);
+      RepSetIterator riter(d_qe->getModel()->getRepSet(), &qrbe);
       if( riter.setQuantifier( f ) ){
         while( !riter.isFinished() ){
           tests++;
           std::vector< Node > terms;
-          for( unsigned k=0; k<riter.getNumTerms(); k++ ){
+          for (unsigned k = 0; k < riter.getNumTerms(); k++)
+          {
             terms.push_back( riter.getCurrentTerm( k ) );
           }
           Node n = d_qe->getInstantiation( f, vars, terms );
@@ -421,7 +422,7 @@ QModelBuilderIG::Statistics::~Statistics(){
 int QModelBuilderIG::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, int effort ) {
   if( optUseModel() ){
     QRepBoundExt qrbe(d_qe);
-    RepSetIterator riter(d_qe->getModel()->getRepSet(),&qrbe);
+    RepSetIterator riter(d_qe->getModel()->getRepSet(), &qrbe);
     if( riter.setQuantifier( f ) ){
       FirstOrderModelIG * fmig = (FirstOrderModelIG*)d_qe->getModel();
       Debug("inst-fmf-ei") << "Reset evaluate..." << std::endl;
@@ -454,11 +455,12 @@ int QModelBuilderIG::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, in
         }
         if( eval==1 ){
           //instantiation is already true -> skip
-          riter.incrementAtIndex( depIndex );
+          riter.incrementAtIndex(depIndex);
         }else{
           //instantiation was not shown to be true, construct the match
           InstMatch m( f );
-          for( unsigned i=0; i<riter.getNumTerms(); i++ ){
+          for (unsigned i = 0; i < riter.getNumTerms(); i++)
+          {
             m.set( d_qe, i, riter.getCurrentTerm( i ) );
           }
           Debug("fmf-model-eval") << "* Add instantiation " << m << std::endl;
@@ -470,7 +472,7 @@ int QModelBuilderIG::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, in
             }
             //if the instantiation is show to be false, and we wish to skip multiple instantiations at once
             if( eval==-1 ){
-              riter.incrementAtIndex( depIndex );
+              riter.incrementAtIndex(depIndex);
             }else{
               riter.increment();
             }

--- a/src/theory/quantifiers/model_builder.cpp
+++ b/src/theory/quantifiers/model_builder.cpp
@@ -108,12 +108,13 @@ void QModelBuilder::debugModel( TheoryModel* m ){
       for( unsigned j=0; j<f[0].getNumChildren(); j++ ){
         vars.push_back( f[0][j] );
       }
-      RepSetIterator riter(d_qe);
+      QRepBoundExt qrbe(d_qe);
+      RepSetIterator riter(d_qe->getModel()->getRepSet(),&qrbe);
       if( riter.setQuantifier( f ) ){
         while( !riter.isFinished() ){
           tests++;
           std::vector< Node > terms;
-          for( int k=0; k<riter.getNumTerms(); k++ ){
+          for( unsigned k=0; k<riter.getNumTerms(); k++ ){
             terms.push_back( riter.getCurrentTerm( k ) );
           }
           Node n = d_qe->getInstantiation( f, vars, terms );
@@ -419,7 +420,8 @@ QModelBuilderIG::Statistics::~Statistics(){
 //do exhaustive instantiation
 int QModelBuilderIG::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, int effort ) {
   if( optUseModel() ){
-    RepSetIterator riter(d_qe);
+    QRepBoundExt qrbe(d_qe);
+    RepSetIterator riter(d_qe->getModel()->getRepSet(),&qrbe);
     if( riter.setQuantifier( f ) ){
       FirstOrderModelIG * fmig = (FirstOrderModelIG*)d_qe->getModel();
       Debug("inst-fmf-ei") << "Reset evaluate..." << std::endl;
@@ -452,11 +454,11 @@ int QModelBuilderIG::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, in
         }
         if( eval==1 ){
           //instantiation is already true -> skip
-          riter.increment2( depIndex );
+          riter.incrementAtIndex( depIndex );
         }else{
           //instantiation was not shown to be true, construct the match
           InstMatch m( f );
-          for( int i=0; i<riter.getNumTerms(); i++ ){
+          for( unsigned i=0; i<riter.getNumTerms(); i++ ){
             m.set( d_qe, i, riter.getCurrentTerm( i ) );
           }
           Debug("fmf-model-eval") << "* Add instantiation " << m << std::endl;
@@ -468,7 +470,7 @@ int QModelBuilderIG::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, in
             }
             //if the instantiation is show to be false, and we wish to skip multiple instantiations at once
             if( eval==-1 ){
-              riter.increment2( depIndex );
+              riter.incrementAtIndex( depIndex );
             }else{
               riter.increment();
             }

--- a/src/theory/quantifiers/model_builder.cpp
+++ b/src/theory/quantifiers/model_builder.cpp
@@ -108,7 +108,7 @@ void QModelBuilder::debugModel( TheoryModel* m ){
       for( unsigned j=0; j<f[0].getNumChildren(); j++ ){
         vars.push_back( f[0][j] );
       }
-      RepSetIterator riter(d_qe, fm->getRepSetPtr());
+      RepSetIterator riter(d_qe);
       if( riter.setQuantifier( f ) ){
         while( !riter.isFinished() ){
           tests++;
@@ -419,7 +419,7 @@ QModelBuilderIG::Statistics::~Statistics(){
 //do exhaustive instantiation
 int QModelBuilderIG::doExhaustiveInstantiation( FirstOrderModel * fm, Node f, int effort ) {
   if( optUseModel() ){
-    RepSetIterator riter(d_qe, d_qe->getModel()->getRepSetPtr());
+    RepSetIterator riter(d_qe);
     if( riter.setQuantifier( f ) ){
       FirstOrderModelIG * fmig = (FirstOrderModelIG*)d_qe->getModel();
       Debug("inst-fmf-ei") << "Reset evaluate..." << std::endl;

--- a/src/theory/quantifiers/model_engine.cpp
+++ b/src/theory/quantifiers/model_engine.cpp
@@ -277,7 +277,8 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
       Trace("fmf-exh-inst-debug") << std::endl;
     }
     //create a rep set iterator and iterate over the (relevant) domain of the quantifier
-    RepSetIterator riter(d_quantEngine);
+    QRepBoundExt qrbe(d_quantEngine);
+    RepSetIterator riter(d_quantEngine->getModel()->getRepSet(),&qrbe);
     if( riter.setQuantifier( f ) ){
       Trace("fmf-exh-inst") << "...exhaustive instantiation set, incomplete=" << riter.isIncomplete() << "..." << std::endl;
       if( !riter.isIncomplete() ){
@@ -286,7 +287,7 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
         while( !riter.isFinished() && ( addedLemmas==0 || !options::fmfOneInstPerRound() ) ){
           //instantiation was not shown to be true, construct the match
           InstMatch m( f );
-          for( int i=0; i<riter.getNumTerms(); i++ ){
+          for( unsigned i=0; i<riter.getNumTerms(); i++ ){
             m.set( d_quantEngine, i, riter.getCurrentTerm( i ) );
           }
           Debug("fmf-model-eval") << "* Add instantiation " << m << std::endl;

--- a/src/theory/quantifiers/model_engine.cpp
+++ b/src/theory/quantifiers/model_engine.cpp
@@ -277,8 +277,7 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
       Trace("fmf-exh-inst-debug") << std::endl;
     }
     //create a rep set iterator and iterate over the (relevant) domain of the quantifier
-    RepSetIterator riter(d_quantEngine,
-                         d_quantEngine->getModel()->getRepSetPtr());
+    RepSetIterator riter(d_quantEngine);
     if( riter.setQuantifier( f ) ){
       Trace("fmf-exh-inst") << "...exhaustive instantiation set, incomplete=" << riter.isIncomplete() << "..." << std::endl;
       if( !riter.isIncomplete() ){

--- a/src/theory/quantifiers/model_engine.cpp
+++ b/src/theory/quantifiers/model_engine.cpp
@@ -278,7 +278,7 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
     }
     //create a rep set iterator and iterate over the (relevant) domain of the quantifier
     QRepBoundExt qrbe(d_quantEngine);
-    RepSetIterator riter(d_quantEngine->getModel()->getRepSet(),&qrbe);
+    RepSetIterator riter(d_quantEngine->getModel()->getRepSet(), &qrbe);
     if( riter.setQuantifier( f ) ){
       Trace("fmf-exh-inst") << "...exhaustive instantiation set, incomplete=" << riter.isIncomplete() << "..." << std::endl;
       if( !riter.isIncomplete() ){
@@ -287,7 +287,8 @@ void ModelEngine::exhaustiveInstantiate( Node f, int effort ){
         while( !riter.isFinished() && ( addedLemmas==0 || !options::fmfOneInstPerRound() ) ){
           //instantiation was not shown to be true, construct the match
           InstMatch m( f );
-          for( unsigned i=0; i<riter.getNumTerms(); i++ ){
+          for (unsigned i = 0; i < riter.getNumTerms(); i++)
+          {
             m.set( d_quantEngine, i, riter.getCurrentTerm( i ) );
           }
           Debug("fmf-model-eval") << "* Add instantiation " << m << std::endl;

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -22,7 +22,7 @@ using namespace CVC4::kind;
 
 namespace CVC4 {
 namespace theory {
-  
+
 void RepSet::clear(){
   d_type_reps.clear();
   d_type_complete.clear();
@@ -60,12 +60,12 @@ Node RepSet::getRepresentative(TypeNode tn, unsigned i) const
   return it->second[i];
 }
 
-void RepSet::getRepresentatives(TypeNode tn, std::vector< Node >& reps ) const 
+void RepSet::getRepresentatives(TypeNode tn, std::vector<Node>& reps) const
 {
   std::map<TypeNode, std::vector<Node> >::const_iterator it =
       d_type_reps.find(tn);
-  Assert( it!=d_type_reps.end() );
-  reps.insert( reps.end(), it->second.begin(), it->second.end() );
+  Assert(it != d_type_reps.end());
+  reps.insert(reps.end(), it->second.begin(), it->second.end());
 }
 
 bool containsStoreAll(Node n, std::unordered_set<Node, NodeHashFunction>& cache)
@@ -188,28 +188,33 @@ void RepSet::toStream(std::ostream& out){
   }
 }
 
-
-RepSetIterator::RepSetIterator( const RepSet * rs, RepBoundExt * rext ) : d_rs(rs), d_rext(rext){
+RepSetIterator::RepSetIterator(const RepSet* rs, RepBoundExt* rext)
+    : d_rs(rs), d_rext(rext)
+{
   d_incomplete = false;
 }
 
-unsigned RepSetIterator::domainSize( unsigned i ) {
+unsigned RepSetIterator::domainSize(unsigned i)
+{
   unsigned v = d_var_order[i];
   return d_domain_elements[v].size();
 }
 
-bool RepSetIterator::setQuantifier( Node q){
+bool RepSetIterator::setQuantifier(Node q)
+{
   Trace("rsi") << "Make rsi for quantified formula " << q << std::endl;
   Assert( d_types.empty() );
   //store indicies
-  for( size_t i=0; i<q[0].getNumChildren(); i++ ){
-    d_types.push_back( q[0][i].getType() );
+  for (size_t i = 0; i < q[0].getNumChildren(); i++)
+  {
+    d_types.push_back(q[0][i].getType());
   }
   d_owner = q;
   return initialize();
 }
 
-bool RepSetIterator::setFunctionDomain( Node op ){
+bool RepSetIterator::setFunctionDomain(Node op)
+{
   Trace("rsi") << "Make rsi for function " << op << std::endl;
   Assert( d_types.empty() );
   TypeNode tn = op.getType();
@@ -220,7 +225,8 @@ bool RepSetIterator::setFunctionDomain( Node op ){
   return initialize();
 }
 
-bool RepSetIterator::initialize(){
+bool RepSetIterator::initialize()
+{
   Trace("rsi") << "Initialize rep set iterator..." << std::endl;
   for( unsigned v=0; v<d_types.size(); v++ ){
     d_index.push_back( 0 );
@@ -235,23 +241,29 @@ bool RepSetIterator::initialize(){
     bool inc = true;
     bool setEnum = false;
     //check if it is externally bound
-    if( d_rext ){
-      inc = !d_rext->initializeRepresentativesForType( tn );
-      RsiEnumType rsiet = d_rext->setBound( d_owner, v, d_domain_elements[v] );
-      if( rsiet!=ENUM_INVALID ){
+    if (d_rext)
+    {
+      inc = !d_rext->initializeRepresentativesForType(tn);
+      RsiEnumType rsiet = d_rext->setBound(d_owner, v, d_domain_elements[v]);
+      if (rsiet != ENUM_INVALID)
+      {
         d_enum_type.push_back(rsiet);
         inc = false;
         setEnum = true;
       }
     }
-    if( inc ){
-      Trace("fmf-incomplete") << "Incomplete because of quantification of type " << tn << std::endl;
+    if (inc)
+    {
+      Trace("fmf-incomplete") << "Incomplete because of quantification of type "
+                              << tn << std::endl;
       d_incomplete = true;
     }
 
     //if we have yet to determine the type of enumeration
-    if( !setEnum ){
-      if( d_rs->hasType( tn ) ){
+    if (!setEnum)
+    {
+      if (d_rs->hasType(tn))
+      {
         d_enum_type.push_back( ENUM_DEFAULT );
         d_rs->getRepresentatives(tn, d_domain_elements[v]);
       }else{
@@ -260,26 +272,31 @@ bool RepSetIterator::initialize(){
       }
     }
   }
-  
-  if( d_rext ){
-    std::vector< unsigned > varOrder;
-    if( d_rext->getVariableOrder( d_owner, varOrder ) ){
+
+  if (d_rext)
+  {
+    std::vector<unsigned> varOrder;
+    if (d_rext->getVariableOrder(d_owner, varOrder))
+    {
       Trace("bound-int-rsi") << "Variable order : ";
-      for( unsigned i=0; i<varOrder.size(); i++) {
+      for (unsigned i = 0; i < varOrder.size(); i++)
+      {
         Trace("bound-int-rsi") << varOrder[i] << " ";
       }
       Trace("bound-int-rsi") << std::endl;
-      std::vector< unsigned > indexOrder;
+      std::vector<unsigned> indexOrder;
       indexOrder.resize(varOrder.size());
-      for( unsigned i=0; i<varOrder.size(); i++){
+      for (unsigned i = 0; i < varOrder.size(); i++)
+      {
         indexOrder[varOrder[i]] = i;
       }
       Trace("bound-int-rsi") << "Will use index order : ";
-      for( unsigned i=0; i<indexOrder.size(); i++) {
+      for (unsigned i = 0; i < indexOrder.size(); i++)
+      {
         Trace("bound-int-rsi") << indexOrder[i] << " ";
       }
       Trace("bound-int-rsi") << std::endl;
-      setIndexOrder( indexOrder );
+      setIndexOrder(indexOrder);
     }
   }
   //now reset the indices
@@ -287,7 +304,8 @@ bool RepSetIterator::initialize(){
   return true;
 }
 
-void RepSetIterator::setIndexOrder( std::vector< unsigned >& indexOrder ){
+void RepSetIterator::setIndexOrder(std::vector<unsigned>& indexOrder)
+{
   d_index_order.clear();
   d_index_order.insert( d_index_order.begin(), indexOrder.begin(), indexOrder.end() );
   //make the d_var_order mapping
@@ -296,19 +314,23 @@ void RepSetIterator::setIndexOrder( std::vector< unsigned >& indexOrder ){
   }
 }
 
-int RepSetIterator::resetIndex( unsigned i, bool initial ) {
+int RepSetIterator::resetIndex(unsigned i, bool initial)
+{
   d_index[i] = 0;
   unsigned v = d_var_order[i];
   Trace("bound-int-rsi") << "Reset " << i << ", var order = " << v << ", initial = " << initial << std::endl;
-  if( d_rext ){
-    if( !d_rext->resetIndex(this, d_owner, v, initial, d_domain_elements[v]) ){
+  if (d_rext)
+  {
+    if (!d_rext->resetIndex(this, d_owner, v, initial, d_domain_elements[v]))
+    {
       return -1;
     }
   }
   return d_domain_elements[v].empty() ? 0 : 1;
 }
 
-int RepSetIterator::incrementAtIndex( int i ){
+int RepSetIterator::incrementAtIndex(int i)
+{
   Assert( !isFinished() );
 #ifdef DISABLE_EVAL_SKIP_MULTIPLE
   i = (int)d_index.size()-1;
@@ -360,26 +382,26 @@ int RepSetIterator::do_reset_increment( int i, bool initial ) {
 
 int RepSetIterator::increment(){
   if( !isFinished() ){
-    return incrementAtIndex( d_index.size()-1 );
+    return incrementAtIndex(d_index.size() - 1);
   }else{
     return -1;
   }
 }
 
-bool RepSetIterator::isFinished() const{
-  return d_index.empty();
-}
-
-Node RepSetIterator::getCurrentTerm( unsigned v, bool valTerm ){
+bool RepSetIterator::isFinished() const { return d_index.empty(); }
+Node RepSetIterator::getCurrentTerm(unsigned v, bool valTerm)
+{
   unsigned ii = d_index_order[v];
   unsigned curr = d_index[ii];
   Trace("rsi-debug") << "rsi : get term " << v << ", index order = " << d_index_order[v] << std::endl;
   Trace("rsi-debug") << "rsi : curr = " << curr << " / " << d_domain_elements[v].size() << std::endl;
-  Assert( 0<=curr && curr<d_domain_elements[v].size() );
+  Assert(0 <= curr && curr < d_domain_elements[v].size());
   Node t = d_domain_elements[v][curr];
-  if( valTerm ){
-    Node tt = d_rs->getTermForRepresentative( t );
-    if( !tt.isNull() ){
+  if (valTerm)
+  {
+    Node tt = d_rs->getTermForRepresentative(t);
+    if (!tt.isNull())
+    {
       return tt;
     }
   }
@@ -400,6 +422,5 @@ void RepSetIterator::debugPrintSmall( const char* c ){
   Debug( c ) << std::endl;
 }
 
-}/* CVC4::theory namespace */
-}/* CVC4 namespace */
-
+} /* CVC4::theory namespace */
+} /* CVC4 namespace */

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -189,9 +189,9 @@ void RepSet::toStream(std::ostream& out){
 }
 
 RepSetIterator::RepSetIterator(const RepSet* rs, RepBoundExt* rext)
-    : d_rs(rs), d_rext(rext)
+    : d_rs(rs), d_rext(rext), d_incomplete(false)
 {
-  d_incomplete = false;
+
 }
 
 unsigned RepSetIterator::domainSize(unsigned i)
@@ -278,24 +278,29 @@ bool RepSetIterator::initialize()
     std::vector<unsigned> varOrder;
     if (d_rext->getVariableOrder(d_owner, varOrder))
     {
-      Trace("bound-int-rsi") << "Variable order : ";
-      for (unsigned i = 0; i < varOrder.size(); i++)
-      {
-        Trace("bound-int-rsi") << varOrder[i] << " ";
+      if(Trace.isOn("bound-int-rsi")){
+        Trace("bound-int-rsi") << "Variable order : ";
+        for (unsigned i = 0; i < varOrder.size(); i++)
+        {
+          Trace("bound-int-rsi") << varOrder[i] << " ";
+        }
+        Trace("bound-int-rsi") << std::endl;
       }
-      Trace("bound-int-rsi") << std::endl;
       std::vector<unsigned> indexOrder;
       indexOrder.resize(varOrder.size());
       for (unsigned i = 0; i < varOrder.size(); i++)
       {
+        Assert(varOrder[i]<indexOrder.size());
         indexOrder[varOrder[i]] = i;
       }
-      Trace("bound-int-rsi") << "Will use index order : ";
-      for (unsigned i = 0; i < indexOrder.size(); i++)
-      {
-        Trace("bound-int-rsi") << indexOrder[i] << " ";
+      if(Trace.isOn("bound-int-rsi")){
+        Trace("bound-int-rsi") << "Will use index order : ";
+        for (unsigned i = 0; i < indexOrder.size(); i++)
+        {
+          Trace("bound-int-rsi") << indexOrder[i] << " ";
+        }
+        Trace("bound-int-rsi") << std::endl;
       }
-      Trace("bound-int-rsi") << std::endl;
       setIndexOrder(indexOrder);
     }
   }

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -193,8 +193,7 @@ RepSetIterator::RepSetIterator( const RepSet * rs, RepBoundExt * rext ) : d_rs(r
   d_incomplete = false;
 }
 
-int RepSetIterator::domainSize( int i ) {
-  Assert(i>=0);
+unsigned RepSetIterator::domainSize( unsigned i ) {
   unsigned v = d_var_order[i];
   return d_domain_elements[v].size();
 }
@@ -367,7 +366,7 @@ int RepSetIterator::increment(){
   }
 }
 
-bool RepSetIterator::isFinished(){
+bool RepSetIterator::isFinished() const{
   return d_index.empty();
 }
 

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -395,6 +395,7 @@ int RepSetIterator::increment(){
 }
 
 bool RepSetIterator::isFinished() const { return d_index.empty(); }
+
 Node RepSetIterator::getCurrentTerm(unsigned v, bool valTerm)
 {
   unsigned ii = d_index_order[v];

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -191,7 +191,6 @@ void RepSet::toStream(std::ostream& out){
 RepSetIterator::RepSetIterator(const RepSet* rs, RepBoundExt* rext)
     : d_rs(rs), d_rext(rext), d_incomplete(false)
 {
-
 }
 
 unsigned RepSetIterator::domainSize(unsigned i)
@@ -278,7 +277,8 @@ bool RepSetIterator::initialize()
     std::vector<unsigned> varOrder;
     if (d_rext->getVariableOrder(d_owner, varOrder))
     {
-      if(Trace.isOn("bound-int-rsi")){
+      if (Trace.isOn("bound-int-rsi"))
+      {
         Trace("bound-int-rsi") << "Variable order : ";
         for (unsigned i = 0; i < varOrder.size(); i++)
         {
@@ -290,10 +290,11 @@ bool RepSetIterator::initialize()
       indexOrder.resize(varOrder.size());
       for (unsigned i = 0; i < varOrder.size(); i++)
       {
-        Assert(varOrder[i]<indexOrder.size());
+        Assert(varOrder[i] < indexOrder.size());
         indexOrder[varOrder[i]] = i;
       }
-      if(Trace.isOn("bound-int-rsi")){
+      if (Trace.isOn("bound-int-rsi"))
+      {
         Trace("bound-int-rsi") << "Will use index order : ";
         for (unsigned i = 0; i < indexOrder.size(); i++)
         {

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -14,19 +14,15 @@
 
 #include <unordered_set>
 
-#include "theory/quantifiers/bounded_integers.h"
-#include "theory/quantifiers/first_order_model.h"
-#include "theory/quantifiers/term_enumeration.h"
-#include "theory/quantifiers/term_util.h"
 #include "theory/rep_set.h"
 #include "theory/type_enumerator.h"
 
 using namespace std;
-using namespace CVC4;
 using namespace CVC4::kind;
-using namespace CVC4::context;
-using namespace CVC4::theory;
 
+namespace CVC4 {
+namespace theory {
+  
 void RepSet::clear(){
   d_type_reps.clear();
   d_type_complete.clear();
@@ -193,40 +189,39 @@ void RepSet::toStream(std::ostream& out){
 }
 
 
-RepSetIterator::RepSetIterator( QuantifiersEngine * qe ) : d_qe(qe){
+RepSetIterator::RepSetIterator( const RepSet * rs, RepBoundExt * rext ) : d_rs(rs), d_rext(rext){
   d_incomplete = false;
 }
 
 int RepSetIterator::domainSize( int i ) {
   Assert(i>=0);
-  int v = d_var_order[i];
+  unsigned v = d_var_order[i];
   return d_domain_elements[v].size();
 }
 
-bool RepSetIterator::setQuantifier( Node f, RepBoundExt* rext ){
-  Trace("rsi") << "Make rsi for " << f << std::endl;
+bool RepSetIterator::setQuantifier( Node q){
+  Trace("rsi") << "Make rsi for quantified formula " << q << std::endl;
   Assert( d_types.empty() );
   //store indicies
-  for( size_t i=0; i<f[0].getNumChildren(); i++ ){
-    d_types.push_back( f[0][i].getType() );
+  for( size_t i=0; i<q[0].getNumChildren(); i++ ){
+    d_types.push_back( q[0][i].getType() );
   }
-  d_owner = f;
-  return initialize( rext );
+  d_owner = q;
+  return initialize();
 }
 
-bool RepSetIterator::setFunctionDomain( Node op, RepBoundExt* rext ){
-  Trace("rsi") << "Make rsi for " << op << std::endl;
+bool RepSetIterator::setFunctionDomain( Node op ){
+  Trace("rsi") << "Make rsi for function " << op << std::endl;
   Assert( d_types.empty() );
   TypeNode tn = op.getType();
   for( size_t i=0; i<tn.getNumChildren()-1; i++ ){
     d_types.push_back( tn[i] );
   }
   d_owner = op;
-  return initialize( rext );
+  return initialize();
 }
 
-bool RepSetIterator::initialize( RepBoundExt* rext ){
-  RepSet* rs = d_qe->getModel()->getRepSetPtr();
+bool RepSetIterator::initialize(){
   Trace("rsi") << "Initialize rep set iterator..." << std::endl;
   for( unsigned v=0; v<d_types.size(); v++ ){
     d_index.push_back( 0 );
@@ -238,21 +233,16 @@ bool RepSetIterator::initialize( RepBoundExt* rext ){
     d_domain_elements.push_back( std::vector< Node >() );
     TypeNode tn = d_types[v];
     Trace("rsi") << "Var #" << v << " is type " << tn << "..." << std::endl;
-    bool inc = !d_qe->getModel()->initializeRepresentativesForType( tn );
+    bool inc = true;
+    bool setEnum = false;
     //check if it is externally bound
-    if( rext && rext->setBound( d_owner, v, tn, d_domain_elements[v] ) ){
-      d_enum_type.push_back( ENUM_DEFAULT );
-      inc = false;
-    //builtin: check if it is bound by bounded integer module
-    }else if( d_owner.getKind()==FORALL && d_qe && d_qe->getBoundedIntegers() ){
-      if( d_qe->getBoundedIntegers()->isBoundVar( d_owner, d_owner[0][v] ) ){
-        unsigned bvt = d_qe->getBoundedIntegers()->getBoundVarType( d_owner, d_owner[0][v] );
-        if( bvt!=quantifiers::BoundedIntegers::BOUND_FINITE ){
-          d_enum_type.push_back( ENUM_BOUND_INT );
-          inc = false;
-        }else{
-          //will treat in default way
-        }
+    if( d_rext ){
+      inc = !d_rext->initializeRepresentativesForType( tn );
+      RsiEnumType rsiet = d_rext->setBound( d_owner, v, d_domain_elements[v] );
+      if( rsiet!=ENUM_INVALID ){
+        d_enum_type.push_back(rsiet);
+        inc = false;
+        setEnum = true;
       }
     }
     if( inc ){
@@ -261,53 +251,44 @@ bool RepSetIterator::initialize( RepBoundExt* rext ){
     }
 
     //if we have yet to determine the type of enumeration
-    if( d_enum_type.size()<=v ){
-      if( rs->hasType( tn ) ){
+    if( !setEnum ){
+      if( d_rs->hasType( tn ) ){
         d_enum_type.push_back( ENUM_DEFAULT );
-        rs->getRepresentatives(tn, d_domain_elements[v]);
+        d_rs->getRepresentatives(tn, d_domain_elements[v]);
       }else{
         Assert( d_incomplete );
         return false;
       }
     }
   }
-  //must set a variable index order based on bounded integers
-  if( d_owner.getKind()==FORALL && d_qe && d_qe->getBoundedIntegers() ){
-    Trace("bound-int-rsi") << "Calculating variable order..." << std::endl;
-    std::vector< int > varOrder;
-    for( unsigned i=0; i<d_qe->getBoundedIntegers()->getNumBoundVars( d_owner ); i++ ){
-      Node v = d_qe->getBoundedIntegers()->getBoundVar( d_owner, i );
-      Trace("bound-int-rsi") << "  bound var #" << i << " is " << v << std::endl;
-      varOrder.push_back( d_qe->getTermUtil()->getVariableNum( d_owner, v ) );
-    }
-    for( unsigned i=0; i<d_owner[0].getNumChildren(); i++) {
-      if( !d_qe->getBoundedIntegers()->isBoundVar(d_owner, d_owner[0][i])) {
-        varOrder.push_back(i);
+  
+  if( d_rext ){
+    std::vector< unsigned > varOrder;
+    if( d_rext->getVariableOrder( d_owner, varOrder ) ){
+      Trace("bound-int-rsi") << "Variable order : ";
+      for( unsigned i=0; i<varOrder.size(); i++) {
+        Trace("bound-int-rsi") << varOrder[i] << " ";
       }
+      Trace("bound-int-rsi") << std::endl;
+      std::vector< unsigned > indexOrder;
+      indexOrder.resize(varOrder.size());
+      for( unsigned i=0; i<varOrder.size(); i++){
+        indexOrder[varOrder[i]] = i;
+      }
+      Trace("bound-int-rsi") << "Will use index order : ";
+      for( unsigned i=0; i<indexOrder.size(); i++) {
+        Trace("bound-int-rsi") << indexOrder[i] << " ";
+      }
+      Trace("bound-int-rsi") << std::endl;
+      setIndexOrder( indexOrder );
     }
-    Trace("bound-int-rsi") << "Variable order : ";
-    for( unsigned i=0; i<varOrder.size(); i++) {
-      Trace("bound-int-rsi") << varOrder[i] << " ";
-    }
-    Trace("bound-int-rsi") << std::endl;
-    std::vector< int > indexOrder;
-    indexOrder.resize(varOrder.size());
-    for( unsigned i=0; i<varOrder.size(); i++){
-      indexOrder[varOrder[i]] = i;
-    }
-    Trace("bound-int-rsi") << "Will use index order : ";
-    for( unsigned i=0; i<indexOrder.size(); i++) {
-      Trace("bound-int-rsi") << indexOrder[i] << " ";
-    }
-    Trace("bound-int-rsi") << std::endl;
-    setIndexOrder( indexOrder );
   }
   //now reset the indices
   do_reset_increment( -1, true );
   return true;
 }
 
-void RepSetIterator::setIndexOrder( std::vector< int >& indexOrder ){
+void RepSetIterator::setIndexOrder( std::vector< unsigned >& indexOrder ){
   d_index_order.clear();
   d_index_order.insert( d_index_order.begin(), indexOrder.begin(), indexOrder.end() );
   //make the d_var_order mapping
@@ -316,20 +297,19 @@ void RepSetIterator::setIndexOrder( std::vector< int >& indexOrder ){
   }
 }
 
-int RepSetIterator::resetIndex( int i, bool initial ) {
+int RepSetIterator::resetIndex( unsigned i, bool initial ) {
   d_index[i] = 0;
-  int v = d_var_order[i];
+  unsigned v = d_var_order[i];
   Trace("bound-int-rsi") << "Reset " << i << ", var order = " << v << ", initial = " << initial << std::endl;
-  if( d_enum_type[v]==ENUM_BOUND_INT ){
-    Assert( d_owner.getKind()==FORALL );
-    if( !d_qe->getBoundedIntegers()->getBoundElements( this, initial, d_owner, d_owner[0][v], d_domain_elements[v] ) ){
+  if( d_rext ){
+    if( !d_rext->resetIndex(this, d_owner, v, initial, d_domain_elements[v]) ){
       return -1;
     }
   }
   return d_domain_elements[v].empty() ? 0 : 1;
 }
 
-int RepSetIterator::increment2( int i ){
+int RepSetIterator::incrementAtIndex( int i ){
   Assert( !isFinished() );
 #ifdef DISABLE_EVAL_SKIP_MULTIPLE
   i = (int)d_index.size()-1;
@@ -381,7 +361,7 @@ int RepSetIterator::do_reset_increment( int i, bool initial ) {
 
 int RepSetIterator::increment(){
   if( !isFinished() ){
-    return increment2( (int)d_index.size()-1 );
+    return incrementAtIndex( d_index.size()-1 );
   }else{
     return -1;
   }
@@ -391,15 +371,15 @@ bool RepSetIterator::isFinished(){
   return d_index.empty();
 }
 
-Node RepSetIterator::getCurrentTerm( int v, bool valTerm ){
-  int ii = d_index_order[v];
-  int curr = d_index[ii];
+Node RepSetIterator::getCurrentTerm( unsigned v, bool valTerm ){
+  unsigned ii = d_index_order[v];
+  unsigned curr = d_index[ii];
   Trace("rsi-debug") << "rsi : get term " << v << ", index order = " << d_index_order[v] << std::endl;
   Trace("rsi-debug") << "rsi : curr = " << curr << " / " << d_domain_elements[v].size() << std::endl;
-  Assert( 0<=curr && curr<(int)d_domain_elements[v].size() );
+  Assert( 0<=curr && curr<d_domain_elements[v].size() );
   Node t = d_domain_elements[v][curr];
   if( valTerm ){
-    Node tt = d_qe->getModel()->getRepSet()->getTermForRepresentative( t );
+    Node tt = d_rs->getTermForRepresentative( t );
     if( !tt.isNull() ){
       return tt;
     }
@@ -420,4 +400,7 @@ void RepSetIterator::debugPrintSmall( const char* c ){
   }
   Debug( c ) << std::endl;
 }
+
+}/* CVC4::theory namespace */
+}/* CVC4 namespace */
 

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -120,7 +120,18 @@ class RepBoundExt;
 /** Rep set iterator.
  *
  * This class is used for iterating over (tuples of) terms
- * in the domain(s) of a RepSet.
+ * in the domain(s) of a RepSet. 
+ * 
+ * To use it, first it must 
+ * be initialized with a call to:
+ * - setQuantifier or setFunctionDomain
+ * which initializes the d_owner field and sets up 
+ * initial information.
+ * 
+ * Then, we increment over the tuples of terms in the
+ * domains of the owner of this iterator using:
+ * - increment and incrementAtIndex
+ * 
  */
 class RepSetIterator {
 public:
@@ -138,10 +149,16 @@ public:
   bool setFunctionDomain( Node op );
   /** increment the iterator */
   int increment();
-  /** increment the iterator at index */
+  /** increment the iterator at index 
+   * This increments the i^th field of the 
+   * iterator, for examples, see operator next_i 
+   * in Figure 2 of Reynolds et al. CADE 2013.
+   */
   int incrementAtIndex( int i );
   /** is the iterator finished? */
-  bool isFinished();
+  bool isFinished() const;
+  /** get domain size of the i^th field of this iterator */
+  unsigned domainSize( unsigned i );
   /** get the i_th term we are considering */
   Node getCurrentTerm( unsigned v, bool valTerm = false );
   /** get the number of terms we are considering */
@@ -151,17 +168,16 @@ public:
   /** get variable order, returns index # */
   unsigned getVariableOrder( unsigned i ) { return d_var_order[i]; }
   /** is incomplete 
-   * 
    * Returns true if we only iterating over a strict subset of 
    * the domain of the quantified formula or function
    */
   bool isIncomplete() { return d_incomplete; }
-  /** debug print */
+  /** debug print methods */
   void debugPrint( const char* c );
   void debugPrintSmall( const char* c );
-  /** enumeration type? */
+  /** enumeration type for each field */
   std::vector< RsiEnumType > d_enum_type;
-  /** current tuple we are considering */
+  /** the current tuple we are considering */
   std::vector< int > d_index;
 private:
   /** rep set associated with this iterator */
@@ -174,8 +190,6 @@ private:
   std::vector< std::vector< Node > > d_domain_elements;
   /** initialize */
   bool initialize();
-  /** get domain size of the i^th field of this iterator */
-  int domainSize( int i );
   /** owner 
    * This is the term that we are iterating for, which may either be:
    * (1) a quantified formula, or
@@ -184,12 +198,14 @@ private:
   Node d_owner;
   /** reset index, 1:success, 0:empty, -1:fail */
   int resetIndex( unsigned i, bool initial = false );
-  /** set index order */
+  /** set index order (see below) */
   void setIndexOrder( std::vector< unsigned >& indexOrder );
   /** do reset increment the iterator at index=counter */
   int do_reset_increment( int counter, bool initial = false );
   /** ordering for variables we are iterating over
-  *  for example, given reps = { a, b } and quantifier forall( x, y, z ) P( x, y, z ) with d_index_order = { 2, 0, 1 },
+  *  For example, given reps = { a, b } and quantifier 
+  *    forall( x, y, z ) P( x, y, z )
+  *  with d_index_order = { 2, 0, 1 },
   *    then we consider instantiations in this order:
   *      a/x a/y a/z
   *      a/x b/y a/z
@@ -199,7 +215,7 @@ private:
   */
   std::vector< unsigned > d_index_order;
   /** variables to index they are considered at
-  * for example, if d_index_order = { 2, 0, 1 }
+  * For example, if d_index_order = { 2, 0, 1 }
   *    then d_var_order = { 0 -> 1, 1 -> 2, 2 -> 0 }
   */
   std::map< unsigned, unsigned > d_var_order;  

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -75,7 +75,7 @@ public:
   /** get representative at index */
   Node getRepresentative(TypeNode tn, unsigned i) const;
   /** get representatives of type tn, appends them to reps */
-  void getRepresentatives(TypeNode tn, std::vector< Node >& reps ) const;
+  void getRepresentatives(TypeNode tn, std::vector<Node>& reps) const;
   /** add representative n for type tn, where n has type tn */
   void add( TypeNode tn, Node n );
   /** returns index in d_type_reps for node n */
@@ -120,156 +120,173 @@ class RepBoundExt;
 /** Rep set iterator.
  *
  * This class is used for iterating over (tuples of) terms
- * in the domain(s) of a RepSet. 
- * 
- * To use it, first it must 
+ * in the domain(s) of a RepSet.
+ *
+ * To use it, first it must
  * be initialized with a call to:
  * - setQuantifier or setFunctionDomain
- * which initializes the d_owner field and sets up 
+ * which initializes the d_owner field and sets up
  * initial information.
- * 
+ *
  * Then, we increment over the tuples of terms in the
  * domains of the owner of this iterator using:
  * - increment and incrementAtIndex
- * 
+ *
  */
 class RepSetIterator {
 public:
-  enum RsiEnumType {
-    ENUM_INVALID = 0,
-    ENUM_DEFAULT,
-    ENUM_BOUND_INT,
-  };
+ enum RsiEnumType
+ {
+   ENUM_INVALID = 0,
+   ENUM_DEFAULT,
+   ENUM_BOUND_INT,
+ };
+
 public:
-  RepSetIterator( const RepSet * rs, RepBoundExt * rext );
-  ~RepSetIterator(){}
-  /** set that this iterator will be iterating over instantiations for a quantifier */
-  bool setQuantifier( Node q );
-  /** set that this iterator will be iterating over the domain of a function */
-  bool setFunctionDomain( Node op );
-  /** increment the iterator */
-  int increment();
-  /** increment the iterator at index 
-   * This increments the i^th field of the 
-   * iterator, for examples, see operator next_i 
-   * in Figure 2 of Reynolds et al. CADE 2013.
-   */
-  int incrementAtIndex( int i );
-  /** is the iterator finished? */
-  bool isFinished() const;
-  /** get domain size of the i^th field of this iterator */
-  unsigned domainSize( unsigned i );
-  /** get the i_th term we are considering */
-  Node getCurrentTerm( unsigned v, bool valTerm = false );
-  /** get the number of terms we are considering */
-  unsigned getNumTerms() { return d_index_order.size(); }
-  /** get index order, returns var # */
-  unsigned getIndexOrder( unsigned v ) { return d_index_order[v]; }
-  /** get variable order, returns index # */
-  unsigned getVariableOrder( unsigned i ) { return d_var_order[i]; }
-  /** is incomplete 
-   * Returns true if we only iterating over a strict subset of 
-   * the domain of the quantified formula or function
-   */
-  bool isIncomplete() { return d_incomplete; }
-  /** debug print methods */
-  void debugPrint( const char* c );
-  void debugPrintSmall( const char* c );
-  /** enumeration type for each field */
-  std::vector< RsiEnumType > d_enum_type;
-  /** the current tuple we are considering */
-  std::vector< int > d_index;
+ RepSetIterator(const RepSet* rs, RepBoundExt* rext);
+ ~RepSetIterator() {}
+ /** set that this iterator will be iterating over instantiations for a
+  * quantifier */
+ bool setQuantifier(Node q);
+ /** set that this iterator will be iterating over the domain of a function */
+ bool setFunctionDomain(Node op);
+ /** increment the iterator */
+ int increment();
+ /** increment the iterator at index
+  * This increments the i^th field of the
+  * iterator, for examples, see operator next_i
+  * in Figure 2 of Reynolds et al. CADE 2013.
+  */
+ int incrementAtIndex(int i);
+ /** is the iterator finished? */
+ bool isFinished() const;
+ /** get domain size of the i^th field of this iterator */
+ unsigned domainSize(unsigned i);
+ /** get the i_th term we are considering */
+ Node getCurrentTerm(unsigned v, bool valTerm = false);
+ /** get the number of terms we are considering */
+ unsigned getNumTerms() { return d_index_order.size(); }
+ /** get index order, returns var # */
+ unsigned getIndexOrder(unsigned v) { return d_index_order[v]; }
+ /** get variable order, returns index # */
+ unsigned getVariableOrder(unsigned i) { return d_var_order[i]; }
+ /** is incomplete
+  * Returns true if we only iterating over a strict subset of
+  * the domain of the quantified formula or function
+  */
+ bool isIncomplete() { return d_incomplete; }
+ /** debug print methods */
+ void debugPrint(const char* c);
+ void debugPrintSmall(const char* c);
+ /** enumeration type for each field */
+ std::vector<RsiEnumType> d_enum_type;
+ /** the current tuple we are considering */
+ std::vector<int> d_index;
+
 private:
-  /** rep set associated with this iterator */
-  const RepSet * d_rs;
-  /** rep set external bound information for this iterator */
-  RepBoundExt * d_rext;
-  /** types we are considering */
-  std::vector< TypeNode > d_types;
-  /** for each argument, the domain we are iterating over */
-  std::vector< std::vector< Node > > d_domain_elements;
-  /** initialize */
-  bool initialize();
-  /** owner 
-   * This is the term that we are iterating for, which may either be:
-   * (1) a quantified formula, or
-   * (2) a function.
-   */
-  Node d_owner;
-  /** reset index, 1:success, 0:empty, -1:fail */
-  int resetIndex( unsigned i, bool initial = false );
-  /** set index order (see below) */
-  void setIndexOrder( std::vector< unsigned >& indexOrder );
-  /** do reset increment the iterator at index=counter */
-  int do_reset_increment( int counter, bool initial = false );
-  /** ordering for variables we are iterating over
-  *  For example, given reps = { a, b } and quantifier 
-  *    forall( x, y, z ) P( x, y, z )
-  *  with d_index_order = { 2, 0, 1 },
-  *    then we consider instantiations in this order:
-  *      a/x a/y a/z
-  *      a/x b/y a/z
-  *      b/x a/y a/z
-  *      b/x b/y a/z
-  *      ...
+ /** rep set associated with this iterator */
+ const RepSet* d_rs;
+ /** rep set external bound information for this iterator */
+ RepBoundExt* d_rext;
+ /** types we are considering */
+ std::vector<TypeNode> d_types;
+ /** for each argument, the domain we are iterating over */
+ std::vector<std::vector<Node> > d_domain_elements;
+ /** initialize */
+ bool initialize();
+ /** owner
+  * This is the term that we are iterating for, which may either be:
+  * (1) a quantified formula, or
+  * (2) a function.
   */
-  std::vector< unsigned > d_index_order;
-  /** variables to index they are considered at
-  * For example, if d_index_order = { 2, 0, 1 }
-  *    then d_var_order = { 0 -> 1, 1 -> 2, 2 -> 0 }
-  */
-  std::map< unsigned, unsigned > d_var_order;  
-  /** incomplete flag */
-  bool d_incomplete;
+ Node d_owner;
+ /** reset index, 1:success, 0:empty, -1:fail */
+ int resetIndex(unsigned i, bool initial = false);
+ /** set index order (see below) */
+ void setIndexOrder(std::vector<unsigned>& indexOrder);
+ /** do reset increment the iterator at index=counter */
+ int do_reset_increment(int counter, bool initial = false);
+ /** ordering for variables we are iterating over
+ *  For example, given reps = { a, b } and quantifier
+ *    forall( x, y, z ) P( x, y, z )
+ *  with d_index_order = { 2, 0, 1 },
+ *    then we consider instantiations in this order:
+ *      a/x a/y a/z
+ *      a/x b/y a/z
+ *      b/x a/y a/z
+ *      b/x b/y a/z
+ *      ...
+ */
+ std::vector<unsigned> d_index_order;
+ /** variables to index they are considered at
+ * For example, if d_index_order = { 2, 0, 1 }
+ *    then d_var_order = { 0 -> 1, 1 -> 2, 2 -> 0 }
+ */
+ std::map<unsigned, unsigned> d_var_order;
+ /** incomplete flag */
+ bool d_incomplete;
 };/* class RepSetIterator */
 
 /** Representative bound external
- * 
- * This class manages bound information 
+ *
+ * This class manages bound information
  * for an instance of a RepSetIterator.
  * Its main functionalities are to set
  * bounds on the domain of the iterator
  * over quantifiers and function arguments.
  */
-class RepBoundExt {
+class RepBoundExt
+{
  public:
   virtual ~RepBoundExt() {}
   /** set bound
-   * 
+   *
    * This method initializes the vector "elements"
-   * with list of terms to iterate over for the i^th 
-   * field of owner, where owner may be : 
-   * (1) A function, in which case we are iterating 
+   * with list of terms to iterate over for the i^th
+   * field of owner, where owner may be :
+   * (1) A function, in which case we are iterating
    *     over domain elements of its argument type,
-   * (2) A quantified formula, in which case we are 
-   *     iterating over domain elements of the type 
+   * (2) A quantified formula, in which case we are
+   *     iterating over domain elements of the type
    *     of its i^th bound variable.
    */
-  virtual RepSetIterator::RsiEnumType setBound(Node owner, unsigned i, std::vector< Node >& elements ) = 0;
-  /** reset index 
-   * 
+  virtual RepSetIterator::RsiEnumType setBound(Node owner,
+                                               unsigned i,
+                                               std::vector<Node>& elements) = 0;
+  /** reset index
+   *
    * This method initializes iteration for the i^th
-   * field of owner, based on the current state of 
+   * field of owner, based on the current state of
    * the iterator rsi. It initializes the vector
-   * "elements" with all appropriate terms to 
+   * "elements" with all appropriate terms to
    * iterate over in this context.
-   * 
+   *
    * initial is whether this is the first call
    * to this function for this iterator.
    */
-  virtual bool resetIndex(RepSetIterator * rsi, Node owner, unsigned i, bool initial, std::vector< Node >& elements ){ return true; }
-  /** initialize representative set for type 
-   * 
-   * Returns true if the representative set associated 
-   * with this bound has been given a complete interpretation 
+  virtual bool resetIndex(RepSetIterator* rsi,
+                          Node owner,
+                          unsigned i,
+                          bool initial,
+                          std::vector<Node>& elements)
+  {
+    return true;
+  }
+  /** initialize representative set for type
+   *
+   * Returns true if the representative set associated
+   * with this bound has been given a complete interpretation
    * for type tn.
    */
-  virtual bool initializeRepresentativesForType( TypeNode tn ) { return false; }
-  /** get variable order 
-   * If this returns true, then varOrder is the order 
+  virtual bool initializeRepresentativesForType(TypeNode tn) { return false; }
+  /** get variable order
+   * If this returns true, then varOrder is the order
    * in which we want to consider variables for the iterator.
    */
-  virtual bool getVariableOrder( Node owner, std::vector< unsigned >& varOrder ) { return false; }
+  virtual bool getVariableOrder(Node owner, std::vector<unsigned>& varOrder)
+  {
+    return false;
+  }
 };
 
 }/* CVC4::theory namespace */

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -194,9 +194,9 @@ private:
  std::vector<TypeNode> d_types;
  /** for each argument, the domain we are iterating over */
  std::vector<std::vector<Node> > d_domain_elements;
- /** initialize 
+ /** initialize
   * This is called when the owner of this iterator is set.
-  * It initializes the typing information for the types 
+  * It initializes the typing information for the types
   * that are involved in this iterator, initializes the
   * domain elements we are iterating over, and variable
   * and index orderings we are considering.
@@ -271,8 +271,8 @@ class RepBoundExt
    * initial is whether this is the first call
    * to this function for this iterator.
    *
-   * This method returns false if we were unable 
-   * to establish (finite) bounds for the current 
+   * This method returns false if we were unable
+   * to establish (finite) bounds for the current
    * field we are considering, which indicates that
    * the iterator will terminate with a failure.
    */

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -132,6 +132,7 @@ class RepBoundExt;
  * domains of the owner of this iterator using:
  * - increment and incrementAtIndex
  *
+ * TODO (#1199): this class needs further documentation.
  */
 class RepSetIterator {
 public:

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -179,6 +179,7 @@ public:
  /** debug print methods */
  void debugPrint(const char* c);
  void debugPrintSmall(const char* c);
+ // TODO (#1199): these should be private
  /** enumeration type for each field */
  std::vector<RsiEnumType> d_enum_type;
  /** the current tuple we are considering */
@@ -261,9 +262,12 @@ class RepBoundExt
    * the iterator rsi. It initializes the vector
    * "elements" with all appropriate terms to
    * iterate over in this context.
-   *
    * initial is whether this is the first call
    * to this function for this iterator.
+   * 
+   * This method returns false if the resulting
+   * set of elements is empty, which indicates that
+   * the iterator can terminate.
    */
   virtual bool resetIndex(RepSetIterator* rsi,
                           Node owner,
@@ -281,8 +285,11 @@ class RepBoundExt
    */
   virtual bool initializeRepresentativesForType(TypeNode tn) { return false; }
   /** get variable order
-   * If this returns true, then varOrder is the order
+   * If this method returns true, then varOrder is the order
    * in which we want to consider variables for the iterator.
+   * If this method returns false, then varOrder is unchanged
+   * and the RepSetIterator is free to choose a default 
+   * variable order.
    */
   virtual bool getVariableOrder(Node owner, std::vector<unsigned>& varOrder)
   {

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -163,17 +163,17 @@ public:
  bool isFinished() const;
  /** get domain size of the i^th field of this iterator */
  unsigned domainSize(unsigned i);
- /** get the i_th term we are considering */
+ /** get the i^th term in the tuple we are considering */
  Node getCurrentTerm(unsigned v, bool valTerm = false);
- /** get the number of terms we are considering */
+ /** get the number of terms in the tuple we are considering */
  unsigned getNumTerms() { return d_index_order.size(); }
  /** get index order, returns var # */
  unsigned getIndexOrder(unsigned v) { return d_index_order[v]; }
  /** get variable order, returns index # */
  unsigned getVariableOrder(unsigned i) { return d_var_order[i]; }
  /** is incomplete
-  * Returns true if we only iterating over a strict subset of
-  * the domain of the quantified formula or function
+  * Returns true if we are iterating over a strict subset of
+  * the domain of the quantified formula or function.
   */
  bool isIncomplete() { return d_incomplete; }
  /** debug print methods */
@@ -194,7 +194,13 @@ private:
  std::vector<TypeNode> d_types;
  /** for each argument, the domain we are iterating over */
  std::vector<std::vector<Node> > d_domain_elements;
- /** initialize */
+ /** initialize 
+  * This is called when the owner of this iterator is set.
+  * It initializes the typing information for the types 
+  * that are involved in this iterator, initializes the
+  * domain elements we are iterating over, and variable
+  * and index orderings we are considering.
+  */
  bool initialize();
  /** owner
   * This is the term that we are iterating for, which may either be:
@@ -220,7 +226,7 @@ private:
  *      ...
  */
  std::vector<unsigned> d_index_order;
- /** variables to index they are considered at
+ /** Map from variables to the index they are considered at
  * For example, if d_index_order = { 2, 0, 1 }
  *    then d_var_order = { 0 -> 1, 1 -> 2, 2 -> 0 }
  */
@@ -265,9 +271,10 @@ class RepBoundExt
    * initial is whether this is the first call
    * to this function for this iterator.
    *
-   * This method returns false if the resulting
-   * set of elements is empty, which indicates that
-   * the iterator can terminate.
+   * This method returns false if we were unable 
+   * to establish (finite) bounds for the current 
+   * field we are considering, which indicates that
+   * the iterator will terminate with a failure.
    */
   virtual bool resetIndex(RepSetIterator* rsi,
                           Node owner,

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -264,7 +264,7 @@ class RepBoundExt
    * iterate over in this context.
    * initial is whether this is the first call
    * to this function for this iterator.
-   * 
+   *
    * This method returns false if the resulting
    * set of elements is empty, which indicates that
    * the iterator can terminate.
@@ -288,7 +288,7 @@ class RepBoundExt
    * If this method returns true, then varOrder is the order
    * in which we want to consider variables for the iterator.
    * If this method returns false, then varOrder is unchanged
-   * and the RepSetIterator is free to choose a default 
+   * and the RepSetIterator is free to choose a default
    * variable order.
    */
   virtual bool getVariableOrder(Node owner, std::vector<unsigned>& varOrder)

--- a/src/theory/rep_set.h
+++ b/src/theory/rep_set.h
@@ -74,6 +74,8 @@ public:
   unsigned getNumRepresentatives(TypeNode tn) const;
   /** get representative at index */
   Node getRepresentative(TypeNode tn, unsigned i) const;
+  /** get representatives */
+  void getRepresentatives(TypeNode tn, std::vector< Node >& reps ) const;
   /** add representative n for type tn, where n has type tn */
   void add( TypeNode tn, Node n );
   /** returns index in d_type_reps for node n */
@@ -161,15 +163,13 @@ private:
   //are we only considering a strict subset of the domain of the quantifier?
   bool d_incomplete;
 public:
-  RepSetIterator( QuantifiersEngine * qe, RepSet* rs );
+  RepSetIterator( QuantifiersEngine * qe );
   ~RepSetIterator(){}
   //set that this iterator will be iterating over instantiations for a quantifier
   bool setQuantifier( Node f, RepBoundExt* rext = NULL );
   //set that this iterator will be iterating over the domain of a function
   bool setFunctionDomain( Node op, RepBoundExt* rext = NULL );
 public:
-  //pointer to model
-  RepSet* d_rep_set;
   //enumeration type?
   std::vector< int > d_enum_type;
   //current tuple we are considering
@@ -186,7 +186,7 @@ public:
   /** is the iterator finished? */
   bool isFinished();
   /** get the i_th term we are considering */
-  Node getCurrentTerm( int v );
+  Node getCurrentTerm( int v, bool valTerm = false );
   /** get the number of terms we are considering */
   int getNumTerms() { return (int)d_index_order.size(); }
   /** debug print */


### PR DESCRIPTION
This fully removes the dependence of rep set (a generic theory model utility) on quantifiers. 
It is further work towards #1199. 

This pull request:
- Moves quantifier-specific code from RepSetIterator into an instance QRepBoundExt of a virtual base class RepBoundExt, thus eliminating the dependency of the model on quantifiers-specific code.
- Makes many members int -> unsigned in RepSetIterator

NOTE : code was reorganized heavily in this commit, but essentially no new code was written in this commit.