### PR TITLE
Transcendental functions check model

### DIFF
--- a/src/options/arith_options
+++ b/src/options/arith_options
@@ -198,7 +198,7 @@ option nlExtSplitZero --nl-ext-split-zero bool :default false
 option nlExtTfTaylorDegree --nl-ext-tf-taylor-deg=N int16_t :default 4 :read-write
  initial degree of polynomials for Taylor approximation
  
-option nlExtTfIncPrecision--nl-ext-tf-inc-prec bool :default true
+option nlExtTfIncPrecision --nl-ext-tf-inc-prec bool :default true
  whether to increment the precision for transcendental function constraints
  
 endmodule

--- a/src/options/arith_options
+++ b/src/options/arith_options
@@ -195,4 +195,8 @@ option nlExtPurify --nl-ext-purify bool :default false
 option nlExtSplitZero --nl-ext-split-zero bool :default false
  intial splits on zero for all variables
 
+option nlExtTfTaylorDegree --nl-ext-tf-taylor-deg=N int16_t :default 4 :read-write
+ default degree of taylor polynomials
+ 
+ 
 endmodule

--- a/src/options/arith_options
+++ b/src/options/arith_options
@@ -197,8 +197,8 @@ option nlExtSplitZero --nl-ext-split-zero bool :default false
 
 option nlExtTfTaylorDegree --nl-ext-tf-taylor-deg=N int16_t :default 4 :read-write
  initial degree of polynomials for Taylor approximation
- 
+
 option nlExtTfIncPrecision --nl-ext-tf-inc-prec bool :default true
  whether to increment the precision for transcendental function constraints
- 
+
 endmodule

--- a/src/options/arith_options
+++ b/src/options/arith_options
@@ -198,7 +198,7 @@ option nlExtSplitZero --nl-ext-split-zero bool :default false
 option nlExtTfTaylorDegree --nl-ext-tf-taylor-deg=N int16_t :default 4 :read-write
  initial degree of polynomials for Taylor approximation
  
-option nlExtTfIncTaylorDegree --nl-ext-tf-inc-taylor-deg bool :default true
- whether to increment degree of polynomials for Taylor approximation
+option nlExtTfIncPrecision--nl-ext-tf-inc-prec bool :default true
+ whether to increment the precision for transcendental function constraints
  
 endmodule

--- a/src/options/arith_options
+++ b/src/options/arith_options
@@ -196,7 +196,9 @@ option nlExtSplitZero --nl-ext-split-zero bool :default false
  intial splits on zero for all variables
 
 option nlExtTfTaylorDegree --nl-ext-tf-taylor-deg=N int16_t :default 4 :read-write
- default degree of taylor polynomials
+ initial degree of polynomials for Taylor approximation
  
+option nlExtTfIncTaylorDegree --nl-ext-tf-inc-taylor-deg bool :default true
+ whether to increment degree of polynomials for Taylor approximation
  
 endmodule

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -381,13 +381,15 @@ RewriteResponse ArithRewriter::postRewriteTranscendental(TNode t) {
   case kind::SINE:
     if(t[0].getKind() == kind::CONST_RATIONAL){
       const Rational& rat = t[0].getConst<Rational>();
-      NodeManager * nm = NodeManager::currentNM();
+      NodeManager* nm = NodeManager::currentNM();
       if(rat.sgn() == 0){
         return RewriteResponse(REWRITE_DONE, nm->mkConst(Rational(0)));
       }
-      else if(rat.sgn()==-1 ){
-        Node ret = nm->mkNode(kind::UMINUS, nm->mkNode( kind::SINE, nm->mkConst(-rat)));
-        return RewriteResponse(REWRITE_AGAIN_FULL, ret );
+      else if (rat.sgn() == -1)
+      {
+        Node ret =
+            nm->mkNode(kind::UMINUS, nm->mkNode(kind::SINE, nm->mkConst(-rat)));
+        return RewriteResponse(REWRITE_AGAIN_FULL, ret);
       }
     }else{
       // get the factor of PI in the argument

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -381,8 +381,13 @@ RewriteResponse ArithRewriter::postRewriteTranscendental(TNode t) {
   case kind::SINE:
     if(t[0].getKind() == kind::CONST_RATIONAL){
       const Rational& rat = t[0].getConst<Rational>();
+      NodeManager * nm = NodeManager::currentNM();
       if(rat.sgn() == 0){
-        return RewriteResponse(REWRITE_DONE, NodeManager::currentNM()->mkConst(Rational(0)));
+        return RewriteResponse(REWRITE_DONE, nm->mkConst(Rational(0)));
+      }
+      else if(rat.sgn()==-1 ){
+        Node ret = nm->mkNode(kind::UMINUS, nm->mkNode( kind::SINE, nm->mkConst(-rat)));
+        return RewriteResponse(REWRITE_AGAIN_FULL, ret );
       }
     }else{
       // get the factor of PI in the argument

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1165,7 +1165,7 @@ bool NonlinearExtension::checkModelTf(const std::vector<Node>& assertions)
   }
   else
   {
-    // TODO
+    // TODO (#1450) check model for general case
     return false;
   }
 }

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1537,12 +1537,6 @@ int NonlinearExtension::checkLastCall(const std::vector<Node>& assertions,
     }
   }
   
-  //------------------------------------check model
-  
-  
-  
-  
-  
   return 0;
 }
 
@@ -1643,8 +1637,7 @@ void NonlinearExtension::check(Theory::Effort e) {
           isIncomplete = true;
           if( !shared_term_value_splits.empty() ){
             std::vector< Node > shared_term_value_lemmas;
-            for( unsigned i=0; i<shared_term_value_splits.size(); i++ ){
-              Node eq = shared_term_value_splits[i];
+            for( const Node& eq : shared_term_value_splits ){
               Node literal = d_containing.getValuation().ensureLiteral(eq);
               d_containing.getOutputChannel().requirePhase(literal, true);
               shared_term_value_lemmas.push_back(literal.orNode(literal.negate()));
@@ -2728,25 +2721,6 @@ std::vector<Node> NonlinearExtension::checkFactoring( const std::vector<Node>& f
     }
   }
   return lemmas;
-}
-
-/** get getUninterpreted function for transcendental function kind k */
-Node NonlinearExtension::getUninterpretedFunctionForTf( Kind k )
-{
-  std::map< Kind, Node >::iterator itt = d_tf_to_uf.find( k );
-  if( itt!=d_tf_to_uf.end() )
-  {
-    return itt->second;
-  }
-  Node utf;
-  if( k==kind::SINE || k==kind::EXPONENTIAL )
-  {
-    TypeNode rt = NodeManager::currentNM()->realType();
-    TypeNode ft = NodeManager::currentNM()->mkFunctionType( rt, rt );
-    utf = NodeManager::currentNM()->mkSkolem( "utf", ft );
-    d_tf_to_uf[k] = utf;
-  }
-  return utf;
 }
   
 Node NonlinearExtension::getFactorSkolem( Node n, std::vector< Node >& lemmas ) {

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1722,6 +1722,7 @@ void NonlinearExtension::check(Theory::Effort e) {
             {
               d_taylor_degree++;
               needsRecheck = true;
+              d_secant_points.clear();
               // increase precision for PI?
               // Difficult since Taylor series is very slow to converge
               Trace("nl-ext") << "...increment Taylor degree to "

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1132,9 +1132,11 @@ std::vector<Node> NonlinearExtension::checkModel(
 bool NonlinearExtension::checkModelTf(const std::vector<Node>& assertions)
 {
   Trace("nl-ext-tf-check-model") << "check-model : Run" << std::endl;
+  std::vector< Node > check_assertions;
   for( const Node& a : assertions )
   {
     Node av = computeModelValue(a);
+    check_assertions.push_back( av );
     Trace("nl-ext-tf-check-model") << "check-model : assertion : " << av << std::endl;
   }
   // add bounds for PI
@@ -1145,6 +1147,8 @@ bool NonlinearExtension::checkModelTf(const std::vector<Node>& assertions)
     Trace("nl-ext-tf-check-model") << "check-model : satisfied approximate bound : ";
     Trace("nl-ext-tf-check-model") << tfb.second.first << " <= " << tf << " <= " << tfb.second.second << std::endl;
   }
+  // TODO
+  
   return false;
 }
 
@@ -1582,10 +1586,11 @@ void NonlinearExtension::check(Theory::Effort e) {
             }
           }
           if(isIncomplete) {
-            if( options::nlExtTfIncTaylorDegree() && !d_tf_rep_map.empty() )
+            if( options::nlExtTfIncPrecision() && !d_tf_rep_map.empty() )
             {
               d_taylor_degree++;
               needsRecheck = true;
+              // TODO : increase precision for PI
               Trace("nl-ext") << "...increment Taylor degree to " << d_taylor_degree << std::endl;
             }
             else
@@ -3311,7 +3316,12 @@ std::vector<Node> NonlinearExtension::checkTranscendentalTangentPlanes()
           else 
           {
             // store for check model bounds 
-            d_tf_check_model_bounds[tf] = std::pair< Node, Node >( model_values[0], model_values[1] );
+            Node atf = computeModelValue( tf );
+            d_tf_check_model_bounds[atf] = std::pair< Node, Node >( model_values[0], model_values[1] );
+            if( tf.getKind()==kind::SINE )
+            {
+              // add for negative ?
+            }
           }
 
           if (is_tangent)

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1722,7 +1722,8 @@ void NonlinearExtension::check(Theory::Effort e) {
             {
               d_taylor_degree++;
               needsRecheck = true;
-              // TODO : increase precision for PI
+              // increase precision for PI?
+              // Difficult since Taylor series is very slow to converge
               Trace("nl-ext") << "...increment Taylor degree to "
                               << d_taylor_degree << std::endl;
             }

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1721,8 +1721,8 @@ void NonlinearExtension::check(Theory::Effort e) {
             if (options::nlExtTfIncPrecision() && !d_tf_rep_map.empty())
             {
               d_taylor_degree++;
-              needsRecheck = true;
               d_secant_points.clear();
+              needsRecheck = true;
               // increase precision for PI?
               // Difficult since Taylor series is very slow to converge
               Trace("nl-ext") << "...increment Taylor degree to "

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -230,16 +230,24 @@ class NonlinearExtension {
 
   /** check model 
    * 
-   * Returns the subset of assertions whose concrete values are not true in the
-   * current model.
+   * Returns the subset of assertions whose concrete values we cannot show are
+   * true in the current model. Notice that we typically cannot compute concrete 
+   * values for assertions involving transcendental functions. Any assertion
+   * whose model value cannot be computed is included in the return value of
+   * this function.
    */
   std::vector<Node> checkModel(const std::vector<Node>& assertions);
   
   /** check model for transcendental functions 
    * 
-   * Check the model using error bounds on the Taylor approximation, as
-   * stored in d_tf_check_model_bounds. For details, see Section 3 of 
-   * Cimatti et al CADE 2017 under the heading "Detecting Satisfiable Formulas".
+   * Check the model using error bounds on the Taylor approximation. 
+   * 
+   * If this function returns true, then all assertions in the input argument 
+   * are satisfied for all interpretations of transcendental functions within
+   * their error bounds (as stored in d_tf_check_model_bounds).
+   * 
+   * For details, see Section 3 of Cimatti et al CADE 2017 under the heading 
+   * "Detecting Satisfiable Formulas".
    */
   bool checkModelTf(const std::vector<Node>& assertions);
   
@@ -453,13 +461,11 @@ private:
    */
   std::map< Kind, std::map< Node, Node > > d_tf_rep_map;  
   
-  /** map from transcendental functions to UF, for check model */
-  std::map< Kind, Node > d_tf_to_uf;
-  
-  /** get getUninterpreted function for transcendental function kind k */
-  Node getUninterpretedFunctionForTf( Kind k );
-  
-  /** check model bounds */
+  /** bounds for transcendental functions 
+   * 
+   * For each transcendental function application t, if this stores the pair
+   * (c_l, c_u) then the model M is such that c_l <= M( t ) <= c_u.
+   */
   std::map< Node, std::pair< Node, Node > > d_tf_check_model_bounds;
   
   // factor skolems
@@ -511,7 +517,13 @@ private:
   std::unordered_map<Node, std::unordered_map<unsigned, Node>, NodeHashFunction>
       d_taylor_rem;
       
-  /** taylor degree */
+  /** taylor degree
+   * 
+   * Indicates that the degree of the polynomials in the Taylor approximation of
+   * all transcendental functions is 2*d_taylor_degree. This value is set 
+   * initially to options::nlExtTfTaylorDegree() and may be incremented
+   * if the option options::nlExtTfIncPrecision() is enabled.
+   */
   unsigned d_taylor_degree;
 
   /** concavity region for transcendental functions

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -440,6 +440,15 @@ private:
    */
   std::map< Kind, std::map< Node, Node > > d_tf_rep_map;  
   
+  /** map from transcendental functions to UF, for check model */
+  std::map< Kind, Node > d_tf_to_uf;
+  
+  /** get getUninterpreted function for transcendental function kind k */
+  Node getUninterpretedFunctionForTf( Kind k );
+  
+  /** check model bounds */
+  std::vector< Node > d_tf_check_model_bounds;
+  
   // factor skolems
   std::map< Node, Node > d_factor_skolem;
   Node getFactorSkolem( Node n, std::vector< Node >& lemmas );

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -251,7 +251,24 @@ class NonlinearExtension {
    */
   bool checkModelTf(const std::vector<Node>& assertions);
 
-  /** simple check */
+  /** simple check model for transcendental functions for literal
+   *
+   * This method returns true if literal is true for all interpretations of
+   * that are within the error bounds of transcendental functions (as stored
+   * in d_tf_check_model_bounds). This is determined by a simple under/over
+   * approximation of the value of sum of (linear) monomials. For example,
+   * if we determine that .8 < sin( 1 ) < .9, this function will return
+   * true for literals like:
+   *   2.0*sin( 1 ) > 1.5
+   *   -1.0*sin( 1 ) < -0.79
+   *   -1.0*sin( 1 ) > -0.91
+   * It will return false for literals like:
+   *   sin( 1 ) > 0.85
+   * It will also return false for literals that are non-linear:
+   *   -0.3*sin( 1 )*sin( 2 ) + sin( 2 ) > .7
+   * where sin( 2 ) is bounded by some interval, since the bounds on these
+   * terms cannot quickly be determined.
+   */
   bool simpleCheckModelTfLit(Node lit);
 
   /** In the following functions, status states a relationship

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -497,6 +497,9 @@ private:
       d_taylor_sum;
   std::unordered_map<Node, std::unordered_map<unsigned, Node>, NodeHashFunction>
       d_taylor_rem;
+      
+  /** taylor degree */
+  unsigned d_taylor_degree;
 
   /** concavity region for transcendental functions
   *

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -228,29 +228,29 @@ class NonlinearExtension {
   void assignOrderIds(std::vector<Node>& vars, NodeMultiset& d_order,
                       unsigned orderType);
 
-  /** check model 
-   * 
+  /** check model
+   *
    * Returns the subset of assertions whose concrete values we cannot show are
-   * true in the current model. Notice that we typically cannot compute concrete 
+   * true in the current model. Notice that we typically cannot compute concrete
    * values for assertions involving transcendental functions. Any assertion
    * whose model value cannot be computed is included in the return value of
    * this function.
    */
   std::vector<Node> checkModel(const std::vector<Node>& assertions);
-  
-  /** check model for transcendental functions 
-   * 
-   * Check the model using error bounds on the Taylor approximation. 
-   * 
-   * If this function returns true, then all assertions in the input argument 
+
+  /** check model for transcendental functions
+   *
+   * Check the model using error bounds on the Taylor approximation.
+   *
+   * If this function returns true, then all assertions in the input argument
    * are satisfied for all interpretations of transcendental functions within
    * their error bounds (as stored in d_tf_check_model_bounds).
-   * 
-   * For details, see Section 3 of Cimatti et al CADE 2017 under the heading 
+   *
+   * For details, see Section 3 of Cimatti et al CADE 2017 under the heading
    * "Detecting Satisfiable Formulas".
    */
   bool checkModelTf(const std::vector<Node>& assertions);
-  
+
   /** simple check */
   bool simpleCheckModelTfLit(Node lit);
 
@@ -459,15 +459,15 @@ private:
    * where r is the current representative of x
    * in the equality engine assoiated with this class.
    */
-  std::map< Kind, std::map< Node, Node > > d_tf_rep_map;  
-  
-  /** bounds for transcendental functions 
-   * 
+  std::map< Kind, std::map< Node, Node > > d_tf_rep_map;
+
+  /** bounds for transcendental functions
+   *
    * For each transcendental function application t, if this stores the pair
    * (c_l, c_u) then the model M is such that c_l <= M( t ) <= c_u.
    */
-  std::map< Node, std::pair< Node, Node > > d_tf_check_model_bounds;
-  
+  std::map<Node, std::pair<Node, Node> > d_tf_check_model_bounds;
+
   // factor skolems
   std::map< Node, Node > d_factor_skolem;
   Node getFactorSkolem( Node n, std::vector< Node >& lemmas );
@@ -516,11 +516,11 @@ private:
       d_taylor_sum;
   std::unordered_map<Node, std::unordered_map<unsigned, Node>, NodeHashFunction>
       d_taylor_rem;
-      
+
   /** taylor degree
-   * 
+   *
    * Indicates that the degree of the polynomials in the Taylor approximation of
-   * all transcendental functions is 2*d_taylor_degree. This value is set 
+   * all transcendental functions is 2*d_taylor_degree. This value is set
    * initially to options::nlExtTfTaylorDegree() and may be incremented
    * if the option options::nlExtTfIncPrecision() is enabled.
    */
@@ -651,8 +651,8 @@ private:
   *   ...where (y > z + w) and x*y are a constraint and term
   *      that occur in the current context.
   */
-  std::vector<Node> checkMonomialInferBounds( std::vector<Node>& nt_lemmas,
-                                              const std::vector<Node>& false_asserts );
+  std::vector<Node> checkMonomialInferBounds(
+      std::vector<Node>& nt_lemmas, const std::vector<Node>& false_asserts);
 
   /** check factoring
   *
@@ -666,7 +666,7 @@ private:
   *   ...where k is fresh and x*z + y*z > t is a
   *      constraint that occurs in the current context.
   */
-  std::vector<Node> checkFactoring( const std::vector<Node>& false_asserts );
+  std::vector<Node> checkFactoring(const std::vector<Node>& false_asserts);
 
   /** check monomial infer resolution bounds
   *

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -242,6 +242,9 @@ class NonlinearExtension {
    * Cimatti et al CADE 2017 under the heading "Detecting Satisfiable Formulas".
    */
   bool checkModelTf(const std::vector<Node>& assertions);
+  
+  /** simple check */
+  bool simpleCheckModelTfLit(Node lit);
 
   /** In the following functions, status states a relationship
   * between two arithmetic terms, where:

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -243,7 +243,7 @@ class NonlinearExtension {
    * Checks the current model using error bounds on the Taylor approximation.
    *
    * If this function returns true, then all assertions in the input argument
-   * "assertions" are satisfied for all interpretations of transcendental 
+   * "assertions" are satisfied for all interpretations of transcendental
    * functions within their error bounds (as stored in d_tf_check_model_bounds).
    *
    * For details, see Section 3 of Cimatti et al CADE 2017 under the heading

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -240,11 +240,11 @@ class NonlinearExtension {
 
   /** check model for transcendental functions
    *
-   * Check the model using error bounds on the Taylor approximation.
+   * Checks the current model using error bounds on the Taylor approximation.
    *
    * If this function returns true, then all assertions in the input argument
-   * are satisfied for all interpretations of transcendental functions within
-   * their error bounds (as stored in d_tf_check_model_bounds).
+   * "assertions" are satisfied for all interpretations of transcendental 
+   * functions within their error bounds (as stored in d_tf_check_model_bounds).
    *
    * For details, see Section 3 of Cimatti et al CADE 2017 under the heading
    * "Detecting Satisfiable Formulas".
@@ -254,7 +254,7 @@ class NonlinearExtension {
   /** simple check model for transcendental functions for literal
    *
    * This method returns true if literal is true for all interpretations of
-   * that are within the error bounds of transcendental functions (as stored
+   * transcendental functions within their error bounds (as stored
    * in d_tf_check_model_bounds). This is determined by a simple under/over
    * approximation of the value of sum of (linear) monomials. For example,
    * if we determine that .8 < sin( 1 ) < .9, this function will return
@@ -264,10 +264,10 @@ class NonlinearExtension {
    *   -1.0*sin( 1 ) > -0.91
    * It will return false for literals like:
    *   sin( 1 ) > 0.85
-   * It will also return false for literals that are non-linear:
+   * It will also return false for literals like:
    *   -0.3*sin( 1 )*sin( 2 ) + sin( 2 ) > .7
-   * where sin( 2 ) is bounded by some interval, since the bounds on these
-   * terms cannot quickly be determined.
+   *   sin( sin( 1 ) ) > .5
+   * since the bounds on these terms cannot quickly be determined.
    */
   bool simpleCheckModelTfLit(Node lit);
 

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -179,7 +179,7 @@ class NonlinearExtension {
    * TheoryArith.
    */
   int checkLastCall(const std::vector<Node>& assertions,
-                    const std::set<Node>& false_asserts,
+                    const std::vector<Node>& false_asserts,
                     const std::vector<Node>& xts);
   //---------------------------------------term utilities
   static bool isArithKind(Kind k);
@@ -231,7 +231,15 @@ class NonlinearExtension {
   /** Returns the subset of assertions whose concrete values are
    * false in the model.
    */
-  std::set<Node> getFalseInModel(const std::vector<Node>& assertions);
+  std::vector<Node> getFalseInModel(const std::vector<Node>& assertions);
+  
+  /** check model for transcendental functions 
+   * 
+   * Check the model using error bounds on the Taylor approximation, as
+   * stored in d_tf_check_model_bounds. For details, see Section 3 of 
+   * Cimatti et al CADE 2017 under the heading "Detecting Satisfiable Formulas".
+   */
+  bool checkModelTf(const std::vector<Node>& assertions);
 
   /** In the following functions, status states a relationship
   * between two arithmetic terms, where:
@@ -627,7 +635,7 @@ private:
   *      that occur in the current context.
   */
   std::vector<Node> checkMonomialInferBounds( std::vector<Node>& nt_lemmas,
-                                              const std::set<Node>& false_asserts );
+                                              const std::vector<Node>& false_asserts );
 
   /** check factoring
   *
@@ -641,7 +649,7 @@ private:
   *   ...where k is fresh and x*z + y*z > t is a
   *      constraint that occurs in the current context.
   */
-  std::vector<Node> checkFactoring( const std::set<Node>& false_asserts );
+  std::vector<Node> checkFactoring( const std::vector<Node>& false_asserts );
 
   /** check monomial infer resolution bounds
   *

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -228,10 +228,12 @@ class NonlinearExtension {
   void assignOrderIds(std::vector<Node>& vars, NodeMultiset& d_order,
                       unsigned orderType);
 
-  /** Returns the subset of assertions whose concrete values are
-   * false in the model.
+  /** check model 
+   * 
+   * Returns the subset of assertions whose concrete values are not true in the
+   * current model.
    */
-  std::vector<Node> getFalseInModel(const std::vector<Node>& assertions);
+  std::vector<Node> checkModel(const std::vector<Node>& assertions);
   
   /** check model for transcendental functions 
    * 
@@ -455,7 +457,7 @@ private:
   Node getUninterpretedFunctionForTf( Kind k );
   
   /** check model bounds */
-  std::vector< Node > d_tf_check_model_bounds;
+  std::map< Node, std::pair< Node, Node > > d_tf_check_model_bounds;
   
   // factor skolems
   std::map< Node, Node > d_factor_skolem;

--- a/src/theory/arith/nonlinear_extension.h
+++ b/src/theory/arith/nonlinear_extension.h
@@ -459,7 +459,7 @@ private:
    * where r is the current representative of x
    * in the equality engine assoiated with this class.
    */
-  std::map< Kind, std::map< Node, Node > > d_tf_rep_map;
+  std::map<Kind, std::map<Node, Node> > d_tf_rep_map;
 
   /** bounds for transcendental functions
    *

--- a/test/regress/regress0/nl/Makefile.am
+++ b/test/regress/regress0/nl/Makefile.am
@@ -78,7 +78,8 @@ TESTS =	\
   nta/exp-n0.5-ub.smt2 \
   nta/exp-n0.5-lb.smt2 \
   nta/dumortier_llibre_artes_ex_5_13.transcendental.k2.smt2 \
-  nta/NAVIGATION2.smt2
+  nta/NAVIGATION2.smt2 \
+  nta/sin1-sat.smt2
 
 # unsolved : garbage_collect.cvc
 

--- a/test/regress/regress0/nl/nta/cos1-tc.smt2
+++ b/test/regress/regress0/nl/nta/cos1-tc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --nl-ext
+; COMMAND-LINE: --nl-ext --no-nl-ext-tf-inc-taylor-deg
 ; EXPECT: unknown
 (set-logic UFNRA)
 (declare-fun f (Real) Real)

--- a/test/regress/regress0/nl/nta/cos1-tc.smt2
+++ b/test/regress/regress0/nl/nta/cos1-tc.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --nl-ext --no-nl-ext-tf-inc-taylor-deg
+; COMMAND-LINE: --nl-ext --no-nl-ext-tf-inc-prec
 ; EXPECT: unknown
 (set-logic UFNRA)
 (declare-fun f (Real) Real)

--- a/test/regress/regress0/nl/nta/sin1-sat.smt2
+++ b/test/regress/regress0/nl/nta/sin1-sat.smt2
@@ -1,0 +1,12 @@
+; COMMAND-LINE: --nl-ext-tf-tplanes
+; EXPECT: sat
+(set-logic QF_NRA)
+(set-info :status unsat)
+(declare-fun x () Real)
+
+(assert (> (sin 1) 0.84))
+(assert (< (sin 1) 0.85))
+(assert (< (- x (sin 1)) 0.000001))
+(assert (< (- (sin 1) x) 0.000001))
+
+(check-sat)

--- a/test/regress/regress0/nl/nta/sin1-sat.smt2
+++ b/test/regress/regress0/nl/nta/sin1-sat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --nl-ext-tf-tplanes
+; COMMAND-LINE: --nl-ext-tf-tplanes --no-check-models
 ; EXPECT: sat
 (set-logic QF_NRA)
 (set-info :status unsat)


### PR DESCRIPTION
This pull request:
- Adds support for a check model using the error bounds from the Taylor approximation of transcendental functions, thus enabling us to answer "SAT" for transcendental functions with irrational values, without providing deltas on model values.
- Adds a scheme for incrementally increasing the precision of the Taylor series.
Both schemes follow the approaches described in "Satisfiability Modulo Transcendental Functions via Incremental Linearization".