### PR TITLE
Make 256 the default cardinality for strings

### DIFF
--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -22,14 +22,13 @@ header = "options/strings_options.h"
   help       = "the strategy of LB rule application: 0-lazy, 1-eager, 2-no"
 
 [[option]]
-  name       = "stdASCII"
+  name       = "stdPrintASCII"
   category   = "regular"
-  long       = "strings-std-ascii"
+  long       = "strings-print-ascii"
   type       = "bool"
-  default    = "true"
-  predicates = ["unsignedLessEqual2"]
+  default    = "false"
   read_only  = true
-  help       = "the alphabet contains only characters from the standard ASCII or the extended one"
+  help       = "the alphabet contains only printable characters from the standard extended ASCII"
 
 [[option]]
   name       = "stringFMF"

--- a/src/theory/strings/regexp_operation.cpp
+++ b/src/theory/strings/regexp_operation.cpp
@@ -39,8 +39,9 @@ RegExpOpr::RegExpOpr()
       d_char_end(),
       d_sigma(NodeManager::currentNM()->mkNode(kind::REGEXP_SIGMA,
                                                std::vector<Node>{})),
-      d_sigma_star(
-          NodeManager::currentNM()->mkNode(kind::REGEXP_STAR, d_sigma)) {}
+      d_sigma_star(NodeManager::currentNM()->mkNode(kind::REGEXP_STAR, d_sigma))
+{
+}
 
 RegExpOpr::~RegExpOpr() {}
 

--- a/src/theory/strings/regexp_operation.cpp
+++ b/src/theory/strings/regexp_operation.cpp
@@ -24,7 +24,7 @@ namespace theory {
 namespace strings {
 
 RegExpOpr::RegExpOpr()
-    : d_lastchar(options::stdASCII() ? '\x7f' : '\xff'),
+    : d_lastchar(options::stdPrintASCII() ? '\x7f' : '\xff'),
       d_emptyString(NodeManager::currentNM()->mkConst(::CVC4::String(""))),
       d_true(NodeManager::currentNM()->mkConst(true)),
       d_false(NodeManager::currentNM()->mkConst(false)),

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -143,7 +143,11 @@ TheoryStrings::TheoryStrings(context::Context* c, context::UserContext* u,
   d_true = NodeManager::currentNM()->mkConst( true );
   d_false = NodeManager::currentNM()->mkConst( false );
 
-  d_card_size = 128;
+  d_card_size = 256;
+  if (options::stdPrintASCII())
+  {
+    d_card_size = 128;
+  }
 }
 
 TheoryStrings::~TheoryStrings() {
@@ -450,10 +454,6 @@ int TheoryStrings::getReduction( int effort, Node n, Node& nr ) {
 
 void TheoryStrings::presolve() {
   Debug("strings-presolve") << "TheoryStrings::Presolving : get fmf options " << (options::stringFMF() ? "true" : "false") << std::endl;
-
-  if(!options::stdASCII()) {
-    d_card_size = 256;
-  }
 }
 
 

--- a/src/theory/strings/theory_strings_type_rules.h
+++ b/src/theory/strings/theory_strings_type_rules.h
@@ -361,8 +361,12 @@ public:
       if(ch[0] > ch[1]) {
         throw TypeCheckingExceptionPrivate(n, "expecting the first constant is less or equal to the second one in regexp range");
       }
-      if(options::stdPrintASCII() && ch[1] > '\x7f') {
-        throw TypeCheckingExceptionPrivate(n, "expecting standard ASCII characters in regexp range when strings-print-ascii is true");
+      if (options::stdPrintASCII() && ch[1] > '\x7f')
+      {
+        throw TypeCheckingExceptionPrivate(n,
+                                           "expecting standard ASCII "
+                                           "characters in regexp range when "
+                                           "strings-print-ascii is true");
       }
     }
     return nodeManager->regExpType();

--- a/src/theory/strings/theory_strings_type_rules.h
+++ b/src/theory/strings/theory_strings_type_rules.h
@@ -361,8 +361,8 @@ public:
       if(ch[0] > ch[1]) {
         throw TypeCheckingExceptionPrivate(n, "expecting the first constant is less or equal to the second one in regexp range");
       }
-      if(options::stdASCII() && ch[1] > '\x7f') {
-        throw TypeCheckingExceptionPrivate(n, "expecting standard ASCII characters in regexp range, or please set the option strings-std-ascii to be false");
+      if(options::stdPrintASCII() && ch[1] > '\x7f') {
+        throw TypeCheckingExceptionPrivate(n, "expecting standard ASCII characters in regexp range when strings-print-ascii is true");
       }
     }
     return nodeManager->regExpType();


### PR DESCRIPTION
Fixes #1781.

Previously the default was 128, which didnt match the documentation on the webpage.