### PR TITLE
Allow metadata lines in test files to have leading spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ config.reconfig
 /personal.conf
 /personal.mk
 /antlr-3.4
-/lfsc-checker/
-/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ config.reconfig
 /personal.conf
 /personal.mk
 /antlr-3.4
+/lfsc-checker/
+/nbproject/

--- a/test/regress/run_regression.py
+++ b/test/regress/run_regression.py
@@ -171,7 +171,7 @@ def run_regression(proof, dump, wrapper, cvc4_binary, benchmark_path, timeout):
         # Skip lines that do not start with a comment character.
         if line[0] != comment_char:
             continue
-        line = line[1:].strip()
+        line = line[1:].lstrip()
 
         if line.startswith(SCRUBBER):
             scrubber = line[len(SCRUBBER):]

--- a/test/regress/run_regression.py
+++ b/test/regress/run_regression.py
@@ -168,10 +168,10 @@ def run_regression(proof, dump, wrapper, cvc4_binary, benchmark_path, timeout):
     expected_exit_status = None
     command_line = ''
     for line in metadata_lines:
-        # Skip lines that do not start with "%"
+        # Skip lines that do not start with a comment character.
         if line[0] != comment_char:
             continue
-        line = line[2:]
+        line = line[1:].strip()
 
         if line.startswith(SCRUBBER):
             scrubber = line[len(SCRUBBER):]


### PR DESCRIPTION
Currently, lines like `;Expect sat` instead of `; Expect sat` cause problems. This PR fixes it.
