### PR TITLE
Aborting on errors in StatisticsRegistry::unregisterStat() instead of…

### DIFF
--- a/src/util/statistics_registry.cpp
+++ b/src/util/statistics_registry.cpp
@@ -17,6 +17,9 @@
 
 #include "util/statistics_registry.h"
 
+#include <cstdlib>
+#include <iostream>
+
 #include "base/cvc4_assert.h"
 #include "lib/clock_gettime.h"
 
@@ -163,9 +166,19 @@ void StatisticsRegistry::registerStat(Stat* s)
 void StatisticsRegistry::unregisterStat(Stat* s)
 {
 #ifdef CVC4_STATISTICS_ON
-  PrettyCheckArgument(d_stats.find(s) != d_stats.end(), s,
-                "Statistic `%s' was not registered with this registry.",
-                s->getName().c_str());
+  try
+  {
+    PrettyCheckArgument(d_stats.find(s) != d_stats.end(),
+                        s,
+                        "Statistic `%s' was not registered with this registry.",
+                        s->getName().c_str());
+  }
+  catch (Exception& e)
+  {
+    std::cerr << "Failure in StatisticsRegistry::unregisterStat():" << e.what()
+              << std::endl;
+    abort();
+  }
   d_stats.erase(s);
 #endif /* CVC4_STATISTICS_ON */
 }/* StatisticsRegistry::unregisterStat_() */
@@ -198,7 +211,16 @@ void TimerStat::start() {
 
 void TimerStat::stop() {
   if(__CVC4_USE_STATISTICS) {
-    PrettyCheckArgument(d_running, *this, "timer not running");
+    try
+    {
+      PrettyCheckArgument(d_running, *this, "timer not running");
+    }
+    catch (Exception& e)
+    {
+      std::cerr << "Fatal failure in TimerStat::stop(): " << e.what()
+                << std::endl;
+      abort();
+    }
     ::timespec end;
     clock_gettime(CLOCK_MONOTONIC, &end);
     d_data += end - d_start;


### PR DESCRIPTION
… throwing exceptions. This is called from destructors and therefore it is inappropriate to throw exceptions. This solution is temporary until Assert() is deprecated in favor of an aborting version. This seems to be involved in a large number of CIDs. Examples: 1452734, 1172222, 1452724, etc.