### PR TITLE
Option to interleave tangent plane inferences

### DIFF
--- a/src/options/arith_options.toml
+++ b/src/options/arith_options.toml
@@ -451,6 +451,14 @@ header = "options/arith_options.h"
   help       = "use non-terminating tangent plane strategy for non-linear"
 
 [[option]]
+  name       = "nlExtTangentPlanesInterleave"
+  category   = "regular"
+  long       = "nl-ext-tplanes-interleave"
+  type       = "bool"
+  default    = "false"
+  help       = "interleave tangent plane strategy for non-linear"
+
+[[option]]
   name       = "nlExtTfTangentPlanes"
   category   = "regular"
   long       = "nl-ext-tf-tplanes"

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1730,7 +1730,8 @@ void SmtEngine::setDefaults() {
   {
     if (!options::nlExtTangentPlanesInterleave.wasSetByUser())
     {
-      options::nlExtTangentPlanesInterleave.sert(true);
+      Trace("smt") << "setting nlExtTangentPlanesInterleave to true" << endl;
+      options::nlExtTangentPlanesInterleave.set(true);
     }
   }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1726,8 +1726,9 @@ void SmtEngine::setDefaults() {
   if (options::arithRewriteEq()) {
     d_earlyTheoryPP = false;
   }
-  if(d_logic.isPure(THEORY_ARITH) && !d_logic.areRealsUsed()) {
-    if( !options::nlExtTangentPlanesInterleave.wasSetByUser() )
+  if (d_logic.isPure(THEORY_ARITH) && !d_logic.areRealsUsed())
+  {
+    if (!options::nlExtTangentPlanesInterleave.wasSetByUser())
     {
       options::nlExtTangentPlanesInterleave.sert(true);
     }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1726,6 +1726,12 @@ void SmtEngine::setDefaults() {
   if (options::arithRewriteEq()) {
     d_earlyTheoryPP = false;
   }
+  if(d_logic.isPure(THEORY_ARITH) && !d_logic.areRealsUsed()) {
+    if( !options::nlExtTangentPlanesInterleave.wasSetByUser() )
+    {
+      options::nlExtTangentPlanesInterleave.sert(true);
+    }
+  }
 
   // Set decision mode based on logic (if not set by user)
   if(!options::decisionMode.wasSetByUser()) {

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1401,13 +1401,13 @@ int NonlinearExtension::checkLastCall(const std::vector<Node>& assertions,
   // nt_lemmas.size() << std::endl;  prioritize lemmas that do not
   // introduce new monomials
   lemmas_proc = flushLemmas(lemmas);
-  
+
   if (options::nlExtTangentPlanes() && options::nlExtTangentPlanesInterleave())
   {
     lemmas = checkTangentPlanes();
-    lemmas_proc += flushLemmas(lemmas);    
+    lemmas_proc += flushLemmas(lemmas);
   }
-  
+
   if (lemmas_proc > 0) {
     Trace("nl-ext") << "  ...finished with " << lemmas_proc << " new lemmas."
                     << std::endl;

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1401,6 +1401,13 @@ int NonlinearExtension::checkLastCall(const std::vector<Node>& assertions,
   // nt_lemmas.size() << std::endl;  prioritize lemmas that do not
   // introduce new monomials
   lemmas_proc = flushLemmas(lemmas);
+  
+  if (options::nlExtTangentPlanes() && options::nlExtTangentPlanesInterleave())
+  {
+    lemmas = checkTangentPlanes();
+    lemmas_proc += flushLemmas(lemmas);    
+  }
+  
   if (lemmas_proc > 0) {
     Trace("nl-ext") << "  ...finished with " << lemmas_proc << " new lemmas."
                     << std::endl;
@@ -1438,7 +1445,7 @@ int NonlinearExtension::checkLastCall(const std::vector<Node>& assertions,
   }
   
   //------------------------------------tangent planes
-  if (options::nlExtTangentPlanes())
+  if (options::nlExtTangentPlanes() && !options::nlExtTangentPlanesInterleave())
   {
     lemmas = checkTangentPlanes();
     d_waiting_lemmas.insert(


### PR DESCRIPTION
Significant improvement on QF_NIA (https://www.starexec.org/starexec/secure/details/job.jsp?id=27815), where --nl-ext-tplanes-interleave is +1397-417 = net gain +980 over 23876 benchmarks.