### PR TITLE
Inlining line_buffered_input to avoid warning about unused variables …

### DIFF
--- a/src/parser/antlr_line_buffered_input.cpp
+++ b/src/parser/antlr_line_buffered_input.cpp
@@ -287,12 +287,11 @@ static void bufferedInputSeek(pANTLR3_INT_STREAM is, ANTLR3_MARKER seekPoint) {
   // rewinding in the original code, which we do not do when rewinding,
   // so this should be fine).
   pANTLR3_INPUT_STREAM input = ((pANTLR3_INPUT_STREAM)(is->super));
-  pANTLR3_LINE_BUFFERED_INPUT_STREAM line_buffered_input =
-      (CVC4::parser::pANTLR3_LINE_BUFFERED_INPUT_STREAM)input;
 
   // Check that we are not seeking backwards.
-  assert(!line_buffered_input->line_buffer->isPtrBefore(
-      (uint8_t*)seekPoint, input->line, input->charPositionInLine));
+  assert(!((CVC4::parser::pANTLR3_LINE_BUFFERED_INPUT_STREAM)input)
+              ->line_buffer->isPtrBefore(
+                  (uint8_t*)seekPoint, input->line, input->charPositionInLine));
 
   while ((ANTLR3_MARKER)(input->nextChar) != seekPoint) {
     is->consume(is);


### PR DESCRIPTION
…in production builds.