### PR TITLE
Remove regular expression constant

### DIFF
--- a/src/theory/strings/kinds
+++ b/src/theory/strings/kinds
@@ -42,7 +42,7 @@ sort STRING_TYPE \
 sort REGEXP_TYPE \
     Cardinality::INTEGERS \
     well-founded \
-        "NodeManager::currentNM()->mkConst(::CVC4::RegExp())" \
+        "NodeManager::currentNM()->mkNode(STRING_TO_REGEXP,NodeManager::currentNM()->mkConst(::CVC4::String()))" \
         "util/regexp.h" \
     "RegExp type"
 
@@ -60,14 +60,7 @@ constant CONST_STRING \
     "util/regexp.h" \
     "a string of characters"
 
-constant CONST_REGEXP \
-    ::CVC4::RegExp \
-    ::CVC4::RegExpHashFunction \
-    "util/regexp.h" \
-    "a regular expression"
-
 typerule CONST_STRING ::CVC4::theory::strings::StringConstantTypeRule
-typerule CONST_REGEXP ::CVC4::theory::strings::RegExpConstantTypeRule
 
 # equal equal / less than / output
 operator STRING_TO_REGEXP 1 "convert string to regexp"

--- a/src/theory/strings/kinds
+++ b/src/theory/strings/kinds
@@ -42,7 +42,7 @@ sort STRING_TYPE \
 sort REGEXP_TYPE \
     Cardinality::INTEGERS \
     well-founded \
-        "NodeManager::currentNM()->mkNode(STRING_TO_REGEXP,NodeManager::currentNM()->mkConst(::CVC4::String()))" \
+        "NodeManager::currentNM()->mkNode(REGEXP_EMPTY, std::vector<Node>() )" \
         "util/regexp.h" \
     "RegExp type"
 

--- a/src/theory/strings/theory_strings_type_rules.h
+++ b/src/theory/strings/theory_strings_type_rules.h
@@ -235,14 +235,6 @@ public:
   }
 };
 
-class RegExpConstantTypeRule {
-public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check)
-  {
-    return nodeManager->regExpType();
-  }
-};
-
 class RegExpConcatTypeRule {
 public:
   inline static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check)

--- a/src/util/regexp.cpp
+++ b/src/util/regexp.cpp
@@ -404,8 +404,4 @@ std::ostream &operator<<(std::ostream &os, const String &s) {
   return os << "\"" << s.toString(true) << "\"";
 }
 
-std::ostream &operator<<(std::ostream &out, const RegExp &s) {
-  return out << "regexp(" << s.getType() << ')';
-}
-
 }  // namespace CVC4

--- a/src/util/regexp.h
+++ b/src/util/regexp.h
@@ -197,35 +197,6 @@ struct CVC4_PUBLIC StringHashFunction {
 
 std::ostream& operator<<(std::ostream& os, const String& s) CVC4_PUBLIC;
 
-class CVC4_PUBLIC RegExp {
- public:
-  RegExp() : d_type(1) {}
-  explicit RegExp(const int t) : d_type(t) {}
-
-  bool operator==(const RegExp& y) const { return d_type == y.d_type; }
-  bool operator!=(const RegExp& y) const { return d_type != y.d_type; }
-  bool operator<(const RegExp& y) const { return d_type < y.d_type; }
-  bool operator>(const RegExp& y) const { return d_type > y.d_type; }
-  bool operator<=(const RegExp& y) const { return d_type <= y.d_type; }
-  bool operator>=(const RegExp& y) const { return d_type >= y.d_type; }
-
-  int getType() const { return d_type; }
-
- private:
-  int d_type;
-}; /* class RegExp */
-
-/**
- * Hash function for the RegExp constants.
- */
-struct CVC4_PUBLIC RegExpHashFunction {
-  inline size_t operator()(const RegExp& s) const {
-    return (size_t)s.getType();
-  }
-}; /* struct RegExpHashFunction */
-
-std::ostream& operator<<(std::ostream& os, const RegExp& s) CVC4_PUBLIC;
-
 }  // namespace CVC4
 
 #endif /* __CVC4__REGEXP_H */


### PR DESCRIPTION
This was only used to fulfill a well-foundedness property in the kinds file. We can return any other reg exp instead.