### PR TITLE
Move (unrecursified) bv::utils::numNodes to lazy_bitblaster.cpp.

### DIFF
--- a/src/theory/bv/lazy_bitblaster.cpp
+++ b/src/theory/bv/lazy_bitblaster.cpp
@@ -33,6 +33,34 @@ namespace CVC4 {
 namespace theory {
 namespace bv {
 
+namespace {
+
+uint64_t numNodes(TNode node, utils::NodeSet& seen)
+{
+  utils::NodeSet::iterator it;
+  std::vector<TNode> stack;
+  uint64_t res = 0;
+
+  stack.push_back(node);
+  while (!stack.empty())
+  {
+    Node n = stack.back();
+    stack.pop_back();
+    it = seen.find(n);
+
+    if (it != seen.end()) continue;
+
+    res += 1;
+    seen.insert(n);
+    for (size_t i = 0, nc = n.getNumChildren(); i < nc; ++i)
+    {
+      stack.push_back(n[i]);
+    }
+  }
+  return res;
+}
+}
+
 
 TLazyBitblaster::TLazyBitblaster(context::Context* c, bv::TheoryBV* bv,
                                  const std::string name, bool emptyNotify)
@@ -194,7 +222,7 @@ uint64_t TLazyBitblaster::computeAtomWeight(TNode node, NodeSet& seen) {
     return 0;
   }
   Node atom_bb = Rewriter::rewrite(d_atomBBStrategies[node.getKind()](node, this));
-  uint64_t size = utils::numNodes(atom_bb, seen);
+  uint64_t size = numNodes(atom_bb, seen);
   return size;
 }
 

--- a/src/theory/bv/lazy_bitblaster.cpp
+++ b/src/theory/bv/lazy_bitblaster.cpp
@@ -215,12 +215,12 @@ void TLazyBitblaster::makeVariable(TNode var, Bits& bits) {
   d_variables.insert(var);
 }
 
-uint64_t TLazyBitblaster::computeAtomWeight(TNode node, NodeSet& seen) {
-  node = node.getKind() == kind::NOT?  node[0] : node;
-  if( !utils::isBitblastAtom( node ) ){
-    return 0;
-  }
-  Node atom_bb = Rewriter::rewrite(d_atomBBStrategies[node.getKind()](node, this));
+uint64_t TLazyBitblaster::computeAtomWeight(TNode node, NodeSet& seen)
+{
+  node = node.getKind() == kind::NOT ? node[0] : node;
+  if (!utils::isBitblastAtom(node)) { return 0; }
+  Node atom_bb =
+      Rewriter::rewrite(d_atomBBStrategies[node.getKind()](node, this));
   uint64_t size = numNodes(atom_bb, seen);
   return size;
 }

--- a/src/theory/bv/lazy_bitblaster.cpp
+++ b/src/theory/bv/lazy_bitblaster.cpp
@@ -35,9 +35,9 @@ namespace bv {
 
 namespace {
 
+/* Determine the number of uncached nodes that a given node consists of.  */
 uint64_t numNodes(TNode node, utils::NodeSet& seen)
 {
-  utils::NodeSet::iterator it;
   std::vector<TNode> stack;
   uint64_t res = 0;
 
@@ -46,9 +46,8 @@ uint64_t numNodes(TNode node, utils::NodeSet& seen)
   {
     Node n = stack.back();
     stack.pop_back();
-    it = seen.find(n);
 
-    if (it != seen.end()) continue;
+    if (seen.find(n) != seen.end()) continue;
 
     res += 1;
     seen.insert(n);

--- a/src/theory/bv/lazy_bitblaster.cpp
+++ b/src/theory/bv/lazy_bitblaster.cpp
@@ -51,10 +51,7 @@ uint64_t numNodes(TNode node, utils::NodeSet& seen)
 
     res += 1;
     seen.insert(n);
-    for (size_t i = 0, nc = n.getNumChildren(); i < nc; ++i)
-    {
-      stack.push_back(n[i]);
-    }
+    stack.insert(stack.end(), n.begin(), n.end());
   }
   return res;
 }

--- a/src/theory/bv/theory_bv_utils.cpp
+++ b/src/theory/bv/theory_bv_utils.cpp
@@ -502,21 +502,6 @@ void intersect(const std::vector<uint32_t>& v1,
 
 /* ------------------------------------------------------------------------- */
 
-uint64_t numNodes(TNode node, NodeSet& seen)
-{
-  if (seen.find(node) != seen.end()) return 0;
-
-  uint64_t size = 1;
-  for (unsigned i = 0; i < node.getNumChildren(); ++i)
-  {
-    size += numNodes(node[i], seen);
-  }
-  seen.insert(node);
-  return size;
-}
-
-/* ------------------------------------------------------------------------- */
-
 void collectVariables(TNode node, NodeSet& vars)
 {
   if (vars.find(node) != vars.end()) return;

--- a/src/theory/bv/theory_bv_utils.h
+++ b/src/theory/bv/theory_bv_utils.h
@@ -197,9 +197,6 @@ void intersect(const std::vector<uint32_t>& v1,
                const std::vector<uint32_t>& v2,
                std::vector<uint32_t>& intersection);
 
-/* Determine the total number of nodes that a given node consists of.  */
-uint64_t numNodes(TNode node, NodeSet& seen);
-
 /* Collect all variables under a given a node.  */
 void collectVariables(TNode node, NodeSet& vars);
 


### PR DESCRIPTION
This unrecursifies and moves bv::utils::numNodes to an unnamed namespace in lazy_bitblaster.cpp (only place where it is used). Tested against the recursive implementation (with a temporary Assertion) on regression tests.