### PR TITLE
Moved and simplified bv::utils::intersect.

### DIFF
--- a/src/theory/bv/slicer.cpp
+++ b/src/theory/bv/slicer.cpp
@@ -397,17 +397,18 @@ void UnionFind::alignSlicings(const ExtractTerm& term1, const ExtractTerm& term2
   Debug("bv-slicer") << "                         " << term2.debugPrint() << endl;
   NormalForm nf1(term1.getBitwidth());
   NormalForm nf2(term2.getBitwidth());
-  
+
   getNormalForm(term1, nf1);
   getNormalForm(term2, nf2);
 
   Assert (nf1.base.getBitwidth() == nf2.base.getBitwidth());
-  
+
   // first check if the two have any common slices
-  std::vector<TermId> intersection; 
-  intersect(nf1.decomp, nf2.decomp, intersection); 
+  std::vector<TermId> intersection;
+  intersect(nf1.decomp, nf2.decomp, intersection);
   for (TermId id : intersection)
   {
+    /* handleCommonSlice() may change the normal form */
     handleCommonSlice(nf1.decomp, nf2.decomp, id);
   }
   // propagate cuts to a fixpoint 

--- a/src/theory/bv/slicer.cpp
+++ b/src/theory/bv/slicer.cpp
@@ -48,23 +48,6 @@ void intersect(const std::vector<TermId>& v1,
   }
 }
 
-void intersectOld(const std::vector<uint32_t>& v1,
-                      const std::vector<uint32_t>& v2,
-                      std::vector<uint32_t>& intersection) {
-  for (unsigned i = 0; i < v1.size(); ++i) {
-    bool found = false;
-    for (unsigned j = 0; j < v2.size(); ++j) {
-      if (v2[j] == v1[i]) {
-        found = true;
-        break;
-      }
-    }
-    if (found) {
-      intersection.push_back(v1[i]);
-    }
-  }
-}
-
 }  // namespace
 
 /**
@@ -423,9 +406,6 @@ void UnionFind::alignSlicings(const ExtractTerm& term1, const ExtractTerm& term2
   // first check if the two have any common slices
   std::vector<TermId> intersection; 
   intersect(nf1.decomp, nf2.decomp, intersection); 
-  std::vector<TermId> intersectionOld;
-  intersectOld(nf1.decomp, nf2.decomp, intersectionOld);
-  Assert(intersection == intersectionOld);
   for (TermId id : intersection)
   {
     handleCommonSlice(nf1.decomp, nf2.decomp, id);

--- a/src/theory/bv/slicer.cpp
+++ b/src/theory/bv/slicer.cpp
@@ -20,13 +20,35 @@
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/rewriter.h"
 
-using namespace CVC4;
-using namespace CVC4::theory;
-using namespace CVC4::theory::bv;
 using namespace std; 
 
 
-const TermId CVC4::theory::bv::UndefinedId = -1; 
+namespace CVC4 {
+namespace theory {
+namespace bv {
+
+const TermId UndefinedId = -1;
+
+namespace {
+
+void intersect(const std::vector<TermId>& v1,
+               const std::vector<TermId>& v2,
+               std::vector<TermId>& intersection)
+{
+  for (const TermId id1 : v1)
+  {
+    for (const TermId id2 : v2)
+    {
+      if (v2[id2] == v1[id1])
+      {
+        intersection.push_back(id1);
+        break;
+      }
+    }
+  }
+}
+
+}  // namespace
 
 /**
  * Base
@@ -381,12 +403,12 @@ void UnionFind::alignSlicings(const ExtractTerm& term1, const ExtractTerm& term2
 
   Assert (nf1.base.getBitwidth() == nf2.base.getBitwidth());
   
-  // first check if the two have any common slices 
+  // first check if the two have any common slices
   std::vector<TermId> intersection; 
-  utils::intersect(nf1.decomp, nf2.decomp, intersection); 
-  for (unsigned i = 0; i < intersection.size(); ++i) {
-    // handle common slice may change the normal form 
-    handleCommonSlice(nf1.decomp, nf2.decomp, intersection[i]); 
+  intersect(nf1.decomp, nf2.decomp, intersection); 
+  for (TermId id : intersection)
+  {
+    handleCommonSlice(nf1.decomp, nf2.decomp, id);
   }
   // propagate cuts to a fixpoint 
   bool changed;
@@ -638,3 +660,7 @@ UnionFind::Statistics::~Statistics() {
   smtStatisticsRegistry()->unregisterStat(&d_avgFindDepth);
   smtStatisticsRegistry()->unregisterStat(&d_numAddedEqualities);
 }
+
+}  // namespace bv
+}  // namespace theory
+}  // namespace CVC4

--- a/src/theory/bv/slicer.cpp
+++ b/src/theory/bv/slicer.cpp
@@ -39,11 +39,28 @@ void intersect(const std::vector<TermId>& v1,
   {
     for (const TermId id2 : v2)
     {
-      if (v2[id2] == v1[id1])
+      if (id2 == id1)
       {
         intersection.push_back(id1);
         break;
       }
+    }
+  }
+}
+
+void intersectOld(const std::vector<uint32_t>& v1,
+                      const std::vector<uint32_t>& v2,
+                      std::vector<uint32_t>& intersection) {
+  for (unsigned i = 0; i < v1.size(); ++i) {
+    bool found = false;
+    for (unsigned j = 0; j < v2.size(); ++j) {
+      if (v2[j] == v1[i]) {
+        found = true;
+        break;
+      }
+    }
+    if (found) {
+      intersection.push_back(v1[i]);
     }
   }
 }
@@ -406,6 +423,9 @@ void UnionFind::alignSlicings(const ExtractTerm& term1, const ExtractTerm& term2
   // first check if the two have any common slices
   std::vector<TermId> intersection; 
   intersect(nf1.decomp, nf2.decomp, intersection); 
+  std::vector<TermId> intersectionOld;
+  intersectOld(nf1.decomp, nf2.decomp, intersectionOld);
+  Assert(intersection == intersectionOld);
   for (TermId id : intersection)
   {
     handleCommonSlice(nf1.decomp, nf2.decomp, id);

--- a/src/theory/bv/theory_bv_utils.cpp
+++ b/src/theory/bv/theory_bv_utils.cpp
@@ -456,26 +456,6 @@ Node flattenAnd(std::vector<TNode>& queue)
 
 /* ------------------------------------------------------------------------- */
 
-// FIXME: dumb code
-void intersect(const std::vector<uint32_t>& v1,
-                      const std::vector<uint32_t>& v2,
-                      std::vector<uint32_t>& intersection) {
-  for (unsigned i = 0; i < v1.size(); ++i) {
-    bool found = false;
-    for (unsigned j = 0; j < v2.size(); ++j) {
-      if (v2[j] == v1[i]) {
-        found = true;
-        break;
-      }
-    }
-    if (found) {
-      intersection.push_back(v1[i]);
-    }
-  }
-}
-
-/* ------------------------------------------------------------------------- */
-
 }/* CVC4::theory::bv::utils namespace */
 }/* CVC4::theory::bv namespace */
 }/* CVC4::theory namespace */


### PR DESCRIPTION
Tested against the recursive implementation with a temporary assertion on regression tests
with --bv-eq-slicer=auto.