### PR TITLE
Fix memory leak in bvminisat

### DIFF
--- a/src/prop/bvminisat/bvminisat.cpp
+++ b/src/prop/bvminisat/bvminisat.cpp
@@ -27,7 +27,7 @@ namespace prop {
 BVMinisatSatSolver::BVMinisatSatSolver(StatisticsRegistry* registry, context::Context* mainSatContext, const std::string& name)
 : context::ContextNotifyObj(mainSatContext, false),
   d_minisat(new BVMinisat::SimpSolver(mainSatContext)),
-  d_minisatNotify(0),
+  d_minisatNotify(nullptr),
   d_assertionsCount(0),
   d_assertionsRealCount(mainSatContext, 0),
   d_lastPropagation(mainSatContext, 0),
@@ -38,8 +38,6 @@ BVMinisatSatSolver::BVMinisatSatSolver(StatisticsRegistry* registry, context::Co
 
 
 BVMinisatSatSolver::~BVMinisatSatSolver() {
-  delete d_minisat;
-  delete d_minisatNotify;
 }
 
 void BVMinisatSatSolver::MinisatNotify::notify(
@@ -54,7 +52,7 @@ void BVMinisatSatSolver::MinisatNotify::notify(
 }
 
 void BVMinisatSatSolver::setNotify(Notify* notify) {
-  d_minisatNotify = new MinisatNotify(notify);
+  d_minisatNotify.reset(new MinisatNotify(notify));
   d_minisat->setNotify(d_minisatNotify);
 }
 

--- a/src/prop/bvminisat/bvminisat.cpp
+++ b/src/prop/bvminisat/bvminisat.cpp
@@ -33,7 +33,7 @@ BVMinisatSatSolver::BVMinisatSatSolver(StatisticsRegistry* registry, context::Co
   d_lastPropagation(mainSatContext, 0),
   d_statistics(registry, name)
 {
-  d_statistics.init(d_minisat);
+  d_statistics.init(d_minisat.get());
 }
 
 
@@ -53,7 +53,7 @@ void BVMinisatSatSolver::MinisatNotify::notify(
 
 void BVMinisatSatSolver::setNotify(Notify* notify) {
   d_minisatNotify.reset(new MinisatNotify(notify));
-  d_minisat->setNotify(d_minisatNotify);
+  d_minisat->setNotify(d_minisatNotify.get());
 }
 
 ClauseId BVMinisatSatSolver::addClause(SatClause& clause,

--- a/src/prop/bvminisat/bvminisat.h
+++ b/src/prop/bvminisat/bvminisat.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "context/cdo.h"
 #include "proof/clause_id.h"
 #include "prop/bvminisat/simp/SimpSolver.h"
@@ -49,8 +51,8 @@ class BVMinisatSatSolver : public BVSatSolverInterface,
     void safePoint(unsigned amount) override { d_notify->safePoint(amount); }
   };
 
-  BVMinisat::SimpSolver* d_minisat;
-  MinisatNotify* d_minisatNotify;
+	std::unique_ptr<BVMinisat::SimpSolver> d_minisat;
+	std::unique_ptr<MinisatNotify> d_minisatNotify;
 
   unsigned d_assertionsCount;
   context::CDO<unsigned> d_assertionsRealCount;


### PR DESCRIPTION
While reviewing #1695, I realized that bvminisat is leaking memory for
each call to setNotify(). This commit uses std::unique_ptr to fix the
issue. It also adds std::unique_ptr to manage d_minisat.