### PR TITLE
Refactor sep-pre-skolem-emp preprocessing pass

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -90,8 +90,8 @@ libcvc4_la_SOURCES = \
 	preprocessing/passes/static_learning.h \
 	preprocessing/passes/symmetry_breaker.cpp \
 	preprocessing/passes/symmetry_breaker.h \
-	preprocessing/passes/sep_skolem_emp.cpp \ 
-	preprocessing/passes/sep_skolem_emp.h \ 
+	preprocessing/passes/sep_skolem_emp.cpp \
+	preprocessing/passes/sep_skolem_emp.h \
 	preprocessing/passes/symmetry_detect.cpp \
 	preprocessing/passes/symmetry_detect.h \
 	preprocessing/passes/synth_rew_rules.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -90,6 +90,8 @@ libcvc4_la_SOURCES = \
 	preprocessing/passes/static_learning.h \
 	preprocessing/passes/symmetry_breaker.cpp \
 	preprocessing/passes/symmetry_breaker.h \
+	preprocessing/passes/sep_skolem_emp.cpp \ 
+	preprocessing/passes/sep_skolem_emp.h \ 
 	preprocessing/passes/symmetry_detect.cpp \
 	preprocessing/passes/symmetry_detect.h \
 	preprocessing/passes/synth_rew_rules.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,12 +86,12 @@ libcvc4_la_SOURCES = \
 	preprocessing/passes/real_to_int.h \
 	preprocessing/passes/rewrite.cpp \
 	preprocessing/passes/rewrite.h \
+	preprocessing/passes/sep_skolem_emp.cpp \
+	preprocessing/passes/sep_skolem_emp.h \
 	preprocessing/passes/static_learning.cpp \
 	preprocessing/passes/static_learning.h \
 	preprocessing/passes/symmetry_breaker.cpp \
 	preprocessing/passes/symmetry_breaker.h \
-	preprocessing/passes/sep_skolem_emp.cpp \
-	preprocessing/passes/sep_skolem_emp.h \
 	preprocessing/passes/symmetry_detect.cpp \
 	preprocessing/passes/symmetry_detect.h \
 	preprocessing/passes/synth_rew_rules.cpp \

--- a/src/preprocessing/passes/sep_skolem_emp.cpp
+++ b/src/preprocessing/passes/sep_skolem_emp.cpp
@@ -20,9 +20,9 @@
 #include <vector>
 
 #include "expr/node.h"
+#include "theory/quantifiers/quant_util.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
-#include "theory/quantifiers/quant_util.h"
 namespace CVC4 {
 namespace preprocessing {
 namespace passes {
@@ -31,49 +31,66 @@ using namespace CVC4::theory;
 
 namespace {
 
-static Node preSkolemEmp( Node n, bool pol, std::map< bool, std::map< Node, Node > >& visited ) {
-          std::map< Node, Node >::iterator it = visited[pol].find( n );
-            if( it==visited[pol].end() ){
-                        Trace("sep-preprocess") << "Pre-skolem emp " << n << " with pol " << pol << std::endl;
-                            Node ret = n;
-                                if( n.getKind()==kind::SEP_EMP ){
-                                              if( !pol ){
-                                                              TypeNode tnx = n[0].getType();
-                                                                      TypeNode tny = n[1].getType();
-                                                                              Node x = NodeManager::currentNM()->mkSkolem( "ex", tnx, "skolem location for negated emp" );
-                                                                                      Node y = NodeManager::currentNM()->mkSkolem( "ey", tny, "skolem data for negated emp" );
-                                                                                              return NodeManager::currentNM()->mkNode( kind::SEP_STAR, 
-                                                                                                                               NodeManager::currentNM()->mkNode( kind::SEP_PTO, x, y ),
-                                                                                                                                                NodeManager::currentNM()->mkConst( true ) ).negate();
-                                                                                                    }
-                                                  }else if( n.getKind()!=kind::FORALL && n.getNumChildren()>0 ){
-                                                                std::vector< Node > children;
-                                                                      bool childChanged = false;
-                                                                            if( n.getMetaKind() == kind::metakind::PARAMETERIZED ){
-                                                                                            children.push_back( n.getOperator() );
-                                                                                                  }
-                                                                                  for( unsigned i=0; i<n.getNumChildren(); i++ ){
-                                                                                                  bool newPol, newHasPol;
-                                                                                                          QuantPhaseReq::getPolarity( n, i, true, pol, newHasPol, newPol );
-                                                                                                                  Node nc = n[i];
-                                                                                                                          if( newHasPol ){
-                                                                                                                                            nc = preSkolemEmp( n[i], newPol, visited );
-                                                                                                                                                      childChanged = childChanged || nc!=n[i];
-                                                                                                                                                              }
-                                                                                                                                  children.push_back( nc );
-                                                                                                                                        }
-                                                                                        if( childChanged ){
-                                                                                                        return NodeManager::currentNM()->mkNode( n.getKind(), children );
-                                                                                                              }
-                                                                                            }
-                                    visited[pol][n] = ret;
-                                        return n;
-                                          }else{
-                                                      return it->second;
-                                                        }
+static Node preSkolemEmp(Node n,
+                         bool pol,
+                         std::map<bool, std::map<Node, Node>>& visited)
+{
+  std::map<Node, Node>::iterator it = visited[pol].find(n);
+  if (it == visited[pol].end())
+  {
+    Trace("sep-preprocess") << "Pre-skolem emp " << n << " with pol " << pol
+                            << std::endl;
+    Node ret = n;
+    if (n.getKind() == kind::SEP_EMP)
+    {
+      if (!pol)
+      {
+        TypeNode tnx = n[0].getType();
+        TypeNode tny = n[1].getType();
+        Node x = NodeManager::currentNM()->mkSkolem(
+            "ex", tnx, "skolem location for negated emp");
+        Node y = NodeManager::currentNM()->mkSkolem(
+            "ey", tny, "skolem data for negated emp");
+        return NodeManager::currentNM()
+            ->mkNode(kind::SEP_STAR,
+                     NodeManager::currentNM()->mkNode(kind::SEP_PTO, x, y),
+                     NodeManager::currentNM()->mkConst(true))
+            .negate();
+      }
+    }
+    else if (n.getKind() != kind::FORALL && n.getNumChildren() > 0)
+    {
+      std::vector<Node> children;
+      bool childChanged = false;
+      if (n.getMetaKind() == kind::metakind::PARAMETERIZED)
+      {
+        children.push_back(n.getOperator());
+      }
+      for (unsigned i = 0; i < n.getNumChildren(); i++)
+      {
+        bool newPol, newHasPol;
+        QuantPhaseReq::getPolarity(n, i, true, pol, newHasPol, newPol);
+        Node nc = n[i];
+        if (newHasPol)
+        {
+          nc = preSkolemEmp(n[i], newPol, visited);
+          childChanged = childChanged || nc != n[i];
+        }
+        children.push_back(nc);
+      }
+      if (childChanged)
+      {
+        return NodeManager::currentNM()->mkNode(n.getKind(), children);
+      }
+    }
+    visited[pol][n] = ret;
+    return n;
+  }
+  else
+  {
+    return it->second;
+  }
 }
-
-
 
 }  // namespace
 
@@ -85,15 +102,17 @@ PreprocessingPassResult SepSkolemEmp::applyInternal(
 {
   for (unsigned i = 0; i < assertionsToPreprocess->size(); ++i)
   {
-       Node prev = (*assertionsToPreprocess)[i];
-       bool pol = true;
-       std::map<bool, std::map<Node,Node>> visited;
-       Node next = preSkolemEmp(prev, pol, visited); 
-       if( next!=prev ){
-          assertionsToPreprocess->replace(i, Rewriter::rewrite(next));
-          Trace("sep-preprocess") << "*** Preprocess sep " << prev << endl;
-          Trace("sep-preprocess") << "   ...got " << (*assertionsToPreprocess)[i] << endl;
-       }
+    Node prev = (*assertionsToPreprocess)[i];
+    bool pol = true;
+    std::map<bool, std::map<Node, Node>> visited;
+    Node next = preSkolemEmp(prev, pol, visited);
+    if (next != prev)
+    {
+      assertionsToPreprocess->replace(i, Rewriter::rewrite(next));
+      Trace("sep-preprocess") << "*** Preprocess sep " << prev << endl;
+      Trace("sep-preprocess") << "   ...got " << (*assertionsToPreprocess)[i]
+                              << endl;
+    }
   }
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/preprocessing/passes/sep_skolem_emp.cpp
+++ b/src/preprocessing/passes/sep_skolem_emp.cpp
@@ -2,7 +2,7 @@
 /*! \file sep_skolem_emp.cpp
  ** \verbatim
  ** Top contributors (to current version):
- **   Andrew Reynolds, Mathias Preiner
+ **   Andrew Reynolds, Mathias Preiner, Yoni Zohar
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -23,6 +23,7 @@
 #include "theory/quantifiers/quant_util.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
+
 namespace CVC4 {
 namespace preprocessing {
 namespace passes {
@@ -31,7 +32,7 @@ using namespace CVC4::theory;
 
 namespace {
 
-static Node preSkolemEmp(Node n,
+Node preSkolemEmp(Node n,
                          bool pol,
                          std::map<bool, std::map<Node, Node>>& visited)
 {
@@ -100,11 +101,11 @@ SepSkolemEmp::SepSkolemEmp(PreprocessingPassContext* preprocContext)
 PreprocessingPassResult SepSkolemEmp::applyInternal(
     AssertionPipeline* assertionsToPreprocess)
 {
+  std::map<bool, std::map<Node, Node>> visited;
   for (unsigned i = 0; i < assertionsToPreprocess->size(); ++i)
   {
     Node prev = (*assertionsToPreprocess)[i];
     bool pol = true;
-    std::map<bool, std::map<Node, Node>> visited;
     Node next = preSkolemEmp(prev, pol, visited);
     if (next != prev)
     {
@@ -113,6 +114,7 @@ PreprocessingPassResult SepSkolemEmp::applyInternal(
       Trace("sep-preprocess") << "   ...got " << (*assertionsToPreprocess)[i]
                               << endl;
     }
+    visited.clear();
   }
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/preprocessing/passes/sep_skolem_emp.cpp
+++ b/src/preprocessing/passes/sep_skolem_emp.cpp
@@ -1,0 +1,103 @@
+/**********************/
+/*! \file sep_skolem_emp.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds, Mathias Preiner
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The sep-pre-skolem-emp preprocessing pass
+ **
+ **/
+
+#include "preprocessing/passes/sep_skolem_emp.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "expr/node.h"
+#include "theory/rewriter.h"
+#include "theory/theory.h"
+#include "theory/quantifiers/quant_util.h"
+namespace CVC4 {
+namespace preprocessing {
+namespace passes {
+
+using namespace CVC4::theory;
+
+namespace {
+
+static Node preSkolemEmp( Node n, bool pol, std::map< bool, std::map< Node, Node > >& visited ) {
+          std::map< Node, Node >::iterator it = visited[pol].find( n );
+            if( it==visited[pol].end() ){
+                        Trace("sep-preprocess") << "Pre-skolem emp " << n << " with pol " << pol << std::endl;
+                            Node ret = n;
+                                if( n.getKind()==kind::SEP_EMP ){
+                                              if( !pol ){
+                                                              TypeNode tnx = n[0].getType();
+                                                                      TypeNode tny = n[1].getType();
+                                                                              Node x = NodeManager::currentNM()->mkSkolem( "ex", tnx, "skolem location for negated emp" );
+                                                                                      Node y = NodeManager::currentNM()->mkSkolem( "ey", tny, "skolem data for negated emp" );
+                                                                                              return NodeManager::currentNM()->mkNode( kind::SEP_STAR, 
+                                                                                                                               NodeManager::currentNM()->mkNode( kind::SEP_PTO, x, y ),
+                                                                                                                                                NodeManager::currentNM()->mkConst( true ) ).negate();
+                                                                                                    }
+                                                  }else if( n.getKind()!=kind::FORALL && n.getNumChildren()>0 ){
+                                                                std::vector< Node > children;
+                                                                      bool childChanged = false;
+                                                                            if( n.getMetaKind() == kind::metakind::PARAMETERIZED ){
+                                                                                            children.push_back( n.getOperator() );
+                                                                                                  }
+                                                                                  for( unsigned i=0; i<n.getNumChildren(); i++ ){
+                                                                                                  bool newPol, newHasPol;
+                                                                                                          QuantPhaseReq::getPolarity( n, i, true, pol, newHasPol, newPol );
+                                                                                                                  Node nc = n[i];
+                                                                                                                          if( newHasPol ){
+                                                                                                                                            nc = preSkolemEmp( n[i], newPol, visited );
+                                                                                                                                                      childChanged = childChanged || nc!=n[i];
+                                                                                                                                                              }
+                                                                                                                                  children.push_back( nc );
+                                                                                                                                        }
+                                                                                        if( childChanged ){
+                                                                                                        return NodeManager::currentNM()->mkNode( n.getKind(), children );
+                                                                                                              }
+                                                                                            }
+                                    visited[pol][n] = ret;
+                                        return n;
+                                          }else{
+                                                      return it->second;
+                                                        }
+}
+
+
+
+}  // namespace
+
+SepSkolemEmp::SepSkolemEmp(PreprocessingPassContext* preprocContext)
+    : PreprocessingPass(preprocContext, "sep-skolem-emp"){};
+
+PreprocessingPassResult SepSkolemEmp::applyInternal(
+    AssertionPipeline* assertionsToPreprocess)
+{
+  for (unsigned i = 0; i < assertionsToPreprocess->size(); ++i)
+  {
+       Node prev = (*assertionsToPreprocess)[i];
+       bool pol = true;
+       std::map<bool, std::map<Node,Node>> visited;
+       Node next = preSkolemEmp(prev, pol, visited); 
+       if( next!=prev ){
+          assertionsToPreprocess->replace(i, Rewriter::rewrite(next));
+          Trace("sep-preprocess") << "*** Preprocess sep " << prev << endl;
+          Trace("sep-preprocess") << "   ...got " << (*assertionsToPreprocess)[i] << endl;
+       }
+  }
+  return PreprocessingPassResult::NO_CONFLICT;
+}
+
+}  // namespace passes
+}  // namespace preprocessing
+}  // namespace CVC4

--- a/src/preprocessing/passes/sep_skolem_emp.h
+++ b/src/preprocessing/passes/sep_skolem_emp.h
@@ -2,7 +2,7 @@
 /*! \file sep_skolem_emp.h
  ** \verbatim
  ** Top contributors (to current version):
- ** Andrew Reynolds, Mathias Preiner
+ ** Andrew Reynolds, Mathias Preiner, Yoni Zohar
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/preprocessing/passes/sep_skolem_emp.h
+++ b/src/preprocessing/passes/sep_skolem_emp.h
@@ -39,4 +39,4 @@ class SepSkolemEmp : public PreprocessingPass
 }  // namespace preprocessing
 }  // namespace CVC4
 
-#endif /* __CVC4__PREPROCESSING__PASSES__SEP_SKOLEM_EMP_H *
+#endif /* __CVC4__PREPROCESSING__PASSES__SEP_SKOLEM_EMP_H */

--- a/src/preprocessing/passes/sep_skolem_emp.h
+++ b/src/preprocessing/passes/sep_skolem_emp.h
@@ -1,0 +1,42 @@
+/*********************                                                        */
+/*! \file sep_skolem_emp.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ ** Andrew Reynolds, Mathias Preiner
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The sep-pre-skolem-emp eprocessing pass
+ **
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef __CVC4__PREPROCESSING__PASSES__SEP_SKOLEM_EMP_H
+#define __CVC4__PREPROCESSING__PASSES__SEP_SKOLEM_EMP_H
+
+#include "preprocessing/preprocessing_pass.h"
+#include "preprocessing/preprocessing_pass_context.h"
+
+namespace CVC4 {
+namespace preprocessing {
+namespace passes {
+
+class SepSkolemEmp : public PreprocessingPass
+{
+ public:
+  SepSkolemEmp(PreprocessingPassContext* preprocContext);
+
+ protected:
+  PreprocessingPassResult applyInternal(
+      AssertionPipeline* assertionsToPreprocess) override;
+};
+
+}  // namespace passes
+}  // namespace preprocessing
+}  // namespace CVC4
+
+#endif /* __CVC4__PREPROCESSING__PASSES__INT_TO_BV_H */

--- a/src/preprocessing/passes/sep_skolem_emp.h
+++ b/src/preprocessing/passes/sep_skolem_emp.h
@@ -39,4 +39,4 @@ class SepSkolemEmp : public PreprocessingPass
 }  // namespace preprocessing
 }  // namespace CVC4
 
-#endif /* __CVC4__PREPROCESSING__PASSES__INT_TO_BV_H */
+#endif /* __CVC4__PREPROCESSING__PASSES__SEP_SKOLEM_EMP_H *

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2712,6 +2712,8 @@ void SmtEnginePrivate::finishInit()
       new BvIntroPow2(d_preprocessingPassContext.get()));
   std::unique_ptr<BVToBool> bvToBool(
       new BVToBool(d_preprocessingPassContext.get()));
+  std::unique_ptr<BVGauss> bvGauss(
+      new BVGauss(d_preprocessingPassContext.get()));
   std::unique_ptr<IntToBV> intToBV(
       new IntToBV(d_preprocessingPassContext.get()));
   std::unique_ptr<PseudoBooleanProcessor> pbProc(
@@ -2735,6 +2737,10 @@ void SmtEnginePrivate::finishInit()
                                            std::move(bvAckermann));
   std::unique_ptr<SepSkolemEmp> sepSkolemEmp(
       new SepSkolemEmp(d_preprocessingPassContext.get()));
+  std::unique_ptr<BVToBool> bvToBool(
+      new BVToBool(d_preprocessingPassContext.get()));
+  std::unique_ptr<BoolToBV> boolToBv(
+      new BoolToBV(d_preprocessingPassContext.get()));
   d_preprocessingPassRegistry.registerPass("bv-gauss", std::move(bvGauss));
   d_preprocessingPassRegistry.registerPass("bv-intro-pow2",
                                            std::move(bvIntroPow2));
@@ -2752,11 +2758,7 @@ void SmtEnginePrivate::finishInit()
   d_preprocessingPassRegistry.registerPass("sep-skolem-emp", std::move(sepSkolemEmp));
   d_preprocessingPassRegistry.registerPass("sep-skolem-emp",
                                            std::move(sepSkolemEmp));
-  std::unique_ptr<BVToBool> bvToBool(
-      new BVToBool(d_preprocessingPassContext.get()));
   d_preprocessingPassRegistry.registerPass("bv-to-bool", std::move(bvToBool));
-  std::unique_ptr<BoolToBV> boolToBv(
-      new BoolToBV(d_preprocessingPassContext.get()));
   d_preprocessingPassRegistry.registerPass("bool-to-bv", std::move(boolToBv));
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2750,6 +2750,8 @@ void SmtEnginePrivate::finishInit()
   d_preprocessingPassRegistry.registerPass("synth-rr", std::move(srrProc));
                                            std::move(pbProc)); 
   d_preprocessingPassRegistry.registerPass("sep-skolem-emp", std::move(sepSkolemEmp));
+  d_preprocessingPassRegistry.registerPass("sep-skolem-emp",
+                                           std::move(sepSkolemEmp));
   std::unique_ptr<BVToBool> bvToBool(
       new BVToBool(d_preprocessingPassContext.get()));
   d_preprocessingPassRegistry.registerPass("bv-to-bool", std::move(bvToBool));
@@ -4235,8 +4237,8 @@ void SmtEnginePrivate::processAssertions() {
     Trace("smt") << "POST boolToBv" << endl;
   }
   if(options::sepPreSkolemEmp()) {
-      d_preprocessingPassRegistry.getPass("sep-skolem-emp")->apply(&d_assertions);
-      Trace("smt") << "POST sepPreSkolemEmp" << endl;
+    d_preprocessingPassRegistry.getPass("sep-skolem-emp")->apply(&d_assertions);
+    Trace("smt") << "POST sepPreSkolemEmp" << endl;
   }
 
   if( d_smt.d_logic.isQuantified() ){

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -79,9 +79,9 @@
 #include "preprocessing/passes/pseudo_boolean_processor.h"
 #include "preprocessing/passes/real_to_int.h"
 #include "preprocessing/passes/rewrite.h"
+#include "preprocessing/passes/sep_skolem_emp.h"
 #include "preprocessing/passes/static_learning.h"
 #include "preprocessing/passes/symmetry_breaker.h"
-#include "preprocessing/passes/sep_skolem_emp.h"
 #include "preprocessing/passes/symmetry_detect.h"
 #include "preprocessing/passes/synth_rew_rules.h"
 #include "preprocessing/preprocessing_pass.h"
@@ -2712,8 +2712,6 @@ void SmtEnginePrivate::finishInit()
       new BvIntroPow2(d_preprocessingPassContext.get()));
   std::unique_ptr<BVToBool> bvToBool(
       new BVToBool(d_preprocessingPassContext.get()));
-  std::unique_ptr<BVGauss> bvGauss(
-      new BVGauss(d_preprocessingPassContext.get()));
   std::unique_ptr<IntToBV> intToBV(
       new IntToBV(d_preprocessingPassContext.get()));
   std::unique_ptr<PseudoBooleanProcessor> pbProc(
@@ -2728,19 +2726,15 @@ void SmtEnginePrivate::finishInit()
       new SymBreakerPass(d_preprocessingPassContext.get()));
   std::unique_ptr<SynthRewRulesPass> srrProc(
       new SynthRewRulesPass(d_preprocessingPassContext.get()));
-  d_preprocessingPassRegistry.registerPass("apply-substs",
+ std::unique_ptr<SepSkolemEmp> sepSkolemEmp(
+      new SepSkolemEmp(d_preprocessingPassContext.get()));
+   d_preprocessingPassRegistry.registerPass("apply-substs",
                                            std::move(applySubsts));
   d_preprocessingPassRegistry.registerPass("bool-to-bv", std::move(boolToBv));
   d_preprocessingPassRegistry.registerPass("bv-abstraction",
                                            std::move(bvAbstract));
   d_preprocessingPassRegistry.registerPass("bv-ackermann",
                                            std::move(bvAckermann));
-  std::unique_ptr<SepSkolemEmp> sepSkolemEmp(
-      new SepSkolemEmp(d_preprocessingPassContext.get()));
-  std::unique_ptr<BVToBool> bvToBool(
-      new BVToBool(d_preprocessingPassContext.get()));
-  std::unique_ptr<BoolToBV> boolToBv(
-      new BoolToBV(d_preprocessingPassContext.get()));
   d_preprocessingPassRegistry.registerPass("bv-gauss", std::move(bvGauss));
   d_preprocessingPassRegistry.registerPass("bv-intro-pow2",
                                            std::move(bvIntroPow2));
@@ -2750,16 +2744,12 @@ void SmtEnginePrivate::finishInit()
                                            std::move(pbProc));
   d_preprocessingPassRegistry.registerPass("real-to-int", std::move(realToInt));
   d_preprocessingPassRegistry.registerPass("rewrite", std::move(rewrite));
+  d_preprocessingPassRegistry.registerPass("sep-skolem-emp",
+                                           std::move(sepSkolemEmp));
   d_preprocessingPassRegistry.registerPass("static-learning", 
                                            std::move(staticLearning));
   d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
   d_preprocessingPassRegistry.registerPass("synth-rr", std::move(srrProc));
-                                           std::move(pbProc)); 
-  d_preprocessingPassRegistry.registerPass("sep-skolem-emp", std::move(sepSkolemEmp));
-  d_preprocessingPassRegistry.registerPass("sep-skolem-emp",
-                                           std::move(sepSkolemEmp));
-  d_preprocessingPassRegistry.registerPass("bv-to-bool", std::move(bvToBool));
-  d_preprocessingPassRegistry.registerPass("bool-to-bv", std::move(boolToBv));
 }
 
 Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, NodeHashFunction>& cache, bool expandOnly)

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4240,7 +4240,6 @@ void SmtEnginePrivate::processAssertions() {
   }
   if(options::sepPreSkolemEmp()) {
     d_preprocessingPassRegistry.getPass("sep-skolem-emp")->apply(&d_assertions);
-    Trace("smt") << "POST sepPreSkolemEmp" << endl;
   }
 
   if( d_smt.d_logic.isQuantified() ){

--- a/src/theory/sep/theory_sep_rewriter.cpp
+++ b/src/theory/sep/theory_sep_rewriter.cpp
@@ -161,58 +161,6 @@ RewriteResponse TheorySepRewriter::postRewrite(TNode node) {
   return RewriteResponse(node==retNode ? REWRITE_DONE : REWRITE_AGAIN_FULL, retNode);
 }
 
-Node TheorySepRewriter::preSkolemEmp( Node n, bool pol, std::map< bool, std::map< Node, Node > >& visited ) {
-  std::map< Node, Node >::iterator it = visited[pol].find( n );
-  if( it==visited[pol].end() ){
-    Trace("sep-preprocess") << "Pre-skolem emp " << n << " with pol " << pol << std::endl;
-    Node ret = n;
-    if( n.getKind()==kind::SEP_EMP ){
-      if( !pol ){
-        TypeNode tnx = n[0].getType();
-        TypeNode tny = n[1].getType();
-        Node x = NodeManager::currentNM()->mkSkolem( "ex", tnx, "skolem location for negated emp" );
-        Node y = NodeManager::currentNM()->mkSkolem( "ey", tny, "skolem data for negated emp" );
-        return NodeManager::currentNM()->mkNode( kind::SEP_STAR, 
-                 NodeManager::currentNM()->mkNode( kind::SEP_PTO, x, y ),
-                 NodeManager::currentNM()->mkConst( true ) ).negate();
-      }
-    }else if( n.getKind()!=kind::FORALL && n.getNumChildren()>0 ){
-      std::vector< Node > children;
-      bool childChanged = false;
-      if( n.getMetaKind() == kind::metakind::PARAMETERIZED ){
-        children.push_back( n.getOperator() );
-      }
-      for( unsigned i=0; i<n.getNumChildren(); i++ ){
-        bool newPol, newHasPol;
-        QuantPhaseReq::getPolarity( n, i, true, pol, newHasPol, newPol );
-        Node nc = n[i];
-        if( newHasPol ){
-          nc = preSkolemEmp( n[i], newPol, visited );
-          childChanged = childChanged || nc!=n[i];
-        }
-        children.push_back( nc );
-      }
-      if( childChanged ){
-        return NodeManager::currentNM()->mkNode( n.getKind(), children );
-      }
-    }
-    visited[pol][n] = ret;
-    return n;
-  }else{
-    return it->second;
-  }
-}
-
-Node TheorySepRewriter::preprocess( Node n ) {
-  if( options::sepPreSkolemEmp() ){
-    bool pol = true;
-    std::map< bool, std::map< Node, Node > > visited;
-    n = preSkolemEmp( n, pol, visited );
-  }
-  return n;
-}
-
-
 }/* CVC4::theory::sep namespace */
 }/* CVC4::theory namespace */
 }/* CVC4 namespace */

--- a/src/theory/sep/theory_sep_rewriter.h
+++ b/src/theory/sep/theory_sep_rewriter.h
@@ -43,10 +43,6 @@ public:
 
   static inline void init() {}
   static inline void shutdown() {}
-private:
-  static Node preSkolemEmp( Node n, bool pol, std::map< bool, std::map< Node, Node > >& visited );
-public:
-  static Node preprocess( Node n );
 };/* class TheorySepRewriter */
 
 }/* CVC4::theory::sep namespace */

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -720,6 +720,7 @@ REG0_TESTS = \
 	regress0/sep/sep-01.smt2 \
 	regress0/sep/sep-plus1.smt2 \
 	regress0/sep/sep-simp-unsat-emp.smt2 \
+	regress0/sep/skolem_emp.smt2 \
 	regress0/sep/trees-1.smt2 \
 	regress0/sep/wand-crash.smt2 \
 	regress0/sets/abt-min.smt2 \

--- a/test/regress/regress0/sep/skolem_emp.smt2
+++ b/test/regress/regress0/sep/skolem_emp.smt2
@@ -1,0 +1,5 @@
+; COMMAND-LINE: --no-check-models --sep-pre-skolem-emp
+; EXPECT: sat
+(set-logic QF_ALL_SUPPORTED)
+(assert (not (emp 0 0)))
+(check-sat)


### PR DESCRIPTION
This refactoring included moving `preSkolemEmp` from `src/theory/sep/theory_sep_rewriter.{h,cpp}` into `src/preprocessing/passes/sep_skolem_emp.{h,cpp}`, and also.
 deleting `preprocess` from `src/theory/sep/theory_sep_rewriter.{h,cpp}`.