### PR TITLE
Fix datatype dump regression

### DIFF
--- a/test/regress/regress0/datatypes/Makefile.am
+++ b/test/regress/regress0/datatypes/Makefile.am
@@ -83,7 +83,8 @@ TESTS =	\
 	model-subterms-min.smt2 \
 	issue1433.smt2 \
         tuples-empty.smt2 \
-        tuples-multitype.smt2
+        tuples-multitype.smt2 \
+        datatype-dump.cvc
 
 # rec5 -- no longer support subrange types
 FAILING_TESTS = \

--- a/test/regress/regress0/datatypes/datatype-dump.cvc
+++ b/test/regress/regress0/datatypes/datatype-dump.cvc
@@ -1,14 +1,15 @@
 % This regression is the same as datatype.cvc but tests the
 % dumping infrastructure.
 %
-% COMMAND-LINE: --dump assertions
+% COMMAND-LINE: --dump raw-benchmark
 %
+% EXPECT: OPTION "incremental" false;
+% EXPECT: OPTION "logic" "ALL";
 % EXPECT: DATATYPE
 % EXPECT:   nat = succ(pred: nat) | zero
 % EXPECT: END;
 % EXPECT: x : nat;
-% EXPECT: ASSERT NOT(NOT(is_succ(x)) AND NOT(is_zero(x)));
-% EXPECT: CHECKSAT;
+% EXPECT: QUERY NOT(is_succ(x)) AND NOT(is_zero(x));
 % EXPECT: invalid
 %
 


### PR DESCRIPTION
Minor modification to the regression: use dump raw-benchmark instead of dump assertions, since this is the new preferred way of dumping the benchmark (assertions is for internal debugging).