### PR TITLE
Fixes for free variables in assertions

### DIFF
--- a/src/smt/term_formula_removal.cpp
+++ b/src/smt/term_formula_removal.cpp
@@ -215,8 +215,11 @@ Node RemoveTermFormulas::run(TNode node, std::vector<Node>& output,
     // The representation is now the skolem
     return skolem;
   }
-  
-  if(node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS || node.getKind()==kind::LAMBDA || node.getKind()==kind::CHOICE) {
+
+  if (node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS
+      || node.getKind() == kind::LAMBDA
+      || node.getKind() == kind::CHOICE)
+  {
     // Remember if we're inside a quantifier
     inQuant = true;
   }else if( !inTerm && hasNestedTermChildren( node ) ){
@@ -275,7 +278,10 @@ Node RemoveTermFormulas::replace(TNode node, bool inQuant, bool inTerm) const {
     return cached.isNull() ? Node(node) : cached;
   }
 
-  if(node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS || node.getKind()==kind::LAMBDA || node.getKind()==kind::CHOICE) {
+  if (node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS
+      || node.getKind() == kind::LAMBDA
+      || node.getKind() == kind::CHOICE)
+  {
     // Remember if we're inside a quantifier
     inQuant = true;
   }else if( !inTerm && hasNestedTermChildren( node ) ){

--- a/src/smt/term_formula_removal.cpp
+++ b/src/smt/term_formula_removal.cpp
@@ -216,7 +216,7 @@ Node RemoveTermFormulas::run(TNode node, std::vector<Node>& output,
     return skolem;
   }
   
-  if(node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS) {
+  if(node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS || node.getKind()==kind::LAMBDA || node.getKind()==kind::CHOICE) {
     // Remember if we're inside a quantifier
     inQuant = true;
   }else if( !inTerm && hasNestedTermChildren( node ) ){
@@ -275,7 +275,7 @@ Node RemoveTermFormulas::replace(TNode node, bool inQuant, bool inTerm) const {
     return cached.isNull() ? Node(node) : cached;
   }
 
-  if(node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS) {
+  if(node.getKind() == kind::FORALL || node.getKind() == kind::EXISTS || node.getKind()==kind::LAMBDA || node.getKind()==kind::CHOICE) {
     // Remember if we're inside a quantifier
     inQuant = true;
   }else if( !inTerm && hasNestedTermChildren( node ) ){

--- a/src/theory/quantifiers/sygus_inference.cpp
+++ b/src/theory/quantifiers/sygus_inference.cpp
@@ -192,7 +192,7 @@ bool SygusInference::simplify(std::vector<Node>& assertions)
 
   // sygus attribute to mark the conjecture as a sygus conjecture
   Trace("sygus-infer") << "Make outer sygus conjecture..." << std::endl;
-  Node sygusVar = nm->mkBoundVar("sygus", nm->booleanType());
+  Node sygusVar = nm->mkSkolem("sygus", nm->booleanType());
   SygusAttribute ca;
   sygusVar.setAttribute(ca, true);
   Node instAttr = nm->mkNode(INST_ATTRIBUTE, sygusVar);

--- a/src/theory/quantifiers/theory_quantifiers.h
+++ b/src/theory/quantifiers/theory_quantifiers.h
@@ -58,10 +58,6 @@ class TheoryQuantifiers : public Theory {
                         Node n,
                         std::vector<Node> node_values,
                         std::string str_value) override;
-  bool ppDontRewriteSubterm(TNode atom) override
-  {
-    return atom.getKind() == kind::FORALL || atom.getKind() == kind::EXISTS;
-  }
 
  private:
   void assertUniversal( Node n );

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -37,6 +37,8 @@ bool PreRegisterVisitor::alreadyVisited(TNode current, TNode parent) {
 
   if( ( parent.getKind() == kind::FORALL ||
         parent.getKind() == kind::EXISTS ||
+        parent.getKind() == kind::LAMBDA ||
+        parent.getKind() == kind::CHOICE ||
         parent.getKind() == kind::REWRITE_RULE ||
         parent.getKind() == kind::SEP_STAR ||
         parent.getKind() == kind::SEP_WAND ||
@@ -181,6 +183,8 @@ bool SharedTermsVisitor::alreadyVisited(TNode current, TNode parent) const {
 
   if( ( parent.getKind() == kind::FORALL ||
         parent.getKind() == kind::EXISTS ||
+        parent.getKind() == kind::LAMBDA ||
+        parent.getKind() == kind::CHOICE ||
         parent.getKind() == kind::REWRITE_RULE ||
         parent.getKind() == kind::SEP_STAR ||
         parent.getKind() == kind::SEP_WAND ||

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -35,17 +35,17 @@ bool PreRegisterVisitor::alreadyVisited(TNode current, TNode parent) {
 
   Debug("register::internal") << "PreRegisterVisitor::alreadyVisited(" << current << "," << parent << ")" << std::endl;
 
-  if( ( parent.getKind() == kind::FORALL ||
-        parent.getKind() == kind::EXISTS ||
-        parent.getKind() == kind::LAMBDA ||
-        parent.getKind() == kind::CHOICE ||
-        parent.getKind() == kind::REWRITE_RULE ||
-        parent.getKind() == kind::SEP_STAR ||
-        parent.getKind() == kind::SEP_WAND ||
-        ( parent.getKind() == kind::SEP_LABEL && current.getType().isBoolean() )
-        // parent.getKind() == kind::CARDINALITY_CONSTRAINT
-      ) &&
-      current != parent ) {
+  if ((parent.getKind() == kind::FORALL || parent.getKind() == kind::EXISTS
+       || parent.getKind() == kind::LAMBDA
+       || parent.getKind() == kind::CHOICE
+       || parent.getKind() == kind::REWRITE_RULE
+       || parent.getKind() == kind::SEP_STAR
+       || parent.getKind() == kind::SEP_WAND
+       || (parent.getKind() == kind::SEP_LABEL && current.getType().isBoolean())
+       // parent.getKind() == kind::CARDINALITY_CONSTRAINT
+       )
+      && current != parent)
+  {
     Debug("register::internal") << "quantifier:true" << std::endl;
     return true;
   }
@@ -181,17 +181,17 @@ bool SharedTermsVisitor::alreadyVisited(TNode current, TNode parent) const {
 
   Debug("register::internal") << "SharedTermsVisitor::alreadyVisited(" << current << "," << parent << ")" << std::endl;
 
-  if( ( parent.getKind() == kind::FORALL ||
-        parent.getKind() == kind::EXISTS ||
-        parent.getKind() == kind::LAMBDA ||
-        parent.getKind() == kind::CHOICE ||
-        parent.getKind() == kind::REWRITE_RULE ||
-        parent.getKind() == kind::SEP_STAR ||
-        parent.getKind() == kind::SEP_WAND ||
-        ( parent.getKind() == kind::SEP_LABEL && current.getType().isBoolean() )
-        // parent.getKind() == kind::CARDINALITY_CONSTRAINT
-      ) &&
-      current != parent ) {
+  if ((parent.getKind() == kind::FORALL || parent.getKind() == kind::EXISTS
+       || parent.getKind() == kind::LAMBDA
+       || parent.getKind() == kind::CHOICE
+       || parent.getKind() == kind::REWRITE_RULE
+       || parent.getKind() == kind::SEP_STAR
+       || parent.getKind() == kind::SEP_WAND
+       || (parent.getKind() == kind::SEP_LABEL && current.getType().isBoolean())
+       // parent.getKind() == kind::CARDINALITY_CONSTRAINT
+       )
+      && current != parent)
+  {
     Debug("register::internal") << "quantifier:true" << std::endl;
     return true;
   }

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -553,11 +553,6 @@ public:
   virtual Node ppRewrite(TNode atom) { return atom; }
 
   /**
-   * Don't preprocess subterm of this term
-   */
-  virtual bool ppDontRewriteSubterm(TNode atom) { return false; }
-
-  /**
    * Notify preprocessed assertions. Called on new assertions after
    * preprocessing before they are asserted to theory engine.
    */

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -394,7 +394,8 @@ void TheoryEngine::preRegister(TNode preprocessed) {
       }
 
       // the atom should not have free variables
-      Debug("theory") << "TheoryEngine::preRegister: " << preprocessed << std::endl;
+      Debug("theory") << "TheoryEngine::preRegister: " << preprocessed
+                      << std::endl;
       Assert(!preprocessed.hasFreeVar());
       // Pre-register the terms in the atom
       Theory::Set theories = NodeVisitor<PreRegisterVisitor>::run(d_preRegistrationVisitor, preprocessed);
@@ -1058,11 +1059,13 @@ Node TheoryEngine::ppTheoryRewrite(TNode term) {
 
   Node newTerm;
   // do not rewrite inside quantifiers
-  if (term.getKind() == kind::FORALL || term.getKind() == kind::EXISTS || term.getKind()==kind::CHOICE || term.getKind()==kind::LAMBDA) 
+  if (term.getKind() == kind::FORALL || term.getKind() == kind::EXISTS
+      || term.getKind() == kind::CHOICE
+      || term.getKind() == kind::LAMBDA)
   {
     newTerm = Rewriter::rewrite(term);
-  } 
-  else 
+  }
+  else
   {
     NodeBuilder<> newNode(term.getKind());
     if (term.getMetaKind() == kind::metakind::PARAMETERIZED) {

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1057,9 +1057,13 @@ Node TheoryEngine::ppTheoryRewrite(TNode term) {
   Trace("theory-pp") << "ppTheoryRewrite { " << term << endl;
 
   Node newTerm;
-  if (theoryOf(term)->ppDontRewriteSubterm(term) || term.getKind()==kind::CHOICE || term.getKind()==kind::LAMBDA) {
+  // do not rewrite inside quantifiers
+  if (term.getKind() == kind::FORALL || term.getKind() == kind::EXISTS || term.getKind()==kind::CHOICE || term.getKind()==kind::LAMBDA) 
+  {
     newTerm = Rewriter::rewrite(term);
-  } else {
+  } 
+  else 
+  {
     NodeBuilder<> newNode(term.getKind());
     if (term.getMetaKind() == kind::metakind::PARAMETERIZED) {
       newNode << term.getOperator();

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1057,7 +1057,7 @@ Node TheoryEngine::ppTheoryRewrite(TNode term) {
   Trace("theory-pp") << "ppTheoryRewrite { " << term << endl;
 
   Node newTerm;
-  if (theoryOf(term)->ppDontRewriteSubterm(term)) {
+  if (theoryOf(term)->ppDontRewriteSubterm(term) || term.getKind()==kind::CHOICE || term.getKind()==kind::LAMBDA) {
     newTerm = Rewriter::rewrite(term);
   } else {
     NodeBuilder<> newNode(term.getKind());

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -394,6 +394,7 @@ void TheoryEngine::preRegister(TNode preprocessed) {
       }
 
       // the atom should not have free variables
+      Debug("theory") << "TheoryEngine::preRegister: " << preprocessed << std::endl;
       Assert(!preprocessed.hasFreeVar());
       // Pre-register the terms in the atom
       Theory::Set theories = NodeVisitor<PreRegisterVisitor>::run(d_preRegistrationVisitor, preprocessed);


### PR DESCRIPTION
This fixes two cases of free variables in assertions:

(1) --sygus-inference mistakenly used a bound variable for an annotation instead of a skolem

(2) CHOICE and LAMBDA can now occur in assertions, in particular CHOICE is used for expanding the definitions of inverse transcendental functions, LAMBDA is allowed in the higher-order smt2 parser.  This PR updates a number of places where we were not treating these as quantifiers.

