### PR TITLE
Converting defined functions and let expressions from Sygus grammars to lambdas

### DIFF
--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -879,11 +879,11 @@ bool DatatypeConstructor::isSygusIdFunc() const {
           && d_sygus_op[0][0] == d_sygus_op[1]);
 }
 
-SygusPrintCallback* DatatypeConstructor::getSygusPrintCallback() const
+std::shared_ptr<SygusPrintCallback> DatatypeConstructor::getSygusPrintCallback() const
 {
   PrettyCheckArgument(
       isResolved(), this, "this datatype constructor is not yet resolved");
-  return d_sygus_pc.get();
+  return d_sygus_pc;
 }
 
 Cardinality DatatypeConstructor::getCardinality( Type t ) const throw(IllegalArgumentException) {

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -300,7 +300,7 @@ class CVC4_PUBLIC DatatypeConstructor {
    * to handle defined or let expressions that
    * appear in user-provided grammars.
    */
-  SygusPrintCallback* getSygusPrintCallback() const;
+  std::shared_ptr<SygusPrintCallback> getSygusPrintCallback() const;
 
   /**
    * Get the tester name for this Datatype constructor.

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1324,7 +1324,7 @@ void Smt2Printer::toStreamSygus(std::ostream& out, TNode n) const throw()
     {
       int cIndex = Datatype::indexOf(n.getOperator().toExpr());
       Assert(!dt[cIndex].getSygusOp().isNull());
-      SygusPrintCallback* spc = dt[cIndex].getSygusPrintCallback();
+      SygusPrintCallback* spc = dt[cIndex].getSygusPrintCallback().get();
       if (spc != nullptr && options::sygusPrintCallbacks())
       {
         spc->toStreamSygus(this, out, n.toExpr());

--- a/src/theory/quantifiers/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus_grammar_norm.cpp
@@ -40,6 +40,7 @@ TypeObject::TypeObject(TypeNode src_tn, std::string type_name)
     : d_dt(Datatype(type_name))
 {
   d_tn = src_tn;
+  d_t = src_tn.toType();
   /* Create an unresolved type */
   d_unres_t = NodeManager::currentNM()
                   ->mkSort(type_name, ExprManager::SORT_FLAG_PLACEHOLDER)
@@ -69,7 +70,7 @@ void SygusGrammarNorm::collectInfoFor(TypeNode tn,
   std::string type_name = ss.str();
   /* Add to global accumulators */
   tos.push_back(TypeObject(tn, type_name));
-  const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
+  const Datatype& dt = static_cast<DatatypeType>(tos.back().d_t).getDatatype();
   tn_to_unres[tn] = tos.back().d_unres_t;
   /* Visit types of constructor arguments */
   for (const DatatypeConstructor& cons : dt)
@@ -92,7 +93,7 @@ void SygusGrammarNorm::normalizeSygusInt(unsigned ind,
                                          Node sygus_vars)
 {
   const Datatype& dt =
-      static_cast<DatatypeType>(tos[ind].d_tn.toType()).getDatatype();
+      static_cast<DatatypeType>(tos[ind].d_t).getDatatype();
   Trace("sygus-grammar-normalize")
       << "Normalizing integer type " << tos[ind].d_tn << " from datatype\n"
       << dt << std::endl;
@@ -113,7 +114,7 @@ TypeNode SygusGrammarNorm::normalizeSygusType(TypeNode tn, Node sygus_vars)
   for (unsigned i = 0, size = tos.size(); i < size; ++i)
   {
     const Datatype& dt =
-        static_cast<DatatypeType>(tos[i].d_tn.toType()).getDatatype();
+        static_cast<DatatypeType>(tos[i].d_t).getDatatype();
     Trace("sygus-grammar-normalize")
         << "Rebuild " << tos[i].d_tn << " from " << dt << std::endl;
     /* Collect information to rebuild constructors */

--- a/src/theory/quantifiers/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus_grammar_norm.cpp
@@ -128,11 +128,11 @@ TypeNode SygusGrammarNorm::normalizeSygusType(TypeNode tn, Node sygus_vars)
        * operator (NOT, ITE, etc) */
       Node exp_sop_n = Node::fromExpr(
           smt::currentSmtEngine()->expandDefinitions(cons.getSygusOp()));
+      tos[i].d_ops.push_back(Rewriter::rewrite(exp_sop_n));
       Trace("sygus-grammar-normalize")
           << "\tOriginal op: " << cons.getSygusOp()
           << "\n\tExpanded one: " << exp_sop_n
-          << "\n\tRewritten one: " << Rewriter::rewrite(exp_sop_n) << std::endl;
-      tos[i].d_ops.push_back(Rewriter::rewrite(exp_sop_n));
+          << "\n\tRewritten one: " << tos[i].d_ops.back() << std::endl;
       tos[i].d_cons_names.push_back(cons.getName());
       tos[i].d_pcb.push_back(cons.getSygusPrintCallback());
       tos[i].d_cons_args_t.push_back(std::vector<Type>());

--- a/src/theory/quantifiers/sygus_grammar_norm.h
+++ b/src/theory/quantifiers/sygus_grammar_norm.h
@@ -47,6 +47,8 @@ struct TypeObject
 
   /* The original typenode this TypeObject is built from */
   TypeNode d_tn;
+  /* The type represented by the typenode */
+  Type d_t;
   /* Operators for each constructor. */
   std::vector<Expr> d_ops;
   /* Names for each constructor. */

--- a/src/theory/quantifiers/sygus_grammar_norm.h
+++ b/src/theory/quantifiers/sygus_grammar_norm.h
@@ -50,9 +50,11 @@ struct TypeObject
   /* The type represented by the typenode */
   Type d_t;
   /* Operators for each constructor. */
-  std::vector<Expr> d_ops;
+  std::vector<Node> d_ops;
   /* Names for each constructor. */
   std::vector<std::string> d_cons_names;
+  /* Print callbacks for each constructor */
+  std::vector<std::shared_ptr<SygusPrintCallback>> d_pcb;
   /* List of argument types for each constructor */
   std::vector<std::vector<Type>> d_cons_args_t;
   /* Unresolved type placeholder */

--- a/src/theory/quantifiers/sygus_grammar_norm.h
+++ b/src/theory/quantifiers/sygus_grammar_norm.h
@@ -47,7 +47,7 @@ struct TypeObject
 
   /* The original typenode this TypeObject is built from */
   TypeNode d_tn;
-  /* The type represented by the typenode */
+  /* The type represented by d_tn */
   Type d_t;
   /* Operators for each constructor. */
   std::vector<Node> d_ops;


### PR DESCRIPTION
This partially solves issue #1344. Definitions are expanded when the grammar normalizer is called. When this becomes default then the code that expands definitions elsewhere will be removed.

The PR also contains minor changes to the PrintCallback and SygusGrammarNormalize module.