### PR TITLE
Adding config/tap-driver.sh to .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ config.reconfig
 /personal.conf
 /personal.mk
 /antlr-3.4
+/lfsc-checker/
+/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@ config.reconfig
 /personal.conf
 /personal.mk
 /antlr-3.4
-/lfsc-checker/
-/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ generated/
 *.gcov
 /lcov/
 /config/compile
+/config/tap-driver.sh
 .cvc4_config
 config.reconfig
 *.swp


### PR DESCRIPTION
#1791 removed config/tap-driver.sh from the repo, as ./autogen.sh adds it automatically.
The current PR prevents this file from being added to the untracked changes list when doing `git status`.