### PR TITLE
Replacing Assert(false) with simpler control flow.

### DIFF
--- a/src/decision/decision_engine.cpp
+++ b/src/decision/decision_engine.cpp
@@ -100,8 +100,8 @@ SatValue DecisionEngine::getPolarity(SatVariable var)
 
 void DecisionEngine::addAssertions(const vector<Node> &assertions)
 {
-  Assert(false);  // doing this so that we revisit what to do
-                  // here. Currently not being used.
+  // Doing this so that we revisit what to do here. Currently not being used.
+  Unimplemented();
 
   // d_result = SAT_VALUE_UNKNOWN;
   // d_assertions.reserve(assertions.size());

--- a/src/printer/sygus_print_callback.cpp
+++ b/src/printer/sygus_print_callback.cpp
@@ -130,14 +130,8 @@ void SygusEmptyConstructorPrinter::toStreamSygus(const Printer* p,
                                                  std::ostream& out,
                                                  Expr e)
 {
-  if (e.getNumChildren() == 1)
-  {
-    p->toStreamSygus(out, e[0]);
-  }
-  else
-  {
-    Assert(false);
-  }
+  AlwaysAssert(e.getNumChildren() == 1);
+  p->toStreamSygus(out, e[0]);
 }
 
 } /* CVC4::printer namespace */

--- a/src/proof/arith_proof.cpp
+++ b/src/proof/arith_proof.cpp
@@ -500,7 +500,7 @@ Node ProofArith::toStreamRecLFSC(std::ostream& out,
                 } else {
                   Debug("pf::arith") << "Error: identical equalities over, but hands don't match what we're proving."
                                      << std::endl;
-                  Assert(false);
+                  Unreachable();
                 }
               } else {
                 // We have a "next node". Use it to guide us.
@@ -521,7 +521,7 @@ Node ProofArith::toStreamRecLFSC(std::ostream& out,
 
                 } else {
                   Debug("pf::arith") << "Error: even length sequence, but I don't know which hand to keep!" << std::endl;
-                  Assert(false);
+                  Unreachable();
                 }
               }
 
@@ -634,8 +634,7 @@ Node ProofArith::toStreamRecLFSC(std::ostream& out,
     Assert(!pf.d_node.isNull());
     Assert(pf.d_children.empty());
     Debug("pf::arith") << "theory proof: " << pf.d_node << " by rule " << int(pf.d_id) << std::endl;
-    AlwaysAssert(false);
-    return pf.d_node;
+    Unreachable();
   }
 }
 

--- a/src/proof/array_proof.cpp
+++ b/src/proof/array_proof.cpp
@@ -741,7 +741,7 @@ Node ProofArray::toStreamRecLFSC(std::ostream& out,
                 } else {
                   Debug("pf::array") << "Error: identical equalities over, but hands don't match what we're proving."
                                      << std::endl;
-                  Assert(false);
+                  Unreachable();
                 }
               } else {
                 // We have a "next node". Use it to guide us.
@@ -765,7 +765,7 @@ Node ProofArray::toStreamRecLFSC(std::ostream& out,
 
                 } else {
                   Debug("pf::array") << "Error: even length sequence, but I don't know which hand to keep!" << std::endl;
-                  Assert(false);
+                  Unreachable();
                 }
               }
 
@@ -1182,8 +1182,7 @@ Node ProofArray::toStreamRecLFSC(std::ostream& out,
     Assert(!pf.d_node.isNull());
     Assert(pf.d_children.empty());
     Debug("mgd") << "theory proof: " << pf.d_node << " by rule " << int(pf.d_id) << std::endl;
-    AlwaysAssert(false);
-    return pf.d_node;
+    Unreachable();
   }
 }
 

--- a/src/proof/proof_output_channel.cpp
+++ b/src/proof/proof_output_channel.cpp
@@ -62,8 +62,7 @@ theory::LemmaStatus ProofOutputChannel::lemma(TNode n, ProofRule rule, bool,
 }
 
 theory::LemmaStatus ProofOutputChannel::splitLemma(TNode, bool) {
-  AlwaysAssert(false);
-  return theory::LemmaStatus(TNode::null(), 0);
+  Unimplemented();
 }
 
 void ProofOutputChannel::requirePhase(TNode n, bool b) {
@@ -73,13 +72,12 @@ void ProofOutputChannel::requirePhase(TNode n, bool b) {
 
 bool ProofOutputChannel::flipDecision() {
   Debug("pf::tp") << "ProofOutputChannel::flipDecision called" << std::endl;
-  AlwaysAssert(false);
-  return false;
+  Unimplemented();
 }
 
 void ProofOutputChannel::setIncomplete() {
   Debug("pf::tp") << "ProofOutputChannel::setIncomplete called" << std::endl;
-  AlwaysAssert(false);
+  Unimplemented();
 }
 
 

--- a/src/proof/uf_proof.cpp
+++ b/src/proof/uf_proof.cpp
@@ -557,7 +557,7 @@ Node ProofUF::toStreamRecLFSC(std::ostream& out,
                 } else {
                   Debug("pf::uf") << "Error: identical equalities over, but hands don't match what we're proving."
                                   << std::endl;
-                  Assert(false);
+                  Unreachable();
                 }
               } else {
                 // We have a "next node". Use it to guide us.
@@ -578,7 +578,7 @@ Node ProofUF::toStreamRecLFSC(std::ostream& out,
 
                 } else {
                   Debug("pf::uf") << "Error: even length sequence, but I don't know which hand to keep!" << std::endl;
-                  Assert(false);
+                  Unreachable();
                 }
               }
 
@@ -725,8 +725,7 @@ Node ProofUF::toStreamRecLFSC(std::ostream& out,
     Assert(!pf.d_node.isNull());
     Assert(pf.d_children.empty());
     Debug("pf::uf") << "theory proof: " << pf.d_node << " by rule " << int(pf.d_id) << std::endl;
-    AlwaysAssert(false);
-    return pf.d_node;
+    Unreachable();
   }
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5326,11 +5326,8 @@ void SmtEngine::printInstantiations( std::ostream& out ) {
   if( options::instFormatMode()==INST_FORMAT_MODE_SZS ){
     out << "% SZS output start Proof for " << d_filename.c_str() << std::endl;
   }
-  if( d_theoryEngine ){
-    d_theoryEngine->printInstantiations( out );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert(d_theoryEngine);
+  d_theoryEngine->printInstantiations( out );
   if( options::instFormatMode()==INST_FORMAT_MODE_SZS ){
     out << "% SZS output end Proof for " << d_filename.c_str() << std::endl;
   }
@@ -5338,11 +5335,8 @@ void SmtEngine::printInstantiations( std::ostream& out ) {
 
 void SmtEngine::printSynthSolution( std::ostream& out ) {
   SmtScope smts(this);
-  if( d_theoryEngine ){
-    d_theoryEngine->printSynthSolution( out );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert(d_theoryEngine);
+  d_theoryEngine->printSynthSolution( out );
 }
 
 Expr SmtEngine::doQuantifierElimination(const Expr& e, bool doFull,
@@ -5409,45 +5403,36 @@ Expr SmtEngine::doQuantifierElimination(const Expr& e, bool doFull,
 
 void SmtEngine::getInstantiatedQuantifiedFormulas( std::vector< Expr >& qs ) {
   SmtScope smts(this);
-  if( d_theoryEngine ){
-    std::vector< Node > qs_n;
-    d_theoryEngine->getInstantiatedQuantifiedFormulas( qs_n );
-    for( unsigned i=0; i<qs_n.size(); i++ ){
-      qs.push_back( qs_n[i].toExpr() );
-    }
-  }else{
-    Assert( false );
+  AlwaysAssert(d_theoryEngine);
+  std::vector< Node > qs_n;
+  d_theoryEngine->getInstantiatedQuantifiedFormulas( qs_n );
+  for( unsigned i=0; i<qs_n.size(); i++ ){
+    qs.push_back( qs_n[i].toExpr() );
   }
 }
 
 void SmtEngine::getInstantiations( Expr q, std::vector< Expr >& insts ) {
   SmtScope smts(this);
-  if( d_theoryEngine ){
-    std::vector< Node > insts_n;
-    d_theoryEngine->getInstantiations( Node::fromExpr( q ), insts_n );
-    for( unsigned i=0; i<insts_n.size(); i++ ){
-      insts.push_back( insts_n[i].toExpr() );
-    }
-  }else{
-    Assert( false );
+  AlwaysAssert(d_theoryEngine);
+  std::vector< Node > insts_n;
+  d_theoryEngine->getInstantiations( Node::fromExpr( q ), insts_n );
+  for( unsigned i=0; i<insts_n.size(); i++ ){
+    insts.push_back( insts_n[i].toExpr() );
   }
 }
 
 void SmtEngine::getInstantiationTermVectors( Expr q, std::vector< std::vector< Expr > >& tvecs ) {
   SmtScope smts(this);
   Assert(options::trackInstLemmas());
-  if( d_theoryEngine ){
-    std::vector< std::vector< Node > > tvecs_n;
-    d_theoryEngine->getInstantiationTermVectors( Node::fromExpr( q ), tvecs_n );
-    for( unsigned i=0; i<tvecs_n.size(); i++ ){
-      std::vector< Expr > tvec;
-      for( unsigned j=0; j<tvecs_n[i].size(); j++ ){
-        tvec.push_back( tvecs_n[i][j].toExpr() );
-      }
-      tvecs.push_back( tvec );
+  AlwaysAssert(d_theoryEngine);
+  std::vector< std::vector< Node > > tvecs_n;
+  d_theoryEngine->getInstantiationTermVectors( Node::fromExpr( q ), tvecs_n );
+  for( unsigned i=0; i<tvecs_n.size(); i++ ){
+    std::vector< Expr > tvec;
+    for( unsigned j=0; j<tvecs_n[i].size(); j++ ){
+      tvec.push_back( tvecs_n[i][j].toExpr() );
     }
-  }else{
-    Assert( false );
+    tvecs.push_back( tvec );
   }
 }
 

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -410,20 +410,17 @@ bool NonLinearExtentionSubstitutionSolver::solve(
                 for (std::map<Node, Node>::iterator itm = msum.begin();
                      itm != msum.end(); ++itm) {
                   if (!itm->first.isNull()) {
-                    if (d_ee->hasTerm(itm->first)) {
-                      Trace("nl-subs-debug")
-                          << "      ...monomial " << itm->first << std::endl;
-                      Node cr = d_ee->getRepresentative(itm->first);
-                      d_term_to_sum[n].push_back(itm->first);
-                      d_term_to_rep_sum[n].push_back(cr);
-                      if (!Contains(d_rep_to_const, cr)) {
-                        if (!IsInVector(d_reps_to_parent_terms[cr], n)) {
-                          d_reps_to_parent_terms[cr].push_back(n);
-                          nconst_count++;
-                        }
+                    AlwaysAssert(d_ee->hasTerm(itm->first));
+                    Trace("nl-subs-debug")
+                        << "      ...monomial " << itm->first << std::endl;
+                    Node cr = d_ee->getRepresentative(itm->first);
+                    d_term_to_sum[n].push_back(itm->first);
+                    d_term_to_rep_sum[n].push_back(cr);
+                    if (!Contains(d_rep_to_const, cr)) {
+                      if (!IsInVector(d_reps_to_parent_terms[cr], n)) {
+                        d_reps_to_parent_terms[cr].push_back(n);
+                        nconst_count++;
                       }
-                    } else {
-                      Assert( false );
                     }
                   }
                 }
@@ -1012,7 +1009,7 @@ int NonlinearExtension::flushLemma(Node lem) {
     Trace("nl-ext-lemma-debug")
         << "NonlinearExtension::Lemma duplicate : " << lem << std::endl;
     // should not generate duplicates
-    // Assert( false );
+    // Unreachable();
     return 0;
   }
   d_lemmas.insert(lem);
@@ -1187,7 +1184,7 @@ int NonlinearExtension::checkLastCall(const std::vector<Node>& assertions,
             //congruence lemma
             Node cong_lemma = NodeManager::currentNM()->mkNode( kind::IMPLIES, a[0].eqNode( itrm->second[0] ), a.eqNode( itrm->second ) );
             lemmas.push_back( cong_lemma );
-            //Assert( false );
+            //Unreachable();
           }
         }else{
           d_tf_rep_map[a.getKind()][r] = a;
@@ -1195,8 +1192,8 @@ int NonlinearExtension::checkLastCall(const std::vector<Node>& assertions,
       }
     }else if( a.getKind()==kind::PI ){
       //TODO?
-    }else{
-      Assert( false );
+    } else {
+      Unreachable();
     }
   }
   

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -1198,10 +1198,8 @@ Node TheoryArithPrivate::ppRewriteTerms(TNode n) {
   case kind::INTS_MODULUS:
   case kind::DIVISION:
     // these should be removed during expand definitions
-    Assert( false );
-    break;
-  
-  case kind::INTS_DIVISION_TOTAL: 
+    Unreachable();
+  case kind::INTS_DIVISION_TOTAL:
   case kind::INTS_MODULUS_TOTAL: {
     Node den = Rewriter::rewrite(n[1]);
     if(!options::rewriteDivk() && den.isConst()) {
@@ -1515,8 +1513,7 @@ void TheoryArithPrivate::setupDivLike(const Variable& v){
   case INTS_DIVISION:
   case INTS_MODULUS:
     // these should be removed during expand definitions
-    Assert( false );
-    break;
+    Unreachable();
   case DIVISION_TOTAL:
     lem = axiomIteForTotalDivision(vnode);
     break;

--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -921,7 +921,7 @@ void TheoryArrays::checkPair(TNode r1, TNode r2)
   switch (eqStatusDomain) {
     case EQUALITY_TRUE_AND_PROPAGATED:
       // Should have been propagated to us
-      Assert(false);
+      Unreachable();
       break;
     case EQUALITY_TRUE:
       // Missed propagation - need to add the pair so that theory engine can force propagation
@@ -929,7 +929,7 @@ void TheoryArrays::checkPair(TNode r1, TNode r2)
       break;
     case EQUALITY_FALSE_AND_PROPAGATED:
       // Should have been propagated to us
-      Assert(false);
+      Unreachable();
     case EQUALITY_FALSE:
     case EQUALITY_FALSE_IN_MODEL:
       // This is unlikely, but I think it could happen

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -1018,7 +1018,7 @@ void SygusSymBreakNew::notifySearchSize( Node m, unsigned s, Node exp, std::vect
         Node exp = (*itx).second;
         assertTester( tindex, n, exp, lemmas );
       }else{
-        Assert( false );
+        Unreachable();
       }
     }
     */
@@ -1093,7 +1093,7 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
       if( !debugTesters( prog, progv, 0, lemmas ) ){
         Trace("sygus-sb") << "  SygusSymBreakNew::check: ...WARNING: considered missing split for " << prog << "." << std::endl;
         // this should not happen generally, it is caused by a sygus term not being assigned a tester
-        //Assert( false );
+        //Unreachable();
       }else{
         //debugging : ensure fairness was properly handled
         if( options::sygusFair()==SYGUS_FAIR_DT_SIZE ){  
@@ -1103,12 +1103,12 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
             
           Trace("sygus-sb") << "  Mv[" << prog << "] = " << progv << ", size = " << prog_szv << std::endl;
           if( prog_szv.getConst<Rational>().getNumerator().toUnsignedInt() > getSearchSizeForAnchor( prog ) ){
-            AlwaysAssert( false );
-            Node szlem = NodeManager::currentNM()->mkNode( kind::OR, prog.eqNode( progv ).negate(),
-                                                                     prog_sz.eqNode( progv_sz ) );
-            Trace("sygus-sb-warn") << "SygusSymBreak : WARNING : adding size correction : " << szlem << std::endl;
-            lemmas.push_back( szlem );                                                     
-            return;
+            Unreachable();
+            // Node szlem = NodeManager::currentNM()->mkNode( kind::OR, prog.eqNode( progv ).negate(),
+            //                                                          prog_sz.eqNode( progv_sz ) );
+            // Trace("sygus-sb-warn") << "SygusSymBreak : WARNING : adding size correction : " << szlem << std::endl;
+            // lemmas.push_back( szlem );                                                     
+            // return;
           }
         }
         

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -1541,9 +1541,8 @@ void TheoryDatatypes::collectModelInfo( TheoryModel* m ){
     bool addCons = false;
     Type tt = eqc.getType().toType();
     const Datatype& dt = ((DatatypeType)tt).getDatatype();
-    if( !d_equalityEngine.hasTerm( eqc ) ){
-      Assert( false );
-    }else{
+    AlwaysAssert(d_equalityEngine.hasTerm( eqc ));
+    
       Trace("dt-cmi") << "NOTICE : Datatypes: no constructor in equivalence class " << eqc << std::endl;
       Trace("dt-cmi") << "   Type : " << eqc.getType() << std::endl;
       EqcInfo* ei = getOrMakeEqcInfo( eqc );
@@ -1573,7 +1572,7 @@ void TheoryDatatypes::collectModelInfo( TheoryModel* m ){
         }
       }
       addCons = true;
-    }
+    
     if( !neqc.isNull() ){
       Trace("dt-cmi") << "Assign : " << neqc << std::endl;
       m->assertEquality( eqc, neqc, true );

--- a/src/theory/quantifiers/bounded_integers.cpp
+++ b/src/theory/quantifiers/bounded_integers.cpp
@@ -499,7 +499,7 @@ void BoundedIntegers::preRegisterQuantifier( Node f ) {
           Trace("bound-int") << "  " << v << " has small finite type." << std::endl;
         }else{
           Trace("bound-int") << "  " << v << " has unknown bound." << std::endl;
-          Assert( false );
+          Unreachable();
         }
       }else{
         Trace("bound-int") << "  " << "*** " << v << " is unbounded." << std::endl;

--- a/src/theory/quantifiers/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/ce_guided_conjecture.cpp
@@ -146,7 +146,7 @@ void CegConjecture::assign( Node q ) {
   {
     d_syntax_guided = false;
   }else{
-    Assert( false );
+    Unreachable();
   }
   
   // initialize the guard
@@ -197,13 +197,10 @@ bool CegConjecture::needsCheck( std::vector< Node >& lem ) {
     bool value;
     Assert( !getGuard().isNull() );
     // non or fully single invocation : look at guard only
-    if( d_qe->getValuation().hasSatValue( getGuard(), value ) ) {
-      if( !value ){
-        Trace("cegqi-engine-debug") << "Conjecture is infeasible." << std::endl;
-        return false;
-      }
-    }else{
-      Assert( false );
+    AlwaysAssert(d_qe->getValuation().hasSatValue( getGuard(), value ) );
+    if( !value ){
+      Trace("cegqi-engine-debug") << "Conjecture is infeasible." << std::endl;
+      return false;
     }
     return true;
   }
@@ -222,12 +219,9 @@ void CegConjecture::doBasicCheck(std::vector< Node >& lems) {
   getCandidateList( clist, true );
   Assert( clist.size()==d_quant[0].getNumChildren() );
   getModelValues( clist, model_terms );
-  if( d_qe->addInstantiation( d_quant, model_terms ) ){
-    //record the instantiation
-    recordInstantiation( model_terms );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( d_qe->addInstantiation( d_quant, model_terms ) );
+  //record the instantiation
+  recordInstantiation( model_terms );
 }
 
 bool CegConjecture::needsRefinement() { 

--- a/src/theory/quantifiers/ce_guided_instantiation.cpp
+++ b/src/theory/quantifiers/ce_guided_instantiation.cpp
@@ -310,12 +310,9 @@ void CegInstantiation::getCRefEvaluationLemmas( CegConjecture * conj, std::vecto
 }
 
 void CegInstantiation::printSynthSolution( std::ostream& out ) {
-  if( d_conj->isAssigned() ){
-    // print the conjecture
-    d_conj->printSynthSolution( out, d_last_inst_si );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( d_conj->isAssigned() );
+  // print the conjecture
+  d_conj->printSynthSolution( out, d_last_inst_si );
 }
 
 void CegInstantiation::preregisterAssertion( Node n ) {

--- a/src/theory/quantifiers/ce_guided_pbe.cpp
+++ b/src/theory/quantifiers/ce_guided_pbe.cpp
@@ -286,25 +286,18 @@ void CegConjecturePbe::getExample(Node e, unsigned i, std::vector<Node>& ex) {
   Assert(!e.isNull());
   std::map<Node, std::vector<std::vector<Node> > >::iterator it =
       d_examples.find(e);
-  if (it != d_examples.end()) {
-    Assert(i < it->second.size());
-    ex.insert(ex.end(), it->second[i].begin(), it->second[i].end());
-  } else {
-    Assert(false);
-  }
+  AlwaysAssert(it != d_examples.end());
+  Assert(i < it->second.size());
+  ex.insert(ex.end(), it->second[i].begin(), it->second[i].end());
 }
 
 Node CegConjecturePbe::getExampleOut(Node e, unsigned i) {
   e = d_tds->getSynthFunForEnumerator(e);
   Assert(!e.isNull());
   std::map<Node, std::vector<Node> >::iterator it = d_examples_out.find(e);
-  if (it != d_examples_out.end()) {
-    Assert(i < it->second.size());
-    return it->second[i];
-  } else {
-    Assert(false);
-    return Node::null();
-  }
+  AlwaysAssert(it != d_examples_out.end());
+  Assert(i < it->second.size());
+  return it->second[i];
 }
 
 Node CegConjecturePbe::addSearchVal(TypeNode tn, Node e, Node bvr) {

--- a/src/theory/quantifiers/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_instantiator.cpp
@@ -436,7 +436,7 @@ bool CegInstantiator::constructInstantiation(SolvedForm& sf, unsigned i)
 #ifdef CVC4_ASSERTIONS
       if( pvtn.isReal() && options::cbqiNestedQE() && !options::cbqiAll() ){
         Trace("cbqi-warn") << "Had to resort to model value." << std::endl;
-        Assert( false );
+        Unreachable();
       }
 #endif
       Node mv = getModelValue( pv );
@@ -1000,7 +1000,7 @@ void CegInstantiator::processAssertions() {
       addToAuxVarSubstitution( subs_lhs, subs_rhs, r, it->second );
     }else{
       Trace("cbqi-proc") << "....no substitution found for auxiliary variable " << r << "!!! type is " << r.getType() << std::endl;
-      Assert( false );
+      Unreachable();
     }
   }
 

--- a/src/theory/quantifiers/conjecture_generator.cpp
+++ b/src/theory/quantifiers/conjecture_generator.cpp
@@ -1644,8 +1644,7 @@ bool TermGenerator::getNextMatch( TermGenEnv * s, TNode eqc, std::map< TypeNode,
       }
     }
   }
-  Assert( false );
-  return false;
+  Unreachable();
 }
 
 unsigned TermGenerator::getDepth( TermGenEnv * s ) {
@@ -1714,10 +1713,8 @@ Node TermGenerator::getTerm( TermGenEnv * s ) {
       }
       return NodeManager::currentNM()->mkNode( s->d_func_kind[f], children );
     }
-  }else{
-    Assert( false );
   }
-  return Node::null();
+  Unreachable();
 }
 
 void TermGenerator::debugPrint( TermGenEnv * s, const char * c, const char * cd ) {
@@ -1898,7 +1895,7 @@ bool TermGenEnv::considerCurrentTerm() {
   }else if( d_tg_alloc[i-1].d_status==5 ){
   }else{
     Trace("sg-gen-tg-debug") << "Bad tg: " << &d_tg_alloc[i-1] << std::endl;
-    Assert( false );
+    Unreachable();
   }
   */
   //if equated two variables, first check if context-independent TODO

--- a/src/theory/quantifiers/equality_query.cpp
+++ b/src/theory/quantifiers/equality_query.cpp
@@ -62,7 +62,7 @@ bool EqualityQueryQuantifiersEngine::processInferences( Theory::Effort e ) {
           if( !d_qe->getTheoryEngine()->needCheck() ){
             Trace("term-db-lemma") << "  all theories passed with no lemmas." << std::endl;
             //this should really never happen (implies arithmetic is incomplete when sharing is enabled)
-            Assert( false );
+            Unreachable();
           }
           Trace("term-db-lemma") << "  add split on : " << eq << std::endl;
         }
@@ -136,7 +136,7 @@ Node EqualityQueryQuantifiersEngine::getInternalRepresentative(Node a,
           if( r.getType().isSort() ){
             Trace("internal-rep-warn") << "No representative for UF constant." << std::endl;
             //should never happen : UF constants should never escape model
-            Assert( false );
+            Unreachable();
           }
         }
       }

--- a/src/theory/quantifiers/full_model_check.cpp
+++ b/src/theory/quantifiers/full_model_check.cpp
@@ -476,7 +476,7 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
         }
         if( !isStar && !ri.isConst() ){
           Trace("fmc-warn") << "Warning : model for " << op << " has non-constant argument in model " << ri << " (from " << c[i] << ")" << std::endl;
-          Assert( false );
+          Unreachable();
         }
         entry_children.push_back(ri);
       }
@@ -484,7 +484,7 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
       Node nv = fm->getRepresentative( v );
       if( !nv.isConst() ){
         Trace("fmc-warn") << "Warning : model for " << op << " has non-constant value in model " << nv << std::endl;
-        Assert( false );
+        Unreachable();
       }
       Node en = (useSimpleModels() && hasNonStar) ? n : NodeManager::currentNM()->mkNode( APPLY_UF, entry_children );
       if( std::find(conds.begin(), conds.end(), n )==conds.end() ){

--- a/src/theory/quantifiers/inst_propagator.cpp
+++ b/src/theory/quantifiers/inst_propagator.cpp
@@ -629,7 +629,7 @@ bool InstPropagator::notifyInstantiation(QuantifiersModule::QEffort quant_e,
                                          std::vector<Node>& terms,
                                          Node body)
 {
-  if( !d_conflict ){
+  AlwaysAssert( !d_conflict );
     if( Trace.isOn("qip-prop") ){
       Trace("qip-prop") << "InstPropagator:: Notify instantiation " << q << " : " << std::endl;
       for( unsigned i=0; i<terms.size(); i++ ){
@@ -657,10 +657,6 @@ bool InstPropagator::notifyInstantiation(QuantifiersModule::QEffort quant_e,
     }
     Trace("qip-prop") << "...finished notify instantiation." << std::endl;
     return !d_conflict;
-  }else{
-    Assert( false );
-    return false;
-  }
 }
 
 void InstPropagator::filterInstantiations() {
@@ -672,7 +668,7 @@ void InstPropagator::filterInstantiations() {
         if( d_relevant_inst.find( it->first )==d_relevant_inst.end() ){
           if( !d_qe->removeInstantiation( it->second.d_q, it->second.d_lem, it->second.d_terms ) ){
             Trace("qip-warn") << "WARNING : did not remove instantiation id " << it->first << std::endl;
-            Assert( false );
+            Unreachable();
           }else{
             Trace("qip-prop-debug") << it->first << " ";
           }

--- a/src/theory/quantifiers/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/inst_strategy_cbqi.cpp
@@ -92,19 +92,16 @@ bool InstStrategyCbqi::registerCbqiLemma( Node q ) {
             if( qepr->isEPR( tn ) ){
               //add totality lemma
               std::map< TypeNode, std::vector< Node > >::iterator itc = qepr->d_consts.find( tn );
-              if( itc!=qepr->d_consts.end() ){
-                Assert( !itc->second.empty() );
-                Node ic = d_quantEngine->getTermUtil()->getInstantiationConstant( q, i );
-                std::vector< Node > disj;
-                for( unsigned j=0; j<itc->second.size(); j++ ){
-                  disj.push_back( ic.eqNode( itc->second[j] ) );
-                }
-                Node tlem = disj.size()==1 ? disj[0] : NodeManager::currentNM()->mkNode( kind::OR, disj );
-                Trace("cbqi-lemma") << "EPR totality lemma : " << tlem << std::endl;
-                d_quantEngine->getOutputChannel().lemma( tlem );
-              }else{
-                Assert( false );
-              }                  
+              AlwaysAssert(itc!=qepr->d_consts.end());
+              Assert( !itc->second.empty() );
+              Node ic = d_quantEngine->getTermUtil()->getInstantiationConstant( q, i );
+              std::vector< Node > disj;
+              for( unsigned j=0; j<itc->second.size(); j++ ){
+                disj.push_back( ic.eqNode( itc->second[j] ) );
+              }
+              Node tlem = disj.size()==1 ? disj[0] : NodeManager::currentNM()->mkNode( kind::OR, disj );
+              Trace("cbqi-lemma") << "EPR totality lemma : " << tlem << std::endl;
+              d_quantEngine->getOutputChannel().lemma( tlem );
             }else{
               Assert( !options::cbqiAll() );
             }
@@ -265,7 +262,7 @@ void InstStrategyCbqi::check(Theory::Effort e, QEffort quant_e)
           }
         }else{
           Trace("cbqi-warn") << "CBQI : Cannot process already eliminated quantified formula " << q << std::endl;
-          Assert( false );
+          Unreachable();
         }
       }
       if( d_quantEngine->inConflict() || d_quantEngine->getNumLemmasWaiting()>lastWaiting ){

--- a/src/theory/quantifiers/macros.cpp
+++ b/src/theory/quantifiers/macros.cpp
@@ -424,7 +424,7 @@ Node QuantifierMacros::simplify( Node n ){
             if( etc.isNull() ){
               //if this does fail, we are incomplete, since we are eliminating quantified formula corresponding to op, 
               //  and not ensuring it applies to n when its types are correct.
-              //Assert( false );
+              //Unreachable();
               success = false;
               break;
             }else if( !etc.isConst() ){

--- a/src/theory/quantifiers/quant_conflict_find.cpp
+++ b/src/theory/quantifiers/quant_conflict_find.cpp
@@ -2054,7 +2054,7 @@ void QuantConflictFind::check(Theory::Effort level, QEffort quant_e)
       Trace("qcf-check2") << "QCF : finished check : already in conflict." << std::endl;
       if( level>=Theory::EFFORT_FULL ){
         Trace("qcf-warn") << "ALREADY IN CONFLICT? " << level << std::endl;
-        //Assert( false );
+        //Unreachable();
       }
     }else{
       int addedLemmas = 0;

--- a/src/theory/quantifiers/quant_split.cpp
+++ b/src/theory/quantifiers/quant_split.cpp
@@ -129,7 +129,7 @@ void QuantDSplit::check(Theory::Effort e, QEffort quant_e)
             Node conc = cons.size()==1 ? cons[0] : NodeManager::currentNM()->mkNode( kind::AND, cons );
             disj.push_back( conc );
           }else{
-            Assert( false );
+            Unreachable();
           }
           lemmas.push_back( disj.size()==1 ? disj[0] : NodeManager::currentNM()->mkNode( kind::OR, disj ) );
         }
@@ -144,4 +144,3 @@ void QuantDSplit::check(Theory::Effort e, QEffort quant_e)
     //d_quant_to_reduce.clear();
   }
 }
-

--- a/src/theory/quantifiers/quantifiers_attributes.cpp
+++ b/src/theory/quantifiers/quantifiers_attributes.cpp
@@ -202,7 +202,7 @@ void QuantAttributes::computeAttributes( Node q ) {
     Node f = d_qattr[q].d_fundef_f;
     if( d_fun_defs.find( f )!=d_fun_defs.end() ){
       Message() << "Cannot define function " << f << " more than once." << std::endl;
-      AlwaysAssert(false);
+      Unreachable();
     }
     d_fun_defs[f] = true;
     d_quantEngine->setOwner( q, d_quantEngine->getFunDefEngine(), 2 );

--- a/src/theory/quantifiers/rewrite_engine.cpp
+++ b/src/theory/quantifiers/rewrite_engine.cpp
@@ -152,7 +152,7 @@ int RewriteEngine::checkRewriteRule( Node f, Theory::Effort e ) {
                     Trace("rewrite-engine-inst-debug") << inst[i] << std::endl;
                   }else{
                     Trace("rewrite-engine-inst-debug") << "OUT_OF_RANGE" << std::endl;
-                    Assert( false );
+                    Unreachable();
                   }
                 }
                 //resize to remove auxiliary variables

--- a/src/theory/quantifiers/skolemize.cpp
+++ b/src/theory/quantifiers/skolemize.cpp
@@ -260,7 +260,7 @@ Node Skolemize::mkSkolemizedBody(Node f,
     {
       Trace("sk-ind") << "Unknown induction for term : " << ind_vars[0]
                       << ", type = " << tn << std::endl;
-      Assert(false);
+      Unreachable();
     }
     Trace("sk-ind") << "Strengthening is : " << n_str_ind << std::endl;
 

--- a/src/theory/quantifiers/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus_grammar_cons.cpp
@@ -439,7 +439,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       sserr << "No implementation for default Sygus grammar of type " << types[i] << std::endl;
       //AlwaysAssert( false, sserr.str() );
       // FIXME
-      AlwaysAssert( false );
+      Unreachable();
     }
     //add for all selectors to this type
     if( !sels[types[i]].empty() ){

--- a/src/theory/quantifiers/sygus_process_conj.cpp
+++ b/src/theory/quantifiers/sygus_process_conj.cpp
@@ -587,12 +587,8 @@ void CegConjectureProcess::initialize(Node n, std::vector<Node>& candidates)
 bool CegConjectureProcess::isArgRelevant(Node f, unsigned i)
 {
   std::map<Node, CegConjectureProcessFun>::iterator its = d_sf_info.find(f);
-  if (its != d_sf_info.end())
-  {
-    return its->second.isArgRelevant(i);
-  }
-  Assert(false);
-  return true;
+  AlwaysAssert(its != d_sf_info.end());
+  return its->second.isArgRelevant(i);
 }
 
 bool CegConjectureProcess::getIrrelevantArgs(Node f,

--- a/src/theory/quantifiers/term_database.cpp
+++ b/src/theory/quantifiers/term_database.cpp
@@ -117,16 +117,9 @@ unsigned TermDb::getNumGroundTerms(Node f) const
 Node TermDb::getGroundTerm(Node f, unsigned i) const
 {
   std::map<Node, std::vector<Node> >::const_iterator it = d_op_map.find(f);
-  if (it != d_op_map.end())
-  {
-    Assert(i < it->second.size());
-    return it->second[i];
-  }
-  else
-  {
-    Assert(false);
-    return Node::null();
-  }
+  AlwaysAssert(it != d_op_map.end());
+  Assert(i < it->second.size());
+  return it->second[i];
 }
 
 unsigned TermDb::getNumTypeGroundTerms(TypeNode tn) const
@@ -144,16 +137,9 @@ Node TermDb::getTypeGroundTerm(TypeNode tn, unsigned i) const
 {
   std::map<TypeNode, std::vector<Node> >::const_iterator it =
       d_type_map.find(tn);
-  if (it != d_type_map.end())
-  {
-    Assert(i < it->second.size());
-    return it->second[i];
-  }
-  else
-  {
-    Assert(false);
-    return Node::null();
-  }
+  AlwaysAssert(it != d_type_map.end());
+  Assert(i < it->second.size());
+  return it->second[i];
 }
 
 Node TermDb::getOrMakeTypeGroundTerm(TypeNode tn)
@@ -358,7 +344,7 @@ void TermDb::computeUfTerms( TNode f ) {
                           lits.push_back( atf.eqNode( nf ).negate() );
                         }else{
                           success = false;
-                          Assert( false );
+                          Unreachable();
                         }
                       }
                     }
@@ -697,9 +683,8 @@ bool TermDb::hasTermCurrent( Node n, bool useMode ) {
       return true;
     }else if( options::termDbMode()==TERM_DB_RELEVANT ){
       return d_has_map.find( n )!=d_has_map.end();
-    }else{
-      Assert( false );
-      return false;
+    } else {
+      Unreachable();
     }
   }
 }

--- a/src/theory/quantifiers/term_database_sygus.cpp
+++ b/src/theory/quantifiers/term_database_sygus.cpp
@@ -1828,11 +1828,8 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
     Node ev = en[0];
     if( track_exp ){
       std::map< Node, Node >::iterator itv = vtm.find( en[0] );
-      if( itv!=vtm.end() ){
-        ev = itv->second;
-      }else{
-        Assert( false );
-      }
+      AlwaysAssert( itv!=vtm.end() );
+      ev = itv->second;
       Assert( en[0].getType()==ev.getType() );
       Assert( ev.isConst() );
     }

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -623,9 +623,8 @@ Node TermUtil::getVtsInfinityIndex( int i, bool isFree, bool create ) {
     return getVtsInfinity( NodeManager::currentNM()->realType(), isFree, create );
   }else if( i==1 ){
     return getVtsInfinity( NodeManager::currentNM()->integerType(), isFree, create );
-  }else{
-    Assert( false );
-    return Node::null();
+  } else {
+    Unreachable();
   }
 }
 
@@ -695,7 +694,7 @@ Node TermUtil::rewriteVtsSymbols( Node n ) {
             Trace("quant-vts-warn") << "Bad vts literal : " << n << ", contains " << vts_sym << " but bad solved form " << slv << "." << std::endl;
             nlit = substituteVtsFreeTerms( n );
             Trace("quant-vts-debug") << "...return " << nlit << std::endl;
-            //Assert( false );
+            //Unreachable();
             //safe case: just convert to free symbols
             return nlit;
           }else{
@@ -719,7 +718,7 @@ Node TermUtil::rewriteVtsSymbols( Node n ) {
           //safe case: just convert to free symbols
           nlit = substituteVtsFreeTerms( n );
           Trace("quant-vts-debug") << "...return " << nlit << std::endl;
-          //Assert( false );
+          //Unreachable();
           return nlit;
         }
       }

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -523,7 +523,7 @@ void QuantifiersEngine::check( Theory::Effort e ){
           return;
         }else{
           //should only fail reset if added a lemma
-          Assert( false );
+          Unreachable();
         }
       }
     }
@@ -1195,7 +1195,7 @@ bool QuantifiersEngine::addInstantiation( Node q, std::vector< Node >& terms, bo
       for( unsigned j=0; j<terms.size(); j++ ){
         Trace("inst") << "   " << terms[j] << std::endl;
       }
-      Assert( false );
+      Unreachable();
     }
 #endif
   }
@@ -1288,7 +1288,7 @@ bool QuantifiersEngine::addInstantiation( Node q, std::vector< Node >& terms, bo
     if( options::instMaxLevel()!=-1 ){
       if( doVts ){
         //virtual term substitution/instantiation level features are incompatible
-        Assert( false );
+        Unreachable();
       }else{
         uint64_t maxInstLevel = 0;
         for( unsigned i=0; i<terms.size(); i++ ){
@@ -1523,7 +1523,7 @@ void QuantifiersEngine::getExplanationForInstLemmas( std::vector< Node >& lems, 
     }
 #endif
   }else{
-    Assert( false );
+    Unreachable();
   }
 }
 

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -438,7 +438,7 @@ void TheorySep::check(Effort e) {
 
             }else{
               //labeled emp should be rewritten
-              Assert( false );
+              Unreachable();
             }
             d_red_conc[s_lbl][s_atom] = conc;
           }else{
@@ -1051,7 +1051,6 @@ void TheorySep::registerRefDataTypes( TypeNode tn1, TypeNode tn2, Node atom ){
       std::stringstream ss;
       ss << "ERROR: specifying heap constraints for two different types : " << tn1 << " -> " << tn2 << " and " << te1 << " -> " << d_loc_to_data_type[te1] << std::endl;
       throw LogicException(ss.str());
-      Assert( false );
     }
     if( tn2.isNull() ){
       Trace("sep-type") << "Sep: assume location type " << tn1 << " (from " << atom << ")" << std::endl;
@@ -1075,7 +1074,6 @@ void TheorySep::registerRefDataTypes( TypeNode tn1, TypeNode tn2, Node atom ){
           std::stringstream ss;
           ss << "ERROR: location type " << tn1 << " is already associated with data type " << itt->second << ", offending atom is " << atom << " with data type " << tn2 << std::endl;
           throw LogicException(ss.str());
-          Assert( false );
         }
       }
     }
@@ -1529,7 +1527,6 @@ void TheorySep::computeLabelModel( Node lbl ) {
         d_label_model[lbl].d_heap_locs_model.push_back( v_val );
       }else{
         throw Exception("Could not establish value of heap in model.");
-        Assert( false );
       }
     }
     for( unsigned j=0; j<d_label_model[lbl].d_heap_locs_model.size(); j++ ){
@@ -1540,7 +1537,7 @@ void TheorySep::computeLabelModel( Node lbl ) {
       std::map< Node, Node >::iterator itm = d_tmodel.find( u );
       if( itm==d_tmodel.end() ) {
         //Trace("sep-process") << "WARNING: could not find symbolic term in model for " << u << std::endl;
-        //Assert( false );
+        //Unreachable();
         //tt = u;
         //TypeNode tn = u.getType().getRefConstituentType();
         TypeNode tn = u.getType();

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -575,17 +575,14 @@ void TheorySetsPrivate::fullEffortCheck(){
             Node s = d_equalityEngine.getRepresentative( n[1] );
             Node x = d_equalityEngine.getRepresentative( n[0] );
             int pindex = eqc==d_true ? 0 : ( eqc==d_false ? 1 : -1 );
-            if( pindex!=-1  ){
-              if( d_pol_mems[pindex][s].find( x )==d_pol_mems[pindex][s].end() ){
-                d_pol_mems[pindex][s][x] = n;
-                Trace("sets-debug2") << "Membership[" << x << "][" << s << "] : " << n << ", pindex = " << pindex << std::endl;
-              }
-              if( d_members_index[s].find( x )==d_members_index[s].end() ){
-                d_members_index[s][x] = n;
-                d_op_list[kind::MEMBER].push_back( n );
-              }
-            }else{
-              Assert( false );
+            AlwaysAssert( pindex!=-1  );
+            if( d_pol_mems[pindex][s].find( x )==d_pol_mems[pindex][s].end() ){
+              d_pol_mems[pindex][s][x] = n;
+              Trace("sets-debug2") << "Membership[" << x << "][" << s << "] : " << n << ", pindex = " << pindex << std::endl;
+            }
+            if( d_members_index[s].find( x )==d_members_index[s].end() ){
+              d_members_index[s][x] = n;
+              d_op_list[kind::MEMBER].push_back( n );
             }
           }
         }else if( n.getKind()==kind::SINGLETON || n.getKind()==kind::UNION || n.getKind()==kind::INTERSECTION || 
@@ -1090,19 +1087,16 @@ void TheorySetsPrivate::checkCardCycles( std::vector< Node >& lemmas ) {
 void TheorySetsPrivate::checkCardCyclesRec( Node eqc, std::vector< Node >& curr, std::vector< Node >& exp, std::vector< Node >& lemmas ) {
   if( std::find( curr.begin(), curr.end(), eqc )!=curr.end() ){
     Trace("sets-debug") << "Found venn region loop..." << std::endl;
-    if( curr.size()>1 ){
-      //all regions must be equal
-      std::vector< Node > conc;
-      for( unsigned i=1; i<curr.size(); i++ ){
-        conc.push_back( curr[0].eqNode( curr[i] ) );
-      }
-      Node fact = conc.size()==1 ? conc[0] : NodeManager::currentNM()->mkNode( kind::AND, conc );
-      assertInference( fact, exp, lemmas, "card_cycle" );
-      flushLemmas( lemmas );
-    }else{
-      //should be guaranteed based on not exploring equal parents
-      Assert( false );
+    //should be guaranteed based on not exploring equal parents
+    AlwaysAssert( curr.size()>1 );
+    //all regions must be equal
+    std::vector< Node > conc;
+    for( unsigned i=1; i<curr.size(); i++ ){
+      conc.push_back( curr[0].eqNode( curr[i] ) );
     }
+    Node fact = conc.size()==1 ? conc[0] : NodeManager::currentNM()->mkNode( kind::AND, conc );
+    assertInference( fact, exp, lemmas, "card_cycle" );
+    flushLemmas( lemmas );
   }else if( std::find( d_set_eqc.begin(), d_set_eqc.end(), eqc )==d_set_eqc.end() ){
     curr.push_back( eqc );
     TypeNode tn = eqc.getType();
@@ -1475,7 +1469,7 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
         Trace("sets-nf") << "----> N " << eqc << " => F " << base << std::endl;
       }else{
         Trace("sets-nf") << "failed to build N " << eqc << std::endl;
-        Assert( false );
+        Unreachable();
       }
     }else{
       //normal form is this equivalence class

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -632,7 +632,7 @@ Node SortInference::simplifyNode( Node n, std::map< Node, Node >& var_bound, Typ
       if( !tn1.isSubtypeOf( tn2 ) && !tn2.isSubtypeOf( tn1 ) ){
         Trace("sort-inference-warn") << "Sort inference created bad equality: " << children[0] << " = " << children[1] << std::endl;
         Trace("sort-inference-warn") << "  Types : " << children[0].getType() << " " << children[1].getType() << std::endl;
-        Assert( false );
+        Unreachable();
       }
       ret = NodeManager::currentNM()->mkNode( kind::EQUAL, children );
     }else if( n.getKind()==kind::APPLY_UF ){
@@ -669,7 +669,7 @@ Node SortInference::simplifyNode( Node n, std::map< Node, Node >& var_bound, Typ
         TypeNode tna = getTypeForId( d_op_arg_types[op][i] );
         if( tn!=tna ){
           Trace("sort-inference-warn") << "Sort inference created bad child: " << n << " " << n[i] << " " << tn << " " << tna << std::endl;
-          Assert( false );
+          Unreachable();
         }
       }
       ret = NodeManager::currentNM()->mkNode( kind::APPLY_UF, children );

--- a/src/theory/strings/regexp_operation.cpp
+++ b/src/theory/strings/regexp_operation.cpp
@@ -908,7 +908,7 @@ bool RegExpOpr::follow( Node r, CVC4::String c, std::vector< unsigned char > &ve
       break;
     default: {
       Trace("strings-error") << "Unsupported term: " << mkString( r ) << " in follow of RegExp." << std::endl;
-      //AlwaysAssert( false );
+      //Unreachable();
       //return Node::null();
       return false;
     }
@@ -1937,7 +1937,7 @@ void RegExpOpr::splitRegExp(Node r, std::vector< PairNodes > &pset) {
       }
       default: {
         Trace("strings-error") << "Unsupported term: " << r << " in splitRegExp." << std::endl;
-        Assert( false );
+        Unreachable();
         //return Node::null();
       }
     }
@@ -1946,54 +1946,54 @@ void RegExpOpr::splitRegExp(Node r, std::vector< PairNodes > &pset) {
 }
 
 void RegExpOpr::flattenRegExp(Node r, std::vector< std::pair< CVC4::String, unsigned > > &fvec) {
-  Assert(false);
-  Assert(checkConstRegExp(r));
-  switch( r.getKind() ) {
-      case kind::REGEXP_EMPTY: {
-        //TODO
-        break;
-      }
-      case kind::REGEXP_SIGMA: {
-        CVC4::String s("a");
-        std::pair< CVC4::String, unsigned > tmp(s, 0);
-        //TODO
-        break;
-      }
-      case kind::STRING_TO_REGEXP: {
-        Assert(r[0].isConst());
-        CVC4::String s = r[0].getConst< CVC4::String >();
-        std::pair< CVC4::String, unsigned > tmp(s, 0);
-        //TODO
-        break;
-      }
-      case kind::REGEXP_CONCAT: {
-        for(unsigned i=0; i<r.getNumChildren(); i++) {
-          //TODO
-        }
-        break;
-      }
-      case kind::REGEXP_UNION: {
-        for(unsigned i=0; i<r.getNumChildren(); ++i) {
-          //TODO
-        }
-        break;
-      }
-      case kind::REGEXP_INTER: {
-        //TODO
-        break;
-      }
-      case kind::REGEXP_STAR: {
-        //TODO
-        break;
-      }
-      case kind::REGEXP_LOOP: {
-        //TODO
-        break;
-      }
-      default: {
-        Unreachable();
-      }
-  }
+  Unimplemented();
+  // Assert(checkConstRegExp(r));
+  // switch( r.getKind() ) {
+  //     case kind::REGEXP_EMPTY: {
+  //       //TODO
+  //       break;
+  //     }
+  //     case kind::REGEXP_SIGMA: {
+  //       CVC4::String s("a");
+  //       std::pair< CVC4::String, unsigned > tmp(s, 0);
+  //       //TODO
+  //       break;
+  //     }
+  //     case kind::STRING_TO_REGEXP: {
+  //       Assert(r[0].isConst());
+  //       CVC4::String s = r[0].getConst< CVC4::String >();
+  //       std::pair< CVC4::String, unsigned > tmp(s, 0);
+  //       //TODO
+  //       break;
+  //     }
+  //     case kind::REGEXP_CONCAT: {
+  //       for(unsigned i=0; i<r.getNumChildren(); i++) {
+  //         //TODO
+  //       }
+  //       break;
+  //     }
+  //     case kind::REGEXP_UNION: {
+  //       for(unsigned i=0; i<r.getNumChildren(); ++i) {
+  //         //TODO
+  //       }
+  //       break;
+  //     }
+  //     case kind::REGEXP_INTER: {
+  //       //TODO
+  //       break;
+  //     }
+  //     case kind::REGEXP_STAR: {
+  //       //TODO
+  //       break;
+  //     }
+  //     case kind::REGEXP_LOOP: {
+  //       //TODO
+  //       break;
+  //     }
+  //     default: {
+  //       Unreachable();
+  //     }
+  // }
 }
 
 void RegExpOpr::disjunctRegExp(Node r, std::vector<Node> &vec_or) {
@@ -2165,7 +2165,7 @@ std::string RegExpOpr::mkString( Node r ) {
       }
       default:
         Trace("strings-error") << "Unsupported term: " << r << " in RegExp." << std::endl;
-        //Assert( false );
+        //Unreachable();
         //return Node::null();
     }
   }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -491,7 +491,7 @@ void TheoryStrings::collectModelInfo( TheoryModel* m ) {
         values_used[ lvalue ] = true;
       }else{
         //Trace("strings-model-warn") << "No length for eqc " << col[i][0] << std::endl;
-        //Assert( false );
+        //Unreachable();
         lts_values.push_back( Node::null() );
       }
     }
@@ -1912,7 +1912,7 @@ Node TheoryStrings::checkCycles( Node eqc, std::vector< Node >& curr, std::vecto
                   }
                   Trace("strings-error") << "Looping term should be congruent : " << n << " " << eqc << " " << ncy << std::endl;
                   //should find a non-empty component, otherwise would have been singular congruent (I_Norm_S)
-                  Assert( false );
+                  Unreachable();
                 }else{
                   return ncy;
                 }
@@ -3034,7 +3034,7 @@ void TheoryStrings::processDeq( Node ni, Node nj ) {
         index++;
       }
     }
-    Assert( false );
+    Unreachable();
   }
 }
 
@@ -4063,13 +4063,10 @@ bool TheoryStrings::normalizePosMemberships(std::map< Node, std::vector< Node > 
     Node x = (*itr_xr).first;
     Node nf_x = x;
     std::vector< Node > nf_x_exp;
-    if(d_normal_forms.find( x ) != d_normal_forms.end()) {
-      //nf_x = mkConcat( d_normal_forms[x] );
-      nf_x_exp.insert(nf_x_exp.end(), d_normal_forms_exp[x].begin(), d_normal_forms_exp[x].end());
-      //Debug("regexp-nf") << "Term: " << x << " has a normal form " << ret << std::endl;
-    } else {
-      Assert(false);
-    }
+    AlwaysAssert(d_normal_forms.find( x ) != d_normal_forms.end());
+    //nf_x = mkConcat( d_normal_forms[x] );
+    nf_x_exp.insert(nf_x_exp.end(), d_normal_forms_exp[x].begin(), d_normal_forms_exp[x].end());
+    //Debug("regexp-nf") << "Term: " << x << " has a normal form " << ret << std::endl;
     Trace("regexp-nf") << "Checking Memberships for N(" << x << ") = " << nf_x << " :" << std::endl;
 
     std::vector< Node > vec_x;
@@ -4292,7 +4289,7 @@ bool TheoryStrings::checkMemberships2() {
         }
         */ 
       }
-      Assert(false); //TODO:tmp
+      Unreachable(); //TODO:tmp
     }
   }
 
@@ -4898,7 +4895,7 @@ Node TheoryStrings::getNormalSymRegExp(Node r, std::vector<Node> &nf_exp) {
     //case kind::REGEXP_RANGE:
     default: {
       Trace("strings-error") << "Unsupported term: " << r << " in normalization SymRegExp." << std::endl;
-      Assert( false );
+      Unreachable();
       //return Node::null();
     }
   }

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -677,16 +677,10 @@ void ExtTheory::markCongruent( Node a, Node b ) {
   registerTerm( a );
   registerTerm( b );
   NodeBoolMap::const_iterator it = d_ext_func_terms.find( b );
-  if( it!=d_ext_func_terms.end() ){
-    if( d_ext_func_terms.find( a )!=d_ext_func_terms.end() ){
-      d_ext_func_terms[a] = d_ext_func_terms[a] && (*it).second;
-    }else{
-      Assert( false );
-    }
-    d_ext_func_terms[b] = false;
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( it!=d_ext_func_terms.end() );
+  AlwaysAssert( d_ext_func_terms.find( a )!=d_ext_func_terms.end() );
+  d_ext_func_terms[a] = d_ext_func_terms[a] && (*it).second;
+  d_ext_func_terms[b] = false;
 }
 
 bool ExtTheory::isContextIndependentInactive(Node n) const {

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1473,52 +1473,33 @@ void TheoryEngine::printSynthSolution( std::ostream& out ) {
 }
 
 void TheoryEngine::getInstantiatedQuantifiedFormulas( std::vector< Node >& qs ) {
-  if( d_quantEngine ){
-    d_quantEngine->getInstantiatedQuantifiedFormulas( qs );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( d_quantEngine );
+  d_quantEngine->getInstantiatedQuantifiedFormulas( qs );
 }
 
 void TheoryEngine::getInstantiations( Node q, std::vector< Node >& insts ) {
-  if( d_quantEngine ){
-    d_quantEngine->getInstantiations( q, insts );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( d_quantEngine );
+  d_quantEngine->getInstantiations( q, insts );
 }
 
 void TheoryEngine::getInstantiationTermVectors( Node q, std::vector< std::vector< Node > >& tvecs ) {
-  if( d_quantEngine ){
-    d_quantEngine->getInstantiationTermVectors( q, tvecs );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( d_quantEngine );
+  d_quantEngine->getInstantiationTermVectors( q, tvecs );
 }
 
 void TheoryEngine::getInstantiations( std::map< Node, std::vector< Node > >& insts ) {
-  if( d_quantEngine ){
-    d_quantEngine->getInstantiations( insts );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( d_quantEngine );
+  d_quantEngine->getInstantiations( insts );
 }
 
 void TheoryEngine::getInstantiationTermVectors( std::map< Node, std::vector< std::vector< Node > > >& insts ) {
-  if( d_quantEngine ){
-    d_quantEngine->getInstantiationTermVectors( insts );
-  }else{
-    Assert( false );
-  }
+  AlwaysAssert( d_quantEngine );
+  d_quantEngine->getInstantiationTermVectors( insts );
 }
 
 Node TheoryEngine::getInstantiatedConjunction( Node q ) {
-  if( d_quantEngine ){
-    return d_quantEngine->getInstantiatedConjunction( q );
-  }else{
-    Assert( false );
-    return Node::null();
-  }
+  AlwaysAssert( d_quantEngine );
+  return d_quantEngine->getInstantiatedConjunction( q );
 }
 
 

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -761,7 +761,7 @@ bool TheoryEngineModelBuilder::buildModel(Model* m)
     {
       Trace("model-builder") << "***Non-empty repSet, size = " << repSet.size()
                              << ", first = " << *(repSet.begin()) << endl;
-      Assert(false);
+      Unreachable();
     }
   }
 #endif /* CVC4_ASSERTIONS */

--- a/src/theory/uf/theory_uf_strong_solver.cpp
+++ b/src/theory/uf/theory_uf_strong_solver.cpp
@@ -871,7 +871,7 @@ bool SortModel::minimize( OutputChannel* out, TheoryModel* m ){
           }
           ++eqcs_i;
         }
-        Assert( false );
+        Unreachable();
       }
 #endif
     }else{
@@ -1983,7 +1983,7 @@ void StrongSolverTheoryUF::check( Theory::Effort level ){
       }
     }else{
       // unhandled uf ss mode
-      Assert( false );
+      Unreachable();
     }
     Trace("uf-ss-solver") << "Done StrongSolverTheoryUF: check " << level << std::endl;
   }


### PR DESCRIPTION
Replacing [Always]Assert(false) with Unreachable() or Unimplemented() as appropriate. Also updating `if (cond) { foo(); } else { Assert(false); }` to `AlwaysAssert(cond); foo();`. This simplifies the control flow in the program. AlwaysAssert has been preferred over Assert() to prevent unsafe behavior (nullptr dereferences, buffer overflows, etc.).

clang-format has intentionally not been applied yet to make the review easier. Once reviewers agree the changes seem ok, clang-format will be applied and reviewers will be requested to approve.

This resolves a several Coverity CIDs. Example: 1362773.