### PR TITLE
Replacing an incorrect reference to an injected class name...

### DIFF
--- a/src/proof/sat_proof.h
+++ b/src/proof/sat_proof.h
@@ -301,7 +301,7 @@ class TSatProof {
   void addToCnfProof(ClauseId id);
 
   // Internal data.
-  typename Solver::Solver* d_solver;
+  Solver* d_solver;
   context::Context* d_context;
   CnfProof* d_cnfProof;
 


### PR DESCRIPTION
when the type was meant.

More discussion on this issue:  http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1310 