### PR TITLE
Make strings fmf apply to all but internally generated Skolems

### DIFF
--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -653,8 +653,7 @@ void TheoryStrings::preRegisterTerm(TNode n) {
           // but not an internally generated Skolem, or a term that does
           // not belong to this theory.
           if (options::stringFMF()
-              && ((n.isVar() && d_all_skolems.find(n) == d_all_skolems.end())
-                  || kindToTheoryId(n.getKind()) != THEORY_STRINGS))
+              && (n.isVar() ? d_all_skolems.find(n) == d_all_skolems.end() : kindToTheoryId(n.getKind()) != THEORY_STRINGS))
           {
             d_input_vars.insert(n);
           }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -652,7 +652,9 @@ void TheoryStrings::preRegisterTerm(TNode n) {
           // then we minimize the length of this term if it is a variable
           // but not an internally generated Skolem, or a term that does
           // not belong to this theory.
-          if ( options::stringFMF() && ( ( n.isVar() && d_all_skolems.find(n)==d_all_skolems.end() ) || theoryOf(n.getKind()!=THEORY_STRINGS ) ) )
+          if (options::stringFMF()
+              && ((n.isVar() && d_all_skolems.find(n) == d_all_skolems.end())
+                  || theoryOf(n.getKind() != THEORY_STRINGS)))
           {
             d_input_vars.insert(n);
           }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -654,7 +654,7 @@ void TheoryStrings::preRegisterTerm(TNode n) {
           // not belong to this theory.
           if (options::stringFMF()
               && ((n.isVar() && d_all_skolems.find(n) == d_all_skolems.end())
-                  || theoryOf(n.getKind() != THEORY_STRINGS)))
+                  || kindToTheoryId(n.getKind()) != THEORY_STRINGS))
           {
             d_input_vars.insert(n);
           }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -3566,7 +3566,6 @@ Node TheoryStrings::mkSkolemCached( Node a, Node b, int id, const char * c, int 
   if( it==d_skolem_cache[a][b].end() ){
     Node sk = mkSkolemS( c, isLenSplit );
     d_skolem_cache[a][b][id] = sk;
-    d_all_skolems.insert(sk);
     return sk;
   }else{
     return it->second;
@@ -3576,6 +3575,7 @@ Node TheoryStrings::mkSkolemCached( Node a, Node b, int id, const char * c, int 
 //isLenSplit: -1-ignore, 0-no restriction, 1-greater than one, 2-one
 Node TheoryStrings::mkSkolemS( const char *c, int isLenSplit ) {
   Node n = NodeManager::currentNM()->mkSkolem( c, NodeManager::currentNM()->stringType(), "string sko" );
+  d_all_skolems.insert(n);
   d_length_lemma_terms_cache.insert( n );
   ++(d_statistics.d_new_skolems);
   if( isLenSplit==0 ){

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -648,9 +648,11 @@ void TheoryStrings::preRegisterTerm(TNode n) {
         TypeNode tn = n.getType();
         if( tn.isString() ) {
           registerTerm( n, 0 );
-          // FMF
-          if (options::stringFMF()
-              && d_all_skolems.find(n) == d_all_skolems.end())
+          // if finite model finding is enabled,
+          // then we minimize the length of this term if it is a variable
+          // but not an internally generated Skolem, or a term that does
+          // not belong to this theory.
+          if ( options::stringFMF() && ( ( n.isVar() && d_all_skolems.find(n)==d_all_skolems.end() ) || theoryOf(n.getKind()!=THEORY_STRINGS ) )
           {
             d_input_vars.insert(n);
           }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -653,7 +653,8 @@ void TheoryStrings::preRegisterTerm(TNode n) {
           // but not an internally generated Skolem, or a term that does
           // not belong to this theory.
           if (options::stringFMF()
-              && (n.isVar() ? d_all_skolems.find(n) == d_all_skolems.end() : kindToTheoryId(n.getKind()) != THEORY_STRINGS))
+              && (n.isVar() ? d_all_skolems.find(n) == d_all_skolems.end()
+                            : kindToTheoryId(n.getKind()) != THEORY_STRINGS))
           {
             d_input_vars.insert(n);
           }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -649,7 +649,9 @@ void TheoryStrings::preRegisterTerm(TNode n) {
         if( tn.isString() ) {
           registerTerm( n, 0 );
           // FMF
-          if( options::stringFMF() && d_all_skolems.find(n)==d_all_skolems.end() ){
+          if (options::stringFMF()
+              && d_all_skolems.find(n) == d_all_skolems.end())
+          {
             d_input_vars.insert(n);
           }
           d_equalityEngine.addTerm(n);

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -652,7 +652,7 @@ void TheoryStrings::preRegisterTerm(TNode n) {
           // then we minimize the length of this term if it is a variable
           // but not an internally generated Skolem, or a term that does
           // not belong to this theory.
-          if ( options::stringFMF() && ( ( n.isVar() && d_all_skolems.find(n)==d_all_skolems.end() ) || theoryOf(n.getKind()!=THEORY_STRINGS ) )
+          if ( options::stringFMF() && ( ( n.isVar() && d_all_skolems.find(n)==d_all_skolems.end() ) || theoryOf(n.getKind()!=THEORY_STRINGS ) ) )
           {
             d_input_vars.insert(n);
           }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -649,7 +649,7 @@ void TheoryStrings::preRegisterTerm(TNode n) {
         if( tn.isString() ) {
           registerTerm( n, 0 );
           // FMF
-          if( n.getKind() == kind::VARIABLE && options::stringFMF() ){
+          if( options::stringFMF() && d_all_skolems.find(n)==d_all_skolems.end() ){
             d_input_vars.insert(n);
           }
           d_equalityEngine.addTerm(n);
@@ -3560,6 +3560,7 @@ Node TheoryStrings::mkSkolemCached( Node a, Node b, int id, const char * c, int 
   if( it==d_skolem_cache[a][b].end() ){
     Node sk = mkSkolemS( c, isLenSplit );
     d_skolem_cache[a][b][id] = sk;
+    d_all_skolems.insert(sk);
     return sk;
   }else{
     return it->second;

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -489,6 +489,8 @@ private:
     sk_id_deq_z,
   };
   std::map<Node, std::map<Node, std::map<int, Node> > > d_skolem_cache;
+  /** the set of all skolems we have generated */
+  std::unordered_set< Node, NodeHashFunction > d_all_skolems;
   Node mkSkolemCached(
       Node a, Node b, int id, const char* c, int isLenSplit = 0);
   inline Node mkSkolemS(const char* c, int isLenSplit = 0);

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -490,7 +490,7 @@ private:
   };
   std::map<Node, std::map<Node, std::map<int, Node> > > d_skolem_cache;
   /** the set of all skolems we have generated */
-  std::unordered_set< Node, NodeHashFunction > d_all_skolems;
+  std::unordered_set<Node, NodeHashFunction> d_all_skolems;
   Node mkSkolemCached(
       Node a, Node b, int id, const char* c, int isLenSplit = 0);
   inline Node mkSkolemS(const char* c, int isLenSplit = 0);


### PR DESCRIPTION
This ensures --sygus-rr-synth-check doesn't hang on relatively simple SAT strings benchmarks.