### PR TITLE
Rewrites for BitVector multiplication

### DIFF
--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -391,15 +391,18 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
   BitVector constant(size, Integer(1));
 
   bool isNeg = false;
-  std::vector<Node> children; 
-  for(const TNode& current : node) {
+  std::vector<Node> children;
+  for (const TNode& current : node)
+  {
     if (current.getKind() == kind::CONST_BITVECTOR) {
       BitVector value = current.getConst<BitVector>();
       constant = constant * value;
       if(constant == BitVector(size, (unsigned) 0)) {
         return utils::mkConst(size, 0); 
       }
-    } else if( current.getKind() == kind::BITVECTOR_NEG ){
+    }
+    else if (current.getKind() == kind::BITVECTOR_NEG)
+    {
       isNeg = !isNeg;
       children.push_back(current[0]);
     } else {
@@ -409,34 +412,41 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
   BitVector oValue = BitVector(size, static_cast<unsigned>(1));
   Node negOne = utils::mkConst(-oValue);
   BitVector noValue = negOne.getConst<BitVector>();
-  
-  if( children.empty() ){
-    if( isNeg ){
+
+  if (children.empty())
+  {
+    if (isNeg)
+    {
       constant = constant * noValue;
     }
-    return utils::mkConst(constant); 
+    return utils::mkConst(constant);
   }
-  
+
   std::sort(children.begin(), children.end());
-  
-  if(constant==noValue){
+
+  if (constant == noValue)
+  {
     isNeg = !isNeg;
-  }else if(constant != oValue) {
-    if( isNeg )
+  }
+  else if (constant != oValue)
+  {
+    if (isNeg)
     {
       isNeg = !isNeg;
       constant = constant * noValue;
     }
     children.push_back(utils::mkConst(constant)); 
   }
-  
-  Node ret = utils::mkNode(kind::BITVECTOR_MULT, children); 
-  
+
+  Node ret = utils::mkNode(kind::BITVECTOR_MULT, children);
+
   // if negative, negate entire node
-  if( isNeg && size>1 ){
-    ret = utils::mkNode( kind::BITVECTOR_NEG, ret );
+  if (isNeg && size > 1)
+  {
+    ret = utils::mkNode(kind::BITVECTOR_NEG, ret);
   }
-  if( node!=ret ){
+  if (node != ret)
+  {
     Trace("ajr-temp") << "Rewrite " << node << " to " << ret << std::endl;
   }
   return ret;

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -414,7 +414,7 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
 
   if (children.empty())
   {
-    Assert( !isNeg );
+    Assert(!isNeg);
     return utils::mkConst(constant);
   }
 

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -410,15 +410,11 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
     }
   }
   BitVector oValue = BitVector(size, static_cast<unsigned>(1));
-  Node negOne = utils::mkConst(-oValue);
-  BitVector noValue = negOne.getConst<BitVector>();
+  BitVector noValue = utils::mkBitVectorOnes(size);
 
   if (children.empty())
   {
-    if (isNeg)
-    {
-      constant = constant * noValue;
-    }
+    Assert( !isNeg );
     return utils::mkConst(constant);
   }
 
@@ -433,7 +429,7 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
     if (isNeg)
     {
       isNeg = !isNeg;
-      constant = constant * noValue;
+      constant = -constant;
     }
     children.push_back(utils::mkConst(constant));
   }

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -435,7 +435,7 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
       isNeg = !isNeg;
       constant = constant * noValue;
     }
-    children.push_back(utils::mkConst(constant)); 
+    children.push_back(utils::mkConst(constant));
   }
 
   Node ret = utils::mkNode(kind::BITVECTOR_MULT, children);

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -445,10 +445,6 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
   {
     ret = utils::mkNode(kind::BITVECTOR_NEG, ret);
   }
-  if (node != ret)
-  {
-    Trace("ajr-temp") << "Rewrite " << node << " to " << ret << std::endl;
-  }
   return ret;
 }
 

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -381,25 +381,7 @@ Node RewriteRule<PlusCombineLikeTerms>::apply(TNode node) {
 
 template<> inline
 bool RewriteRule<MultSimplify>::applies(TNode node) {
-  if (node.getKind() != kind::BITVECTOR_MULT) {
-    return false;
-  }
-  TNode::iterator child_it = node.begin();
-  TNode::iterator child_next = child_it + 1;
-  for(; child_next != node.end(); ++child_it, ++child_next) {
-    if ((*child_it).isConst() ||
-        !((*child_it) < (*child_next))) {
-      return true;
-    }
-  }
-  if ((*child_it).isConst()) {
-    BitVector bv = (*child_it).getConst<BitVector>();
-    if (bv == BitVector(utils::getSize(node), (unsigned) 0) ||
-        bv == BitVector(utils::getSize(node), (unsigned) 1)) {
-      return true;
-    }
-  }
-  return false;
+  return node.getKind() == kind::BITVECTOR_MULT;
 }
 
 template<> inline
@@ -408,31 +390,56 @@ Node RewriteRule<MultSimplify>::apply(TNode node) {
   unsigned size = utils::getSize(node); 
   BitVector constant(size, Integer(1));
 
+  bool isNeg = false;
   std::vector<Node> children; 
-  for(unsigned i = 0; i < node.getNumChildren(); ++i) {
-    TNode current = node[i];
+  for(const TNode& current : node) {
     if (current.getKind() == kind::CONST_BITVECTOR) {
       BitVector value = current.getConst<BitVector>();
       constant = constant * value;
       if(constant == BitVector(size, (unsigned) 0)) {
         return utils::mkConst(size, 0); 
       }
+    } else if( current.getKind() == kind::BITVECTOR_NEG ){
+      isNeg = !isNeg;
+      children.push_back(current[0]);
     } else {
       children.push_back(current); 
     }
   }
-
+  BitVector oValue = BitVector(size, static_cast<unsigned>(1));
+  Node negOne = utils::mkConst(-oValue);
+  BitVector noValue = negOne.getConst<BitVector>();
+  
+  if( children.empty() ){
+    if( isNeg ){
+      constant = constant * noValue;
+    }
+    return utils::mkConst(constant); 
+  }
+  
   std::sort(children.begin(), children.end());
-
-  if(constant != BitVector(size, (unsigned)1)) {
+  
+  if(constant==noValue){
+    isNeg = !isNeg;
+  }else if(constant != oValue) {
+    if( isNeg )
+    {
+      isNeg = !isNeg;
+      constant = constant * noValue;
+    }
     children.push_back(utils::mkConst(constant)); 
   }
   
-  if(children.size() == 0) {
-    return utils::mkConst(size, (unsigned)1); 
+  Node ret = utils::mkNode(kind::BITVECTOR_MULT, children); 
+  
+  // if negative, negate entire node
+  if( isNeg && size>1 ){
+    ret = utils::mkNode( kind::BITVECTOR_NEG, ret );
   }
-
-  return utils::mkNode(kind::BITVECTOR_MULT, children); 
+  if( node!=ret ){
+    Trace("ajr-temp") << "Rewrite " << node << " to " << ret << std::endl;
+  }
+  return ret;
 }
 
 

--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -1009,7 +1009,7 @@ inline Node RewriteRule<UremPow2>::apply(TNode node)
   Node ret;
   if (power == 0)
   {
-    ret = utils::mkConst(utils::getSize(node), 0);
+    ret = utils::mkZero(utils::getSize(node));
   }
   else
   {

--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -751,13 +751,14 @@ Node RewriteRule<NotUle>::apply(TNode node) {
  * (a * 2^k) ==> a[n-k-1:0] 0_k
  */
 
-template<> inline
-bool RewriteRule<MultPow2>::applies(TNode node)
+template <>
+inline bool RewriteRule<MultPow2>::applies(TNode node)
 {
   if (node.getKind() != kind::BITVECTOR_MULT)
     return false;
 
-  for(const Node& cn : node ){
+  for (const Node& cn : node)
+  {
     bool cIsNeg = false;
     if (utils::isPow2Const(cn, cIsNeg))
     {
@@ -767,8 +768,8 @@ bool RewriteRule<MultPow2>::applies(TNode node)
   return false; 
 }
 
-template<> inline
-Node RewriteRule<MultPow2>::apply(TNode node)
+template <>
+inline Node RewriteRule<MultPow2>::apply(TNode node)
 {
   Debug("bv-rewrite") << "RewriteRule<MultPow2>(" << node << ")" << std::endl;
 
@@ -776,7 +777,8 @@ Node RewriteRule<MultPow2>::apply(TNode node)
   std::vector<Node>  children;
   unsigned exponent = 0;
   bool isNeg = false;
-  for(const Node& cn : node ){
+  for (const Node& cn : node)
+  {
     bool cIsNeg = false;
     unsigned exp = utils::isPow2Const(cn, cIsNeg);
     if (exp) {
@@ -787,7 +789,7 @@ Node RewriteRule<MultPow2>::apply(TNode node)
       }
     }
     else {
-      children.push_back(cn); 
+      children.push_back(cn);
     }
   }
 
@@ -904,8 +906,8 @@ Node RewriteRule<NegIdemp>::apply(TNode node) {
  * (a udiv 2^k) ==> 0_k a[n-1: k]
  */
 
-template<> inline
-bool RewriteRule<UdivPow2>::applies(TNode node)
+template <>
+inline bool RewriteRule<UdivPow2>::applies(TNode node)
 {
   bool isNeg = false;
   if (node.getKind() == kind::BITVECTOR_UDIV_TOTAL
@@ -916,8 +918,8 @@ bool RewriteRule<UdivPow2>::applies(TNode node)
   return false;
 }
 
-template<> inline
-Node RewriteRule<UdivPow2>::apply(TNode node)
+template <>
+inline Node RewriteRule<UdivPow2>::apply(TNode node)
 {
   Debug("bv-rewrite") << "RewriteRule<UdivPow2>(" << node << ")" << std::endl;
   unsigned size = utils::getSize(node);
@@ -925,7 +927,7 @@ Node RewriteRule<UdivPow2>::apply(TNode node)
   bool isNeg = false;
   unsigned power = utils::isPow2Const(node[1], isNeg) - 1;
   Node ret;
-  if (power == 0) 
+  if (power == 0)
   {
     ret = a;
   }
@@ -985,8 +987,8 @@ inline Node RewriteRule<UdivOne>::apply(TNode node) {
  * (a urem 2^k) ==> 0_(n-k) a[k-1:0]
  */
 
-template<> inline
-bool RewriteRule<UremPow2>::applies(TNode node)
+template <>
+inline bool RewriteRule<UremPow2>::applies(TNode node)
 {
   bool isNeg;
   if (node.getKind() == kind::BITVECTOR_UREM_TOTAL
@@ -997,8 +999,8 @@ bool RewriteRule<UremPow2>::applies(TNode node)
   return false;
 }
 
-template<> inline
-Node RewriteRule<UremPow2>::apply(TNode node)
+template <>
+inline Node RewriteRule<UremPow2>::apply(TNode node)
 {
   Debug("bv-rewrite") << "RewriteRule<UremPow2>(" << node << ")" << std::endl;
   TNode a = node[0];

--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -757,7 +757,8 @@ bool RewriteRule<MultPow2>::applies(TNode node) {
     return false;
 
   for(unsigned i = 0; i < node.getNumChildren(); ++i) {
-    if (utils::isPow2Const(node[i])) {
+    bool cIsNeg = false;
+    if (utils::isPow2Const(node[i],cIsNeg)) {
       return true; 
     }
   }
@@ -768,12 +769,18 @@ template<> inline
 Node RewriteRule<MultPow2>::apply(TNode node) {
   Debug("bv-rewrite") << "RewriteRule<MultPow2>(" << node << ")" << std::endl;
 
+  unsigned size = utils::getSize(node);
   std::vector<Node>  children;
   unsigned exponent = 0; 
+  bool isNeg = false;
   for(unsigned i = 0; i < node.getNumChildren(); ++i) {
-    unsigned exp = utils::isPow2Const(node[i]);
+    bool cIsNeg = false;
+    unsigned exp = utils::isPow2Const(node[i], cIsNeg);
     if (exp) {
       exponent += exp - 1;
+      if( cIsNeg ){
+        isNeg = !isNeg;
+      }
     }
     else {
       children.push_back(node[i]); 
@@ -781,8 +788,12 @@ Node RewriteRule<MultPow2>::apply(TNode node) {
   }
 
   Node a = utils::mkNode(kind::BITVECTOR_MULT, children); 
+  
+  if( isNeg && size>1 ){
+    a = utils::mkNode(kind::BITVECTOR_NEG,a);
+  }
 
-  Node extract = utils::mkExtract(a, utils::getSize(node) - exponent - 1, 0);
+  Node extract = utils::mkExtract(a, size - exponent - 1, 0);
   Node zeros = utils::mkConst(exponent, 0);
   return utils::mkConcat(extract, zeros); 
 }
@@ -890,22 +901,35 @@ Node RewriteRule<NegIdemp>::apply(TNode node) {
 
 template<> inline
 bool RewriteRule<UdivPow2>::applies(TNode node) {
-  return (node.getKind() == kind::BITVECTOR_UDIV_TOTAL &&
-          utils::isPow2Const(node[1]));
+  bool isNeg = false;
+  if (node.getKind() == kind::BITVECTOR_UDIV_TOTAL &&
+          utils::isPow2Const(node[1],isNeg))
+  {
+    return !isNeg;
+  }
+  return false;
 }
 
 template<> inline
 Node RewriteRule<UdivPow2>::apply(TNode node) {
   Debug("bv-rewrite") << "RewriteRule<UdivPow2>(" << node << ")" << std::endl;
+  unsigned size = utils::getSize(node);
   Node a = node[0];
-  unsigned power = utils::isPow2Const(node[1]) -1;
+  bool isNeg = false;
+  unsigned power = utils::isPow2Const(node[1],isNeg) -1;
+  Node ret;
   if (power == 0) {
-    return a; 
+    ret = a; 
+  }else{
+    Node extract = utils::mkExtract(a, size - 1, power);
+    Node zeros = utils::mkConst(power, 0);
+    
+    ret = utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract); 
   }
-  Node extract = utils::mkExtract(a, utils::getSize(node) - 1, power);
-  Node zeros = utils::mkConst(power, 0);
-  
-  return utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract); 
+  if( isNeg && size>1 ){
+    ret = utils::mkNode(kind::BITVECTOR_NEG,ret);
+  }
+  return ret;
 }
 
 /**
@@ -952,21 +976,29 @@ inline Node RewriteRule<UdivOne>::apply(TNode node) {
 
 template<> inline
 bool RewriteRule<UremPow2>::applies(TNode node) {
-  return (node.getKind() == kind::BITVECTOR_UREM_TOTAL &&
-          utils::isPow2Const(node[1]));
+  bool isNeg;
+  if(node.getKind() == kind::BITVECTOR_UREM_TOTAL &&
+          utils::isPow2Const(node[1],isNeg)){
+    return !isNeg;
+  }
+  return false;
 }
 
 template<> inline
 Node RewriteRule<UremPow2>::apply(TNode node) {
   Debug("bv-rewrite") << "RewriteRule<UremPow2>(" << node << ")" << std::endl;
   TNode a = node[0];
-  unsigned power = utils::isPow2Const(node[1]) - 1;
+  bool isNeg = false;
+  unsigned power = utils::isPow2Const(node[1],isNeg) - 1;
+  Node ret;
   if (power == 0) {
-    return utils::mkConst(utils::getSize(node), 0);
+    ret = utils::mkConst(utils::getSize(node), 0);
+  }else{
+    Node extract = utils::mkExtract(a, power - 1, 0);
+    Node zeros = utils::mkConst(utils::getSize(node) - power, 0);
+    ret = utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract); 
   }
-  Node extract = utils::mkExtract(a, power - 1, 0);
-  Node zeros = utils::mkConst(utils::getSize(node) - power, 0);
-  return utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract); 
+  return ret;
 }
 
 /**

--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -752,13 +752,14 @@ Node RewriteRule<NotUle>::apply(TNode node) {
  */
 
 template<> inline
-bool RewriteRule<MultPow2>::applies(TNode node) {
+bool RewriteRule<MultPow2>::applies(TNode node)
+{
   if (node.getKind() != kind::BITVECTOR_MULT)
     return false;
 
-  for(unsigned i = 0; i < node.getNumChildren(); ++i) {
+  for(const Node& cn : node ){
     bool cIsNeg = false;
-    if (utils::isPow2Const(node[i], cIsNeg))
+    if (utils::isPow2Const(cn, cIsNeg))
     {
       return true; 
     }
@@ -767,16 +768,17 @@ bool RewriteRule<MultPow2>::applies(TNode node) {
 }
 
 template<> inline
-Node RewriteRule<MultPow2>::apply(TNode node) {
+Node RewriteRule<MultPow2>::apply(TNode node)
+{
   Debug("bv-rewrite") << "RewriteRule<MultPow2>(" << node << ")" << std::endl;
 
   unsigned size = utils::getSize(node);
   std::vector<Node>  children;
   unsigned exponent = 0;
   bool isNeg = false;
-  for(unsigned i = 0; i < node.getNumChildren(); ++i) {
+  for(const Node& cn : node ){
     bool cIsNeg = false;
-    unsigned exp = utils::isPow2Const(node[i], cIsNeg);
+    unsigned exp = utils::isPow2Const(cn, cIsNeg);
     if (exp) {
       exponent += exp - 1;
       if (cIsNeg)
@@ -785,7 +787,7 @@ Node RewriteRule<MultPow2>::apply(TNode node) {
       }
     }
     else {
-      children.push_back(node[i]); 
+      children.push_back(cn); 
     }
   }
 
@@ -903,7 +905,8 @@ Node RewriteRule<NegIdemp>::apply(TNode node) {
  */
 
 template<> inline
-bool RewriteRule<UdivPow2>::applies(TNode node) {
+bool RewriteRule<UdivPow2>::applies(TNode node)
+{
   bool isNeg = false;
   if (node.getKind() == kind::BITVECTOR_UDIV_TOTAL
       && utils::isPow2Const(node[1], isNeg))
@@ -914,14 +917,16 @@ bool RewriteRule<UdivPow2>::applies(TNode node) {
 }
 
 template<> inline
-Node RewriteRule<UdivPow2>::apply(TNode node) {
+Node RewriteRule<UdivPow2>::apply(TNode node)
+{
   Debug("bv-rewrite") << "RewriteRule<UdivPow2>(" << node << ")" << std::endl;
   unsigned size = utils::getSize(node);
   Node a = node[0];
   bool isNeg = false;
   unsigned power = utils::isPow2Const(node[1], isNeg) - 1;
   Node ret;
-  if (power == 0) {
+  if (power == 0) 
+  {
     ret = a;
   }
   else
@@ -981,7 +986,8 @@ inline Node RewriteRule<UdivOne>::apply(TNode node) {
  */
 
 template<> inline
-bool RewriteRule<UremPow2>::applies(TNode node) {
+bool RewriteRule<UremPow2>::applies(TNode node)
+{
   bool isNeg;
   if (node.getKind() == kind::BITVECTOR_UREM_TOTAL
       && utils::isPow2Const(node[1], isNeg))
@@ -992,19 +998,21 @@ bool RewriteRule<UremPow2>::applies(TNode node) {
 }
 
 template<> inline
-Node RewriteRule<UremPow2>::apply(TNode node) {
+Node RewriteRule<UremPow2>::apply(TNode node)
+{
   Debug("bv-rewrite") << "RewriteRule<UremPow2>(" << node << ")" << std::endl;
   TNode a = node[0];
   bool isNeg = false;
   unsigned power = utils::isPow2Const(node[1], isNeg) - 1;
   Node ret;
-  if (power == 0) {
+  if (power == 0)
+  {
     ret = utils::mkConst(utils::getSize(node), 0);
   }
   else
   {
     Node extract = utils::mkExtract(a, power - 1, 0);
-    Node zeros = utils::mkConst(utils::getSize(node) - power, 0);
+    Node zeros = utils::mkZero(utils::getSize(node) - power);
     ret = utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract);
   }
   return ret;

--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -758,7 +758,8 @@ bool RewriteRule<MultPow2>::applies(TNode node) {
 
   for(unsigned i = 0; i < node.getNumChildren(); ++i) {
     bool cIsNeg = false;
-    if (utils::isPow2Const(node[i],cIsNeg)) {
+    if (utils::isPow2Const(node[i], cIsNeg))
+    {
       return true; 
     }
   }
@@ -771,14 +772,15 @@ Node RewriteRule<MultPow2>::apply(TNode node) {
 
   unsigned size = utils::getSize(node);
   std::vector<Node>  children;
-  unsigned exponent = 0; 
+  unsigned exponent = 0;
   bool isNeg = false;
   for(unsigned i = 0; i < node.getNumChildren(); ++i) {
     bool cIsNeg = false;
     unsigned exp = utils::isPow2Const(node[i], cIsNeg);
     if (exp) {
       exponent += exp - 1;
-      if( cIsNeg ){
+      if (cIsNeg)
+      {
         isNeg = !isNeg;
       }
     }
@@ -787,10 +789,11 @@ Node RewriteRule<MultPow2>::apply(TNode node) {
     }
   }
 
-  Node a = utils::mkNode(kind::BITVECTOR_MULT, children); 
-  
-  if( isNeg && size>1 ){
-    a = utils::mkNode(kind::BITVECTOR_NEG,a);
+  Node a = utils::mkNode(kind::BITVECTOR_MULT, children);
+
+  if (isNeg && size > 1)
+  {
+    a = utils::mkNode(kind::BITVECTOR_NEG, a);
   }
 
   Node extract = utils::mkExtract(a, size - exponent - 1, 0);
@@ -902,8 +905,8 @@ Node RewriteRule<NegIdemp>::apply(TNode node) {
 template<> inline
 bool RewriteRule<UdivPow2>::applies(TNode node) {
   bool isNeg = false;
-  if (node.getKind() == kind::BITVECTOR_UDIV_TOTAL &&
-          utils::isPow2Const(node[1],isNeg))
+  if (node.getKind() == kind::BITVECTOR_UDIV_TOTAL
+      && utils::isPow2Const(node[1], isNeg))
   {
     return !isNeg;
   }
@@ -916,18 +919,21 @@ Node RewriteRule<UdivPow2>::apply(TNode node) {
   unsigned size = utils::getSize(node);
   Node a = node[0];
   bool isNeg = false;
-  unsigned power = utils::isPow2Const(node[1],isNeg) -1;
+  unsigned power = utils::isPow2Const(node[1], isNeg) - 1;
   Node ret;
   if (power == 0) {
-    ret = a; 
-  }else{
+    ret = a;
+  }
+  else
+  {
     Node extract = utils::mkExtract(a, size - 1, power);
     Node zeros = utils::mkConst(power, 0);
-    
-    ret = utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract); 
+
+    ret = utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract);
   }
-  if( isNeg && size>1 ){
-    ret = utils::mkNode(kind::BITVECTOR_NEG,ret);
+  if (isNeg && size > 1)
+  {
+    ret = utils::mkNode(kind::BITVECTOR_NEG, ret);
   }
   return ret;
 }
@@ -977,8 +983,9 @@ inline Node RewriteRule<UdivOne>::apply(TNode node) {
 template<> inline
 bool RewriteRule<UremPow2>::applies(TNode node) {
   bool isNeg;
-  if(node.getKind() == kind::BITVECTOR_UREM_TOTAL &&
-          utils::isPow2Const(node[1],isNeg)){
+  if (node.getKind() == kind::BITVECTOR_UREM_TOTAL
+      && utils::isPow2Const(node[1], isNeg))
+  {
     return !isNeg;
   }
   return false;
@@ -989,14 +996,16 @@ Node RewriteRule<UremPow2>::apply(TNode node) {
   Debug("bv-rewrite") << "RewriteRule<UremPow2>(" << node << ")" << std::endl;
   TNode a = node[0];
   bool isNeg = false;
-  unsigned power = utils::isPow2Const(node[1],isNeg) - 1;
+  unsigned power = utils::isPow2Const(node[1], isNeg) - 1;
   Node ret;
   if (power == 0) {
     ret = utils::mkConst(utils::getSize(node), 0);
-  }else{
+  }
+  else
+  {
     Node extract = utils::mkExtract(a, power - 1, 0);
     Node zeros = utils::mkConst(utils::getSize(node) - power, 0);
-    ret = utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract); 
+    ret = utils::mkNode(kind::BITVECTOR_CONCAT, zeros, extract);
   }
   return ret;
 }

--- a/src/theory/bv/theory_bv_utils.h
+++ b/src/theory/bv/theory_bv_utils.h
@@ -272,20 +272,23 @@ inline Node mkConjunction(const std::set<TNode> nodes) {
   return conjunction;
 }
 
-inline unsigned isPow2Const(TNode node, bool& isNeg) {
+inline unsigned isPow2Const(TNode node, bool& isNeg)
+{
   if (node.getKind() != kind::CONST_BITVECTOR) {
     return false; 
   }
 
   BitVector bv = node.getConst<BitVector>();
-  unsigned p = bv.isPow2(); 
-  if( p!=0 ){
+  unsigned p = bv.isPow2();
+  if (p != 0)
+  {
     isNeg = false;
     return p;
   }
   BitVector nbv = -bv;
-  p = nbv.isPow2(); 
-  if( p!=0 ){
+  p = nbv.isPow2();
+  if (p != 0)
+  {
     isNeg = true;
     return p;
   }

--- a/src/theory/bv/theory_bv_utils.h
+++ b/src/theory/bv/theory_bv_utils.h
@@ -272,6 +272,11 @@ inline Node mkConjunction(const std::set<TNode> nodes) {
   return conjunction;
 }
 
+/**
+ * If node is a constant of the form 2^c or -2^c, then this function returns
+ * c+1. Otherwise, this function returns 0. The flag isNeg is updated to
+ * indicate whether node is negative.
+ */
 inline unsigned isPow2Const(TNode node, bool& isNeg)
 {
   if (node.getKind() != kind::CONST_BITVECTOR) {

--- a/src/theory/bv/theory_bv_utils.h
+++ b/src/theory/bv/theory_bv_utils.h
@@ -272,13 +272,24 @@ inline Node mkConjunction(const std::set<TNode> nodes) {
   return conjunction;
 }
 
-inline unsigned isPow2Const(TNode node) {
+inline unsigned isPow2Const(TNode node, bool& isNeg) {
   if (node.getKind() != kind::CONST_BITVECTOR) {
     return false; 
   }
 
   BitVector bv = node.getConst<BitVector>();
-  return bv.isPow2(); 
+  unsigned p = bv.isPow2(); 
+  if( p!=0 ){
+    isNeg = false;
+    return p;
+  }
+  BitVector nbv = -bv;
+  p = nbv.isPow2(); 
+  if( p!=0 ){
+    isNeg = true;
+    return p;
+  }
+  return false;
 }
 
 inline Node mkOr(const std::vector<Node>& nodes) {

--- a/test/regress/regress0/bv/Makefile.am
+++ b/test/regress/regress0/bv/Makefile.am
@@ -103,7 +103,9 @@ SMT_TESTS = \
 	bv-int-collapse2.smt2 \
 	bv-int-collapse2-sat.smt2 \
 	divtest_2_5.smt2 \
-	divtest_2_6.smt2
+	divtest_2_6.smt2 \
+	mul-neg-unsat.smt2 \
+	mul-negpow2.smt2
 
 # This benchmark is currently disabled as it uses --check-proof
 # bench_38.delta.smt2

--- a/test/regress/regress0/bv/mul-neg-unsat.smt2
+++ b/test/regress/regress0/bv/mul-neg-unsat.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_BV)
+(set-info :status unsat)
+(declare-fun a () (_ BitVec 32))
+(declare-fun b () (_ BitVec 32))
+(assert (not (= (bvmul a b) (bvmul (bvneg a) (bvneg b)))))
+(check-sat)

--- a/test/regress/regress0/bv/mul-negpow2.smt2
+++ b/test/regress/regress0/bv/mul-negpow2.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_BV)
+(set-info :status unsat)
+(declare-fun a () (_ BitVec 32))
+(declare-fun b () (_ BitVec 32))
+(assert (not (= (bvmul a (_ bv4294967040 32)) (bvshl (bvneg a) (_ bv8 32)))))
+(check-sat)


### PR DESCRIPTION
Two improvements to rewriting for bit-vector multiplication:
- MultSimplify is extended to pull bvneg from children.
- MultPow2 is extended for the case of multiplication by negative powers of 2.

Leads to +344-268 (+76 net gain) on quantifier-free logics of SMTLIB with bitvectors: https://www.starexec.org/starexec/secure/details/job.jsp?id=25673 
See CVC4-122917-6-gn

Leads to approximately +40 net gain on quantified BV from SMTLIB: https://www.starexec.org/starexec/secure/details/job.jsp?id=25665
See improvement around CVC4-122917-3-gn