### PR TITLE
Fix rewrite for string replace

### DIFF
--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -1926,10 +1926,6 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
   if( node[1]==node[2] ){
     return returnRewrite(node, node[0], "rpl-id");
   }
-  else if (node[0] == node[1])
-  {
-    return returnRewrite(node, node[2], "rpl-replace");
-  }
   else if (node[0].isConst() && node[0].getConst<String>().isEmptyString())
   {
     return returnRewrite(node, node[0], "rpl-empty");
@@ -1937,6 +1933,10 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
   else if (node[1].isConst() && node[1].getConst<String>().isEmptyString())
   {
     return returnRewrite(node, node[0], "rpl-rpl-empty");
+  }
+  else if (node[0] == node[1])
+  {
+    return returnRewrite(node, node[2], "rpl-replace");
   }
 
   std::vector<Node> children0;
@@ -1977,8 +1977,12 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
       CVC4::String s3 = s.substr((int)p + (int)t.size());
       Node ns1 = NodeManager::currentNM()->mkConst(::CVC4::String(s1));
       Node ns3 = NodeManager::currentNM()->mkConst(::CVC4::String(s3));
-      Node ret = NodeManager::currentNM()->mkNode(
-          kind::STRING_CONCAT, ns1, node[2], ns3);
+      std::vector< Node > children;
+      children.push_back( ns1 );
+      children.push_back( node[2] );
+      children.push_back( ns3 );
+      children.insert( children.end(), children0.begin()+1, children0.end() );
+      Node ret = mkConcat( kind::STRING_CONCAT, children );
       return returnRewrite(node, ret, "rpl-const-find");
     }
   }

--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -1945,26 +1945,22 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
     std::size_t p = s.find(t);
     if (p == std::string::npos)
     {
-      if (node[0].isConst())
+      if (children0.size()==1)
       {
         return returnRewrite(node, node[0], "rpl-const-nfind");
       }
-      else
+      if (s.overlap(t) == 0)
       {
-        if (s.overlap(t) == 0)
-        {
-          std::vector<Node> spl;
-          spl.insert(spl.end(), children0.begin() + 1, children0.end());
-          Node ret = NodeManager::currentNM()->mkNode(
-              kind::STRING_CONCAT,
-              children0[0],
-              NodeManager::currentNM()->mkNode(
-                  kind::STRING_STRREPL,
-                  mkConcat(kind::STRING_CONCAT, spl),
-                  node[1],
-                  node[2]));
-          return returnRewrite(node, ret, "rpl-prefix-nfind");
-        }
+        std::vector<Node> spl(children0.begin() + 1, children0.end());
+        Node ret = NodeManager::currentNM()->mkNode(
+            kind::STRING_CONCAT,
+            children0[0],
+            NodeManager::currentNM()->mkNode(
+                kind::STRING_STRREPL,
+                mkConcat(kind::STRING_CONCAT, spl),
+                node[1],
+                node[2]));
+        return returnRewrite(node, ret, "rpl-prefix-nfind");
       }
     }
     else

--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -1949,6 +1949,7 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
       {
         return returnRewrite(node, node[0], "rpl-const-nfind");
       }
+      // if no overlap, we can pull the first child
       if (s.overlap(t) == 0)
       {
         std::vector<Node> spl(children0.begin() + 1, children0.end());

--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -1945,7 +1945,7 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
     std::size_t p = s.find(t);
     if (p == std::string::npos)
     {
-      if (children0.size()==1)
+      if (children0.size() == 1)
       {
         return returnRewrite(node, node[0], "rpl-const-nfind");
       }
@@ -1955,11 +1955,10 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
         Node ret = NodeManager::currentNM()->mkNode(
             kind::STRING_CONCAT,
             children0[0],
-            NodeManager::currentNM()->mkNode(
-                kind::STRING_STRREPL,
-                mkConcat(kind::STRING_CONCAT, spl),
-                node[1],
-                node[2]));
+            NodeManager::currentNM()->mkNode(kind::STRING_STRREPL,
+                                             mkConcat(kind::STRING_CONCAT, spl),
+                                             node[1],
+                                             node[2]));
         return returnRewrite(node, ret, "rpl-prefix-nfind");
       }
     }
@@ -1969,12 +1968,12 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
       CVC4::String s3 = s.substr((int)p + (int)t.size());
       Node ns1 = NodeManager::currentNM()->mkConst(::CVC4::String(s1));
       Node ns3 = NodeManager::currentNM()->mkConst(::CVC4::String(s3));
-      std::vector< Node > children;
-      children.push_back( ns1 );
-      children.push_back( node[2] );
-      children.push_back( ns3 );
-      children.insert( children.end(), children0.begin()+1, children0.end() );
-      Node ret = mkConcat( kind::STRING_CONCAT, children );
+      std::vector<Node> children;
+      children.push_back(ns1);
+      children.push_back(node[2]);
+      children.push_back(ns3);
+      children.insert(children.end(), children0.begin() + 1, children0.end());
+      Node ret = mkConcat(kind::STRING_CONCAT, children);
       return returnRewrite(node, ret, "rpl-const-find");
     }
   }
@@ -1993,12 +1992,12 @@ Node TheoryStringsRewriter::rewriteReplace( Node node ) {
       // currently by the semantics of replace, if the second argument is
       // empty, then we return the first argument.
       // hence, we test whether the second argument must be non-empty here.
-      // if it definitely non-empty, we can use rules that successfully replace 
+      // if it definitely non-empty, we can use rules that successfully replace
       // node[1]->node[2] among those below.
       Node l1 = NodeManager::currentNM()->mkNode(kind::STRING_LENGTH, node[1]);
       Node zero = NodeManager::currentNM()->mkConst(CVC4::Rational(0));
       bool is_non_empty = checkEntailArith(l1, zero, true);
-      
+
       if (node[0] == node[1] && is_non_empty)
       {
         return returnRewrite(node, node[2], "rpl-replace");

--- a/test/regress/regress0/strings/Makefile.am
+++ b/test/regress/regress0/strings/Makefile.am
@@ -95,7 +95,8 @@ TESTS = \
   substr-rewrites.smt2 \
   norn-ab.smt2 \
   type002.smt2 \
-  strip-endpt-sound.smt2
+  strip-endpt-sound.smt2 \
+  repl-rewrites2.smt2
 
 FAILING_TESTS =
 

--- a/test/regress/regress0/strings/Makefile.am
+++ b/test/regress/regress0/strings/Makefile.am
@@ -96,7 +96,8 @@ TESTS = \
   norn-ab.smt2 \
   type002.smt2 \
   strip-endpt-sound.smt2 \
-  repl-rewrites2.smt2
+  repl-rewrites2.smt2 \
+  repl-soundness-sem.smt2
 
 FAILING_TESTS =
 

--- a/test/regress/regress0/strings/repl-rewrites2.smt2
+++ b/test/regress/regress0/strings/repl-rewrites2.smt2
@@ -8,5 +8,7 @@
 (not (= (str.replace "" "" "c") ""))
 (not (= (str.replace (str.++ "abc" y) "b" x) (str.++ "a" x "c" y)))
 (not (= (str.replace "" "abc" "de") ""))
+(not (= (str.replace "ab" "ab" "de") "de"))
+(not (= (str.replace "ab" "" "de") "ab"))
 ))
 (check-sat)

--- a/test/regress/regress0/strings/repl-rewrites2.smt2
+++ b/test/regress/regress0/strings/repl-rewrites2.smt2
@@ -1,0 +1,12 @@
+; COMMAND-LINE: --strings-exp
+; EXPECT: unsat
+(set-logic ALL)
+(set-info :status unsat)
+(declare-fun x () String)
+(declare-fun y () String)
+(assert (or
+(not (= (str.replace "" "" "c") ""))
+(not (= (str.replace (str.++ "abc" y) "b" x) (str.++ "a" x "c" y)))
+(not (= (str.replace "" "abc" "de") ""))
+))
+(check-sat)

--- a/test/regress/regress0/strings/repl-soundness-sem.smt2
+++ b/test/regress/regress0/strings/repl-soundness-sem.smt2
@@ -1,0 +1,12 @@
+; COMMAND-LINE: --strings-exp
+; EXPECT: sat
+(set-logic ALL)
+(set-info :status sat)
+(declare-fun x () String)
+(declare-fun y () String)
+(assert (and
+(= (str.replace x x "abc") "")
+(= (str.replace (str.++ x y) x "abc") (str.++ x y))
+(= (str.replace (str.++ x y) (str.substr x 0 2) "abc") y)
+))
+(check-sat)


### PR DESCRIPTION
Fixes a several issues in the rewrite for replace:
- The rewriter was non-terminating in a corner case when the second argument of str.replace was "".
- The rewriter for str.replace was unsound for cases when the second argument of str.replace could be empty. Due to the updated semantics of replace which is no-op when the second argument is empty, certain rewrites can only be applied when we can definitely show the second argument is non-empty. An example of an unsound rewrite is str.replace( x, x, y ) ---> y
- Generalizes an existing rule so that we rewrite cases like str.replace( str.++( "ab", x ), "b", y ) ---> str.++( "a", y, x ).