### PR TITLE
correct instruction for running example

### DIFF
--- a/proofs/signatures/example-arrays.plf
+++ b/proofs/signatures/example-arrays.plf
@@ -1,4 +1,4 @@
-; to check, run : lfsc sat.plf smt.plf th_base.plf example.plf
+; to check, run : lfscc sat.plf smt.plf th_base.plf th_arrays.plf example-arrays.plf
 
 ; --------------------------------------------------------------------------------
 ; literals :


### PR DESCRIPTION
Changes:
1. Run **lfscc** and not **lfscc**
2. include **th_arrays.plf**
3. correct file name for the example