### PR TITLE
Moved (unrecursified) bv::utils::collectVars.

### DIFF
--- a/src/theory/bv/bv_subtheory_algebraic.cpp
+++ b/src/theory/bv/bv_subtheory_algebraic.cpp
@@ -23,6 +23,7 @@
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/theory_model.h"
 
+#include <unordered_set>
 
 using namespace CVC4::context;
 using namespace CVC4::prop;
@@ -41,6 +42,7 @@ namespace {
 void collectVariables(TNode node, utils::NodeSet& vars)
 {
   std::vector<TNode> stack;
+  std::unordered_set<TNode, TNodeHashFunction> visited;
 
   stack.push_back(node);
   while (!stack.empty())
@@ -49,6 +51,8 @@ void collectVariables(TNode node, utils::NodeSet& vars)
     stack.pop_back();
 
     if (vars.find(n) != vars.end()) continue;
+    if (visited.find(n) != visited.end()) continue;
+    visited.insert(n);
 
     if (Theory::isLeafOf(n, THEORY_BV) && n.getKind() != kind::CONST_BITVECTOR)
     {

--- a/src/theory/bv/theory_bv_utils.cpp
+++ b/src/theory/bv/theory_bv_utils.cpp
@@ -496,24 +496,6 @@ void intersect(const std::vector<uint32_t>& v1,
 
 /* ------------------------------------------------------------------------- */
 
-void collectVariables(TNode node, NodeSet& vars)
-{
-  if (vars.find(node) != vars.end()) return;
-
-  if (Theory::isLeafOf(node, THEORY_BV)
-      && node.getKind() != kind::CONST_BITVECTOR)
-  {
-    vars.insert(node);
-    return;
-  }
-  for (unsigned i = 0; i < node.getNumChildren(); ++i)
-  {
-    collectVariables(node[i], vars);
-  }
-}
-
-/* ------------------------------------------------------------------------- */
-
 }/* CVC4::theory::bv::utils namespace */
 }/* CVC4::theory::bv namespace */
 }/* CVC4::theory namespace */

--- a/src/theory/bv/theory_bv_utils.h
+++ b/src/theory/bv/theory_bv_utils.h
@@ -2,7 +2,7 @@
 /*! \file theory_bv_utils.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Aina Niemetz, Dejan Jovanovic, Morgan Deters
+ **   Aina Niemetz, Dejan Jovanovic, Tim King
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -193,9 +193,6 @@ Node flattenAnd(std::vector<TNode>& queue);
 void intersect(const std::vector<uint32_t>& v1,
                const std::vector<uint32_t>& v2,
                std::vector<uint32_t>& intersection);
-
-/* Collect all variables under a given a node.  */
-void collectVariables(TNode node, NodeSet& vars);
 
 }
 }


### PR DESCRIPTION
This unrecursifies and moves bv::utils::collectVars to an unnamed namespace in bv_subtheory_algebraic.cpp (only place where it is used). Tested against the recursive implementation (with a temporary Assertion) on regression tests.