### PR TITLE
Check free variables in assertions

### DIFF
--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -530,6 +530,13 @@ bool Expr::isConst() const {
   return d_node->isConst();
 }
 
+bool Expr::hasFreeVariable() const 
+{
+  ExprManagerScope ems(*this);
+  Assert(d_node != NULL, "Unexpected NULL expression pointer!");
+  return d_node->hasFreeVar();
+}
+
 void Expr::toStream(std::ostream& out, int depth, bool types, size_t dag,
                     OutputLanguage language) const {
   ExprManagerScope ems(*this);

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -530,7 +530,7 @@ bool Expr::isConst() const {
   return d_node->isConst();
 }
 
-bool Expr::hasFreeVariable() const 
+bool Expr::hasFreeVariable() const
 {
   ExprManagerScope ems(*this);
   Assert(d_node != NULL, "Unexpected NULL expression pointer!");

--- a/src/expr/expr_template.h
+++ b/src/expr/expr_template.h
@@ -525,10 +525,10 @@ public:
    * @return true if a constant expression
    */
   bool isConst() const;
-  
+
   /**
    * Returns true iff this expression contains a free variable.
-   * 
+   *
    * @return true iff this node contains a free variable.
    */
   bool hasFreeVariable() const;

--- a/src/expr/expr_template.h
+++ b/src/expr/expr_template.h
@@ -525,6 +525,13 @@ public:
    * @return true if a constant expression
    */
   bool isConst() const;
+  
+  /**
+   * Returns true iff this expression contains a free variable.
+   * 
+   * @return true iff this node contains a free variable.
+   */
+  bool hasFreeVariable() const;
 
   /* A note on isAtomic() and isAtomicFormula() (in CVC3 parlance)..
    *

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -146,41 +146,49 @@ bool NodeTemplate<ref_count>::hasFreeVar()
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(*this);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
     // can skip if it doesn't have a bound variable
-    if( cur.hasBoundVar() )
+    if (cur.hasBoundVar())
     {
       Kind k = cur.getKind();
-      bool isQuant = k==kind::FORALL || k==kind::EXISTS || k==kind::LAMBDA || k==kind::CHOICE;
-      std::unordered_map<TNode, bool, TNodeHashFunction>::iterator itv = visited.find(cur);
-      if (itv == visited.end()) {
-        if( k==kind::BOUND_VARIABLE ){
-          if( bound_var.find(cur)==bound_var.end() )
+      bool isQuant = k == kind::FORALL || k == kind::EXISTS || k == kind::LAMBDA
+                     || k == kind::CHOICE;
+      std::unordered_map<TNode, bool, TNodeHashFunction>::iterator itv =
+          visited.find(cur);
+      if (itv == visited.end())
+      {
+        if (k == kind::BOUND_VARIABLE)
+        {
+          if (bound_var.find(cur) == bound_var.end())
           {
             return true;
           }
         }
-        else if( isQuant )
+        else if (isQuant)
         {
-          for (const TNode& cn : cur[0]) {
+          for (const TNode& cn : cur[0])
+          {
             // should not shadow
-            Assert( bound_var.find(cn)==bound_var.end() );
+            Assert(bound_var.find(cn) == bound_var.end());
             bound_var.insert(cn);
           }
           visit.push_back(cur);
         }
         // must visit quantifiers again to clean up below
         visited[cur] = !isQuant;
-        for (const TNode& cn : cur) {
+        for (const TNode& cn : cur)
+        {
           visit.push_back(cn);
         }
       }
-      else if( !itv->second )
+      else if (!itv->second)
       {
-        Assert( isQuant );
-        for (const TNode& cn : cur[0]) {
+        Assert(isQuant);
+        for (const TNode& cn : cur[0])
+        {
           bound_var.erase(cn);
         }
         visited[cur] = true;

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -434,7 +434,7 @@ public:
    * @return true iff this node contains a bound variable.
    */
   bool hasBoundVar();
-  
+
   /**
    * Returns true iff this node contains a free variable.
    * @return true iff this node contains a free variable.

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -434,6 +434,12 @@ public:
    * @return true iff this node contains a bound variable.
    */
   bool hasBoundVar();
+  
+  /**
+   * Returns true iff this node contains a free variable.
+   * @return true iff this node contains a free variable.
+   */
+  bool hasFreeVar();
 
   /**
    * Convert this Node into an Expr using the currently-in-scope

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -429,6 +429,17 @@ command [std::unique_ptr<CVC4::Command>* cmd]
         csen->setMuted(true);
         PARSER_STATE->preemptCommand(csen);
       }
+      // if sygus, check whether it has a free variable
+      // this is because, due to the sygus format, one can write assertions
+      // that have free function variables in them
+      if (PARSER_STATE->sygus())
+      {
+        if (expr.hasFreeVariable())
+        {
+          PARSER_STATE->parseError("Assertion has free variable. Perhaps you "
+                                   "meant constraint instead of assert?");
+        }
+      }
     }
   | /* check-sat */
     CHECK_SAT_TOK { PARSER_STATE->checkThatLogicIsSet(); }

--- a/src/theory/quantifiers/single_inv_partition.cpp
+++ b/src/theory/quantifiers/single_inv_partition.cpp
@@ -251,9 +251,10 @@ bool SingleInvocationPartition::init(std::vector<Node>& funcs,
         std::vector<Node> bvs;
         TermUtil::getBoundVars(cr, bvs);
         // bound variables must be contained in the single invocation variables
-        for( const Node& bv : bvs )
+        for (const Node& bv : bvs)
         {
-          if( std::find( d_si_vars.begin(), d_si_vars.end(), bv )==d_si_vars.end() )
+          if (std::find(d_si_vars.begin(), d_si_vars.end(), bv)
+              == d_si_vars.end())
           {
             // getBoundVars also collects functions in the rare case that we are
             // synthesizing a function with 0 arguments, take this into account
@@ -261,13 +262,14 @@ bool SingleInvocationPartition::init(std::vector<Node>& funcs,
             if (std::find(d_input_funcs.begin(), d_input_funcs.end(), bv)
                 == d_input_funcs.end())
             {
-              Trace("si-prt") << "...not ground single invocation." << std::endl;
+              Trace("si-prt")
+                  << "...not ground single invocation." << std::endl;
               ngroundSingleInvocation = true;
               singleInvocation = false;
             }
           }
         }
-        if( singleInvocation )
+        if (singleInvocation)
         {
           Trace("si-prt") << "...ground single invocation" << std::endl;
         }

--- a/src/theory/quantifiers/single_inv_partition.cpp
+++ b/src/theory/quantifiers/single_inv_partition.cpp
@@ -250,37 +250,26 @@ bool SingleInvocationPartition::init(std::vector<Node>& funcs,
         // now must check if it has other bound variables
         std::vector<Node> bvs;
         TermUtil::getBoundVars(cr, bvs);
-        if (bvs.size() > d_si_vars.size())
+        // bound variables must be contained in the single invocation variables
+        for( const Node& bv : bvs )
         {
-          // getBoundVars also collects functions in the rare case that we are
-          // synthesizing a function with 0 arguments
-          // take these into account below.
-          unsigned n_const_synth_fun = 0;
-          for (unsigned j = 0; j < bvs.size(); j++)
+          if( std::find( d_si_vars.begin(), d_si_vars.end(), bv )==d_si_vars.end() )
           {
-            if (std::find(d_input_funcs.begin(), d_input_funcs.end(), bvs[j])
-                != d_input_funcs.end())
+            // getBoundVars also collects functions in the rare case that we are
+            // synthesizing a function with 0 arguments, take this into account
+            // here.
+            if (std::find(d_input_funcs.begin(), d_input_funcs.end(), bv)
+                == d_input_funcs.end())
             {
-              n_const_synth_fun++;
+              Trace("si-prt") << "...not ground single invocation." << std::endl;
+              ngroundSingleInvocation = true;
+              singleInvocation = false;
             }
           }
-          if (bvs.size() - n_const_synth_fun > d_si_vars.size())
-          {
-            Trace("si-prt") << "...not ground single invocation." << std::endl;
-            ngroundSingleInvocation = true;
-            singleInvocation = false;
-          }
-          else
-          {
-            Trace("si-prt") << "...ground single invocation : success, after "
-                               "removing 0-arg synth functions."
-                            << std::endl;
-          }
         }
-        else
+        if( singleInvocation )
         {
-          Trace("si-prt") << "...ground single invocation : success."
-                          << std::endl;
+          Trace("si-prt") << "...ground single invocation" << std::endl;
         }
       }
       else

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -137,7 +137,6 @@ void PreRegisterVisitor::visit(TNode current, TNode parent) {
   
   Theory::Set visitedTheories = d_visited[current];
   Debug("register::internal") << "PreRegisterVisitor::visit(" << current << "," << parent << "): previously registered with " << Theory::setToString(visitedTheories) << std::endl;
-  Assert(!current.hasFreeVar());
   if (!Theory::setContains(currentTheoryId, visitedTheories)) {
     visitedTheories = Theory::setInsert(currentTheoryId, visitedTheories);
     d_visited[current] = visitedTheories;

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -137,7 +137,7 @@ void PreRegisterVisitor::visit(TNode current, TNode parent) {
   
   Theory::Set visitedTheories = d_visited[current];
   Debug("register::internal") << "PreRegisterVisitor::visit(" << current << "," << parent << "): previously registered with " << Theory::setToString(visitedTheories) << std::endl;
-  Assert( !current.hasFreeVar() );
+  Assert(!current.hasFreeVar());
   if (!Theory::setContains(currentTheoryId, visitedTheories)) {
     visitedTheories = Theory::setInsert(currentTheoryId, visitedTheories);
     d_visited[current] = visitedTheories;

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -137,6 +137,7 @@ void PreRegisterVisitor::visit(TNode current, TNode parent) {
   
   Theory::Set visitedTheories = d_visited[current];
   Debug("register::internal") << "PreRegisterVisitor::visit(" << current << "," << parent << "): previously registered with " << Theory::setToString(visitedTheories) << std::endl;
+  Assert( !current.hasFreeVar() );
   if (!Theory::setContains(currentTheoryId, visitedTheories)) {
     visitedTheories = Theory::setInsert(currentTheoryId, visitedTheories);
     d_visited[current] = visitedTheories;

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -393,6 +393,8 @@ void TheoryEngine::preRegister(TNode preprocessed) {
         d_sharedTerms.addEqualityToPropagate(preprocessed);
       }
 
+      // the atom should not have free variables
+      Assert(!preprocessed.hasFreeVar());
       // Pre-register the terms in the atom
       Theory::Set theories = NodeVisitor<PreRegisterVisitor>::run(d_preRegistrationVisitor, preprocessed);
       theories = Theory::setRemove(THEORY_BOOL, theories);


### PR DESCRIPTION
This PR ensures that we catch cases when free (universal) variables appear in assertions.

This includes:
- A (debug) assertion when atoms are registered in theory_engine.
- A parser-level check that catches when the user uses synth functions in "assert" in sygus inputs, which is a common mistake.  

This required adding the function Expr::hasFreeVariable().

This caught one internal bug in debug mode (in single_inv_partition.cpp, fixed also in this commit).