### PR TITLE
Internal sygus type checking

### DIFF
--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -14,13 +14,13 @@
 
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 
+#include "base/cvc4_check.h"
 #include "options/quantifiers_options.h"
 #include "theory/arith/arith_msum.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/term_database.h"
 #include "theory/quantifiers/term_util.h"
 #include "theory/quantifiers_engine.h"
-#include "base/cvc4_check.h"
 
 using namespace std;
 using namespace CVC4::kind;
@@ -663,13 +663,15 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
           d_ops[tn][n] = i;
           d_arg_ops[tn][i] = n;
           Trace("sygus-db") << std::endl;
-          // ensure that terms that this constructor encodes are 
+          // ensure that terms that this constructor encodes are
           // of the type specified in the datatype. This will fail if
           // e.g. bitvector-and is a constructor of an integer grammar.
           std::map<int, Node> pre;
-          Node g = mkGeneric(dt,i,pre);
+          Node g = mkGeneric(dt, i, pre);
           TypeNode gtn = g.getType();
-          CVC4_CHECK(gtn.isSubtypeOf(btn)) << "Sygus datatype " << dt.getName() << " encodes terms that are not of type " << btn << std::endl;
+          CVC4_CHECK(gtn.isSubtypeOf(btn))
+              << "Sygus datatype " << dt.getName()
+              << " encodes terms that are not of type " << btn << std::endl;
         }
         //register connected types
         for( unsigned i=0; i<dt.getNumConstructors(); i++ ){

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -20,6 +20,7 @@
 #include "theory/quantifiers/term_database.h"
 #include "theory/quantifiers/term_util.h"
 #include "theory/quantifiers_engine.h"
+#include "base/cvc4_check.h"
 
 using namespace std;
 using namespace CVC4::kind;
@@ -662,6 +663,10 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
           d_ops[tn][n] = i;
           d_arg_ops[tn][i] = n;
           Trace("sygus-db") << std::endl;
+          std::map<int, Node> pre;
+          Node g = mkGeneric(dt,i,pre);
+          TypeNode gtn = g.getType();
+          CVC4_CHECK(gtn.isSubtypeOf(btn)) << "Sygus datatype " << dt.getName() << " encodes terms that are not of type " << btn << std::endl;
         }
         //register connected types
         for( unsigned i=0; i<dt.getNumConstructors(); i++ ){

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -663,6 +663,9 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
           d_ops[tn][n] = i;
           d_arg_ops[tn][i] = n;
           Trace("sygus-db") << std::endl;
+          // ensure that terms that this constructor encodes are 
+          // of the type specified in the datatype. This will fail if
+          // e.g. bitvector-and is a constructor of an integer grammar.
           std::map<int, Node> pre;
           Node g = mkGeneric(dt,i,pre);
           TypeNode gtn = g.getType();


### PR DESCRIPTION
This makes CVC4 abort if a sygus grammar is ill-formed, for example:

A -> A+A | bvand( A, A ) | ...

Previously, CVC4 would crash.

We eventually should make it so that for grammars like the one above, CVC4 would throw a TypeCheckingException. This will depend on how #1170 is resolved.