### PR TITLE
Fix linearization for terms where the solve variable does not occur.

### DIFF
--- a/src/theory/quantifiers/ceg_t_instantiator.cpp
+++ b/src/theory/quantifiers/ceg_t_instantiator.cpp
@@ -1456,7 +1456,8 @@ static Node getPvCoeff(TNode pv, TNode n)
  *  pv * -(a * b * c)
  *
  * Returns the normalized node if the resulting term is linear w.r.t. pv and
- * a null node otherwise.
+ * a null node otherwise. If pv does not occur in children it returns a
+ * multiplication over children.
  */
 static Node normalizePvMult(
     TNode pv,
@@ -1572,7 +1573,8 @@ static bool isLinearPlus(
  *  pv * (a - c) + b
  *
  * Returns the normalized node if the resulting term is linear w.r.t. pv and
- * a null node otherwise.
+ * a null node otherwise. If pv does not occur in children it returns an
+ * addition over children.
  */
 static Node normalizePvPlus(
     Node pv,

--- a/test/unit/theory/theory_quantifiers_bv_instantiator_white.h
+++ b/test/unit/theory/theory_quantifiers_bv_instantiator_white.h
@@ -162,6 +162,10 @@ void BvInstantiatorWhite::testNormalizePvMult()
   Node norm_xx = normalizePvMult(x, {x, neg_x}, contains_x);
   TS_ASSERT(norm_xx.isNull());
 
+  /* nothing to normalize -> create a * a */
+  Node norm_aa = normalizePvMult(x, {a, a}, contains_x);
+  TS_ASSERT(norm_aa == Rewriter::rewrite(mkMult(a, a)));
+
   /* normalize x * a -> x * a */
   Node norm_xa = normalizePvMult(x, {x, a}, contains_x);
   TS_ASSERT(contains_x[norm_xa]);
@@ -257,6 +261,10 @@ void BvInstantiatorWhite::testNormalizePvPlus()
   contains_x[mult_bx] = true;
   Node norm_abx = normalizePvPlus(x, {a, mult_bx}, contains_x);
   TS_ASSERT(norm_abx.isNull());
+
+  /* nothing to normalize -> create a + a */
+  Node norm_aa = normalizePvPlus(x, {a, a}, contains_x);
+  TS_ASSERT(norm_aa == Rewriter::rewrite(mkPlus(a, a)));
 
   /* x + a -> x + a */
   Node norm_xa = normalizePvPlus(x, {x, a}, contains_x);


### PR DESCRIPTION
normalizePvMult and normalizePvPlus did not handle the case correctly where the solve variable does not occur in any of it's children.