### PR TITLE
Sygus print callbacks

### DIFF
--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -905,6 +905,12 @@ bool DatatypeConstructor::isSygusIdFunc() const {
   return d_sygus_let_args.size()==1 && d_sygus_let_args[0]==d_sygus_let_body;
 }
 
+SygusPrintCallback * DatatypeConstructor::getSygusPrintCallback()  const {
+  PrettyCheckArgument(isResolved(), this, "this datatype constructor is not yet resolved");
+  // TODO  (#1344) return the stored callback
+  return nullptr;
+}
+
 Cardinality DatatypeConstructor::getCardinality( Type t ) const throw(IllegalArgumentException) {
   PrettyCheckArgument(isResolved(), this, "this datatype constructor is not yet resolved");
 

--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -905,8 +905,10 @@ bool DatatypeConstructor::isSygusIdFunc() const {
   return d_sygus_let_args.size()==1 && d_sygus_let_args[0]==d_sygus_let_body;
 }
 
-SygusPrintCallback * DatatypeConstructor::getSygusPrintCallback()  const {
-  PrettyCheckArgument(isResolved(), this, "this datatype constructor is not yet resolved");
+SygusPrintCallback* DatatypeConstructor::getSygusPrintCallback() const
+{
+  PrettyCheckArgument(
+      isResolved(), this, "this datatype constructor is not yet resolved");
   // TODO  (#1344) return the stored callback
   return nullptr;
 }

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -176,6 +176,8 @@ public:
 
 };/* class DatatypeConstructorArg */
 
+class Printer;
+
 /** sygus datatype constructor printer 
  * 
  * This is a virtual class that is used to specify
@@ -187,9 +189,14 @@ class CVC4_PUBLIC SygusPrintCallback {
 public:
   SygusPrintCallback(){}
   ~SygusPrintCallback(){}
-  /** prints term e to output stream out */
-  virtual void toStreamSygus( std::ostream& out, Expr e,
-                              OutputLanguage = language::output::LANG_AUTO ) = 0;
+  /** 
+   * Writes the term that sygus datatype expression e
+   * encodes to stream out. p is the printer that 
+   * requested that expression e be written on output
+   * stream out. Calls may be made to p to print 
+   * subterms of e.
+   */
+  virtual void toStreamSygus( const Printer * p, std::ostream& out, Expr e ) const = 0;
 };
 
 /**

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -178,25 +178,28 @@ public:
 
 class Printer;
 
-/** sygus datatype constructor printer 
- * 
+/** sygus datatype constructor printer
+ *
  * This is a virtual class that is used to specify
- * a custom printing callback for sygus terms. This is 
+ * a custom printing callback for sygus terms. This is
  * useful for sygus grammars that include defined
  * functions or let expressions.
  */
-class CVC4_PUBLIC SygusPrintCallback {
-public:
-  SygusPrintCallback(){}
-  ~SygusPrintCallback(){}
-  /** 
+class CVC4_PUBLIC SygusPrintCallback
+{
+ public:
+  SygusPrintCallback() {}
+  ~SygusPrintCallback() {}
+  /**
    * Writes the term that sygus datatype expression e
-   * encodes to stream out. p is the printer that 
+   * encodes to stream out. p is the printer that
    * requested that expression e be written on output
-   * stream out. Calls may be made to p to print 
+   * stream out. Calls may be made to p to print
    * subterms of e.
    */
-  virtual void toStreamSygus( const Printer * p, std::ostream& out, Expr e ) const = 0;
+  virtual void toStreamSygus(const Printer* p,
+                             std::ostream& out,
+                             Expr e) const = 0;
 };
 
 /**
@@ -331,12 +334,12 @@ public:
   /** is this a sygus identity function */
   bool isSygusIdFunc() const;
   /** get sygus print callback
-   * This class stores custom ways of printing 
+   * This class stores custom ways of printing
    * sygus datatype constructors, for instance,
-   * to handle defined or let expressions that 
+   * to handle defined or let expressions that
    * appear in user-provided grammars.
    */
-  SygusPrintCallback * getSygusPrintCallback() const;
+  SygusPrintCallback* getSygusPrintCallback() const;
 
   /**
    * Get the tester name for this Datatype constructor.

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -176,6 +176,22 @@ public:
 
 };/* class DatatypeConstructorArg */
 
+/** sygus datatype constructor printer 
+ * 
+ * This is a virtual class that is used to specify
+ * a custom printing callback for sygus terms. This is 
+ * useful for sygus grammars that include defined
+ * functions or let expressions.
+ */
+class CVC4_PUBLIC SygusPrintCallback {
+public:
+  SygusPrintCallback(){}
+  ~SygusPrintCallback(){}
+  /** prints term e to output stream out */
+  virtual void toStreamSygus( std::ostream& out, Expr e,
+                              OutputLanguage = language::output::LANG_AUTO ) = 0;
+};
+
 /**
  * A constructor for a Datatype.
  */
@@ -307,6 +323,13 @@ public:
   unsigned getNumSygusLetInputArgs() const;
   /** is this a sygus identity function */
   bool isSygusIdFunc() const;
+  /** get sygus print callback
+   * This class stores custom ways of printing 
+   * sygus datatype constructors, for instance,
+   * to handle defined or let expressions that 
+   * appear in user-provided grammars.
+   */
+  SygusPrintCallback * getSygusPrintCallback() const;
 
   /**
    * Get the tester name for this Datatype constructor.

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -70,7 +70,8 @@ Printer* Printer::makePrinter(OutputLanguage lang) throw() {
   }
 }/* Printer::makePrinter() */
 
-void Printer::toStreamSygus(std::ostream& out, TNode n) const throw() {
+void Printer::toStreamSygus(std::ostream& out, TNode n) const throw()
+{
   // no sygus-specific printing associated with this printer,
   // just print the original term
   toStream(out, n, -1, false, 1);

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -70,7 +70,11 @@ Printer* Printer::makePrinter(OutputLanguage lang) throw() {
   }
 }/* Printer::makePrinter() */
 
-
+void Printer::toStreamSygus(std::ostream& out, TNode n) const throw() {
+  // no sygus-specific printing associated with this printer,
+  // just print the original term
+  toStream(out, n, -1, false, 1);
+}
 
 void Printer::toStream(std::ostream& out, const Model& m) const throw() {
   for(size_t i = 0; i < m.getNumCommands(); ++i) {

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -61,7 +61,7 @@ public:
   /** Write a Node out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, TNode n,
                         int toDepth, bool types, size_t dag) const throw() = 0;
-                        
+
   /** Write a Command out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, const Command* c,
                         int toDepth, bool types, size_t dag) const throw() = 0;
@@ -75,18 +75,18 @@ public:
   /** Write an UnsatCore out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, const UnsatCore& core) const throw();
 
-  /** 
-   * Write the term that sygus datatype term n 
+  /**
+   * Write the term that sygus datatype term n
    * encodes to a stream with this Printer.
-   * For example, consider the datatype term 
-   *   (C_plus (C_minus C_x C_0) C_y) 
+   * For example, consider the datatype term
+   *   (C_plus (C_minus C_x C_0) C_y)
    * where C_plus, C_minus, C_x, C_0, C_y are constructors
    * whose sygus operators PLUS, MINUS, x, 0, y.
    * This is equivalent to printing the integer term:
    *   (PLUS (MINUS x 0) y)
    */
   virtual void toStreamSygus(std::ostream& out, TNode n) const throw();
-  
+
 };/* class Printer */
 
 }/* CVC4 namespace */

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -76,7 +76,7 @@ public:
   virtual void toStream(std::ostream& out, const UnsatCore& core) const throw();
 
   /** 
-   * Write the term that sygus datatype term node n 
+   * Write the term that sygus datatype term n 
    * encodes to a stream with this Printer.
    * For example, consider the datatype term 
    *   (C_plus (C_minus C_x C_0) C_y) 

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -61,7 +61,7 @@ public:
   /** Write a Node out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, TNode n,
                         int toDepth, bool types, size_t dag) const throw() = 0;
-
+                        
   /** Write a Command out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, const Command* c,
                         int toDepth, bool types, size_t dag) const throw() = 0;
@@ -69,14 +69,24 @@ public:
   /** Write a CommandStatus out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, const CommandStatus* s) const throw() = 0;
 
-
-
   /** Write a Model out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, const Model& m) const throw();
 
   /** Write an UnsatCore out to a stream with this Printer. */
   virtual void toStream(std::ostream& out, const UnsatCore& core) const throw();
 
+  /** 
+   * Write the term that sygus datatype term node n 
+   * encodes to a stream with this Printer.
+   * For example, consider the datatype term 
+   *   (C_plus (C_minus C_x C_0) C_y) 
+   * where C_plus, C_minus, C_x, C_0, C_y are constructors
+   * whose sygus operators PLUS, MINUS, x, 0, y.
+   * This is equivalent to printing the integer term:
+   *   (PLUS (MINUS x 0) y)
+   */
+  virtual void toStreamSygus(std::ostream& out, TNode n) const throw();
+  
 };/* class Printer */
 
 }/* CVC4 namespace */

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -82,7 +82,7 @@ public:
    *   (C_plus (C_minus C_x C_0) C_y)
    * where C_plus, C_minus, C_x, C_0, C_y are constructors
    * whose sygus operators are PLUS, MINUS, x, 0, y.
-   * In this case, this method is equivalent to printing 
+   * In this case, this method is equivalent to printing
    * the integer term:
    *   (PLUS (MINUS x 0) y)
    * This method may make calls to sygus printing callback

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -81,9 +81,12 @@ public:
    * For example, consider the datatype term
    *   (C_plus (C_minus C_x C_0) C_y)
    * where C_plus, C_minus, C_x, C_0, C_y are constructors
-   * whose sygus operators PLUS, MINUS, x, 0, y.
-   * This is equivalent to printing the integer term:
+   * whose sygus operators are PLUS, MINUS, x, 0, y.
+   * In this case, this method is equivalent to printing 
+   * the integer term:
    *   (PLUS (MINUS x 0) y)
+   * This method may make calls to sygus printing callback
+   * methods stored in sygus datatype constructors.
    */
   virtual void toStreamSygus(std::ostream& out, TNode n) const throw();
 

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -364,10 +364,10 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
   case kind::CHAIN: break;
   case kind::FUNCTION_TYPE:
     out << "->";
-    for (size_t i = 0; i < n.getNumChildren(); ++i)
+    for (Node nc : n)
     {
       out << " ";
-      toStream(out, n[i], toDepth, types, TypeNode::null());
+      toStream(out, nc, toDepth, types, TypeNode::null());
     }
     out << ")";
     return;
@@ -1338,10 +1338,10 @@ void Smt2Printer::toStreamSygus(std::ostream& out, TNode n) const throw()
         out << dt[cIndex].getSygusOp();
         if (n.getNumChildren() > 0)
         {
-          for (unsigned i = 0; i < n.getNumChildren(); i++)
+          for (Node nc : n)
           {
             out << " ";
-            toStreamSygus(out, n[i]);
+            toStreamSygus(out, nc);
           }
           out << ")";
         }

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1315,7 +1315,7 @@ void Smt2Printer::toStreamSygus(std::ostream& out, TNode n) const throw() {
       Assert( !dt[cIndex].getSygusOp().isNull() );
       SygusPrintCallback * spc = dt[cIndex].getSygusPrintCallback();
       if( spc!=nullptr ){
-        spc->toStreamSygus( out, n.toExpr() );        
+        spc->toStreamSygus( this, out, n.toExpr() );        
       }else{
         if( n.getNumChildren()>0 ){
           out << "(";

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -364,7 +364,8 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
   case kind::CHAIN: break;
   case kind::FUNCTION_TYPE:
     out << "->";
-    for(size_t i = 0; i < n.getNumChildren(); ++i) {
+    for (size_t i = 0; i < n.getNumChildren(); ++i)
+    {
       out << " ";
       toStream(out, n[i], toDepth, types, TypeNode::null());
     }
@@ -382,11 +383,13 @@ void Smt2Printer::toStream(std::ostream& out, TNode n,
 
     // uf theory
   case kind::APPLY_UF: typeChildren = true; break;
-    // higher-order
+  // higher-order
   case kind::HO_APPLY: break;
-  case kind::LAMBDA: out << smtKindString(k) << " "; break;
-  
-    // arith theory
+  case kind::LAMBDA:
+    out << smtKindString(k) << " ";
+    break;
+
+  // arith theory
   case kind::PLUS:
   case kind::MULT:
   case kind::NONLINEAR_MULT:
@@ -819,10 +822,11 @@ static string smtKindString(Kind k) throw() {
 
     // uf theory
   case kind::APPLY_UF: break;
-  
-  case kind::LAMBDA: return "lambda";
 
-    // arith theory
+  case kind::LAMBDA:
+    return "lambda";
+
+  // arith theory
   case kind::PLUS: return "+";
   case kind::MULT:
   case kind::NONLINEAR_MULT: return "*";
@@ -1310,32 +1314,43 @@ void Smt2Printer::toStream(std::ostream& out, const Model& m, const Command* c) 
   }
 }
 
-void Smt2Printer::toStreamSygus(std::ostream& out, TNode n) const throw() {
-  if( n.getKind()==kind::APPLY_CONSTRUCTOR ){
+void Smt2Printer::toStreamSygus(std::ostream& out, TNode n) const throw()
+{
+  if (n.getKind() == kind::APPLY_CONSTRUCTOR)
+  {
     TypeNode tn = n.getType();
     const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-    if( dt.isSygus() ){
-      int cIndex = Datatype::indexOf( n.getOperator().toExpr() );
-      Assert( !dt[cIndex].getSygusOp().isNull() );
-      SygusPrintCallback * spc = dt[cIndex].getSygusPrintCallback();
-      if( spc!=nullptr ){
-        spc->toStreamSygus( this, out, n.toExpr() );        
-      }else{
-        if( n.getNumChildren()>0 ){
+    if (dt.isSygus())
+    {
+      int cIndex = Datatype::indexOf(n.getOperator().toExpr());
+      Assert(!dt[cIndex].getSygusOp().isNull());
+      SygusPrintCallback* spc = dt[cIndex].getSygusPrintCallback();
+      if (spc != nullptr)
+      {
+        spc->toStreamSygus(this, out, n.toExpr());
+      }
+      else
+      {
+        if (n.getNumChildren() > 0)
+        {
           out << "(";
         }
         out << dt[cIndex].getSygusOp();
-        if( n.getNumChildren()>0 ){
-          for( unsigned i=0; i<n.getNumChildren(); i++ ){
+        if (n.getNumChildren() > 0)
+        {
+          for (unsigned i = 0; i < n.getNumChildren(); i++)
+          {
             out << " ";
-            toStreamSygus( out, n[i] );
+            toStreamSygus(out, n[i]);
           }
           out << ")";
         }
       }
       return;
     }
-  }else{
+  }
+  else
+  {
     // cannot convert term to analog, print original
     toStream(out, n, -1, false, 1);
   }
@@ -1764,7 +1779,7 @@ static OutputLanguage variantToLanguage(Variant variant) throw() {
     return language::output::LANG_SMTLIB_V2_5;
   }
 }
-  
+
 }/* CVC4::printer::smt2 namespace */
 }/* CVC4::printer namespace */
 }/* CVC4 namespace */

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -48,10 +48,11 @@ public:
   void toStream(std::ostream& out, const CommandStatus* s) const throw();
   void toStream(std::ostream& out, const SExpr& sexpr) const throw();
   void toStream(std::ostream& out, const Model& m) const throw();
-  /** print the unsat core to the stream out.
-  * We use the expression names that are stored in the SMT engine associated 
-  * with the core (UnsatCore::getSmtEngine) for printing named assertions.
-  */
+  /** 
+   * Writes the unsat core to the stream out.
+   * We use the expression names that are stored in the SMT engine associated 
+   * with the core (UnsatCore::getSmtEngine) for printing named assertions.
+   */
   void toStream(std::ostream& out, const UnsatCore& core) const throw();
   /** 
    * Write the term that sygus datatype term node n 

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -53,6 +53,11 @@ public:
   * with the core (UnsatCore::getSmtEngine) for printing named assertions.
   */
   void toStream(std::ostream& out, const UnsatCore& core) const throw();
+  /** 
+   * Write the term that sygus datatype term node n 
+   * encodes to a stream with this Printer.
+   */
+  virtual void toStreamSygus(std::ostream& out, TNode n) const throw() override;
 };/* class Smt2Printer */
 
 }/* CVC4::printer::smt2 namespace */

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -48,14 +48,14 @@ public:
   void toStream(std::ostream& out, const CommandStatus* s) const throw();
   void toStream(std::ostream& out, const SExpr& sexpr) const throw();
   void toStream(std::ostream& out, const Model& m) const throw();
-  /** 
+  /**
    * Writes the unsat core to the stream out.
-   * We use the expression names that are stored in the SMT engine associated 
+   * We use the expression names that are stored in the SMT engine associated
    * with the core (UnsatCore::getSmtEngine) for printing named assertions.
    */
   void toStream(std::ostream& out, const UnsatCore& core) const throw();
-  /** 
-   * Write the term that sygus datatype term node n 
+  /**
+   * Write the term that sygus datatype term node n
    * encodes to a stream with this Printer.
    */
   virtual void toStreamSygus(std::ostream& out, TNode n) const throw() override;

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -19,89 +19,108 @@ using namespace std;
 
 namespace CVC4 {
 namespace printer {
-  
-SygusLetExpressionPrinter::SygusLetExpressionPrinter( Node let_body, std::vector< Node >& let_args, unsigned ninput_args ) {
 
-  
+SygusLetExpressionPrinter::SygusLetExpressionPrinter(
+    Node let_body, std::vector<Node>& let_args, unsigned ninput_args)
+{
 }
 
-void SygusLetExpressionConstructorPrinter::doStrReplace(std::string& str, const std::string& oldStr, const std::string& newStr)
+void SygusLetExpressionConstructorPrinter::doStrReplace(
+    std::string& str, const std::string& oldStr, const std::string& newStr)
 {
   size_t pos = 0;
-  while((pos = str.find(oldStr, pos)) != std::string::npos){
-     str.replace(pos, oldStr.length(), newStr);
-     pos += newStr.length();
+  while ((pos = str.find(oldStr, pos)) != std::string::npos)
+  {
+    str.replace(pos, oldStr.length(), newStr);
+    pos += newStr.length();
   }
 }
-  
-void SygusLetExpressionConstructorPrinter::toStreamSygus( Printer * p, std::ostream& out, Expr e ) 
+
+void SygusLetExpressionConstructorPrinter::toStreamSygus(Printer* p,
+                                                         std::ostream& out,
+                                                         Expr e)
 {
   std::stringstream let_out;
-  //print as let term
-  if( d_sygus_num_let_input_args>0 ){
+  // print as let term
+  if (d_sygus_num_let_input_args > 0)
+  {
     let_out << "(let (";
   }
-  std::vector< Node > subs_lvs;
-  std::vector< Node > new_lvs;
-  for( unsigned i=0; i<d_sygus_let_args.size(); i++ ){
+  std::vector<Node> subs_lvs;
+  std::vector<Node> new_lvs;
+  for (unsigned i = 0; i < d_sygus_let_args.size(); i++)
+  {
     Node v = d_sygus_let_args[i];
-    subs_lvs.push_back( v );
+    subs_lvs.push_back(v);
     std::stringstream ss;
     ss << "_l_" << new_lvs.size();
-    Node lv = NodeManager::currentNM()->mkBoundVar( ss.str(), v.getType() );
-    new_lvs.push_back( lv );
-    //map free variables to proper terms
-    if( i<d_sygus_num_let_input_args ){
-      //it should be printed as a let argument
+    Node lv = NodeManager::currentNM()->mkBoundVar(ss.str(), v.getType());
+    new_lvs.push_back(lv);
+    // map free variables to proper terms
+    if (i < d_sygus_num_let_input_args)
+    {
+      // it should be printed as a let argument
       let_out << "(";
       let_out << lv << " " << lv.getType() << " ";
-      p->toStreamSygus( let_out, e[i] );
+      p->toStreamSygus(let_out, e[i]);
       let_out << ")";
     }
   }
-  if( d_sygus_num_let_input_args>0 ){
+  if (d_sygus_num_let_input_args > 0)
+  {
     let_out << ") ";
   }
-  //print the body
-  Node slet_body = d_let_body.substitute( subs_lvs.begin(), subs_lvs.end(), new_lvs.begin(), new_lvs.end() );
-  new_lvs.insert( new_lvs.end(), lvs.begin(), lvs.end() );
-  p->toStreamSygus( let_out, slet_body );
-  if( d_sygus_num_let_input_args>0 ){
+  // print the body
+  Node slet_body = d_let_body.substitute(
+      subs_lvs.begin(), subs_lvs.end(), new_lvs.begin(), new_lvs.end());
+  new_lvs.insert(new_lvs.end(), lvs.begin(), lvs.end());
+  p->toStreamSygus(let_out, slet_body);
+  if (d_sygus_num_let_input_args > 0)
+  {
     let_out << ")";
   }
-  //do variable substitutions since 
-  // ASSUMING : let_vars are interpreted literally and do not represent a class of variables
+  // do variable substitutions since
+  // ASSUMING : let_vars are interpreted literally and do not represent a class
+  // of variables
   std::string lbody = let_out.str();
-  for( unsigned i=0; i<d_sygus_let_args.size(); i++ ){
+  for (unsigned i = 0; i < d_sygus_let_args.size(); i++)
+  {
     std::stringstream old_str;
     old_str << new_lvs[i];
     std::stringstream new_str;
-    if( i>=d_sygus_num_let_input_args ){
-      p->toStreamSygus( new_str, Node::fromExpr( e[i] ) );
-    }else{
+    if (i >= d_sygus_num_let_input_args)
+    {
+      p->toStreamSygus(new_str, Node::fromExpr(e[i]));
+    }
+    else
+    {
       new_str << d_sygus_let_args[i];
     }
-    doStrReplace( lbody, old_str.str().c_str(), new_str.str().c_str() );
+    doStrReplace(lbody, old_str.str().c_str(), new_str.str().c_str());
   }
   out << lbody;
 }
-  
-SygusNamedConstructorPrinter::SygusNamedConstructorPrinter( std::string name ) : 
-d_name(name) {
 
-  
+SygusNamedConstructorPrinter::SygusNamedConstructorPrinter(std::string name)
+    : d_name(name)
+{
 }
 
-void SygusNamedConstructorPrinter::toStreamSygus( Printer * p, std::ostream& out, Expr e ) 
+void SygusNamedConstructorPrinter::toStreamSygus(Printer* p,
+                                                 std::ostream& out,
+                                                 Expr e)
 {
-  if( e.getNumChildren()>0 ){
+  if (e.getNumChildren() > 0)
+  {
     out << "(";
   }
   out << d_name;
-  if( e.getNumChildren()>0 ){
-    for( unsigned i=0; i<e.getNumChildren(); i++ ){
+  if (e.getNumChildren() > 0)
+  {
+    for (unsigned i = 0; i < e.getNumChildren(); i++)
+    {
       out << " ";
-      p->toStreamSygus( out, e[i] );
+      p->toStreamSygus(out, e[i]);
     }
     out << ")";
   }

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -127,18 +127,15 @@ void SygusNamedConstructorPrinter::toStreamSygus(Printer* p,
 }
 
 void SygusEmptyConstructorPrinter::toStreamSygus(const Printer* p,
-                                                 std::ostream& out,
-                                                 Expr e)
+                   std::ostream& out,
+                   Expr e) 
 {
-  if (e.getNumChildren() == 1)
-  {
-    p->toStreamSygus(out, e[0]);
-  }
-  else
-  {
+  if( e.getNumChildren()==1 ){
+    p->toStreamSygus(out,e[0]);
+  }else{
     Assert(false);
   }
 }
-
+                             
 } /* CVC4::printer namespace */
 } /* CVC4 namespace */

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -34,8 +34,7 @@ void SygusLetExpressionConstructorPrinter::doStrReplace(std::string& str, const 
   }
 }
   
-void SygusLetExpressionConstructorPrinter::toStreamSygus( std::ostream& out, Expr e,
-                                                          OutputLanguage language ) 
+void SygusLetExpressionConstructorPrinter::toStreamSygus( Printer * p, std::ostream& out, Expr e ) 
 {
   std::stringstream let_out;
   //print as let term
@@ -56,7 +55,7 @@ void SygusLetExpressionConstructorPrinter::toStreamSygus( std::ostream& out, Exp
       //it should be printed as a let argument
       let_out << "(";
       let_out << lv << " " << lv.getType() << " ";
-      Printer::getPrinter(language)->toStreamSygus( let_out, e[i] );
+      p->toStreamSygus( let_out, e[i] );
       let_out << ")";
     }
   }
@@ -66,7 +65,7 @@ void SygusLetExpressionConstructorPrinter::toStreamSygus( std::ostream& out, Exp
   //print the body
   Node slet_body = d_let_body.substitute( subs_lvs.begin(), subs_lvs.end(), new_lvs.begin(), new_lvs.end() );
   new_lvs.insert( new_lvs.end(), lvs.begin(), lvs.end() );
-  Printer::getPrinter(language)->toStreamSygus( let_out, slet_body );
+  p->toStreamSygus( let_out, slet_body );
   if( d_sygus_num_let_input_args>0 ){
     let_out << ")";
   }
@@ -78,7 +77,7 @@ void SygusLetExpressionConstructorPrinter::toStreamSygus( std::ostream& out, Exp
     old_str << new_lvs[i];
     std::stringstream new_str;
     if( i>=d_sygus_num_let_input_args ){
-      Printer::getPrinter(language)->toStreamSygus( new_str, Node::fromExpr( e[i] ) );
+      p->toStreamSygus( new_str, Node::fromExpr( e[i] ) );
     }else{
       new_str << d_sygus_let_args[i];
     }
@@ -93,8 +92,7 @@ d_name(name) {
   
 }
 
-void SygusNamedConstructorPrinter::toStreamSygus( std::ostream& out, Expr e,
-                                                  OutputLanguage language ) 
+void SygusNamedConstructorPrinter::toStreamSygus( Printer * p, std::ostream& out, Expr e ) 
 {
   if( e.getNumChildren()>0 ){
     out << "(";
@@ -103,7 +101,7 @@ void SygusNamedConstructorPrinter::toStreamSygus( std::ostream& out, Expr e,
   if( e.getNumChildren()>0 ){
     for( unsigned i=0; i<e.getNumChildren(); i++ ){
       out << " ";
-      Printer::getPrinter(language)->toStreamSygus( out, e[i] );
+      p->toStreamSygus( out, e[i] );
     }
     out << ")";
   }

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -126,5 +126,16 @@ void SygusNamedConstructorPrinter::toStreamSygus(Printer* p,
   }
 }
 
+void SygusEmptyConstructorPrinter::toStreamSygus(const Printer* p,
+                   std::ostream& out,
+                   Expr e) 
+{
+  if( e.getNumChildren()==1 ){
+    p->toStreamSygus(out,e[0]);
+  }else{
+    Assert(false);
+  }
+}
+                             
 } /* CVC4::printer namespace */
 } /* CVC4 namespace */

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -117,10 +117,10 @@ void SygusNamedConstructorPrinter::toStreamSygus(Printer* p,
   out << d_name;
   if (e.getNumChildren() > 0)
   {
-    for (unsigned i = 0; i < e.getNumChildren(); i++)
+    for (Expr ec : e)
     {
       out << " ";
-      p->toStreamSygus(out, e[i]);
+      p->toStreamSygus(out, ec);
     }
     out << ")";
   }

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -127,15 +127,18 @@ void SygusNamedConstructorPrinter::toStreamSygus(Printer* p,
 }
 
 void SygusEmptyConstructorPrinter::toStreamSygus(const Printer* p,
-                   std::ostream& out,
-                   Expr e) 
+                                                 std::ostream& out,
+                                                 Expr e)
 {
-  if( e.getNumChildren()==1 ){
-    p->toStreamSygus(out,e[0]);
-  }else{
+  if (e.getNumChildren() == 1)
+  {
+    p->toStreamSygus(out, e[0]);
+  }
+  else
+  {
     Assert(false);
   }
 }
-                             
+
 } /* CVC4::printer namespace */
 } /* CVC4 namespace */

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -1,0 +1,113 @@
+/*********************                                                        */
+/*! \file sygus_print_callback.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2017 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Implementation of sygus print callbacks
+ **/
+
+#include "printer/sygus_print_callback.h"
+
+using namespace CVC4::kind;
+using namespace std;
+
+namespace CVC4 {
+namespace printer {
+  
+SygusLetExpressionPrinter::SygusLetExpressionPrinter( Node let_body, std::vector< Node >& let_args, unsigned ninput_args ) {
+
+  
+}
+
+void SygusLetExpressionConstructorPrinter::doStrReplace(std::string& str, const std::string& oldStr, const std::string& newStr)
+{
+  size_t pos = 0;
+  while((pos = str.find(oldStr, pos)) != std::string::npos){
+     str.replace(pos, oldStr.length(), newStr);
+     pos += newStr.length();
+  }
+}
+  
+void SygusLetExpressionConstructorPrinter::toStreamSygus( std::ostream& out, Expr e,
+                                                          OutputLanguage language ) 
+{
+  std::stringstream let_out;
+  //print as let term
+  if( d_sygus_num_let_input_args>0 ){
+    let_out << "(let (";
+  }
+  std::vector< Node > subs_lvs;
+  std::vector< Node > new_lvs;
+  for( unsigned i=0; i<d_sygus_let_args.size(); i++ ){
+    Node v = d_sygus_let_args[i];
+    subs_lvs.push_back( v );
+    std::stringstream ss;
+    ss << "_l_" << new_lvs.size();
+    Node lv = NodeManager::currentNM()->mkBoundVar( ss.str(), v.getType() );
+    new_lvs.push_back( lv );
+    //map free variables to proper terms
+    if( i<d_sygus_num_let_input_args ){
+      //it should be printed as a let argument
+      let_out << "(";
+      let_out << lv << " " << lv.getType() << " ";
+      Printer::getPrinter(language)->toStreamSygus( let_out, e[i] );
+      let_out << ")";
+    }
+  }
+  if( d_sygus_num_let_input_args>0 ){
+    let_out << ") ";
+  }
+  //print the body
+  Node slet_body = d_let_body.substitute( subs_lvs.begin(), subs_lvs.end(), new_lvs.begin(), new_lvs.end() );
+  new_lvs.insert( new_lvs.end(), lvs.begin(), lvs.end() );
+  Printer::getPrinter(language)->toStreamSygus( let_out, slet_body );
+  if( d_sygus_num_let_input_args>0 ){
+    let_out << ")";
+  }
+  //do variable substitutions since 
+  // ASSUMING : let_vars are interpreted literally and do not represent a class of variables
+  std::string lbody = let_out.str();
+  for( unsigned i=0; i<d_sygus_let_args.size(); i++ ){
+    std::stringstream old_str;
+    old_str << new_lvs[i];
+    std::stringstream new_str;
+    if( i>=d_sygus_num_let_input_args ){
+      Printer::getPrinter(language)->toStreamSygus( new_str, Node::fromExpr( e[i] ) );
+    }else{
+      new_str << d_sygus_let_args[i];
+    }
+    doStrReplace( lbody, old_str.str().c_str(), new_str.str().c_str() );
+  }
+  out << lbody;
+}
+  
+SygusNamedConstructorPrinter::SygusNamedConstructorPrinter( std::string name ) : 
+d_name(name) {
+
+  
+}
+
+void SygusNamedConstructorPrinter::toStreamSygus( std::ostream& out, Expr e,
+                                                  OutputLanguage language ) 
+{
+  if( e.getNumChildren()>0 ){
+    out << "(";
+  }
+  out << d_name;
+  if( e.getNumChildren()>0 ){
+    for( unsigned i=0; i<e.getNumChildren(); i++ ){
+      out << " ";
+      Printer::getPrinter(language)->toStreamSygus( out, e[i] );
+    }
+    out << ")";
+  }
+}
+
+} /* CVC4::printer namespace */
+} /* CVC4 namespace */

--- a/src/printer/sygus_print_callback.h
+++ b/src/printer/sygus_print_callback.h
@@ -1,5 +1,5 @@
 /*********************                                                        */
-/*! \file sygus_print.h
+/*! \file sygus_print_callback.h
  ** \verbatim
  ** Top contributors (to current version):
  **   Andrew Reynolds
@@ -78,9 +78,9 @@ private:
  *   A -> f( A ) | 0
  * where f is defined as:
  *   (define-fun ((x Int)) Int (+ x 1))
- * this constructor can be used to name the first 
- * sygus datatype constructor f, whose analog 
- * operator is (lambda (x) (+ x 1)).
+ * this class can be used as a callback for printing 
+ * the first sygus datatype constructor f, where we use
+ * analog operator (lambda (x) (+ x 1)). 
  */
 class SygusNamedConstructorPrinter : public SygusDatatypeConstructorPrinter
 {

--- a/src/printer/sygus_print_callback.h
+++ b/src/printer/sygus_print_callback.h
@@ -1,0 +1,101 @@
+/*********************                                                        */
+/*! \file sygus_print.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2017 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief sygus print callback functions
+ **/
+
+#include "cvc4_private.h"
+
+
+#ifndef __CVC4__PRINTER__SYGUS_PRINT_CALLBACK_H
+#define __CVC4__PRINTER__SYGUS_PRINT_CALLBACK_H
+
+#include <vector>
+
+#include "expr/node.h"
+
+namespace CVC4 {
+namespace printer {
+
+/** sygus let expression constructor printer
+ * 
+ * This class is used for printing sygus 
+ * datatype constructor terms whose top symbol 
+ * is a let expression.  
+ * For example, for example: 
+ *   A -> (let ((x B)) (+ A 1)) | x | (+ A A) | 0
+ *   B -> 0 | 1
+ * the first constructor for A takes as arguments 
+ * (B,A) and has operator 
+ *   (lambda ((y B) (z A)) (+ z 1))
+ * CVC4's support for let expressions in grammars
+ * is highly limited, since notice that the 
+ * argument y : B is unused. 
+ * 
+ * For the above constructor, we have that 
+ *   d_let_body is (+ z 1),
+ *   d_sygus_let_args is { y, z },
+ *   d_sygus_num_let_input_args is 1, since
+ *     y is an original input argument of the 
+ *     let expression, but z is not.
+ */
+class SygusLetExpressionConstructorPrinter : public SygusDatatypeConstructorPrinter
+{
+public:
+  SygusLetExpressionPrinter( Node let_body, std::vector< Node >& let_args, unsigned ninput_args );
+  ~SygusLetExpressionPrinter(){}
+  /** print sygus term */
+  virtual void toStreamSygus( std::ostream& out, Expr e,
+                              OutputLanguage language = language::output::LANG_AUTO ) override;
+private:
+  /** let body of the sygus term */
+  Node d_sygus_let_body;
+  /** let arguments */
+  std::vector< Node > d_sygus_let_args;
+  /** number of arguments that are interpreted as input arguments */
+  unsigned d_sygus_num_let_input_args;
+  /** do string replace 
+   * Replaces all occurrences of oldStr with newStr in str.
+   */
+  void doStrReplace(std::string& str, const std::string& oldStr, const std::string& newStr) const;
+};
+
+/** sygus named constructor printer
+ * 
+ * This callback is used for explicitly naming 
+ * the builtin term that a sygus datatype constructor 
+ * should be printed as. This is used for printing
+ * terms in sygus grammars that involve defined 
+ * functions. For example, for grammar :
+ *   A -> f( A ) | 0
+ * where f is defined as:
+ *   (define-fun ((x Int)) Int (+ x 1))
+ * this constructor can be used to name the first 
+ * sygus datatype constructor f, whose analog 
+ * operator is (lambda (x) (+ x 1)).
+ */
+class SygusNamedConstructorPrinter : public SygusDatatypeConstructorPrinter
+{
+public:
+  SygusNamedConstructorPrinter( std::string name );
+  ~SygusNamedConstructorPrinter(){}
+  /** print sygus term */
+  virtual void toStreamSygus( std::ostream& out, Expr e,
+                              OutputLanguage language = language::output::LANG_AUTO ) override;
+private:
+  /** the defined function name */
+  std::string d_name;
+};
+  
+} /* CVC4::printer namespace */
+} /* CVC4 namespace */
+
+#endif /* __CVC4__PRINTER__SYGUS_PRINT_CALLBACK_H */

--- a/src/printer/sygus_print_callback.h
+++ b/src/printer/sygus_print_callback.h
@@ -14,7 +14,6 @@
 
 #include "cvc4_private.h"
 
-
 #ifndef __CVC4__PRINTER__SYGUS_PRINT_CALLBACK_H
 #define __CVC4__PRINTER__SYGUS_PRINT_CALLBACK_H
 
@@ -26,73 +25,84 @@ namespace CVC4 {
 namespace printer {
 
 /** sygus let expression constructor printer
- * 
- * This class is used for printing sygus 
- * datatype constructor terms whose top symbol 
- * is a let expression.  
- * For example, for example: 
+ *
+ * This class is used for printing sygus
+ * datatype constructor terms whose top symbol
+ * is a let expression.
+ * For example, for example:
  *   A -> (let ((x B)) (+ A 1)) | x | (+ A A) | 0
  *   B -> 0 | 1
- * the first constructor for A takes as arguments 
- * (B,A) and has operator 
+ * the first constructor for A takes as arguments
+ * (B,A) and has operator
  *   (lambda ((y B) (z A)) (+ z 1))
  * CVC4's support for let expressions in grammars
- * is highly limited, since notice that the 
- * argument y : B is unused. 
- * 
- * For the above constructor, we have that 
+ * is highly limited, since notice that the
+ * argument y : B is unused.
+ *
+ * For the above constructor, we have that
  *   d_let_body is (+ z 1),
  *   d_sygus_let_args is { y, z },
  *   d_sygus_num_let_input_args is 1, since
- *     y is an original input argument of the 
+ *     y is an original input argument of the
  *     let expression, but z is not.
  */
-class SygusLetExpressionConstructorPrinter : public SygusDatatypeConstructorPrinter
+class SygusLetExpressionConstructorPrinter
+    : public SygusDatatypeConstructorPrinter
 {
-public:
-  SygusLetExpressionPrinter( Node let_body, std::vector< Node >& let_args, unsigned ninput_args );
-  ~SygusLetExpressionPrinter(){}
+ public:
+  SygusLetExpressionPrinter(Node let_body,
+                            std::vector<Node>& let_args,
+                            unsigned ninput_args);
+  ~SygusLetExpressionPrinter() {}
   /** print sygus term e on output out using printer p */
-  virtual void toStreamSygus(const Printer * p, std::ostream& out, Expr e) const override;
-private:
+  virtual void toStreamSygus(const Printer* p,
+                             std::ostream& out,
+                             Expr e) const override;
+
+ private:
   /** let body of the sygus term */
   Node d_sygus_let_body;
   /** let arguments */
-  std::vector< Node > d_sygus_let_args;
+  std::vector<Node> d_sygus_let_args;
   /** number of arguments that are interpreted as input arguments */
   unsigned d_sygus_num_let_input_args;
-  /** do string replace 
+  /** do string replace
    * Replaces all occurrences of oldStr with newStr in str.
    */
-  void doStrReplace(std::string& str, const std::string& oldStr, const std::string& newStr) const;
+  void doStrReplace(std::string& str,
+                    const std::string& oldStr,
+                    const std::string& newStr) const;
 };
 
 /** sygus named constructor printer
- * 
- * This callback is used for explicitly naming 
- * the builtin term that a sygus datatype constructor 
+ *
+ * This callback is used for explicitly naming
+ * the builtin term that a sygus datatype constructor
  * should be printed as. This is used for printing
- * terms in sygus grammars that involve defined 
+ * terms in sygus grammars that involve defined
  * functions. For example, for grammar :
  *   A -> f( A ) | 0
  * where f is defined as:
  *   (define-fun ((x Int)) Int (+ x 1))
- * this class can be used as a callback for printing 
+ * this class can be used as a callback for printing
  * the first sygus datatype constructor f, where we use
- * analog operator (lambda (x) (+ x 1)). 
+ * analog operator (lambda (x) (+ x 1)).
  */
 class SygusNamedConstructorPrinter : public SygusDatatypeConstructorPrinter
 {
-public:
-  SygusNamedConstructorPrinter( std::string name );
-  ~SygusNamedConstructorPrinter(){}
+ public:
+  SygusNamedConstructorPrinter(std::string name);
+  ~SygusNamedConstructorPrinter() {}
   /** print sygus term e on output out using printer p */
-  virtual void toStreamSygus(const Printer * p, std::ostream& out, Expr e) const override;
-private:
+  virtual void toStreamSygus(const Printer* p,
+                             std::ostream& out,
+                             Expr e) const override;
+
+ private:
   /** the defined function name */
   std::string d_name;
 };
-  
+
 } /* CVC4::printer namespace */
 } /* CVC4 namespace */
 

--- a/src/printer/sygus_print_callback.h
+++ b/src/printer/sygus_print_callback.h
@@ -52,9 +52,8 @@ class SygusLetExpressionConstructorPrinter : public SygusDatatypeConstructorPrin
 public:
   SygusLetExpressionPrinter( Node let_body, std::vector< Node >& let_args, unsigned ninput_args );
   ~SygusLetExpressionPrinter(){}
-  /** print sygus term */
-  virtual void toStreamSygus( std::ostream& out, Expr e,
-                              OutputLanguage language = language::output::LANG_AUTO ) override;
+  /** print sygus term e on output out using printer p */
+  virtual void toStreamSygus(const Printer * p, std::ostream& out, Expr e) const override;
 private:
   /** let body of the sygus term */
   Node d_sygus_let_body;
@@ -87,9 +86,8 @@ class SygusNamedConstructorPrinter : public SygusDatatypeConstructorPrinter
 public:
   SygusNamedConstructorPrinter( std::string name );
   ~SygusNamedConstructorPrinter(){}
-  /** print sygus term */
-  virtual void toStreamSygus( std::ostream& out, Expr e,
-                              OutputLanguage language = language::output::LANG_AUTO ) override;
+  /** print sygus term e on output out using printer p */
+  virtual void toStreamSygus(const Printer * p, std::ostream& out, Expr e) const override;
 private:
   /** the defined function name */
   std::string d_name;

--- a/src/printer/sygus_print_callback.h
+++ b/src/printer/sygus_print_callback.h
@@ -103,6 +103,27 @@ class SygusNamedConstructorPrinter : public SygusDatatypeConstructorPrinter
   std::string d_name;
 };
 
+/** sygus empty printer
+ *
+ * This callback is used for printing constructors whose operators are 
+ * implicit, such as identity functions. For example, for grammar :
+ *   A -> B
+ *   B -> x | 0 | 1
+ * The first constructor of A, call it cons, has sygus operator (lambda (x) x).
+ * Call toStreamSygus on cons( t ) should call toStreamSygus on t directly.
+ */
+class SygusEmptyConstructorPrinter : public SygusDatatypeConstructorPrinter
+{
+ public:
+  SygusEmptyConstructorPrinter(std::string name);
+  ~SygusEmptyConstructorPrinter() {}
+  /** print sygus term e on output out using printer p */
+  virtual void toStreamSygus(const Printer* p,
+                             std::ostream& out,
+                             Expr e) const override;
+};
+
+
 } /* CVC4::printer namespace */
 } /* CVC4 namespace */
 

--- a/src/printer/sygus_print_callback.h
+++ b/src/printer/sygus_print_callback.h
@@ -105,7 +105,7 @@ class SygusNamedConstructorPrinter : public SygusDatatypeConstructorPrinter
 
 /** sygus empty printer
  *
- * This callback is used for printing constructors whose operators are 
+ * This callback is used for printing constructors whose operators are
  * implicit, such as identity functions. For example, for grammar :
  *   A -> B
  *   B -> x | 0 | 1
@@ -122,7 +122,6 @@ class SygusEmptyConstructorPrinter : public SygusDatatypeConstructorPrinter
                              std::ostream& out,
                              Expr e) const override;
 };
-
 
 } /* CVC4::printer namespace */
 } /* CVC4 namespace */

--- a/src/printer/sygus_print_callback.h
+++ b/src/printer/sygus_print_callback.h
@@ -29,7 +29,7 @@ namespace printer {
  * This class is used for printing sygus
  * datatype constructor terms whose top symbol
  * is a let expression.
- * For example, for example:
+ * For example, for grammar:
  *   A -> (let ((x B)) (+ A 1)) | x | (+ A A) | 0
  *   B -> 0 | 1
  * the first constructor for A takes as arguments


### PR DESCRIPTION
This is the first step towards addressing #1344, and also is work towards #1235.

This pull request:
- adds a generic callback mechanism for sygus datatype constructors. 
- adds a printing method in src/printer/printer.h for printing the terms that sygus datatype terms encode.

This allows much more flexibility in the future for handling artifacts from the sygus input format, and will allow us to eliminate a number of hard-coded fields in DatatypeConstructor, such as d_let_body (which is now a part of the printing callback, which can be specified as an instance of a virtual base class).

Notice that the new code in this commit has been copied from existing places in the code, such as TermDbSygus.  This code will be eliminated in a separate PR once all the components for the new printing architecture are ready (which will require 1-2 more intermediate PRs).
