### PR TITLE
Warn about trailing spaces in src/Makefile.am

### DIFF
--- a/contrib/new-theory
+++ b/contrib/new-theory
@@ -16,6 +16,13 @@ if [ ! -e src/theory/theory_engine.h ]; then
   exit 1
 fi
 
+# Trailing whitespaces in src/Makefile.am mess with the regexps (and are
+# generally undesirable, so we throw an error instead of ignoring them).
+if grep -q '[[:blank:]]$' src/Makefile.am; then
+	echo "ERROR: trailing whitespaces in src/Makefile.am" >&2
+	exit 1
+fi
+
 if [ $# -ge 1 -a "$1" = --alternate ]; then
   shift
   alternate=true


### PR DESCRIPTION
The contrib/new-theory script expects no trailing whitespaces in
src/Makefile.am otherwise it inserts the list files of the new theory at
a wrong place in the file. This commit adds a check for that in the
beginning of the script. Since contrib/new-theory is run as part of our
Travis tests, this will allow us to detect trailing spaces and fix them
rather than silently ignoring them.