### PR TITLE
Fix issue with mkConst/getConst of TypeConstant

### DIFF
--- a/src/expr/kind_template.h
+++ b/src/expr/kind_template.h
@@ -64,7 +64,7 @@ struct KindHashFunction {
 /**
  * The enumeration for the built-in atomic types.
  */
-enum TypeConstant {
+enum CVC4_PUBLIC TypeConstant {
 ${type_constant_list}
 #line 70 "${template}"
   LAST_TYPE


### PR DESCRIPTION
When compiling the Java bindings on macOS, the linker complained about
CVC4::ExprManager::mkConst<CVC4::TypeConstant>() and
CVC4::Expr::getConst<CVC4::TypeConstant>() being undefined. After some
research, I found that the issue has been introduced by commit
36bf9f8bcb2a1a3aea1f90eb4d13aed3bbf6da8f. It looks like adding the
-no-undefined flags resulted in the symbols in question being omitted
due to TypeConstant not being exported. This commit makes TypeConstant
CVC4_PUBLIC, which fixes the issue.