### PR TITLE
Print candidate rewrites in terms of original grammar

### DIFF
--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -794,7 +794,8 @@ bool SygusSymBreakNew::registerSearchValue( Node a, Node n, Node nv, unsigned d,
             d_sampler[a].find(tn);
         if (its == d_sampler[a].end())
         {
-          d_sampler[a][tn].initializeSygus(d_tds, nv, options::sygusSamples(), false);
+          d_sampler[a][tn].initializeSygus(
+              d_tds, nv, options::sygusSamples(), false);
           its = d_sampler[a].find(tn);
         }
         Node bvr_sample_ret;

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -794,7 +794,7 @@ bool SygusSymBreakNew::registerSearchValue( Node a, Node n, Node nv, unsigned d,
             d_sampler[a].find(tn);
         if (its == d_sampler[a].end())
         {
-          d_sampler[a][tn].initializeSygus(d_tds, nv, options::sygusSamples());
+          d_sampler[a][tn].initializeSygus(d_tds, nv, options::sygusSamples(), false);
           its = d_sampler[a].find(tn);
         }
         Node bvr_sample_ret;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -620,29 +620,34 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
         if (its == d_sampler.end())
         {
           d_sampler[prog].initializeSygusExt(
-              d_qe, prog, options::sygusSamples());
+              d_qe, prog, options::sygusSamples(), true);
           its = d_sampler.find(prog);
         }
-        Node solb = sygusDb->sygusToBuiltin(sol, prog.getType());
-        Node eq_sol = its->second.registerTerm(solb);
+        Node eq_sol = its->second.registerTerm(sol);
         // eq_sol is a candidate solution that is equivalent to sol
-        if (eq_sol != solb)
+        if (eq_sol != sol)
         {
           ++(cei->d_statistics.d_candidate_rewrites);
           if (!eq_sol.isNull())
           {
-            // Terms solb and eq_sol are equivalent under sample points but do
-            // not rewrite to the same term. Hence, this indicates a candidate
-            // rewrite.
-            out << "(candidate-rewrite " << solb << " " << eq_sol << ")"
-                << std::endl;
+            // The analog of terms sol and eq_sol are equivalent under sample 
+            // points but do not rewrite to the same term. Hence, this indicates
+            // a candidatr rewrite.
+            Printer * p = Printer::getPrinter(options::outputLanguage());
+            out << "(candidate-rewrite ";
+            p->toStreamSygus(out, sol);
+            out << " ";
+            p->toStreamSygus(out, eq_sol);
+            out << ")" << std::endl;
             ++(cei->d_statistics.d_candidate_rewrites_print);
             // debugging information
             if (Trace.isOn("sygus-rr-debug"))
             {
               ExtendedRewriter* er = sygusDb->getExtRewriter();
+              Node solb = sygusDb->sygusToBuiltin( sol );
               Node solbr = er->extendedRewrite(solb);
-              Node eq_solr = er->extendedRewrite(eq_sol);
+              Node eq_solb = sygusDb->sygusToBuiltin( eq_sol );
+              Node eq_solr = er->extendedRewrite(eq_solb);
               Trace("sygus-rr-debug")
                   << "; candidate #1 ext-rewrites to: " << solbr << std::endl;
               Trace("sygus-rr-debug")

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -632,7 +632,7 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
           {
             // The analog of terms sol and eq_sol are equivalent under sample
             // points but do not rewrite to the same term. Hence, this indicates
-            // a candidatr rewrite.
+            // a candidate rewrite.
             Printer* p = Printer::getPrinter(options::outputLanguage());
             out << "(candidate-rewrite ";
             p->toStreamSygus(out, sol);

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -630,10 +630,10 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
           ++(cei->d_statistics.d_candidate_rewrites);
           if (!eq_sol.isNull())
           {
-            // The analog of terms sol and eq_sol are equivalent under sample 
+            // The analog of terms sol and eq_sol are equivalent under sample
             // points but do not rewrite to the same term. Hence, this indicates
             // a candidatr rewrite.
-            Printer * p = Printer::getPrinter(options::outputLanguage());
+            Printer* p = Printer::getPrinter(options::outputLanguage());
             out << "(candidate-rewrite ";
             p->toStreamSygus(out, sol);
             out << " ";
@@ -644,9 +644,9 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
             if (Trace.isOn("sygus-rr-debug"))
             {
               ExtendedRewriter* er = sygusDb->getExtRewriter();
-              Node solb = sygusDb->sygusToBuiltin( sol );
+              Node solb = sygusDb->sygusToBuiltin(sol);
               Node solbr = er->extendedRewrite(solb);
-              Node eq_solb = sygusDb->sygusToBuiltin( eq_sol );
+              Node eq_solb = sygusDb->sygusToBuiltin(eq_sol);
               Node eq_solr = er->extendedRewrite(eq_solb);
               Trace("sygus-rr-debug")
                   << "; candidate #1 ext-rewrites to: " << solbr << std::endl;

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -64,13 +64,14 @@ Node LazyTrie::add(Node n,
   return Node::null();
 }
 
-SygusSampler::SygusSampler() : d_tds(nullptr), d_is_valid(false) {}
+SygusSampler::SygusSampler() : d_tds(nullptr), d_use_sygus_type(false), d_is_valid(false) {}
 
 void SygusSampler::initialize(TypeNode tn,
                               std::vector<Node>& vars,
                               unsigned nsamples)
 {
   d_tds = nullptr;
+  d_use_sygus_type = false;
   d_is_valid = true;
   d_tn = tn;
   d_ftn = TypeNode::null();
@@ -105,9 +106,10 @@ void SygusSampler::initialize(TypeNode tn,
   initializeSamples(nsamples);
 }
 
-void SygusSampler::initializeSygus(TermDbSygus* tds, Node f, unsigned nsamples)
+void SygusSampler::initializeSygus(TermDbSygus* tds, Node f, unsigned nsamples, bool useSygusType)
 {
   d_tds = tds;
+  d_use_sygus_type = useSygusType;
   d_is_valid = true;
   d_ftn = f.getType();
   Assert(d_ftn.isDatatype());
@@ -282,8 +284,23 @@ Node SygusSampler::registerTerm(Node n, bool forceKeep)
 {
   if (d_is_valid)
   {
-    Assert(n.getType() == d_tn);
-    return d_trie.add(n, this, 0, d_samples.size(), forceKeep);
+    Node bn = n;
+    // if this is a sygus type, get its builtin analog
+    if( d_use_sygus_type )
+    {
+      Assert( !d_ftn.isNull() );
+      bn = d_tds->sygusToBuiltin(n);
+      bn = Rewriter::rewrite( bn );
+      d_builtin_to_sygus[bn] = n;
+    }
+    Assert(bn.getType() == d_tn);
+    Node res = d_trie.add(bn, this, 0, d_samples.size(), forceKeep);
+    if( d_use_sygus_type )
+    {
+      Assert( d_builtin_to_sygus.find( res )==d_builtin_to_sygus.end() );
+      res = res!=bn ? d_builtin_to_sygus[res] : n;
+    }
+    return res;
   }
   return n;
 }
@@ -645,9 +662,9 @@ void SygusSampler::registerSygusType(TypeNode tn)
 
 void SygusSamplerExt::initializeSygusExt(QuantifiersEngine* qe,
                                          Node f,
-                                         unsigned nsamples)
+                                         unsigned nsamples, bool useSygusType)
 {
-  SygusSampler::initializeSygus(qe->getTermDatabaseSygus(), f, nsamples);
+  SygusSampler::initializeSygus(qe->getTermDatabaseSygus(), f, nsamples, useSygusType);
 
   // initialize the dynamic rewriter
   std::stringstream ss;

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -64,7 +64,10 @@ Node LazyTrie::add(Node n,
   return Node::null();
 }
 
-SygusSampler::SygusSampler() : d_tds(nullptr), d_use_sygus_type(false), d_is_valid(false) {}
+SygusSampler::SygusSampler()
+    : d_tds(nullptr), d_use_sygus_type(false), d_is_valid(false)
+{
+}
 
 void SygusSampler::initialize(TypeNode tn,
                               std::vector<Node>& vars,
@@ -106,7 +109,10 @@ void SygusSampler::initialize(TypeNode tn,
   initializeSamples(nsamples);
 }
 
-void SygusSampler::initializeSygus(TermDbSygus* tds, Node f, unsigned nsamples, bool useSygusType)
+void SygusSampler::initializeSygus(TermDbSygus* tds,
+                                   Node f,
+                                   unsigned nsamples,
+                                   bool useSygusType)
 {
   d_tds = tds;
   d_use_sygus_type = useSygusType;
@@ -286,19 +292,19 @@ Node SygusSampler::registerTerm(Node n, bool forceKeep)
   {
     Node bn = n;
     // if this is a sygus type, get its builtin analog
-    if( d_use_sygus_type )
+    if (d_use_sygus_type)
     {
-      Assert( !d_ftn.isNull() );
+      Assert(!d_ftn.isNull());
       bn = d_tds->sygusToBuiltin(n);
-      bn = Rewriter::rewrite( bn );
+      bn = Rewriter::rewrite(bn);
       d_builtin_to_sygus[bn] = n;
     }
     Assert(bn.getType() == d_tn);
     Node res = d_trie.add(bn, this, 0, d_samples.size(), forceKeep);
-    if( d_use_sygus_type )
+    if (d_use_sygus_type)
     {
-      Assert( d_builtin_to_sygus.find( res )==d_builtin_to_sygus.end() );
-      res = res!=bn ? d_builtin_to_sygus[res] : n;
+      Assert(d_builtin_to_sygus.find(res) == d_builtin_to_sygus.end());
+      res = res != bn ? d_builtin_to_sygus[res] : n;
     }
     return res;
   }
@@ -662,9 +668,11 @@ void SygusSampler::registerSygusType(TypeNode tn)
 
 void SygusSamplerExt::initializeSygusExt(QuantifiersEngine* qe,
                                          Node f,
-                                         unsigned nsamples, bool useSygusType)
+                                         unsigned nsamples,
+                                         bool useSygusType)
 {
-  SygusSampler::initializeSygus(qe->getTermDatabaseSygus(), f, nsamples, useSygusType);
+  SygusSampler::initializeSygus(
+      qe->getTermDatabaseSygus(), f, nsamples, useSygusType);
 
   // initialize the dynamic rewriter
   std::stringstream ss;

--- a/src/theory/quantifiers/sygus_sampler.h
+++ b/src/theory/quantifiers/sygus_sampler.h
@@ -153,7 +153,8 @@ class SygusSampler : public LazyTrieEvaluator
    * nsamples : number of sample points this class will test,
    * useSygusType : whether we will register terms with this sampler that have
    * the same type as f. If this flag is false, then we will be registering
-   * terms of the analog of the type of f.
+   * terms of the analog of the type of f, that is, the builtin type that
+   * f's type encodes in the deep embedding.
    */
   void initializeSygus(TermDbSygus* tds,
                        Node f,

--- a/src/theory/quantifiers/sygus_sampler.h
+++ b/src/theory/quantifiers/sygus_sampler.h
@@ -151,11 +151,14 @@ class SygusSampler : public LazyTrieEvaluator
    * f : a term of some SyGuS datatype type whose values we will be
    * testing under the free variables in the grammar of f,
    * nsamples : number of sample points this class will test,
-   * useSygusType : whether we will register terms with this sampler that have 
-   * the same type as f. If this flag is false, then we will be registering 
+   * useSygusType : whether we will register terms with this sampler that have
+   * the same type as f. If this flag is false, then we will be registering
    * terms of the analog of the type of f.
    */
-  void initializeSygus(TermDbSygus* tds, Node f, unsigned nsamples, bool useSygusType);
+  void initializeSygus(TermDbSygus* tds,
+                       Node f,
+                       unsigned nsamples,
+                       bool useSygusType);
   /** register term n with this sampler database
    *
    * forceKeep is whether we wish to force that n is chosen as a representative
@@ -228,7 +231,7 @@ class SygusSampler : public LazyTrieEvaluator
   /** whether we are registering terms of type d_ftn */
   bool d_use_sygus_type;
   /** map from builtin terms to the sygus term they correspond to */
-  std::map< Node, Node > d_builtin_to_sygus;
+  std::map<Node, Node> d_builtin_to_sygus;
   /** all variables we are sampling values for */
   std::vector<Node> d_vars;
   /** type variables
@@ -336,7 +339,10 @@ class SygusSamplerExt : public SygusSampler
 {
  public:
   /** initialize extended */
-  void initializeSygusExt(QuantifiersEngine* qe, Node f, unsigned nsamples, bool useSygusType);
+  void initializeSygusExt(QuantifiersEngine* qe,
+                          Node f,
+                          unsigned nsamples,
+                          bool useSygusType);
   /** register term n with this sampler database
    *
    * This returns either null, or a term ret with the same guarantees as

--- a/src/theory/quantifiers/sygus_sampler.h
+++ b/src/theory/quantifiers/sygus_sampler.h
@@ -148,11 +148,14 @@ class SygusSampler : public LazyTrieEvaluator
   /** initialize sygus
    *
    * tds : pointer to sygus database,
-   * f : a term of some SyGuS datatype type whose (builtin) values we will be
+   * f : a term of some SyGuS datatype type whose values we will be
    * testing under the free variables in the grammar of f,
-   * nsamples : number of sample points this class will test.
+   * nsamples : number of sample points this class will test,
+   * useSygusType : whether we will register terms with this sampler that have 
+   * the same type as f. If this flag is false, then we will be registering 
+   * terms of the analog of the type of f.
    */
-  void initializeSygus(TermDbSygus* tds, Node f, unsigned nsamples);
+  void initializeSygus(TermDbSygus* tds, Node f, unsigned nsamples, bool useSygusType);
   /** register term n with this sampler database
    *
    * forceKeep is whether we wish to force that n is chosen as a representative
@@ -222,6 +225,10 @@ class SygusSampler : public LazyTrieEvaluator
   TypeNode d_tn;
   /** the sygus type for this sampler (if applicable). */
   TypeNode d_ftn;
+  /** whether we are registering terms of type d_ftn */
+  bool d_use_sygus_type;
+  /** map from builtin terms to the sygus term they correspond to */
+  std::map< Node, Node > d_builtin_to_sygus;
   /** all variables we are sampling values for */
   std::vector<Node> d_vars;
   /** type variables
@@ -329,7 +336,7 @@ class SygusSamplerExt : public SygusSampler
 {
  public:
   /** initialize extended */
-  void initializeSygusExt(QuantifiersEngine* qe, Node f, unsigned nsamples);
+  void initializeSygusExt(QuantifiersEngine* qe, Node f, unsigned nsamples, bool useSygusType);
   /** register term n with this sampler database
    *
    * This returns either null, or a term ret with the same guarantees as


### PR DESCRIPTION
Previously candidate rewrites were printed for terms that are expanded but non-rewritten.

This updates it so that candidate rewrites are printed for terms that are unexpanded.

For example, if we have grammar:

(define-fun f ((x Int)) Int (+ x 1))
A -> (f A) | x | 1

Then a possible rewrite that was printed was:

(candidate-rewrite ((lambda ((x Int)) (+ x 1)) 1) (+ 1 1))

With this update, we now print:

(candidate-rewrite (f 1) (+ 1 1))