### PR TITLE
Add timeout (option) to regression script

### DIFF
--- a/test/regress/Makefile.am
+++ b/test/regress/Makefile.am
@@ -57,5 +57,5 @@ EXTRA_DIST = \
 	regress0/tptp/Axioms/SYN000_0.ax \
 	Makefile.levels \
 	Makefile.tests \
-  run_regression.py \
+	run_regression.py \
 	README.md

--- a/test/regress/README.md
+++ b/test/regress/README.md
@@ -16,7 +16,16 @@ For example:
 TEST_REGEX=quantifiers make regress0
 ```
 
-Runs regression tests from level 0 that have "quantifiers" in their name.
+This runs regression tests from level 0 that have "quantifiers" in their name.
+
+By default, each invocation of CVC4 is done with a 10 minute timeout. To use a
+different timeout, set the `TEST_TIMEOUT` environment variable:
+
+```
+TEST_TIMEOUT=0.5s make regress0
+```
+
+This runs regression tests from level 0 with a 0,5 second timeout.
 
 ## Adding New Regressions
 

--- a/test/regress/run_regression.py
+++ b/test/regress/run_regression.py
@@ -41,13 +41,13 @@ def run_process(args, cwd, timeout, s_input=None):
 
     out = ''
     err = ''
+    exit_status = 124
     timer = threading.Timer(timeout, lambda p: p.kill(), [proc])
     try:
         timer.start()
         out, err = proc.communicate(input=s_input)
         exit_status = proc.returncode
     finally:
-        exit_status = 124
         timer.cancel()
 
     return out, err, exit_status

--- a/test/regress/run_regression.py
+++ b/test/regress/run_regression.py
@@ -28,7 +28,9 @@ COMMAND_LINE = 'COMMAND-LINE: '
 def run_process(args, cwd, timeout, s_input=None):
     """Runs a process with a timeout `timeout` in seconds. `args` are the
     arguments to execute, `cwd` is the working directory and `s_input` is the
-    input to be sent to the process over stdin."""
+    input to be sent to the process over stdin. Returns the output, the error
+    output and the exit code of the process. If the process times out, the
+    output and the error output are empty and the exit code is 124."""
 
     proc = subprocess.Popen(
         args,
@@ -37,14 +39,18 @@ def run_process(args, cwd, timeout, s_input=None):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
 
+    out = ''
+    err = ''
     timer = threading.Timer(timeout, lambda p: p.kill(), [proc])
     try:
         timer.start()
         out, err = proc.communicate(input=s_input)
+        exit_status = proc.returncode
     finally:
+        exit_status = 124
         timer.cancel()
 
-    return out, err, proc.returncode
+    return out, err, exit_status
 
 
 def run_benchmark(dump, wrapper, scrubber, error_scrubber, cvc4_binary,


### PR DESCRIPTION
This commit adds the option to run regressions with a timeout using the
`TEST_TIMEOUT` environment variable. The default timeout is set to 10
minutes. This should make it less likely that our nightly builds hang
and makes it easier to sort out slow tests.

Default timeout tested with regression level 2 on a debug build with
proofs.