### PR TITLE
Skolemize candidate rewrite rule checks

### DIFF
--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -113,7 +113,7 @@ bool InstStrategyCbqi::registerCbqiLemma( Node q ) {
       //compute dependencies between quantified formulas
       if( options::cbqiLitDepend() || options::cbqiInnermost() ){
         std::vector< Node > ics;
-        TermUtil::computeVarContains( q, ics );
+        TermUtil::computeInstConstContains( q, ics );
         d_parent_quant[q].clear();
         d_children_quant[q].clear();
         std::vector< Node > dep;

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -113,7 +113,7 @@ bool InstStrategyCbqi::registerCbqiLemma( Node q ) {
       //compute dependencies between quantified formulas
       if( options::cbqiLitDepend() || options::cbqiInnermost() ){
         std::vector< Node > ics;
-        TermUtil::computeInstConstContains( q, ics );
+        TermUtil::computeInstConstContains(q, ics);
         d_parent_quant[q].clear();
         d_children_quant[q].clear();
         std::vector< Node > dep;

--- a/src/theory/quantifiers/ematching/inst_match_generator.cpp
+++ b/src/theory/quantifiers/ematching/inst_match_generator.cpp
@@ -598,7 +598,7 @@ InstMatchGeneratorMultiLinear::InstMatchGeneratorMultiLinear( Node q, std::vecto
   //order patterns to maximize eager matching failures
   std::map< Node, std::vector< Node > > var_contains;
   for( const Node& pat : pats ){
-    quantifiers::TermUtil::getInstConstContainsNode( q, pat, var_contains[ pat ] );
+    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, var_contains[ pat ] );
   }
   std::map< Node, std::vector< Node > > var_to_node;
   for( std::map< Node, std::vector< Node > >::iterator it = var_contains.begin(); it != var_contains.end(); ++it ){
@@ -713,7 +713,7 @@ InstMatchGeneratorMulti::InstMatchGeneratorMulti(Node q,
   Trace("multi-trigger-cache") << "Making smart multi-trigger for " << q << std::endl;
   std::map< Node, std::vector< Node > > var_contains;
   for( const Node& pat : pats ){
-    quantifiers::TermUtil::getInstConstContainsNode( q, pat, var_contains[ pat ] );
+    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, var_contains[ pat ] );
   }
   //convert to indicies
   for( std::map< Node, std::vector< Node > >::iterator it = var_contains.begin(); it != var_contains.end(); ++it ){

--- a/src/theory/quantifiers/ematching/inst_match_generator.cpp
+++ b/src/theory/quantifiers/ematching/inst_match_generator.cpp
@@ -597,8 +597,10 @@ int VarMatchGeneratorTermSubs::getNextMatch(Node q,
 InstMatchGeneratorMultiLinear::InstMatchGeneratorMultiLinear( Node q, std::vector< Node >& pats, QuantifiersEngine* qe ) {
   //order patterns to maximize eager matching failures
   std::map< Node, std::vector< Node > > var_contains;
-  for( const Node& pat : pats ){
-    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, var_contains[ pat ] );
+  for (const Node& pat : pats)
+  {
+    quantifiers::TermUtil::computeInstConstContainsForQuant(
+        q, pat, var_contains[pat]);
   }
   std::map< Node, std::vector< Node > > var_to_node;
   for( std::map< Node, std::vector< Node > >::iterator it = var_contains.begin(); it != var_contains.end(); ++it ){
@@ -712,8 +714,10 @@ InstMatchGeneratorMulti::InstMatchGeneratorMulti(Node q,
 {
   Trace("multi-trigger-cache") << "Making smart multi-trigger for " << q << std::endl;
   std::map< Node, std::vector< Node > > var_contains;
-  for( const Node& pat : pats ){
-    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, var_contains[ pat ] );
+  for (const Node& pat : pats)
+  {
+    quantifiers::TermUtil::computeInstConstContainsForQuant(
+        q, pat, var_contains[pat]);
   }
   //convert to indicies
   for( std::map< Node, std::vector< Node > >::iterator it = var_contains.begin(); it != var_contains.end(); ++it ){

--- a/src/theory/quantifiers/ematching/inst_match_generator.cpp
+++ b/src/theory/quantifiers/ematching/inst_match_generator.cpp
@@ -597,7 +597,9 @@ int VarMatchGeneratorTermSubs::getNextMatch(Node q,
 InstMatchGeneratorMultiLinear::InstMatchGeneratorMultiLinear( Node q, std::vector< Node >& pats, QuantifiersEngine* qe ) {
   //order patterns to maximize eager matching failures
   std::map< Node, std::vector< Node > > var_contains;
-  qe->getTermUtil()->getVarContains( q, pats, var_contains );
+  for( const Node& pat : pats ){
+    quantifiers::TermUtil::getInstConstContainsNode( q, pat, var_contains[ pat ] );
+  }
   std::map< Node, std::vector< Node > > var_to_node;
   for( std::map< Node, std::vector< Node > >::iterator it = var_contains.begin(); it != var_contains.end(); ++it ){
     for( unsigned i=0; i<it->second.size(); i++ ){
@@ -710,7 +712,9 @@ InstMatchGeneratorMulti::InstMatchGeneratorMulti(Node q,
 {
   Trace("multi-trigger-cache") << "Making smart multi-trigger for " << q << std::endl;
   std::map< Node, std::vector< Node > > var_contains;
-  qe->getTermUtil()->getVarContains( q, pats, var_contains );
+  for( const Node& pat : pats ){
+    quantifiers::TermUtil::getInstConstContainsNode( q, pat, var_contains[ pat ] );
+  }
   //convert to indicies
   for( std::map< Node, std::vector< Node > >::iterator it = var_contains.begin(); it != var_contains.end(); ++it ){
     Trace("multi-trigger-cache") << "Pattern " << it->first << " contains: ";

--- a/src/theory/quantifiers/ematching/trigger.cpp
+++ b/src/theory/quantifiers/ematching/trigger.cpp
@@ -36,7 +36,7 @@ namespace inst {
 
 void TriggerTermInfo::init( Node q, Node n, int reqPol, Node reqPolEq ){
   if( d_fv.empty() ){
-    quantifiers::TermUtil::computeInstConstContainsForQuant( q, n, d_fv );
+    quantifiers::TermUtil::computeInstConstContainsForQuant(q, n, d_fv);
   }
   if( d_reqPol==0 ){
     d_reqPol = reqPol;
@@ -134,8 +134,10 @@ bool Trigger::mkTriggerTerms( Node q, std::vector< Node >& nodes, unsigned n_var
   std::map< Node, std::vector< Node > > patterns;
   size_t varCount = 0;
   std::map< Node, std::vector< Node > > varContains;
-  for( const Node& pat : temp ){
-    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, varContains[ pat ] );
+  for (const Node& pat : temp)
+  {
+    quantifiers::TermUtil::computeInstConstContainsForQuant(
+        q, pat, varContains[pat]);
   }
   for( unsigned i=0; i<temp.size(); i++ ){
     bool foundVar = false;
@@ -872,8 +874,9 @@ void Trigger::getTriggerVariables(Node n, Node q, std::vector<Node>& t_vars)
   std::vector< Node > exclude;
   collectPatTerms(q, n, patTerms, quantifiers::TRIGGER_SEL_ALL, exclude, tinfo);
   //collect all variables from all patterns in patTerms, add to t_vars
-  for( const Node& pat : patTerms ){
-    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, t_vars );
+  for (const Node& pat : patTerms)
+  {
+    quantifiers::TermUtil::computeInstConstContainsForQuant(q, pat, t_vars);
   }
 }
 

--- a/src/theory/quantifiers/ematching/trigger.cpp
+++ b/src/theory/quantifiers/ematching/trigger.cpp
@@ -36,7 +36,7 @@ namespace inst {
 
 void TriggerTermInfo::init( Node q, Node n, int reqPol, Node reqPolEq ){
   if( d_fv.empty() ){
-    quantifiers::TermUtil::getInstConstContainsNode( q, n, d_fv );
+    quantifiers::TermUtil::computeInstConstContainsForQuant( q, n, d_fv );
   }
   if( d_reqPol==0 ){
     d_reqPol = reqPol;
@@ -135,7 +135,7 @@ bool Trigger::mkTriggerTerms( Node q, std::vector< Node >& nodes, unsigned n_var
   size_t varCount = 0;
   std::map< Node, std::vector< Node > > varContains;
   for( const Node& pat : temp ){
-    quantifiers::TermUtil::getInstConstContainsNode( q, pat, varContains[ pat ] );
+    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, varContains[ pat ] );
   }
   for( unsigned i=0; i<temp.size(); i++ ){
     bool foundVar = false;
@@ -873,7 +873,7 @@ void Trigger::getTriggerVariables(Node n, Node q, std::vector<Node>& t_vars)
   collectPatTerms(q, n, patTerms, quantifiers::TRIGGER_SEL_ALL, exclude, tinfo);
   //collect all variables from all patterns in patTerms, add to t_vars
   for( const Node& pat : patTerms ){
-    quantifiers::TermUtil::getInstConstContainsNode( q, pat, t_vars );
+    quantifiers::TermUtil::computeInstConstContainsForQuant( q, pat, t_vars );
   }
 }
 

--- a/src/theory/quantifiers/ematching/trigger.cpp
+++ b/src/theory/quantifiers/ematching/trigger.cpp
@@ -36,7 +36,7 @@ namespace inst {
 
 void TriggerTermInfo::init( Node q, Node n, int reqPol, Node reqPolEq ){
   if( d_fv.empty() ){
-    quantifiers::TermUtil::getVarContainsNode( q, n, d_fv );
+    quantifiers::TermUtil::getInstConstContainsNode( q, n, d_fv );
   }
   if( d_reqPol==0 ){
     d_reqPol = reqPol;
@@ -134,7 +134,9 @@ bool Trigger::mkTriggerTerms( Node q, std::vector< Node >& nodes, unsigned n_var
   std::map< Node, std::vector< Node > > patterns;
   size_t varCount = 0;
   std::map< Node, std::vector< Node > > varContains;
-  quantifiers::TermUtil::getVarContains( q, temp, varContains );
+  for( const Node& pat : temp ){
+    quantifiers::TermUtil::getInstConstContainsNode( q, pat, varContains[ pat ] );
+  }
   for( unsigned i=0; i<temp.size(); i++ ){
     bool foundVar = false;
     for( unsigned j=0; j<varContains[ temp[i] ].size(); j++ ){
@@ -744,7 +746,7 @@ void Trigger::filterTriggerInstances(std::vector<Node>& nodes)
   std::map<unsigned, std::vector<Node> > fvs;
   for (unsigned i = 0, size = nodes.size(); i < size; i++)
   {
-    quantifiers::TermUtil::computeVarContains(nodes[i], fvs[i]);
+    quantifiers::TermUtil::computeInstConstContains(nodes[i], fvs[i]);
   }
   std::vector<bool> active;
   active.resize(nodes.size(), true);
@@ -870,8 +872,8 @@ void Trigger::getTriggerVariables(Node n, Node q, std::vector<Node>& t_vars)
   std::vector< Node > exclude;
   collectPatTerms(q, n, patTerms, quantifiers::TRIGGER_SEL_ALL, exclude, tinfo);
   //collect all variables from all patterns in patTerms, add to t_vars
-  for( unsigned i=0; i<patTerms.size(); i++ ){
-    quantifiers::TermUtil::getVarContainsNode( q, patTerms[i], t_vars );
+  for( const Node& pat : patTerms ){
+    quantifiers::TermUtil::getInstConstContainsNode( q, pat, t_vars );
   }
 }
 

--- a/src/theory/quantifiers/macros.cpp
+++ b/src/theory/quantifiers/macros.cpp
@@ -156,7 +156,7 @@ bool QuantifierMacros::isGroundUfTerm( Node f, Node n ) {
   Node icn = d_qe->getTermUtil()->substituteBoundVariablesToInstConstants(n, f);
   Trace("macros-debug2") << "Get free variables in " << icn << std::endl;
   std::vector< Node > var;
-  d_qe->getTermUtil()->getVarContainsNode( f, icn, var );
+  quantifiers::TermUtil::getInstConstContainsNode( f, icn, var );
   Trace("macros-debug2") << "Get trigger variables for " << icn << std::endl;
   std::vector< Node > trigger_var;
   inst::Trigger::getTriggerVariables( icn, f, trigger_var );

--- a/src/theory/quantifiers/macros.cpp
+++ b/src/theory/quantifiers/macros.cpp
@@ -156,7 +156,7 @@ bool QuantifierMacros::isGroundUfTerm( Node f, Node n ) {
   Node icn = d_qe->getTermUtil()->substituteBoundVariablesToInstConstants(n, f);
   Trace("macros-debug2") << "Get free variables in " << icn << std::endl;
   std::vector< Node > var;
-  quantifiers::TermUtil::computeInstConstContainsForQuant( f, icn, var );
+  quantifiers::TermUtil::computeInstConstContainsForQuant(f, icn, var);
   Trace("macros-debug2") << "Get trigger variables for " << icn << std::endl;
   std::vector< Node > trigger_var;
   inst::Trigger::getTriggerVariables( icn, f, trigger_var );

--- a/src/theory/quantifiers/macros.cpp
+++ b/src/theory/quantifiers/macros.cpp
@@ -156,7 +156,7 @@ bool QuantifierMacros::isGroundUfTerm( Node f, Node n ) {
   Node icn = d_qe->getTermUtil()->substituteBoundVariablesToInstConstants(n, f);
   Trace("macros-debug2") << "Get free variables in " << icn << std::endl;
   std::vector< Node > var;
-  quantifiers::TermUtil::getInstConstContainsNode( f, icn, var );
+  quantifiers::TermUtil::computeInstConstContainsForQuant( f, icn, var );
   Trace("macros-debug2") << "Get trigger variables for " << icn << std::endl;
   std::vector< Node > trigger_var;
   inst::Trigger::getTriggerVariables( icn, f, trigger_var );

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -624,33 +624,34 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
               SmtEngine rrChecker(nm->toExprManager());
               rrChecker.setLogic(smt::currentSmtEngine()->getLogicInfo());
               Node crr = solbr.eqNode(eq_solr).negate();
-              Trace("rr-check")
-                  << "Check candidate rewrite : " << crr << std::endl;
+              Trace("rr-check") << "Check candidate rewrite : " << crr
+                                << std::endl;
               // quantify over the free variables in crr
               std::vector<Node> fvs;
               TermUtil::computeVarContains(crr, fvs);
-              std::map< Node, unsigned > fv_index;
-              std::vector< Node > sks;
+              std::map<Node, unsigned> fv_index;
+              std::vector<Node> sks;
               if (!fvs.empty())
               {
                 // map to skolems
-                for( unsigned i=0,size=fvs.size(); i<size; i++ )
+                for (unsigned i = 0, size = fvs.size(); i < size; i++)
                 {
                   Node v = fvs[i];
                   fv_index[v] = i;
                   std::map<Node, Node>::iterator itf = d_fv_to_skolem.find(v);
-                  if( itf==d_fv_to_skolem.end() )
+                  if (itf == d_fv_to_skolem.end())
                   {
-                    Node sk = nm->mkSkolem("rrck",v.getType());
+                    Node sk = nm->mkSkolem("rrck", v.getType());
                     d_fv_to_skolem[v] = sk;
                     sks.push_back(sk);
                   }
                   else
                   {
-                    sks.push_back( itf->second );
+                    sks.push_back(itf->second);
                   }
                 }
-                crr = crr.substitute(fvs.begin(),fvs.end(),sks.begin(),sks.end());
+                crr = crr.substitute(
+                    fvs.begin(), fvs.end(), sks.begin(), sks.end());
               }
               rrChecker.assertFormula(crr.toExpr());
               Result r = rrChecker.checkSat();
@@ -666,9 +667,9 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
                 std::vector<Node> pt;
                 for (const Node& v : vars)
                 {
-                  std::map< Node, unsigned >::iterator itf = fv_index.find(v);
+                  std::map<Node, unsigned>::iterator itf = fv_index.find(v);
                   Node val;
-                  if( itf==fv_index.end() )
+                  if (itf == fv_index.end())
                   {
                     // not in conjecture, can use arbitrary value
                     val = v.getType().mkGroundTerm();
@@ -678,7 +679,8 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
                     // get the model value of its skolem
                     Node sk = sks[itf->second];
                     val = Node::fromExpr(rrChecker.getValue(sk.toExpr()));
-                    Trace("rr-check") << "  " << v << " -> " << val << std::endl;
+                    Trace("rr-check") << "  " << v << " -> " << val
+                                      << std::endl;
                   }
                   pt.push_back(val);
                 }

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -624,16 +624,34 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
               SmtEngine rrChecker(nm->toExprManager());
               rrChecker.setLogic(smt::currentSmtEngine()->getLogicInfo());
               Node crr = solbr.eqNode(eq_solr).negate();
+              Trace("rr-check")
+                  << "Check candidate rewrite : " << crr << std::endl;
               // quantify over the free variables in crr
               std::vector<Node> fvs;
               TermUtil::computeVarContains(crr, fvs);
+              std::map< Node, unsigned > fv_index;
+              std::vector< Node > sks;
               if (!fvs.empty())
               {
-                Node bvl_fvs = nm->mkNode(BOUND_VAR_LIST, fvs);
-                crr = nm->mkNode(EXISTS, bvl_fvs, crr);
+                // map to skolems
+                for( unsigned i=0,size=fvs.size(); i<size; i++ )
+                {
+                  Node v = fvs[i];
+                  fv_index[v] = i;
+                  std::map<Node, Node>::iterator itf = d_fv_to_skolem.find(v);
+                  if( itf==d_fv_to_skolem.end() )
+                  {
+                    Node sk = nm->mkSkolem("rrck",v.getType());
+                    d_fv_to_skolem[v] = sk;
+                    sks.push_back(sk);
+                  }
+                  else
+                  {
+                    sks.push_back( itf->second );
+                  }
+                }
+                crr = crr.substitute(fvs.begin(),fvs.end(),sks.begin(),sks.end());
               }
-              Trace("rr-check")
-                  << "Check candidate rewrite : " << crr << std::endl;
               rrChecker.assertFormula(crr.toExpr());
               Result r = rrChecker.checkSat();
               Trace("rr-check") << "...result : " << r << std::endl;
@@ -648,15 +666,27 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
                 std::vector<Node> pt;
                 for (const Node& v : vars)
                 {
-                  Node val = Node::fromExpr(rrChecker.getValue(v.toExpr()));
-                  Trace("rr-check") << "  " << v << " -> " << val << std::endl;
+                  std::map< Node, unsigned >::iterator itf = fv_index.find(v);
+                  Node val;
+                  if( itf==fv_index.end() )
+                  {
+                    // not in conjecture, can use arbitrary value
+                    val = v.getType().mkGroundTerm();
+                  }
+                  else
+                  {
+                    // get the model value of its skolem
+                    Node sk = sks[itf->second];
+                    val = Node::fromExpr(rrChecker.getValue(sk.toExpr()));
+                    Trace("rr-check") << "  " << v << " -> " << val << std::endl;
+                  }
                   pt.push_back(val);
                 }
                 d_sampler[prog].addSamplePoint(pt);
                 // add the solution again
+                // by construction of the above point, we should be unique now
                 Node eq_sol_new = its->second.registerTerm(sol);
-                Assert(!r.asSatisfiabilityResult().isSat()
-                       || eq_sol_new == sol);
+                Assert(eq_sol_new == sol);
               }
               else
               {

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -620,9 +620,18 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
               // Notice we don't set produce-models. rrChecker takes the same
               // options as the SmtEngine we belong to, where we ensure that
               // produce-models is set.
-              SmtEngine rrChecker(NodeManager::currentNM()->toExprManager());
+              NodeManager * nm = NodeManager::currentNM();
+              SmtEngine rrChecker(nm->toExprManager());
               rrChecker.setLogic(smt::currentSmtEngine()->getLogicInfo());
               Node crr = solbr.eqNode(eq_solr).negate();
+              // quantify over the free variables in crr
+              std::vector< Node > fvs;
+              TermUtil::computeVarContains( crr, fvs );
+              if( !fvs.empty() )
+              {
+                Node bvl_fvs = nm->mkNode( BOUND_VAR_LIST, fvs );
+                crr = nm->mkNode( EXISTS, bvl_fvs, crr );
+              }
               Trace("rr-check")
                   << "Check candidate rewrite : " << crr << std::endl;
               rrChecker.assertFormula(crr.toExpr());

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -620,17 +620,17 @@ void CegConjecture::printSynthSolution( std::ostream& out, bool singleInvocation
               // Notice we don't set produce-models. rrChecker takes the same
               // options as the SmtEngine we belong to, where we ensure that
               // produce-models is set.
-              NodeManager * nm = NodeManager::currentNM();
+              NodeManager* nm = NodeManager::currentNM();
               SmtEngine rrChecker(nm->toExprManager());
               rrChecker.setLogic(smt::currentSmtEngine()->getLogicInfo());
               Node crr = solbr.eqNode(eq_solr).negate();
               // quantify over the free variables in crr
-              std::vector< Node > fvs;
-              TermUtil::computeVarContains( crr, fvs );
-              if( !fvs.empty() )
+              std::vector<Node> fvs;
+              TermUtil::computeVarContains(crr, fvs);
+              if (!fvs.empty())
               {
-                Node bvl_fvs = nm->mkNode( BOUND_VAR_LIST, fvs );
-                crr = nm->mkNode( EXISTS, bvl_fvs, crr );
+                Node bvl_fvs = nm->mkNode(BOUND_VAR_LIST, fvs);
+                crr = nm->mkNode(EXISTS, bvl_fvs, crr);
               }
               Trace("rr-check")
                   << "Check candidate rewrite : " << crr << std::endl;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -247,9 +247,9 @@ private:
    * rewrite rules.
    */
   std::map<Node, SygusSamplerExt> d_sampler;
-  /** 
-   * Cache of skolems for each free variable that appears in a synthesis check 
-   * (for --sygus-rr-synth-check). 
+  /**
+   * Cache of skolems for each free variable that appears in a synthesis check
+   * (for --sygus-rr-synth-check).
    */
   std::map<Node, Node> d_fv_to_skolem;
 };

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -247,6 +247,11 @@ private:
    * rewrite rules.
    */
   std::map<Node, SygusSamplerExt> d_sampler;
+  /** 
+   * Cache of skolems for each free variable that appears in a synthesis check 
+   * (for --sygus-rr-synth-check). 
+   */
+  std::map<Node, Node> d_fv_to_skolem;
 };
 
 } /* namespace CVC4::theory::quantifiers */

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -311,15 +311,6 @@ void TermUtil::computeVarContainsInternal( Node n, Kind k, std::vector< Node >& 
   } while (!visit.empty());  
 }
 
-/*
-void TermUtil::getInstConstContains( Node f, std::vector< Node >& pats, std::map< Node, std::vector< Node > >& varContains ){
-  for( const Node& pat : pats ){
-    varContains[ pat].clear();
-    getInstConstContainsNode( f, pat, varContains[ pat ] );
-  }
-}
-*/
-
 void TermUtil::getInstConstContainsNode( Node q, Node n, std::vector< Node >& vars ){
   std::vector< Node > ics;
   computeInstConstContains( n, ics );

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -271,11 +271,9 @@ void TermUtil::computeInstConstContains( Node n, std::vector< Node >& ics ){
   computeVarContainsInternal( n, INST_CONSTANT, ics );
 }
 
-/*
 void TermUtil::computeVarContains( Node n, std::vector< Node >& vars ) {
   computeVarContainsInternal( n, BOUND_VARIABLE, vars );
 }
-*/
 
 void TermUtil::computeQuantContains( Node n, std::vector< Node >& quants ) {
   computeVarContainsInternal( n, FORALL, quants );

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -925,7 +925,7 @@ Node TermUtil::getTypeValueOffset(TypeNode tn,
 
 Node TermUtil::mkTypeConst(TypeNode tn, bool pol)
 {
-  return pol ? mkTypeMaxValue(tn) : mkTypeValue(tn, 0);
+  return pol ? mkTypeValue(tn, 0) : mkTypeMaxValue(tn);
 }
 
 bool TermUtil::isAntisymmetric(Kind k, Kind& dk)

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -300,6 +300,10 @@ void TermUtil::computeVarContainsInternal( Node n, Kind k, std::vector< Node >& 
       }
       else
       {
+        if( cur.hasOperator() )
+        {
+          visit.push_back(cur.getOperator());
+        }
         for( const Node& cn : cur )
         {
           visit.push_back(cn);

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -267,51 +267,68 @@ Node TermUtil::substituteInstConstants(Node n, Node q, std::vector<Node>& terms)
                       terms.end());
 }
 
-void TermUtil::computeVarContains( Node n, std::vector< Node >& varContains ) {
-  std::map< Node, bool > visited;
-  computeVarContains2( n, INST_CONSTANT, varContains, visited );
+void TermUtil::computeInstConstContains( Node n, std::vector< Node >& ics ){
+  computeVarContainsInternal( n, INST_CONSTANT, ics );
 }
 
-void TermUtil::computeQuantContains( Node n, std::vector< Node >& quantContains ) {
-  std::map< Node, bool > visited;
-  computeVarContains2( n, FORALL, quantContains, visited );
+/*
+void TermUtil::computeVarContains( Node n, std::vector< Node >& vars ) {
+  computeVarContainsInternal( n, BOUND_VARIABLE, vars );
+}
+*/
+
+void TermUtil::computeQuantContains( Node n, std::vector< Node >& quants ) {
+  computeVarContainsInternal( n, FORALL, quants );
 }
 
+void TermUtil::computeVarContainsInternal( Node n, Kind k, std::vector< Node >& vars ){
+  std::unordered_set<TNode, TNodeHashFunction> visited;
+  std::unordered_set<TNode, TNodeHashFunction>::iterator it;
+  std::vector<TNode> visit;
+  TNode cur;
+  visit.push_back(n);
+  do {
+    cur = visit.back();
+    visit.pop_back();
+    it = visited.find(cur);
 
-void TermUtil::computeVarContains2( Node n, Kind k, std::vector< Node >& varContains, std::map< Node, bool >& visited ){
-  if( visited.find( n )==visited.end() ){
-    visited[n] = true;
-    if( n.getKind()==k ){
-      if( std::find( varContains.begin(), varContains.end(), n )==varContains.end() ){
-        varContains.push_back( n );
-      }
-    }else{
-      if (n.hasOperator())
+    if (it == visited.end()) {
+      visited.insert(cur);
+      if( cur.getKind()==k )
       {
-        computeVarContains2(n.getOperator(), k, varContains, visited);
+        if( std::find( vars.begin(), vars.end(), cur )==vars.end() ){
+          vars.push_back( cur );
+        }
       }
-      for( unsigned i=0; i<n.getNumChildren(); i++ ){
-        computeVarContains2( n[i], k, varContains, visited );
+      else
+      {
+        for( const Node& cn : cur )
+        {
+          visit.push(cn);
+        }
       }
     }
-  }
+  } while (!visit.empty());  
 }
 
-void TermUtil::getVarContains( Node f, std::vector< Node >& pats, std::map< Node, std::vector< Node > >& varContains ){
-  for( unsigned i=0; i<pats.size(); i++ ){
-    varContains[ pats[i] ].clear();
-    getVarContainsNode( f, pats[i], varContains[ pats[i] ] );
+/*
+void TermUtil::getInstConstContains( Node f, std::vector< Node >& pats, std::map< Node, std::vector< Node > >& varContains ){
+  for( const Node& pat : pats ){
+    varContains[ pat].clear();
+    getInstConstContainsNode( f, pat, varContains[ pat ] );
   }
 }
+*/
 
-void TermUtil::getVarContainsNode( Node f, Node n, std::vector< Node >& varContains ){
-  std::vector< Node > vars;
-  computeVarContains( n, vars );
-  for( unsigned j=0; j<vars.size(); j++ ){
-    Node v = vars[j];
-    if( v.getAttribute(InstConstantAttribute())==f ){
-      if( std::find( varContains.begin(), varContains.end(), v )==varContains.end() ){
-        varContains.push_back( v );
+void TermUtil::getInstConstContainsNode( Node q, Node n, std::vector< Node >& vars ){
+  std::vector< Node > ics;
+  computeInstConstContains( n, ics );
+  for( const Node& v : ics )
+  {
+    if( v.getAttribute(InstConstantAttribute())==q )
+    {
+      if( std::find( vars.begin(), vars.end(), v )==vars.end() ){
+        vars.push_back( v );
       }
     }
   }
@@ -919,7 +936,7 @@ Node TermUtil::getTypeValueOffset(TypeNode tn,
 
 Node TermUtil::mkTypeConst(TypeNode tn, bool pol)
 {
-  return pol ? mkTypeValue(tn, 0) : mkTypeMaxValue(tn);
+  return pol ? mkTypeMaxValue(tn) : mkTypeValue(tn, 0);
 }
 
 bool TermUtil::isAntisymmetric(Kind k, Kind& dk)

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -309,7 +309,7 @@ void TermUtil::computeVarContainsInternal( Node n, Kind k, std::vector< Node >& 
   } while (!visit.empty());  
 }
 
-void TermUtil::getInstConstContainsNode( Node q, Node n, std::vector< Node >& vars ){
+void TermUtil::computeInstConstContainsForQuant( Node q, Node n, std::vector< Node >& vars ){
   std::vector< Node > ics;
   computeInstConstContains( n, ics );
   for( const Node& v : ics )

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -267,61 +267,74 @@ Node TermUtil::substituteInstConstants(Node n, Node q, std::vector<Node>& terms)
                       terms.end());
 }
 
-void TermUtil::computeInstConstContains( Node n, std::vector< Node >& ics ){
-  computeVarContainsInternal( n, INST_CONSTANT, ics );
+void TermUtil::computeInstConstContains(Node n, std::vector<Node>& ics)
+{
+  computeVarContainsInternal(n, INST_CONSTANT, ics);
 }
 
-void TermUtil::computeVarContains( Node n, std::vector< Node >& vars ) {
-  computeVarContainsInternal( n, BOUND_VARIABLE, vars );
+void TermUtil::computeVarContains(Node n, std::vector<Node>& vars)
+{
+  computeVarContainsInternal(n, BOUND_VARIABLE, vars);
 }
 
-void TermUtil::computeQuantContains( Node n, std::vector< Node >& quants ) {
-  computeVarContainsInternal( n, FORALL, quants );
+void TermUtil::computeQuantContains(Node n, std::vector<Node>& quants)
+{
+  computeVarContainsInternal(n, FORALL, quants);
 }
 
-void TermUtil::computeVarContainsInternal( Node n, Kind k, std::vector< Node >& vars ){
+void TermUtil::computeVarContainsInternal(Node n,
+                                          Kind k,
+                                          std::vector<Node>& vars)
+{
   std::unordered_set<TNode, TNodeHashFunction> visited;
   std::unordered_set<TNode, TNodeHashFunction>::iterator it;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
     it = visited.find(cur);
 
-    if (it == visited.end()) {
+    if (it == visited.end())
+    {
       visited.insert(cur);
-      if( cur.getKind()==k )
+      if (cur.getKind() == k)
       {
-        if( std::find( vars.begin(), vars.end(), cur )==vars.end() ){
-          vars.push_back( cur );
+        if (std::find(vars.begin(), vars.end(), cur) == vars.end())
+        {
+          vars.push_back(cur);
         }
       }
       else
       {
-        if( cur.hasOperator() )
+        if (cur.hasOperator())
         {
           visit.push_back(cur.getOperator());
         }
-        for( const Node& cn : cur )
+        for (const Node& cn : cur)
         {
           visit.push_back(cn);
         }
       }
     }
-  } while (!visit.empty());  
+  } while (!visit.empty());
 }
 
-void TermUtil::computeInstConstContainsForQuant( Node q, Node n, std::vector< Node >& vars ){
-  std::vector< Node > ics;
-  computeInstConstContains( n, ics );
-  for( const Node& v : ics )
+void TermUtil::computeInstConstContainsForQuant(Node q,
+                                                Node n,
+                                                std::vector<Node>& vars)
+{
+  std::vector<Node> ics;
+  computeInstConstContains(n, ics);
+  for (const Node& v : ics)
   {
-    if( v.getAttribute(InstConstantAttribute())==q )
+    if (v.getAttribute(InstConstantAttribute()) == q)
     {
-      if( std::find( vars.begin(), vars.end(), v )==vars.end() ){
-        vars.push_back( v );
+      if (std::find(vars.begin(), vars.end(), v) == vars.end())
+      {
+        vars.push_back(v);
       }
     }
   }

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -304,7 +304,7 @@ void TermUtil::computeVarContainsInternal( Node n, Kind k, std::vector< Node >& 
       {
         for( const Node& cn : cur )
         {
-          visit.push(cn);
+          visit.push_back(cn);
         }
       }
     }

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -180,25 +180,25 @@ public:
   static Node getQuantSimplify( Node n );
 
  private:
-  /** adds the set of nodes of kind k in n to varContains */
+  /** adds the set of nodes of kind k in n to vars */
   static void computeVarContainsInternal(Node n,
                                          Kind k,
-                                         std::vector<Node>& varContains);
+                                         std::vector<Node>& vars);
 
  public:
-  /** adds the set of nodes of kind INST_CONSTANT in n to varContains */
+  /** adds the set of nodes of kind INST_CONSTANT in n to ics */
   static void computeInstConstContains(Node n, std::vector<Node>& ics);
-  /** adds the set of nodes of kind BOUND_VARIABLE in n to varContains */
+  /** adds the set of nodes of kind BOUND_VARIABLE in n to vars */
   static void computeVarContains(Node n, std::vector<Node>& vars);
-  /** adds the set of (top-level) nodes of kind FORALL in n to varContains */
+  /** adds the set of (top-level) nodes of kind FORALL in n to quants */
   static void computeQuantContains(Node n, std::vector<Node>& quants);
   /**
-   * adds the set of nodes of kind INST_CONSTANT in n that belong to quantified
-   * formula q to varContains
+   * Adds the set of nodes of kind INST_CONSTANT in n that belong to quantified
+   * formula q to vars.
    */
   static void computeInstConstContainsForQuant(Node q,
                                                Node n,
-                                               std::vector<Node>& varContains);
+                                               std::vector<Node>& vars);
 
   // for term ordering
  private:

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -186,7 +186,7 @@ public:
   /** adds the set of nodes of kind INST_CONSTANT in n to varContains */
   static void computeInstConstContains( Node n, std::vector< Node >& ics );
   /** adds the set of nodes of kind BOUND_VARIABLE in n to varContains */
-  //static void computeVarContains( Node n, std::vector< Node >& vars );
+  static void computeVarContains( Node n, std::vector< Node >& vars );
   /** adds the set of (top-level) nodes of kind FORALL in n to varContains */
   static void computeQuantContains( Node n, std::vector< Node >& quants );
   /** 

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -180,20 +180,20 @@ public:
   static Node getQuantSimplify( Node n );
 
  private:
-  /** helper function for compute var contains */
-  static void computeVarContains2( Node n, Kind k, std::vector< Node >& varContains, std::map< Node, bool >& visited );
+  /** adds the set of nodes of kind k in n to varContains */
+  static void computeVarContainsInternal( Node n, Kind k, std::vector< Node >& varContains);
  public:
-  /** compute var contains */
-  static void computeVarContains( Node n, std::vector< Node >& varContains );
-  /** get var contains for each of the patterns in pats */
-  static void getVarContains( Node f, std::vector< Node >& pats, std::map< Node, std::vector< Node > >& varContains );
-  /** get var contains for node n */
-  static void getVarContainsNode( Node f, Node n, std::vector< Node >& varContains );
-  /** compute quant contains */
-  static void computeQuantContains( Node n, std::vector< Node >& quantContains );
-  // TODO (#1216) : this should be in trigger.h
-  /** filter all nodes that have instances */
-  static void filterInstances( std::vector< Node >& nodes );
+  /** adds the set of nodes of kind INST_CONSTANT in n to varContains */
+  static void computeInstConstContains( Node n, std::vector< Node >& ics );
+  /** adds the set of nodes of kind BOUND_VARIABLE in n to varContains */
+  //static void computeVarContains( Node n, std::vector< Node >& vars );
+  /** adds the set of (top-level) nodes of kind FORALL in n to varContains */
+  static void computeQuantContains( Node n, std::vector< Node >& quants );
+  /** 
+   * adds the set of nodes of kind INST_CONSTANT in n that belong to quantified
+   * formula q to varContains 
+   */
+  static void getInstConstContainsNode( Node q, Node n, std::vector< Node >& varContains );
 
 //for term ordering
 private:

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -181,22 +181,27 @@ public:
 
  private:
   /** adds the set of nodes of kind k in n to varContains */
-  static void computeVarContainsInternal( Node n, Kind k, std::vector< Node >& varContains);
+  static void computeVarContainsInternal(Node n,
+                                         Kind k,
+                                         std::vector<Node>& varContains);
+
  public:
   /** adds the set of nodes of kind INST_CONSTANT in n to varContains */
-  static void computeInstConstContains( Node n, std::vector< Node >& ics );
+  static void computeInstConstContains(Node n, std::vector<Node>& ics);
   /** adds the set of nodes of kind BOUND_VARIABLE in n to varContains */
-  static void computeVarContains( Node n, std::vector< Node >& vars );
+  static void computeVarContains(Node n, std::vector<Node>& vars);
   /** adds the set of (top-level) nodes of kind FORALL in n to varContains */
-  static void computeQuantContains( Node n, std::vector< Node >& quants );
-  /** 
+  static void computeQuantContains(Node n, std::vector<Node>& quants);
+  /**
    * adds the set of nodes of kind INST_CONSTANT in n that belong to quantified
-   * formula q to varContains 
+   * formula q to varContains
    */
-  static void computeInstConstContainsForQuant( Node q, Node n, std::vector< Node >& varContains );
+  static void computeInstConstContainsForQuant(Node q,
+                                               Node n,
+                                               std::vector<Node>& varContains);
 
-//for term ordering
-private:
+  // for term ordering
+ private:
   /** operator id count */
   int d_op_id_count;
   /** map from operators to id */

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -193,7 +193,7 @@ public:
    * adds the set of nodes of kind INST_CONSTANT in n that belong to quantified
    * formula q to varContains 
    */
-  static void getInstConstContainsNode( Node q, Node n, std::vector< Node >& varContains );
+  static void computeInstConstContainsForQuant( Node q, Node n, std::vector< Node >& varContains );
 
 //for term ordering
 private:


### PR DESCRIPTION
Avoid assertion failures when using --sygus-rr-synth-check.

This also cleans up the utilities for computing free variables in term_util.