### PR TITLE
allowing bool to bv without quantifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ config.reconfig
 /personal.conf
 /personal.mk
 /antlr-3.4
+/lfsc-checker/
+/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@ config.reconfig
 /personal.conf
 /personal.mk
 /antlr-3.4
-/lfsc-checker/
-/nbproject/

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1472,9 +1472,9 @@ void SmtEngine::setDefaults() {
     }
   }
 
-  if (options::cbqiBv()) {
+  if (options::cbqiBv() && d_logic.isQuantified()) {
     if(options::boolToBitvector.wasSetByUser()) {
-      throw OptionException("bool-to-bv not supported with CBQI BV");
+      throw OptionException("bool-to-bv not supported with CBQI BV for quantified logics");
     }
     Notice() << "SmtEngine: turning off bool-to-bitvector to support CBQI BV"
              << endl;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1472,9 +1472,11 @@ void SmtEngine::setDefaults() {
     }
   }
 
-  if (options::cbqiBv() && d_logic.isQuantified()) {
+  if (options::cbqiBv() && d_logic.isQuantified())
+  {
     if(options::boolToBitvector.wasSetByUser()) {
-      throw OptionException("bool-to-bv not supported with CBQI BV for quantified logics");
+      throw OptionException(
+          "bool-to-bv not supported with CBQI BV for quantified logics");
     }
     Notice() << "SmtEngine: turning off bool-to-bitvector to support CBQI BV"
              << endl;

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -2834,7 +2834,7 @@ Node BvInverter::solveBvLit(Node sv,
   litk = k = lit.getKind();
 
   /* Note: option --bool-to-bv is currently disabled when CBQI BV
-   *       is enabled. We currently do not support Boolean operators
+   *       is enabled and the logic is quantified. We currently do not support Boolean operators
    *       that are interpreted as bit-vector operators of width 1.  */
 
   /* Boolean layer ----------------------------------------------- */

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -2834,7 +2834,8 @@ Node BvInverter::solveBvLit(Node sv,
   litk = k = lit.getKind();
 
   /* Note: option --bool-to-bv is currently disabled when CBQI BV
-   *       is enabled and the logic is quantified. We currently do not support Boolean operators
+   *       is enabled and the logic is quantified. We currently do not support
+   * Boolean operators
    *       that are interpreted as bit-vector operators of width 1.  */
 
   /* Boolean layer ----------------------------------------------- */

--- a/src/theory/quantifiers/bv_inverter.cpp
+++ b/src/theory/quantifiers/bv_inverter.cpp
@@ -2834,8 +2834,8 @@ Node BvInverter::solveBvLit(Node sv,
   litk = k = lit.getKind();
 
   /* Note: option --bool-to-bv is currently disabled when CBQI BV
-   *       is enabled and the logic is quantified. We currently do not support
-   * Boolean operators
+   *       is enabled and the logic is quantified. 
+   *       We currently do not support Boolean operators
    *       that are interpreted as bit-vector operators of width 1.  */
 
   /* Boolean layer ----------------------------------------------- */


### PR DESCRIPTION
Currently: to use --bool-to-bv, you must also add --no-cbqi-bv. Otherwise, an exception is thrown.
The reason: --cbqi-bv is enabled by default, and its combination with --bool-to-bv is not supported.
The problem: The above holds even if the logic at hand is quantifier-free.

Fix: throwing the exception only for logics with quantifiers.