### PR TITLE
Core improvements to extended rewriter

### DIFF
--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -1051,12 +1051,31 @@ bool ExtendedRewriter::inferSubstitution(Node n,
     {
       n = slv_eq;
     }
+    NodeManager * nm = NodeManager::currentNM();
+    
+    Node v[2];
     for (unsigned i = 0; i < 2; i++)
     {
-      TNode r1 = n[i];
-      TNode r2 = n[1 - i];
+      if( n[i].isVar() || n[i].isConst() )
+      {
+        v[i] = n[i];
+      }
+      else if( TermUtil::isNegate(n[i].getKind()) && n[i][0].isVar() )
+      {
+        v[i] = n[i][0];
+      }
+    }
+    for (unsigned i = 0; i < 2; i++)
+    {
+      TNode r1 = v[i];
+      Node r2 = v[1 - i];
       if (r1.isVar() && ((r2.isVar() && r1 < r2) || r2.isConst()))
       {
+        r2 = n[1-i];
+        if( v[i]!=n[i] )
+        {
+          r2 = nm->mkNode( n[i].getKind(), r2 );
+        }
         // TODO (#1706) : union find
         if (std::find(vars.begin(), vars.end(), r1) == vars.end())
         {

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -42,18 +42,16 @@ void ExtendedRewriter::setCache(Node n, Node ret)
   n.setAttribute(era, ret);
 }
 
-void addChild( Node nc, std::vector< Node >& children, bool isNonAdditive, bool& childChanged )
+bool ExtendedRewriter::addToChildren( Node nc, std::vector< Node >& children, bool dropDup)
 {
   // If the operator is non-additive, do not consider duplicates
-  if (isNonAdditive
+  if (dropDup
       && std::find(children.begin(), children.end(), nc) != children.end())
   {
-    childChanged = true;
+    return false;
   }
-  else
-  {
-    children.push_back(nc);
-  }  
+  children.push_back(nc);
+  return true; 
 }
 
 Node ExtendedRewriter::extendedRewrite(Node n)
@@ -120,12 +118,15 @@ Node ExtendedRewriter::extendedRewrite(Node n)
       {
         for( const Node& ncc : nc )
         {
-          addChild( ncc, children, isNonAdditive, childChanged );
+          if( !addToChildren( ncc, children, isNonAdditive ) )
+          {
+            childChanged = true;
+          }
         }
       }
-      else
+      else if( !addToChildren( nc, children, isNonAdditive ) )
       {
-        addChild( nc, children, isNonAdditive, childChanged );
+        childChanged = true;
       }
     }
     Assert(!children.empty());

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -42,7 +42,9 @@ void ExtendedRewriter::setCache(Node n, Node ret)
   n.setAttribute(era, ret);
 }
 
-bool ExtendedRewriter::addToChildren( Node nc, std::vector< Node >& children, bool dropDup)
+bool ExtendedRewriter::addToChildren(Node nc,
+                                     std::vector<Node>& children,
+                                     bool dropDup)
 {
   // If the operator is non-additive, do not consider duplicates
   if (dropDup
@@ -51,7 +53,7 @@ bool ExtendedRewriter::addToChildren( Node nc, std::vector< Node >& children, bo
     return false;
   }
   children.push_back(nc);
-  return true; 
+  return true;
 }
 
 Node ExtendedRewriter::extendedRewrite(Node n)
@@ -114,17 +116,17 @@ Node ExtendedRewriter::extendedRewrite(Node n)
     {
       Node nc = extendedRewrite(n[i]);
       childChanged = nc != n[i] || childChanged;
-      if( isAssoc && nc.getKind()==n.getKind() )
+      if (isAssoc && nc.getKind() == n.getKind())
       {
-        for( const Node& ncc : nc )
+        for (const Node& ncc : nc)
         {
-          if( !addToChildren( ncc, children, isNonAdditive ) )
+          if (!addToChildren(ncc, children, isNonAdditive))
           {
             childChanged = true;
           }
         }
       }
-      else if( !addToChildren( nc, children, isNonAdditive ) )
+      else if (!addToChildren(nc, children, isNonAdditive))
       {
         childChanged = true;
       }
@@ -1068,16 +1070,16 @@ bool ExtendedRewriter::inferSubstitution(Node n,
     {
       n = slv_eq;
     }
-    NodeManager * nm = NodeManager::currentNM();
-    
+    NodeManager* nm = NodeManager::currentNM();
+
     Node v[2];
     for (unsigned i = 0; i < 2; i++)
     {
-      if( n[i].isVar() || n[i].isConst() )
+      if (n[i].isVar() || n[i].isConst())
       {
         v[i] = n[i];
       }
-      else if( TermUtil::isNegate(n[i].getKind()) && n[i][0].isVar() )
+      else if (TermUtil::isNegate(n[i].getKind()) && n[i][0].isVar())
       {
         v[i] = n[i][0];
       }
@@ -1088,10 +1090,10 @@ bool ExtendedRewriter::inferSubstitution(Node n,
       Node r2 = v[1 - i];
       if (r1.isVar() && ((r2.isVar() && r1 < r2) || r2.isConst()))
       {
-        r2 = n[1-i];
-        if( v[i]!=n[i] )
+        r2 = n[1 - i];
+        if (v[i] != n[i])
         {
-          r2 = nm->mkNode( n[i].getKind(), r2 );
+          r2 = nm->mkNode(n[i].getKind(), r2);
         }
         // TODO (#1706) : union find
         if (std::find(vars.begin(), vars.end(), r1) == vars.end())

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -939,16 +939,16 @@ Node ExtendedRewriter::extendedRewriteEqChain(
   }
 
   // sorted right associative chain
-  bool has_const = false;
-  unsigned const_index = 0;
+  bool has_nvar = false;
+  unsigned nvar_index = 0;
   for (std::pair<const Node, bool>& cp : cstatus)
   {
     if (cp.second)
     {
-      if (cp.first.isConst())
+      if (!cp.first.isVar())
       {
-        has_const = true;
-        const_index = children.size();
+        has_nvar = true;
+        nvar_index = children.size();
       }
       children.push_back(cp.first);
     }
@@ -959,7 +959,7 @@ Node ExtendedRewriter::extendedRewriteEqChain(
   if (!gpol)
   {
     // negate the constant child if it exists
-    unsigned nindex = has_const ? const_index : 0;
+    unsigned nindex = has_nvar ? nvar_index : 0;
     children[nindex] = TermUtil::mkNegate(notk, children[nindex]);
   }
   new_ret = children.back();

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -1093,7 +1093,8 @@ bool ExtendedRewriter::inferSubstitution(Node n,
         r2 = n[1 - i];
         if (v[i] != n[i])
         {
-          r2 = nm->mkNode(n[i].getKind(), r2);
+          Assert( TermUtil::isNegate( n[i].getKind() ) );
+          r2 = TermUtil::mkNegate(n[i].getKind(), r2);
         }
         // TODO (#1706) : union find
         if (std::find(vars.begin(), vars.end(), r1) == vars.end())

--- a/src/theory/quantifiers/extended_rewrite.h
+++ b/src/theory/quantifiers/extended_rewrite.h
@@ -67,12 +67,12 @@ class ExtendedRewriter
   /** cache that the extended rewritten form of n is ret */
   void setCache(Node n, Node ret);
   /** add to children
-   * 
+   *
    * Adds nc to the vector of children, if dropDup is true, we do not add
-   * nc if it already occurs in children. This method returns false in this 
+   * nc if it already occurs in children. This method returns false in this
    * case, otherwise it returns true.
    */
-  bool addToChildren( Node nc, std::vector< Node >& children, bool dropDup );
+  bool addToChildren(Node nc, std::vector<Node>& children, bool dropDup);
 
   //--------------------------------------generic utilities
   /** Rewrite ITE, for example:

--- a/src/theory/quantifiers/extended_rewrite.h
+++ b/src/theory/quantifiers/extended_rewrite.h
@@ -66,6 +66,13 @@ class ExtendedRewriter
   bool d_aggr;
   /** cache that the extended rewritten form of n is ret */
   void setCache(Node n, Node ret);
+  /** add to children
+   * 
+   * Adds nc to the vector of children, if dropDup is true, we do not add
+   * nc if it already occurs in children. This method returns false in this 
+   * case, otherwise it returns true.
+   */
+  bool addToChildren( Node nc, std::vector< Node >& children, bool dropDup );
 
   //--------------------------------------generic utilities
   /** Rewrite ITE, for example:

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -811,9 +811,9 @@ Node TermUtil::mkNegate(Kind notk, Node n)
   return NodeManager::currentNM()->mkNode(notk, n);
 }
 
-bool TermUtil::isNegate( Kind k )
+bool TermUtil::isNegate(Kind k)
 {
-  return k==NOT || k==BITVECTOR_NOT || k==BITVECTOR_NEG || k==UMINUS;
+  return k == NOT || k == BITVECTOR_NOT || k == BITVECTOR_NEG || k == UMINUS;
 }
 
 bool TermUtil::isAssoc( Kind k ) {

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -813,7 +813,7 @@ Node TermUtil::mkNegate(Kind notk, Node n)
 
 bool TermUtil::isNegate( Kind k )
 {
-  return k==NOT || k==BITVECTOR_NOT || k==BITVECTOR_NEG;
+  return k==NOT || k==BITVECTOR_NOT || k==BITVECTOR_NEG || k==UMINUS;
 }
 
 bool TermUtil::isAssoc( Kind k ) {

--- a/src/theory/quantifiers/term_util.cpp
+++ b/src/theory/quantifiers/term_util.cpp
@@ -811,6 +811,11 @@ Node TermUtil::mkNegate(Kind notk, Node n)
   return NodeManager::currentNM()->mkNode(notk, n);
 }
 
+bool TermUtil::isNegate( Kind k )
+{
+  return k==NOT || k==BITVECTOR_NOT || k==BITVECTOR_NEG;
+}
+
 bool TermUtil::isAssoc( Kind k ) {
   return k == PLUS || k == MULT || k == AND || k == OR || k == BITVECTOR_PLUS
          || k == BITVECTOR_MULT || k == BITVECTOR_AND || k == BITVECTOR_OR

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -291,7 +291,10 @@ public:
   static int getTermDepth( Node n );
   /** simple negate */
   static Node simpleNegate( Node n );
-  /** is negate? */
+  /** is the kind k a negation kind? 
+   * 
+   * A kind k is a negation kind if <k>( <k>( n ) ) = n.
+   */
   static bool isNegate( Kind k );
   /**
    * Make negated term, returns the negation of n wrt Kind notk, eliminating

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -291,11 +291,11 @@ public:
   static int getTermDepth( Node n );
   /** simple negate */
   static Node simpleNegate( Node n );
-  /** is the kind k a negation kind? 
-   * 
+  /** is the kind k a negation kind?
+   *
    * A kind k is a negation kind if <k>( <k>( n ) ) = n.
    */
-  static bool isNegate( Kind k );
+  static bool isNegate(Kind k);
   /**
    * Make negated term, returns the negation of n wrt Kind notk, eliminating
    * double negation if applicable, e.g. mkNegate( ~, ~x ) ---> x.

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -291,6 +291,8 @@ public:
   static int getTermDepth( Node n );
   /** simple negate */
   static Node simpleNegate( Node n );
+  /** is negate? */
+  static bool isNegate( Kind k );
   /**
    * Make negated term, returns the negation of n wrt Kind notk, eliminating
    * double negation if applicable, e.g. mkNegate( ~, ~x ) ---> x.


### PR DESCRIPTION
- Makes inferSubstitution allow substitutions of the form x -> ~y
- Improves heuristic for equality chain normalization so that it prefers negating non-variable children.
- Fixes a corner case where children of AC operators were not being sorted.

This gives us 0% redundancy on crci size 4, and further improves:
24.2 % -> 5.3% redundancy for size 5 crci
58.5 % -> 44.8% redundancy for size 6 crci
81.2 % -> 73.8% redundancy for size 7 crci