### PR TITLE
Add side conditions for inequalities over BITVECTOR_UDIV for CBQI BV.

### DIFF
--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -724,7 +724,7 @@ static Node getScBvUdiv(bool pol,
     {
       if (pol)
       {
-        /* s udiv x < t
+        /* x udiv s < t
          * with side condition:
          * (=> (bvsle t z) (bvslt (bvudiv min s) t))
          * where z = 0 with getSize(z) = w
@@ -738,7 +738,7 @@ static Node getScBvUdiv(bool pol,
       }
       else
       {
-        /* s udiv x >= t
+        /* x udiv s >= t
          * with side condition:
          * (or
          *   (bvsge (bvudiv ones s) t)

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -533,6 +533,7 @@ static Node getScBvAndOr(bool pol,
                          Node t)
 {
   Assert (k == BITVECTOR_AND || k == BITVECTOR_OR);
+  Assert (litk == EQUAL || litk == BITVECTOR_SLT || litk == BITVECTOR_ULT);
 
   NodeManager* nm = NodeManager::currentNM();
   Node scl, scr;
@@ -547,7 +548,6 @@ static Node getScBvAndOr(bool pol,
        * t & s = t
        * t | s = t */
       scl = nm->mkNode(EQUAL, t, nm->mkNode(k, t, s));
-      scr = nm->mkNode(EQUAL, nm->mkNode(k, x, s), t);
     }
     else
     {
@@ -570,7 +570,91 @@ static Node getScBvAndOr(bool pol,
         Node n = bv::utils::mkOnes(w);
         scl = nm->mkNode(OR, s.eqNode(n).notNode(), t.eqNode(n).notNode());
       }
-      scr = nm->mkNode(DISTINCT, nm->mkNode(k, x, s), t);
+    }
+  }
+  else if (litk == BITVECTOR_ULT)
+  {
+    if (pol)
+    {
+      if (k == BITVECTOR_AND)
+      {
+        /* x & s < t
+         * with side condition (synthesized):
+         * t != 0 */
+        Node z = bv::utils::mkZero(bv::utils::getSize(t));
+        scl = t.eqNode(z).notNode();
+      }
+      else
+      {
+        /* x | s < t
+         * with side condition (synthesized):
+         * (bvult s t) */
+        scl = nm->mkNode(BITVECTOR_ULT, s, t);
+      }
+    }
+    else
+    {
+      if (k == BITVECTOR_AND)
+      {
+        /* x & s >= t
+         * with side condition (synthesized):
+         * (not (bvult s t)) */
+        scl = nm->mkNode(BITVECTOR_UGE, s, t);
+      }
+      else
+      {
+        /* x | s >= t
+         * with side condition (synthesized):
+         * true (no side condition) */
+        scl = nm->mkConst<bool>(true);
+      }
+    }
+  }
+  else if (litk == BITVECTOR_SLT)
+  {
+    if (pol)
+    {
+      if (k == BITVECTOR_AND)
+      {
+        /* x & s < t
+         * with side condition (synthesized):
+         * (bvslt (bvand (bvnot (bvneg t)) s) t) */
+        Node nnt = nm->mkNode(BITVECTOR_NOT, nm->mkNode(BITVECTOR_NEG, t));
+        scl = nm->mkNode(BITVECTOR_SLT, nm->mkNode(BITVECTOR_AND, nnt, s), t);
+      }
+      else
+      {
+        /* x | s < t
+         * with side condition (synthesized):
+         * (bvslt (bvor (bvnot (bvsub s t)) s) t) */
+        Node st = nm->mkNode(BITVECTOR_NOT, nm->mkNode(BITVECTOR_SUB, s, t));
+        scl = nm->mkNode(BITVECTOR_SLT, nm->mkNode(BITVECTOR_OR, st, s), t);
+      }
+    }
+    else
+    {
+      if (k == BITVECTOR_AND)
+      {
+        /* x & s >= t
+         * with side condition (case = combined with synthesized bvsgt):
+         * (or
+         *  (= (bvand s t) t)
+         *  (bvslt t (bvand (bvsub t s) s))
+         * ) */
+        Node sc_sgt = nm->mkNode(
+            BITVECTOR_SLT,
+            t,
+            nm->mkNode(BITVECTOR_AND, nm->mkNode(BITVECTOR_SUB, t, s), s));
+        Node sc_eq = nm->mkNode(BITVECTOR_AND, s, t).eqNode(t);
+        scl = sc_eq.orNode(sc_sgt);
+      }
+      else
+      {
+        /* x | s >= t
+         * with side condition (synthesized):
+         * (not (bvslt s (bvand s t))) */
+        scl = nm->mkNode(BITVECTOR_SGE, s, nm->mkNode(BITVECTOR_AND, s, t));
+      }
     }
   }
   else
@@ -578,7 +662,8 @@ static Node getScBvAndOr(bool pol,
     return Node::null();
   }
 
-  Node sc = nm->mkNode(IMPLIES, scl, scr);
+  scr = nm->mkNode(litk, nm->mkNode(k, x, s), t);
+  Node sc = nm->mkNode(IMPLIES, scl, pol ? scr : scr.notNode());
   Trace("bv-invert") << "Add SC_" << k << "(" << x << "): " << sc << std::endl;
   return sc;
 }

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -819,7 +819,7 @@ static Node getScBvUdiv(bool pol,
         Node min = bv::utils::mkConst(bv_min);
         Node sle = nm->mkNode(BITVECTOR_SLE, t, z);
         Node div2 = nm->mkNode(BITVECTOR_UDIV_TOTAL, min, s);
-      Node slt = nm->mkNode(BITVECTOR_SLT, div2, t);
+        Node slt = nm->mkNode(BITVECTOR_SLT, div2, t);
         Node o2 = nm->mkNode(IMPLIES, sle, slt);
         scl = nm->mkNode(OR, o1, o2);
       }

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -736,7 +736,7 @@ static Node getScBvUdiv(bool pol,
 
   Node scr =
     nm->mkNode(litk, idx == 0 ? nm->mkNode(k, x, s) : nm->mkNode(k, s, x), t);
-  Node sc = nm->mkNode(IMPLIES, scl, scr);
+  Node sc = nm->mkNode(IMPLIES, scl, pol ? scr : scr.notNode());
   Trace("bv-invert") << "Add SC_" << k << "(" << x << "): " << sc << std::endl;
   return sc;
 }

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -616,7 +616,7 @@ static Node getScBvUdiv(bool pol,
       else
       {
         /* s udiv x != t
-         * no side condition */
+         * true (no side condition) */
         scl = nm->mkConst<bool>(true);
       }
     }
@@ -661,7 +661,7 @@ static Node getScBvUdiv(bool pol,
       else
       {
         /* s udiv x >= t
-         * no side condition */
+         * true (no side condition) */
         scl = nm->mkConst<bool>(true);
       }
     }

--- a/test/unit/theory/theory_quantifiers_bv_inverter_white.h
+++ b/test/unit/theory/theory_quantifiers_bv_inverter_white.h
@@ -83,7 +83,6 @@ class TheoryQuantifiersBvInverter : public CxxTest::TestSuite
            || k == BITVECTOR_OR
            || k == BITVECTOR_LSHR
            || k == BITVECTOR_ASHR
-
            || k == BITVECTOR_SHL);
 
     Node sc = getsc(pol, litk, k, idx, d_sk, d_s, d_t);
@@ -474,6 +473,26 @@ class TheoryQuantifiersBvInverter : public CxxTest::TestSuite
     runTest(false, BITVECTOR_ULT, BITVECTOR_UDIV_TOTAL, 1, getScBvUdiv);
   }
 
+  void testGetScBvUdivUgtTrue0()
+  {
+    runTest(true, BITVECTOR_UGT, BITVECTOR_UDIV_TOTAL, 0, getScBvUdiv);
+  }
+
+  void testGetScBvUdivUgtTrue1()
+  {
+    runTest(true, BITVECTOR_UGT, BITVECTOR_UDIV_TOTAL, 1, getScBvUdiv);
+  }
+
+  void testGetScBvUdivUgtFalse0()
+  {
+    runTest(false, BITVECTOR_UGT, BITVECTOR_UDIV_TOTAL, 0, getScBvUdiv);
+  }
+
+  void testGetScBvUdivUgtFalse1()
+  {
+    runTest(false, BITVECTOR_UGT, BITVECTOR_UDIV_TOTAL, 1, getScBvUdiv);
+  }
+
   void testGetScBvUdivSltTrue0()
   {
     runTest(true, BITVECTOR_SLT, BITVECTOR_UDIV_TOTAL, 0, getScBvUdiv);
@@ -492,6 +511,26 @@ class TheoryQuantifiersBvInverter : public CxxTest::TestSuite
   void testGetScBvUdivSltFalse1()
   {
     runTest(false, BITVECTOR_SLT, BITVECTOR_UDIV_TOTAL, 1, getScBvUdiv);
+  }
+
+  void testGetScBvUdivSgtTrue0()
+  {
+    runTest(true, BITVECTOR_SGT, BITVECTOR_UDIV_TOTAL, 0, getScBvUdiv);
+  }
+
+  void testGetScBvUdivSgtTrue1()
+  {
+    runTest(true, BITVECTOR_SGT, BITVECTOR_UDIV_TOTAL, 1, getScBvUdiv);
+  }
+
+  void testGetScBvUdivSgtFalse0()
+  {
+    runTest(false, BITVECTOR_SGT, BITVECTOR_UDIV_TOTAL, 0, getScBvUdiv);
+  }
+
+  void testGetScBvUdivSgtFalse1()
+  {
+    runTest(false, BITVECTOR_SGT, BITVECTOR_UDIV_TOTAL, 1, getScBvUdiv);
   }
 
   /* And */


### PR DESCRIPTION
We now can handle all cases of (in|dis)equality over BITVECTOR_UREM. This also simplifies some of the side conditions for equality.