### PR TITLE
Fix output of --show-trace-tags.

### DIFF
--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -1564,11 +1564,11 @@ void OptionsHandler::showDebugTags(std::string option) {
 
 void OptionsHandler::showTraceTags(std::string option) {
   if(Configuration::isTracingBuild()) {
-    std::cout << "available tags:";
+    std::cout << "available tags:" << std::endl;
     unsigned ntags = Configuration::getNumTraceTags();
     char const* const* tags = Configuration::getTraceTags();
     for (unsigned i = 0; i < ntags; ++ i) {
-      std::cout << tags[i];
+      std::cout << "  " << tags[i] << std::endl;
     }
     std::cout << std::endl;
   } else {


### PR DESCRIPTION
Now prints each tag in a separate line. Fixes #1429.

```
available tags:
  abmqi-debug
  abs-model-debug
  aeq
  aeq-debug
  aeq-debug2
  ag-miniscope
  ag-miniscope-debug
  alpha-eq
  ambqi-check
  ambqi-check-debug
  ambqi-check-debug2
  ambqi-check-debug3
  ambqi-check-try
  ambqi-debug
  ambqi-inst
  ...
```

Previously it was:
```
available tags:abmqi-debugabs-model-debugaeqaeq-debugaeq-debug2ag-miniscopeag-miniscope-debugalpha-eqambqi-checkambqi-check-debugambqi-check-debug2ambqi-check-debug3ambqi-check-tryambqi-debugambqi-inst...
```
