### PR TITLE
Simplify sygus wrt miniscoping

### DIFF
--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -129,10 +129,12 @@ void CegConjecture::assign( Node q ) {
 
   if (d_qe->getQuantAttributes()->isSygus(q))
   {
-    //if the base instantiation is an existential, store its variables
-    if( d_base_inst.getKind()==NOT && d_base_inst[0].getKind()==FORALL ){
-      for( const Node& v : d_base_inst[0][0] ){
-        d_inner_vars.push_back( v );
+    // if the base instantiation is an existential, store its variables
+    if (d_base_inst.getKind() == NOT && d_base_inst[0].getKind() == FORALL)
+    {
+      for (const Node& v : d_base_inst[0][0])
+      {
+        d_inner_vars.push_back(v);
       }
     }
     d_syntax_guided = true;
@@ -292,24 +294,33 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   ic.push_back( d_quant.negate() );
 
   //immediately skolemize inner existentials
-  Node dr = Rewriter::rewrite( inst );
-  if( dr.getKind()==NOT && dr[0].getKind()==FORALL ){
-    if( constructed_cand ){
+  Node dr = Rewriter::rewrite(inst);
+  if (dr.getKind() == NOT && dr[0].getKind() == FORALL)
+  {
+    if (constructed_cand)
+    {
       ic.push_back(d_qe->getSkolemize()->getSkolemizedBody(dr[0]).negate());
     }
-    if( sk_refine ){
-      Assert( !isGround() );
-      d_ce_sk.push_back( dr[0] );
+    if (sk_refine)
+    {
+      Assert(!isGround());
+      d_ce_sk.push_back(dr[0]);
     }
-  }else{
-    if( constructed_cand ){
-      ic.push_back( dr );
-      if( !d_inner_vars.empty() ){
-        Trace("cegqi-debug") << "*** quantified disjunct : " << inst << " simplifies to " << dr << std::endl;
+  }
+  else
+  {
+    if (constructed_cand)
+    {
+      ic.push_back(dr);
+      if (!d_inner_vars.empty())
+      {
+        Trace("cegqi-debug") << "*** quantified disjunct : " << inst
+                             << " simplifies to " << dr << std::endl;
       }
     }
-    if( sk_refine ){
-      d_ce_sk.push_back( Node::null() );
+    if (sk_refine)
+    {
+      d_ce_sk.push_back(Node::null());
     }
   }
   if( constructed_cand ){
@@ -337,43 +348,59 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   std::vector< Node > sk_subs;
   //collect the substitution over all disjuncts
   Node ce_q = d_ce_sk[0];
-  if( !ce_q.isNull() ){
+  if (!ce_q.isNull())
+  {
     std::vector<Node> skolems;
     d_qe->getSkolemize()->getSkolemConstants(ce_q, skolems);
     Assert(d_inner_vars.size() == skolems.size());
-    std::vector< Node > model_values;
+    std::vector<Node> model_values;
     getModelValues(skolems, model_values);
-    sk_vars.insert( sk_vars.end(), d_inner_vars.begin(), d_inner_vars.end() );
-    sk_subs.insert( sk_subs.end(), model_values.begin(), model_values.end() );
-  }else{
-    if( !d_inner_vars.empty() ){
-      //denegrate case : quantified disjunct was trivially true and does not need to be refined
-      //add trivial substitution (in case we need substitution for previous cex's)
-      for( unsigned i=0; i<d_inner_vars.size(); i++ ){
-        sk_vars.push_back( d_inner_vars[i] );
-        sk_subs.push_back( getModelValue( d_inner_vars[i] ) ); // will return dummy value
+    sk_vars.insert(sk_vars.end(), d_inner_vars.begin(), d_inner_vars.end());
+    sk_subs.insert(sk_subs.end(), model_values.begin(), model_values.end());
+  }
+  else
+  {
+    if (!d_inner_vars.empty())
+    {
+      // denegrate case : quantified disjunct was trivially true and does not
+      // need to be refined
+      // add trivial substitution (in case we need substitution for previous
+      // cex's)
+      for (unsigned i = 0; i < d_inner_vars.size(); i++)
+      {
+        sk_vars.push_back(d_inner_vars[i]);
+        sk_subs.push_back(
+            getModelValue(d_inner_vars[i]));  // will return dummy value
       }
     }
   }
-  
+
   //for conditional evaluation
   std::vector< Node > lem_c;
   std::vector< Node > inst_cond_c;
   Trace("cegqi-refine") << "doRefine : Construct refinement lemma..." << std::endl;
-  Trace("cegqi-refine-debug") << "  For counterexample point : " << ce_q << std::endl;
+  Trace("cegqi-refine-debug")
+      << "  For counterexample point : " << ce_q << std::endl;
   Node c_disj;
-  if( !ce_q.isNull() ){
-    Assert( d_base_inst.getKind()==kind::NOT && d_base_inst[0].getKind()==kind::FORALL );
+  if (!ce_q.isNull())
+  {
+    Assert(d_base_inst.getKind() == kind::NOT
+           && d_base_inst[0].getKind() == kind::FORALL);
     c_disj = d_base_inst[0][1];
-  }else{
-    if( d_inner_vars.empty() ){
+  }
+  else
+  {
+    if (d_inner_vars.empty())
+    {
       c_disj = d_base_inst.negate();
     }
   }
-  if( !c_disj.isNull() ){
-    //compute the body, inst_cond
-    //standard CEGIS refinement : plug in values, assert that d_candidates must satisfy entire specification
-    lem_c.push_back( c_disj );
+  if (!c_disj.isNull())
+  {
+    // compute the body, inst_cond
+    // standard CEGIS refinement : plug in values, assert that d_candidates must
+    // satisfy entire specification
+    lem_c.push_back(c_disj);
   }
   Assert( sk_vars.size()==sk_subs.size() );
   

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -358,7 +358,7 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   }
   else
   {
-    Assert( d_inner_vars.empty() );
+    Assert(d_inner_vars.empty());
   }
 
   std::vector< Node > lem_c;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -383,11 +383,7 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
 
   base_lem = base_lem.substitute( sk_vars.begin(), sk_vars.end(), sk_subs.begin(), sk_subs.end() );
   base_lem = Rewriter::rewrite( base_lem );
-  d_master->registerRefinementLemma(sk_vars, base_lem);
-
-  Node lem =
-      NodeManager::currentNM()->mkNode(OR, getGuard().negate(), base_lem);
-  lems.push_back( lem );
+  d_master->registerRefinementLemma(sk_vars, base_lem, lems);
 
   d_ce_sk.clear();
 }

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -162,13 +162,12 @@ private:
   Node d_base_inst;
   /** list of variables on inner quantification */
   std::vector< Node > d_inner_vars;
-  /** 
-   * The set of current extentially quantified formulas whose couterexamples we 
+  /**
+   * The set of current extentially quantified formulas whose couterexamples we
    * must refine. This may be added to during calls to doCheck(). The model
    * values for skolems of these formulas are analyzed during doRefine().
    */
-  std::vector< Node > d_ce_sk;
-
+  std::vector<Node> d_ce_sk;
 
   /** the asserted (negated) conjecture */
   Node d_quant;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -160,13 +160,14 @@ private:
   * this is the formula  exists y. P( d_candidates, y ).
   */
   Node d_base_inst;
-  /** expand base inst to disjuncts */
-  std::vector< Node > d_base_disj;
   /** list of variables on inner quantification */
   std::vector< Node > d_inner_vars;
-  std::vector< std::vector< Node > > d_inner_vars_disj;
-  /** current extential quantifeirs whose couterexamples we must refine */
-  std::vector< std::vector< Node > > d_ce_sk;
+  /** 
+   * The set of current extentially quantified formulas whose couterexamples we 
+   * must refine. This may be added to during calls to doCheck(). The model
+   * values for skolems of these formulas are analyzed during doRefine().
+   */
+  std::vector< Node > d_ce_sk;
 
 
   /** the asserted (negated) conjecture */

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -163,8 +163,8 @@ private:
   /** list of variables on inner quantification */
   std::vector< Node > d_inner_vars;
   /**
-   * The set of current extentially quantified formulas whose couterexamples we
-   * must refine. This may be added to during calls to doCheck(). The model
+   * The set of current existentially quantified formulas whose couterexamples
+   * we must refine. This may be added to during calls to doCheck(). The model
    * values for skolems of these formulas are analyzed during doRefine().
    */
   std::vector<Node> d_ce_sk;

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -150,7 +150,7 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
   return true;
 }
 
-void Cegis::registerRefinementLemma(const std::vector< Node >& vars, Node lem)
+void Cegis::registerRefinementLemma(const std::vector<Node>& vars, Node lem)
 {
   d_refinement_lemmas.push_back(lem);
 }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -150,7 +150,8 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
   return true;
 }
 
-void Cegis::registerRefinementLemma(const std::vector<Node>& vars, Node lem,
+void Cegis::registerRefinementLemma(const std::vector<Node>& vars,
+                                    Node lem,
                                     std::vector<Node>& lems)
 {
   d_refinement_lemmas.push_back(lem);
@@ -159,7 +160,8 @@ void Cegis::registerRefinementLemma(const std::vector<Node>& vars, Node lem,
   // "this conjecture has a solution", hence this lemma states:
   // if the parent conjecture has a solution, it satisfies the specification
   // for the given concrete point.
-  Node rlem = NodeManager::currentNM()->mkNode(OR, d_parent->getGuard().negate(), lem);
+  Node rlem =
+      NodeManager::currentNM()->mkNode(OR, d_parent->getGuard().negate(), lem);
   lems.push_back(rlem);
 }
 

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -150,7 +150,7 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
   return true;
 }
 
-void Cegis::registerRefinementLemma(Node lem)
+void Cegis::registerRefinementLemma(const std::vector< Node >& vars, Node lem)
 {
   d_refinement_lemmas.push_back(lem);
 }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -150,9 +150,17 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
   return true;
 }
 
-void Cegis::registerRefinementLemma(const std::vector<Node>& vars, Node lem)
+void Cegis::registerRefinementLemma(const std::vector<Node>& vars, Node lem,
+                                    std::vector<Node>& lems)
 {
   d_refinement_lemmas.push_back(lem);
+  // Make the refinement lemma and add it to lems.
+  // This lemma is guarded by the parent's guard, which has the semantics
+  // "this conjecture has a solution", hence this lemma states:
+  // if the parent conjecture has a solution, it satisfies the specification
+  // for the given concrete point.
+  Node rlem = NodeManager::currentNM()->mkNode(OR, d_parent->getGuard().negate(), lem);
+  lems.push_back(rlem);
 }
 
 void Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -57,7 +57,8 @@ class Cegis : public SygusModule
                                    std::vector<Node>& candidate_values,
                                    std::vector<Node>& lems) override;
   /** register refinement lemma */
-  virtual void registerRefinementLemma(const std::vector< Node >& vars, Node lem) override;
+  virtual void registerRefinementLemma(const std::vector<Node>& vars,
+                                       Node lem) override;
 
  private:
   /** If CegConjecture::d_base_inst is exists y. P( d, y ), then this is y. */

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -56,8 +56,8 @@ class Cegis : public SygusModule
                                    const std::vector<Node>& candidates,
                                    std::vector<Node>& candidate_values,
                                    std::vector<Node>& lems) override;
-  /** register refinement lemma 
-   * 
+  /** register refinement lemma
+   *
    * This function stores lem as a refinement lemma, and adds it to lems.
    */
   virtual void registerRefinementLemma(const std::vector<Node>& vars,

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -57,7 +57,7 @@ class Cegis : public SygusModule
                                    std::vector<Node>& candidate_values,
                                    std::vector<Node>& lems) override;
   /** register refinement lemma */
-  virtual void registerRefinementLemma(Node lem) override;
+  virtual void registerRefinementLemma(const std::vector< Node >& vars, Node lem) override;
 
  private:
   /** If CegConjecture::d_base_inst is exists y. P( d, y ), then this is y. */

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -56,9 +56,13 @@ class Cegis : public SygusModule
                                    const std::vector<Node>& candidates,
                                    std::vector<Node>& candidate_values,
                                    std::vector<Node>& lems) override;
-  /** register refinement lemma */
+  /** register refinement lemma 
+   * 
+   * This function stores lem as a refinement lemma, and adds it to lems.
+   */
   virtual void registerRefinementLemma(const std::vector<Node>& vars,
-                                       Node lem) override;
+                                       Node lem,
+                                       std::vector<Node>& lems) override;
 
  private:
   /** If CegConjecture::d_base_inst is exists y. P( d, y ), then this is y. */

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -104,8 +104,13 @@ class SygusModule
    * under this substitution. In particular, in the above example, this function
    * is called when the refinement lemma P( v, cex ) has a model M. In calls to
    * this function, the argument vars is cex and lem is P( k, cex^M ).
+   * 
+   * This function may also add lemmas to lems, which are sent out as lemmas
+   * on the output channel of quantifiers by the caller. For an example of
+   * such lemmas, see Cegis::registerRefinementLemma.
    */
-  virtual void registerRefinementLemma(const std::vector<Node>& vars, Node lem)
+  virtual void registerRefinementLemma(const std::vector<Node>& vars, Node lem,
+                                   std::vector<Node>& lems)
   {
   }
 

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -104,13 +104,14 @@ class SygusModule
    * under this substitution. In particular, in the above example, this function
    * is called when the refinement lemma P( v, cex ) has a model M. In calls to
    * this function, the argument vars is cex and lem is P( k, cex^M ).
-   * 
+   *
    * This function may also add lemmas to lems, which are sent out as lemmas
    * on the output channel of quantifiers by the caller. For an example of
    * such lemmas, see Cegis::registerRefinementLemma.
    */
-  virtual void registerRefinementLemma(const std::vector<Node>& vars, Node lem,
-                                   std::vector<Node>& lems)
+  virtual void registerRefinementLemma(const std::vector<Node>& vars,
+                                       Node lem,
+                                       std::vector<Node>& lems)
   {
   }
 

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -81,7 +81,7 @@ class SygusModule
    * If this function returns true, it adds to candidate_values a list of terms
    * of the same length and type as candidates that are candidate solutions
    * to the synthesis conjecture in question. This candidate { v } will then be
-   * tested by testing the (un)satisfiablity of P( v, k' ) for fresh k' by the
+   * tested by testing the (un)satisfiablity of P( v, cex ) for fresh cex by the
    * caller.
    *
    * This function may also add lemmas to lems, which are sent out as lemmas
@@ -102,8 +102,8 @@ class SygusModule
    * value { v } to candidate_values for candidates = { k }. This function is
    * called if the base instantiation of the synthesis conjecture has a model
    * under this substitution. In particular, in the above example, this function
-   * is called when the refinement lemma P( v, k' ) has a model M. In calls to
-   * this function, the argument vars is v and lem is P( v^M, k' ).
+   * is called when the refinement lemma P( v, cex ) has a model M. In calls to
+   * this function, the argument vars is cex and lem is P( k, cex^M ).
    */
   virtual void registerRefinementLemma(const std::vector<Node>& vars, Node lem)
   {

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -105,7 +105,10 @@ class SygusModule
    * is called when the refinement lemma P( v, k' ) has a model M. In calls to
    * this function, the argument vars is v and lem is P( v^M, k' ).
    */
-  virtual void registerRefinementLemma(const std::vector< Node >& vars, Node lem) {}
+  virtual void registerRefinementLemma(const std::vector<Node>& vars, Node lem)
+  {
+  }
+
  protected:
   /** reference to quantifier engine */
   QuantifiersEngine* d_qe;

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -102,10 +102,10 @@ class SygusModule
    * value { v } to candidate_values for candidates = { k }. This function is
    * called if the base instantiation of the synthesis conjecture has a model
    * under this substitution. In particular, in the above example, this function
-   * is called when the refinement lemma P( v, k' ) has a model. The argument
-   * lem in the call to this function is P( v, k' ).
+   * is called when the refinement lemma P( v, k' ) has a model M. In calls to
+   * this function, the argument vars is v and lem is P( v^M, k' ).
    */
-  virtual void registerRefinementLemma(Node lem) {}
+  virtual void registerRefinementLemma(const std::vector< Node >& vars, Node lem) {}
  protected:
   /** reference to quantifier engine */
   QuantifiersEngine* d_qe;


### PR DESCRIPTION
Previously, the sygus module needed to be robust to miniscoping, e.g. a synthesis conjecture could be rewritten:

exists f. forall x. P( f, x ) ^ Q( f, x ) --> exists f. ( forall x. P( x ) ) ^ ( forall x. Q( x ) )

This required the module to handle multiple disjuncts in the negation of the above formula.  Now, miniscoping is explicitly disallowed, hence the code can be simplified. 

This is in preparation for further optimizations.