### PR TITLE
Optimization for sygus streaming mode

### DIFF
--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -319,7 +319,8 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
       d_ce_sk.push_back(Node::null());
     }
   }
-  if( !lem.isNull() ){
+  if (!lem.isNull())
+  {
     lem = Rewriter::rewrite( lem );
     //eagerly unfold applications of evaluation function
     if( options::sygusDirectEval() ){
@@ -342,7 +343,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
       // This is the "verification lemma", which states
       // either this conjecture does not have a solution, or candidate_values
       // is a solution for this conjecture.
-      lem = nm->mkNode(OR, d_quant.negate(), lem );
+      lem = nm->mkNode(OR, d_quant.negate(), lem);
       lem = getStreamGuardedLemma(lem);
       lems.push_back(lem);
     }

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -333,7 +333,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
     // record the instantiation
     // this is used for remembering the solution
     recordInstantiation(candidate_values);
-    if( lem==d_quant.negate() && options::sygusStream() )
+    if (lem == d_quant.negate() && options::sygusStream())
     {
       // short circuit the check
       // instead, we immediately print the current solution.
@@ -343,7 +343,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
     else
     {
       lem = getStreamGuardedLemma(lem);
-      lems.push_back( lem );
+      lems.push_back(lem);
     }
   }
 }
@@ -528,20 +528,21 @@ void CegConjecture::printAndContinueStream()
   // get the current output stream
   // this output stream should coincide with wherever --dump-synth is output on
   Options& nodeManagerOptions = NodeManager::currentNM()->getOptions();
-  printSynthSolution( *nodeManagerOptions.getOut(), false );
-  
+  printSynthSolution(*nodeManagerOptions.getOut(), false);
+
   // We will not refine the current candidate solution since it is a solution
   // thus, we clear information regarding the current refinement
   d_ce_sk.clear();
-  // However, we need to exclude the current solution using an explicit 
+  // However, we need to exclude the current solution using an explicit
   // blocking clause, so that we proceed to the next solution.
   std::vector<Node> terms;
   d_master->getTermList(d_candidates, terms);
-  std::vector< Node > exp;
+  std::vector<Node> exp;
   for (const Node& cprog : terms)
   {
     Node sol = cprog;
-    if( !d_cinfo[cprog].d_inst.empty() ){
+    if (!d_cinfo[cprog].d_inst.empty())
+    {
       sol = d_cinfo[cprog].d_inst.back();
       // add to explanation of exclusion
       d_qe->getTermDatabaseSygus()
@@ -549,11 +550,14 @@ void CegConjecture::printAndContinueStream()
           ->getExplanationForConstantEquality(cprog, sol, exp);
     }
   }
-  Assert( !exp.empty() );
-  Node exc_lem = exp.size()==1 ? exp[0] : NodeManager::currentNM()->mkNode( kind::AND, exp );
+  Assert(!exp.empty());
+  Node exc_lem = exp.size() == 1
+                     ? exp[0]
+                     : NodeManager::currentNM()->mkNode(kind::AND, exp);
   exc_lem = exc_lem.negate();
-  Trace("cegqi-lemma") << "Cegqi::Lemma : stream exclude current solution : " << exc_lem << std::endl;
-  d_qe->getOutputChannel().lemma( exc_lem );
+  Trace("cegqi-lemma") << "Cegqi::Lemma : stream exclude current solution : "
+                       << exc_lem << std::endl;
+  d_qe->getOutputChannel().lemma(exc_lem);
 }
 
 void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation ) {

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -330,9 +330,21 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
       std::map< Node, Node > visited_n;
       lem = d_qe->getTermDatabaseSygus()->getEagerUnfold( lem, visited_n );
     }
-    lem = getStreamGuardedLemma(lem);
-    lems.push_back( lem );
+    // record the instantiation
+    // this is used for remembering the solution
     recordInstantiation(candidate_values);
+    if( lem==d_quant.negate() && options::sygusStream() )
+    {
+      // short circuit the check
+      // instead, we immediately print the current solution.
+      // this saves us from introducing a check lemma and a new guard.
+      printAndContinueStream();
+    }
+    else
+    {
+      lem = getStreamGuardedLemma(lem);
+      lems.push_back( lem );
+    }
   }
 }
         
@@ -479,43 +491,13 @@ Node CegConjecture::getNextDecisionRequest( unsigned& priority ) {
             return curr_stream_guard;
           }else{
             if( !value ){
-              Assert(d_master != nullptr);
               Trace("cegqi-debug") << "getNextDecision : we have a new solution since stream guard was propagated false: " << curr_stream_guard << std::endl;
-              // we have generated a solution, print it
-              // get the current output stream
-              // this output stream should coincide with wherever --dump-synth is output on
-              Options& nodeManagerOptions = NodeManager::currentNM()->getOptions();
-              printSynthSolution( *nodeManagerOptions.getOut(), false );
               // need to make the next stream guard
               needs_new_stream_guard = true;
-              
-              // We will not refine the current candidate solution since it is a solution
-              // thus, we clear information regarding the current refinement
-              d_ce_sk.clear();
-              // However, we need to exclude the current solution using an
-              // explicit refinement
-              // so that we proceed to the next solution.
-              std::vector<Node> terms;
-              d_master->getTermList(d_candidates, terms);
-              Trace("cegqi-debug") << "getNextDecision : solution was : " << std::endl;
-              std::vector< Node > exp;
-              for (const Node& cprog : terms)
-              {
-                Node sol = cprog;
-                if( !d_cinfo[cprog].d_inst.empty() ){
-                  sol = d_cinfo[cprog].d_inst.back();
-                  // add to explanation of exclusion
-                  d_qe->getTermDatabaseSygus()
-                      ->getExplain()
-                      ->getExplanationForConstantEquality(cprog, sol, exp);
-                }
-                Trace("cegqi-debug") << "  " << cprog << " -> " << sol << std::endl;
-              }
-              Assert( !exp.empty() );
-              Node exc_lem = exp.size()==1 ? exp[0] : NodeManager::currentNM()->mkNode( kind::AND, exp );
-              exc_lem = exc_lem.negate();
-              Trace("cegqi-lemma") << "Cegqi::Lemma : stream exclude current solution : " << exc_lem << std::endl;
-              d_qe->getOutputChannel().lemma( exc_lem );
+              // the guard has propagated false, indicating that a verify
+              // lemma was unsatisfiable. Hence, the previous candidate is
+              // an actual solution. We print and continue the stream.
+              printAndContinueStream();
             }
           }
         }
@@ -537,6 +519,41 @@ Node CegConjecture::getNextDecisionRequest( unsigned& priority ) {
     } 
   }
   return Node::null();
+}
+
+void CegConjecture::printAndContinueStream()
+{
+  Assert(d_master != nullptr);
+  // we have generated a solution, print it
+  // get the current output stream
+  // this output stream should coincide with wherever --dump-synth is output on
+  Options& nodeManagerOptions = NodeManager::currentNM()->getOptions();
+  printSynthSolution( *nodeManagerOptions.getOut(), false );
+  
+  // We will not refine the current candidate solution since it is a solution
+  // thus, we clear information regarding the current refinement
+  d_ce_sk.clear();
+  // However, we need to exclude the current solution using an explicit 
+  // blocking clause, so that we proceed to the next solution.
+  std::vector<Node> terms;
+  d_master->getTermList(d_candidates, terms);
+  std::vector< Node > exp;
+  for (const Node& cprog : terms)
+  {
+    Node sol = cprog;
+    if( !d_cinfo[cprog].d_inst.empty() ){
+      sol = d_cinfo[cprog].d_inst.back();
+      // add to explanation of exclusion
+      d_qe->getTermDatabaseSygus()
+          ->getExplain()
+          ->getExplanationForConstantEquality(cprog, sol, exp);
+    }
+  }
+  Assert( !exp.empty() );
+  Node exc_lem = exp.size()==1 ? exp[0] : NodeManager::currentNM()->mkNode( kind::AND, exp );
+  exc_lem = exc_lem.negate();
+  Trace("cegqi-lemma") << "Cegqi::Lemma : stream exclude current solution : " << exc_lem << std::endl;
+  d_qe->getOutputChannel().lemma( exc_lem );
 }
 
 void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation ) {

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -226,6 +226,12 @@ private:
    * returned by getCurrentStreamGuard, otherwise this returns n.
    */
   Node getStreamGuardedLemma(Node n) const;
+  /** 
+   * Prints the current synthesis solution to the output stream indicated by
+   * the Options object, send a lemma blocking the current solution to the 
+   * output channel.
+   */
+  void printAndContinueStream();
   //-------------------------------- end sygus stream
   //-------------------------------- non-syntax guided (deprecated)
   /** Whether we are syntax-guided (e.g. was the input in SyGuS format).

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -226,9 +226,9 @@ private:
    * returned by getCurrentStreamGuard, otherwise this returns n.
    */
   Node getStreamGuardedLemma(Node n) const;
-  /** 
+  /**
    * Prints the current synthesis solution to the output stream indicated by
-   * the Options object, send a lemma blocking the current solution to the 
+   * the Options object, send a lemma blocking the current solution to the
    * output channel.
    */
   void printAndContinueStream();


### PR DESCRIPTION
Short cuts the case when a candidate solution trivially holds, avoids sending a verification lemma in this case.

As a consequence, this makes --sygus-rr-synth roughly 3x faster on average.