### PR TITLE
Refactor static learning preprocessing pass

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -80,6 +80,8 @@ libcvc4_la_SOURCES = \
 	preprocessing/passes/bv_to_bool.h \
 	preprocessing/passes/real_to_int.cpp \
 	preprocessing/passes/real_to_int.h \
+	preprocessing/passes/static_learning.cpp \
+	preprocessing/passes/static_learning.h \
 	preprocessing/passes/symmetry_breaker.cpp \
 	preprocessing/passes/symmetry_breaker.h \
 	preprocessing/passes/symmetry_detect.cpp \

--- a/src/preprocessing/passes/static_learning.cpp
+++ b/src/preprocessing/passes/static_learning.cpp
@@ -16,19 +16,12 @@
 #include "preprocessing/passes/static_learning.h"
 
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 #include "expr/node.h"
-#include "preprocessing/passes/static_learning.h"
-#include "theory/rewriter.h"
-#include "theory/theory.h"
 
 namespace CVC4 {
 namespace preprocessing {
 namespace passes {
-
-using namespace CVC4::theory;
 
 StaticLearning::StaticLearning(PreprocessingPassContext* preprocContext)
     : PreprocessingPass(preprocContext, "static-learning"){};

--- a/src/preprocessing/passes/static_learning.cpp
+++ b/src/preprocessing/passes/static_learning.cpp
@@ -1,0 +1,58 @@
+/*********************                                                        */
+/*! \file static_learning.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Yoni Zohar
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The static learning preprocessing pass
+ **
+ **/
+
+#include "preprocessing/passes/static_learning.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "expr/node.h"
+#include "theory/rewriter.h"
+#include "theory/theory.h"
+#include "preprocessing/passes/static_learning.h"
+
+namespace CVC4 {
+namespace preprocessing {
+namespace passes {
+
+using namespace CVC4::theory;
+
+
+StaticLearning::StaticLearning(PreprocessingPassContext* preprocContext)
+    : PreprocessingPass(preprocContext, "static-learning"){};
+
+PreprocessingPassResult StaticLearning::applyInternal(
+    AssertionPipeline* assertionsToPreprocess)
+{
+          NodeManager::currentResourceManager()->spendResource(
+                options::preprocessStep());
+
+                  for (unsigned i = 0; i < assertionsToPreprocess->size(); ++ i) {
+                              NodeBuilder<> learned(kind::AND);
+                                  learned << (*assertionsToPreprocess)[i];
+                                      d_preprocContext->getTheoryEngine()->ppStaticLearn((*assertionsToPreprocess)[i], learned);
+                                          if(learned.getNumChildren() == 1) {
+                                                        learned.clear();
+                                                            } else {
+                                                                          assertionsToPreprocess->replace(i, learned);
+                                                            }
+                  }
+  return PreprocessingPassResult::NO_CONFLICT;
+}
+
+}  // namespace passes
+}  // namespace preprocessing
+}  // namespace CVC4

--- a/src/preprocessing/passes/static_learning.cpp
+++ b/src/preprocessing/passes/static_learning.cpp
@@ -20,9 +20,9 @@
 #include <vector>
 
 #include "expr/node.h"
+#include "preprocessing/passes/static_learning.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
-#include "preprocessing/passes/static_learning.h"
 
 namespace CVC4 {
 namespace preprocessing {
@@ -30,26 +30,30 @@ namespace passes {
 
 using namespace CVC4::theory;
 
-
 StaticLearning::StaticLearning(PreprocessingPassContext* preprocContext)
     : PreprocessingPass(preprocContext, "static-learning"){};
 
 PreprocessingPassResult StaticLearning::applyInternal(
     AssertionPipeline* assertionsToPreprocess)
 {
-          NodeManager::currentResourceManager()->spendResource(
-                options::preprocessStep());
+  NodeManager::currentResourceManager()->spendResource(
+      options::preprocessStep());
 
-                  for (unsigned i = 0; i < assertionsToPreprocess->size(); ++ i) {
-                              NodeBuilder<> learned(kind::AND);
-                                  learned << (*assertionsToPreprocess)[i];
-                                      d_preprocContext->getTheoryEngine()->ppStaticLearn((*assertionsToPreprocess)[i], learned);
-                                          if(learned.getNumChildren() == 1) {
-                                                        learned.clear();
-                                                            } else {
-                                                                          assertionsToPreprocess->replace(i, learned);
-                                                            }
-                  }
+  for (unsigned i = 0; i < assertionsToPreprocess->size(); ++i)
+  {
+    NodeBuilder<> learned(kind::AND);
+    learned << (*assertionsToPreprocess)[i];
+    d_preprocContext->getTheoryEngine()->ppStaticLearn(
+        (*assertionsToPreprocess)[i], learned);
+    if (learned.getNumChildren() == 1)
+    {
+      learned.clear();
+    }
+    else
+    {
+      assertionsToPreprocess->replace(i, learned);
+    }
+  }
   return PreprocessingPassResult::NO_CONFLICT;
 }
 

--- a/src/preprocessing/passes/static_learning.h
+++ b/src/preprocessing/passes/static_learning.h
@@ -1,0 +1,42 @@
+/*********************                                                        */
+/*! \file static_learning.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Yoni Zohar
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The static learning preprocessing pass
+ **
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef __CVC4__PREPROCESSING__PASSES__STATIC_LEARNING_H
+#define __CVC4__PREPROCESSING__PASSES__STATIC_LEARNING_H
+
+#include "preprocessing/preprocessing_pass.h"
+#include "preprocessing/preprocessing_pass_context.h"
+
+namespace CVC4 {
+namespace preprocessing {
+namespace passes {
+
+class StaticLearning : public PreprocessingPass
+{
+ public:
+  StaticLearning(PreprocessingPassContext* preprocContext);
+
+ protected:
+  PreprocessingPassResult applyInternal(
+      AssertionPipeline* assertionsToPreprocess) override;
+};
+
+}  // namespace passes
+}  // namespace preprocessing
+}  // namespace CVC4
+
+#endif /* __CVC4__PREPROCESSING__PASSES__STATIC_LEARNING_H */

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4246,13 +4246,11 @@ void SmtEnginePrivate::processAssertions() {
     d_preprocessingPassRegistry.getPass("sym-break")->apply(&d_assertions);
   }
 
-  dumpAssertions("pre-static-learning", d_assertions);
   if(options::doStaticLearning()) {
     d_preprocessingPassRegistry.getPass("static-learning")
         ->apply(&d_assertions);
     Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : post-static-learning" << endl;
   }
-  dumpAssertions("post-static-learning", d_assertions);
   Debug("smt") << " d_assertions     : " << d_assertions.size() << endl;
 
   Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : pre-ite-removal" << endl;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4253,14 +4253,8 @@ void SmtEnginePrivate::processAssertions() {
 
   dumpAssertions("pre-static-learning", d_assertions);
   if(options::doStaticLearning()) {
-    Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : pre-static-learning" << endl;
-    // Perform static learning
-    Chat() << "doing static learning..." << endl;
     Trace("simplify") << "SmtEnginePrivate::processAssertions(): "
                       << "performing static learning" << endl;
-    d_smt.finalOptionsAreSet();
-    TimerStat::CodeTimer staticLearningTimer(
-        d_smt.d_stats->d_staticLearningTime);
     d_preprocessingPassRegistry.getPass("static-learning")
         ->apply(&d_assertions);
     Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : post-static-learning" << endl;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2654,6 +2654,8 @@ void SmtEnginePrivate::finishInit() {
   d_preprocessingPassRegistry.registerPass("real-to-int", std::move(realToInt));
   d_preprocessingPassRegistry.registerPass("static-learning", std::move(staticLearning));
   d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
+  d_preprocessingPassRegistry.registerPass("static-learning",
+                                           std::move(staticLearning));
 }
 
 Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, NodeHashFunction>& cache, bool expandOnly)
@@ -4257,7 +4259,8 @@ void SmtEnginePrivate::processAssertions() {
     Trace("simplify") << "SmtEnginePrivate::processAssertions(): "
                       << "performing static learning" << endl;
     d_smt.finalOptionsAreSet();
-    TimerStat::CodeTimer staticLearningTimer(d_smt.d_stats->d_staticLearningTime);
+    TimerStat::CodeTimer staticLearningTimer(
+        d_smt.d_stats->d_staticLearningTime);
     d_preprocessingPassRegistry.getPass("static-learning")
         ->apply(&d_assertions);
     Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : post-static-learning" << endl;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -191,8 +191,6 @@ struct SmtEngineStatistics {
   IntStat d_numMiplibAssertionsRemoved;
   /** number of constant propagations found during nonclausal simp */
   IntStat d_numConstantProps;
-  /** time spent in static learning */
-  TimerStat d_staticLearningTime;
   /** time spent in simplifying ITEs */
   TimerStat d_simpITETime;
   /** time spent in simplifying ITEs */
@@ -234,7 +232,6 @@ struct SmtEngineStatistics {
     d_miplibPassTime("smt::SmtEngine::miplibPassTime"),
     d_numMiplibAssertionsRemoved("smt::SmtEngine::numMiplibAssertionsRemoved", 0),
     d_numConstantProps("smt::SmtEngine::numConstantProps", 0),
-    d_staticLearningTime("smt::SmtEngine::staticLearningTime"),
     d_simpITETime("smt::SmtEngine::simpITETime"),
     d_unconstrainedSimpTime("smt::SmtEngine::unconstrainedSimpTime"),
     d_iteRemovalTime("smt::SmtEngine::iteRemovalTime"),
@@ -259,7 +256,6 @@ struct SmtEngineStatistics {
     smtStatisticsRegistry()->registerStat(&d_miplibPassTime);
     smtStatisticsRegistry()->registerStat(&d_numMiplibAssertionsRemoved);
     smtStatisticsRegistry()->registerStat(&d_numConstantProps);
-    smtStatisticsRegistry()->registerStat(&d_staticLearningTime);
     smtStatisticsRegistry()->registerStat(&d_simpITETime);
     smtStatisticsRegistry()->registerStat(&d_unconstrainedSimpTime);
     smtStatisticsRegistry()->registerStat(&d_iteRemovalTime);
@@ -285,7 +281,6 @@ struct SmtEngineStatistics {
     smtStatisticsRegistry()->unregisterStat(&d_miplibPassTime);
     smtStatisticsRegistry()->unregisterStat(&d_numMiplibAssertionsRemoved);
     smtStatisticsRegistry()->unregisterStat(&d_numConstantProps);
-    smtStatisticsRegistry()->unregisterStat(&d_staticLearningTime);
     smtStatisticsRegistry()->unregisterStat(&d_simpITETime);
     smtStatisticsRegistry()->unregisterStat(&d_unconstrainedSimpTime);
     smtStatisticsRegistry()->unregisterStat(&d_iteRemovalTime);
@@ -4253,16 +4248,12 @@ void SmtEnginePrivate::processAssertions() {
 
   dumpAssertions("pre-static-learning", d_assertions);
   if(options::doStaticLearning()) {
-    Trace("simplify") << "SmtEnginePrivate::processAssertions(): "
-                      << "performing static learning" << endl;
     d_preprocessingPassRegistry.getPass("static-learning")
         ->apply(&d_assertions);
     Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : post-static-learning" << endl;
   }
   dumpAssertions("post-static-learning", d_assertions);
-
   Debug("smt") << " d_assertions     : " << d_assertions.size() << endl;
-
 
   Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : pre-ite-removal" << endl;
   dumpAssertions("pre-ite-removal", d_assertions);

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4249,7 +4249,6 @@ void SmtEnginePrivate::processAssertions() {
   if(options::doStaticLearning()) {
     d_preprocessingPassRegistry.getPass("static-learning")
         ->apply(&d_assertions);
-    Trace("smt-proc") << "SmtEnginePrivate::processAssertions() : post-static-learning" << endl;
   }
   Debug("smt") << " d_assertions     : " << d_assertions.size() << endl;
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2647,10 +2647,9 @@ void SmtEnginePrivate::finishInit() {
   d_preprocessingPassRegistry.registerPass("pseudo-boolean-processor",
                                            std::move(pbProc));
   d_preprocessingPassRegistry.registerPass("real-to-int", std::move(realToInt));
-  d_preprocessingPassRegistry.registerPass("static-learning", std::move(staticLearning));
-  d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
-  d_preprocessingPassRegistry.registerPass("static-learning",
+  d_preprocessingPassRegistry.registerPass("static-learning", 
                                            std::move(staticLearning));
+  d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
 }
 
 Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, NodeHashFunction>& cache, bool expandOnly)


### PR DESCRIPTION
Moved the call to `TheoryEnging::ppStaticLearn` into the preprocessing pass. 
I left the calls to `finalOptionsAreSet()`
and to `staticLearningTimer` in smt_engine.cpp. The former is a private `SmtEngine` function, and the latter is called with a private `SmtEngine` parameter (`d_smt.d_stats->d_staticLearningTime`).

Current regression tests cover this pass, and so I did not add new tests.