### PR TITLE
Fix printing of multiple datatypes

### DIFF
--- a/src/printer/cvc/cvc_printer.cpp
+++ b/src/printer/cvc/cvc_printer.cpp
@@ -1457,6 +1457,7 @@ static void toStream(std::ostream& out,
           out << ')';
         }
       }
+      firstDatatype = false;
     }
     out << endl << "END;";
   }


### PR DESCRIPTION
Due to a bug, CVC4 has been printing no separators between different
datatypes. Fixes #1868.