### PR TITLE
Fix sygus substr static symmetry breaking

### DIFF
--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -555,7 +555,8 @@ bool TermDbSygus::considerConst( const Datatype& pdt, TypeNode tnp, Node c, Kind
         }
       }
     }else if( pk==STRING_SUBSTR ){
-      if( c==one_c && arg==2 ){
+      if (c == one_c && arg == 2)
+      {
         rt.d_req_kind = STRING_CHARAT;
         rt.d_children[0].d_req_type = getArgType( pdt[pc], 0 );
         rt.d_children[1].d_req_type = getArgType( pdt[pc], 1 );

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -555,7 +555,7 @@ bool TermDbSygus::considerConst( const Datatype& pdt, TypeNode tnp, Node c, Kind
         }
       }
     }else if( pk==STRING_SUBSTR ){
-      if( c==one_c ){
+      if( c==one_c && arg==2 ){
         rt.d_req_kind = STRING_CHARAT;
         rt.d_children[0].d_req_type = getArgType( pdt[pc], 0 );
         rt.d_children[1].d_req_type = getArgType( pdt[pc], 1 );


### PR DESCRIPTION
Was unsoundly pruning a class of solutions with 1 as second argument of substr.