### PR TITLE
Fix 'make regress'

### DIFF
--- a/test/regress/Makefile.am
+++ b/test/regress/Makefile.am
@@ -22,7 +22,9 @@ endif
 MAKEFLAGS = -k
 
 export VERBOSE = 1
-.PHONY: regress0 regress1 regress2 regress3 regress4
+.PHONY: regress regress0 regress1 regress2 regress3 regress4
+
+regress: regress1
 
 regress0:
 	REGRESSION_LEVEL=0 $(MAKE) check


### PR DESCRIPTION
Commit b8db52f9bad5b1053810c93f0067de8423349da3 removed the option to do "make regress" (I only tested with "make regressX" and "make check"). This commit reenables "make regress".