### PR TITLE
Fix sampler filtering

### DIFF
--- a/src/theory/quantifiers/sygus_sampler.h
+++ b/src/theory/quantifiers/sygus_sampler.h
@@ -207,7 +207,8 @@ class SygusSampler : public LazyTrieEvaluator
    * are those that occur in the range d_type_vars.
    */
   bool containsFreeVariables(Node a, Node b);
- private:
+
+ protected:
   /** sygus term database of d_qe */
   TermDbSygus* d_tds;
   /** samples */


### PR DESCRIPTION
This fixes an issue with candidate rewrite rule filtering.

The ordered check in SygusSamplerExt needs to account to whether or not we are using the sygus type, this was broken in #1635.