### PR TITLE
Unrecursified bv::utils::isEqualityTerm, added visited cache.

### DIFF
--- a/src/theory/bv/theory_bv_utils.cpp
+++ b/src/theory/bv/theory_bv_utils.cpp
@@ -162,7 +162,7 @@ bool isCoreTerm(TNode term, TNodeBoolMap& cache)
   return true;
 }
 
-bool isEqualityTermNew(TNode term, TNodeBoolMap& cache)
+bool isEqualityTerm(TNode term, TNodeBoolMap& cache)
 {
   TNode t = term.getKind() == kind::NOT ? term[0] : term;
 
@@ -226,50 +226,6 @@ bool isEqualityTermNew(TNode term, TNodeBoolMap& cache)
   }
   Assert(cache.find(t) != cache.end());
   return cache[t];
-}
-
-bool isEqualityTermOld(TNode term, TNodeBoolMap& cache)
-{
-  term = term.getKind() == kind::NOT ? term[0] : term;
-  TNodeBoolMap::const_iterator it = cache.find(term);
-  if (it != cache.end())
-  {
-    return it->second;
-  }
-
-  if (term.getNumChildren() == 0) return true;
-
-  if (theory::Theory::theoryOf(theory::THEORY_OF_TERM_BASED, term) == THEORY_BV)
-  {
-    Kind k = term.getKind();
-    if (k != kind::CONST_BITVECTOR && k != kind::EQUAL
-        && term.getMetaKind() != kind::metakind::VARIABLE)
-    {
-      cache[term] = false;
-      return false;
-    }
-  }
-
-  for (unsigned i = 0; i < term.getNumChildren(); ++i)
-  {
-    if (!isEqualityTerm(term[i], cache))
-    {
-      cache[term] = false;
-      return false;
-    }
-  }
-
-  cache[term] = true;
-  return true;
-}
-
-bool isEqualityTerm(TNode term, TNodeBoolMap& cache)
-{
-  TNodeBoolMap cachecopy(cache);
-  bool resold = isEqualityTermOld(term, cache);
-  bool resnew = isEqualityTermNew(term, cachecopy);
-  Assert(resold==resnew);
-  return resold;
 }
 
 bool isBitblastAtom(Node lit)


### PR DESCRIPTION
Tested against the recursive implementation (with a temporary Assertion) on regression tests.