### PR TITLE
Make symmetry-breaker-exp into a preprocessing pass

### DIFF
--- a/src/preprocessing/passes/symmetry_breaker.cpp
+++ b/src/preprocessing/passes/symmetry_breaker.cpp
@@ -131,26 +131,26 @@ PreprocessingPassResult SymBreakerPass::applyInternal(
   std::vector<std::vector<Node>> part;
   SymmetryDetect symd;
   symd.getPartition(part, assertionsToPreprocess->ref());
-  if( Trace.isOn("sym-break-pass") )
+  if (Trace.isOn("sym-break-pass"))
   {
     Trace("sym-break-pass") << "Detected symmetry partition:" << std::endl;
-    for( const std::vector< Node >& p : part )
+    for (const std::vector<Node>& p : part)
     {
       Trace("sym-break-pass") << "  " << p << std::endl;
     }
   }
   // construct the symmetry breaking constraint
-  Trace("sym-break-pass") << "Construct symmetry breaking constraint..." << std::endl;
+  Trace("sym-break-pass") << "Construct symmetry breaking constraint..."
+                          << std::endl;
   SymmetryBreaker symb;
   Node sbConstraint = symb.generateSymBkConstraints(part);
   // add symmetry breaking constraint to the set of assertions
   Trace("sym-break-pass") << "...got: " << sbConstraint << std::endl;
   // add to assertions
   assertionsToPreprocess->push_back(sbConstraint);
-  
+
   return PreprocessingPassResult::NO_CONFLICT;
 }
-
 
 }  // namespace passes
 }  // namespace preprocessing

--- a/src/preprocessing/passes/symmetry_breaker.cpp
+++ b/src/preprocessing/passes/symmetry_breaker.cpp
@@ -145,6 +145,8 @@ PreprocessingPassResult SymBreakerPass::applyInternal(
   Node sbConstraint = symb.generateSymBkConstraints(part);
   // add symmetry breaking constraint to the set of assertions
   Trace("sym-break-pass") << "...got: " << sbConstraint << std::endl;
+  // add to assertions
+  assertionsToPreprocess->push_back(sbConstraint);
   
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/preprocessing/passes/symmetry_breaker.cpp
+++ b/src/preprocessing/passes/symmetry_breaker.cpp
@@ -146,8 +146,12 @@ PreprocessingPassResult SymBreakerPass::applyInternal(
   Node sbConstraint = symb.generateSymBkConstraints(part);
   // add symmetry breaking constraint to the set of assertions
   Trace("sym-break-pass") << "...got: " << sbConstraint << std::endl;
-  // add to assertions
-  assertionsToPreprocess->push_back(sbConstraint);
+  // if not true
+  if( !sbConstraint.isConst() )
+  {
+    // add to assertions
+    assertionsToPreprocess->push_back(sbConstraint);
+  }
 
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/preprocessing/passes/symmetry_breaker.cpp
+++ b/src/preprocessing/passes/symmetry_breaker.cpp
@@ -147,7 +147,7 @@ PreprocessingPassResult SymBreakerPass::applyInternal(
   // add symmetry breaking constraint to the set of assertions
   Trace("sym-break-pass") << "...got: " << sbConstraint << std::endl;
   // if not true
-  if( !sbConstraint.isConst() )
+  if (!sbConstraint.isConst())
   {
     // add to assertions
     assertionsToPreprocess->push_back(sbConstraint);

--- a/src/preprocessing/passes/symmetry_breaker.h
+++ b/src/preprocessing/passes/symmetry_breaker.h
@@ -20,6 +20,9 @@
 #include <vector>
 #include "expr/node.h"
 
+#include "preprocessing/preprocessing_pass.h"
+#include "preprocessing/preprocessing_pass_context.h"
+
 namespace CVC4 {
 namespace preprocessing {
 namespace passes {
@@ -83,6 +86,22 @@ class SymmetryBreaker
    * */
   Kind getOrderKind(Node node);
 };
+
+/** 
+ * This class detects symmetries in the input assertions in the form of a
+ * partition (see symmetry_detect.h), and subsequently adds symmetry breaking
+ * constraints that correspond to this partition, using the above class.
+ */
+class SymBreakerPass : public PreprocessingPass
+{
+ public:
+  SymBreakerPass(PreprocessingPassContext* preprocContext);
+
+ protected:
+  PreprocessingPassResult applyInternal(
+      AssertionPipeline* assertionsToPreprocess) override;
+};
+
 
 }  // namespace passes
 }  // namespace preprocessing

--- a/src/preprocessing/passes/symmetry_breaker.h
+++ b/src/preprocessing/passes/symmetry_breaker.h
@@ -87,7 +87,7 @@ class SymmetryBreaker
   Kind getOrderKind(Node node);
 };
 
-/** 
+/**
  * This class detects symmetries in the input assertions in the form of a
  * partition (see symmetry_detect.h), and subsequently adds symmetry breaking
  * constraints that correspond to this partition, using the above class.
@@ -101,7 +101,6 @@ class SymBreakerPass : public PreprocessingPass
   PreprocessingPassResult applyInternal(
       AssertionPipeline* assertionsToPreprocess) override;
 };
-
 
 }  // namespace passes
 }  // namespace preprocessing

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2598,10 +2598,10 @@ void SmtEnginePrivate::finishInit() {
       new IntToBV(d_preprocessingPassContext.get()));
   std::unique_ptr<PseudoBooleanProcessor> pbProc(
       new PseudoBooleanProcessor(d_preprocessingPassContext.get()));
-  std::unique_ptr<SymBreakerPass> sbProc(
-      new SymBreakerPass(d_preprocessingPassContext.get()));
   std::unique_ptr<RealToInt> realToInt(
       new RealToInt(d_preprocessingPassContext.get()));
+  std::unique_ptr<SymBreakerPass> sbProc(
+      new SymBreakerPass(d_preprocessingPassContext.get()));
   d_preprocessingPassRegistry.registerPass("bool-to-bv", std::move(boolToBv));
   d_preprocessingPassRegistry.registerPass("bv-abstraction",
                                            std::move(bvAbstract));
@@ -2612,8 +2612,8 @@ void SmtEnginePrivate::finishInit() {
   d_preprocessingPassRegistry.registerPass("int-to-bv", std::move(intToBV));
   d_preprocessingPassRegistry.registerPass("pseudo-boolean-processor",
                                            std::move(pbProc));
-  d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
   d_preprocessingPassRegistry.registerPass("real-to-int", std::move(realToInt));
+  d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
 }
 
 Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, NodeHashFunction>& cache, bool expandOnly)

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2598,6 +2598,8 @@ void SmtEnginePrivate::finishInit() {
       new IntToBV(d_preprocessingPassContext.get()));
   std::unique_ptr<PseudoBooleanProcessor> pbProc(
       new PseudoBooleanProcessor(d_preprocessingPassContext.get()));
+  std::unique_ptr<SymBreakerPass> sbProc(
+      new SymBreakerPass(d_preprocessingPassContext.get()));
   std::unique_ptr<RealToInt> realToInt(
       new RealToInt(d_preprocessingPassContext.get()));
   d_preprocessingPassRegistry.registerPass("bool-to-bv", std::move(boolToBv));
@@ -2610,6 +2612,7 @@ void SmtEnginePrivate::finishInit() {
   d_preprocessingPassRegistry.registerPass("int-to-bv", std::move(intToBV));
   d_preprocessingPassRegistry.registerPass("pseudo-boolean-processor",
                                            std::move(pbProc));
+  d_preprocessingPassRegistry.registerPass("sym-break",std::move(sbProc));
   d_preprocessingPassRegistry.registerPass("real-to-int", std::move(realToInt));
 }
 
@@ -4198,11 +4201,7 @@ void SmtEnginePrivate::processAssertions() {
 
   if (options::symmetryBreakerExp())
   {
-    SymmetryDetect symd;
-    SymmetryBreaker symb;
-    vector<vector<Node>> part;
-    symd.getPartition(part, d_assertions.ref());
-    Node sbConstraint = symb.generateSymBkConstraints(part);
+    d_preprocessingPassRegistry.getPass("sym-break")->apply(&d_assertions);
   }
 
   dumpAssertions("pre-static-learning", d_assertions);

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4201,6 +4201,7 @@ void SmtEnginePrivate::processAssertions() {
 
   if (options::symmetryBreakerExp())
   {
+    // apply symmetry breaking
     d_preprocessingPassRegistry.getPass("sym-break")->apply(&d_assertions);
   }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2612,7 +2612,7 @@ void SmtEnginePrivate::finishInit() {
   d_preprocessingPassRegistry.registerPass("int-to-bv", std::move(intToBV));
   d_preprocessingPassRegistry.registerPass("pseudo-boolean-processor",
                                            std::move(pbProc));
-  d_preprocessingPassRegistry.registerPass("sym-break",std::move(sbProc));
+  d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
   d_preprocessingPassRegistry.registerPass("real-to-int", std::move(realToInt));
 }
 

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -1522,6 +1522,7 @@ REG1_TESTS = \
 	regress1/sym/sym4.smt2 \
 	regress1/sym/sym5.smt2 \
 	regress1/sym/sym6.smt2 \
+	regress1/sym/sym7-uf.smt2 \
 	regress1/test12.cvc \
 	regress1/trim.cvc \
 	regress1/uf2.smt2 \

--- a/test/regress/regress1/sym/sym1.smt2
+++ b/test/regress/regress1/sym/sym1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --symmetry-detect
+; COMMAND-LINE: --symmetry-breaker-exp
 (set-logic ALL)
 (set-info :status sat)
 (declare-fun x () Int)

--- a/test/regress/regress1/sym/sym2.smt2
+++ b/test/regress/regress1/sym/sym2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --symmetry-detect
+; COMMAND-LINE: --symmetry-breaker-exp
 (set-logic ALL)
 (set-info :status sat)
 (declare-fun x () Int)

--- a/test/regress/regress1/sym/sym3.smt2
+++ b/test/regress/regress1/sym/sym3.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --symmetry-detect
+; COMMAND-LINE: --symmetry-breaker-exp
 (set-logic ALL)
 (set-info :status sat)
 (declare-fun x () Int)

--- a/test/regress/regress1/sym/sym4.smt2
+++ b/test/regress/regress1/sym/sym4.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --symmetry-detect
+; COMMAND-LINE: --symmetry-breaker-exp
 (set-info :smt-lib-version 2.6)
 (set-logic QF_LIA)
 (set-info :category "crafted")

--- a/test/regress/regress1/sym/sym5.smt2
+++ b/test/regress/regress1/sym/sym5.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --symmetry-detect
+; COMMAND-LINE: --symmetry-breaker-exp
 (set-logic ALL)
 (set-info :status unsat)
 (declare-fun A () (Set Int))

--- a/test/regress/regress1/sym/sym6.smt2
+++ b/test/regress/regress1/sym/sym6.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --symmetry-detect
+; COMMAND-LINE: --symmetry-breaker-exp
 (set-logic ALL)
 (set-info :status sat)
 (declare-fun x () Int)

--- a/test/regress/regress1/sym/sym7-uf.smt2
+++ b/test/regress/regress1/sym/sym7-uf.smt2
@@ -1,0 +1,19 @@
+; COMMAND-LINE: --symmetry-breaker-exp
+(set-logic ALL)
+(set-info :status sat)
+(declare-sort U 0)
+(declare-fun x () U)
+(declare-fun y () U)
+(declare-fun z () U)
+(declare-fun w () U)
+(declare-fun u () U)
+(declare-fun v () U)
+(declare-fun a () U)
+(declare-fun P (U) Bool)
+
+;(assert (distinct w u v a))
+;(assert (or (= x y) (= x z) (= y z)))
+(assert (or (P x) (P y) (P z) (P w)))
+
+(check-sat)
+

--- a/test/regress/regress1/sym/sym7-uf.smt2
+++ b/test/regress/regress1/sym/sym7-uf.smt2
@@ -15,5 +15,6 @@
 ;(assert (or (= x y) (= x z) (= y z)))
 (assert (or (P x) (P y) (P z) (P w)))
 
+; should get { x, y, z }, { w }, { u, v, a }
 (check-sat)
 

--- a/test/regress/regress1/sym/sym7-uf.smt2
+++ b/test/regress/regress1/sym/sym7-uf.smt2
@@ -11,8 +11,8 @@
 (declare-fun a () U)
 (declare-fun P (U) Bool)
 
-;(assert (distinct w u v a))
-;(assert (or (= x y) (= x z) (= y z)))
+(assert (distinct w u v a))
+(assert (or (= x y) (= x z) (= y z)))
 (assert (or (P x) (P y) (P z) (P w)))
 
 ; should get { x, y, z }, { w }, { u, v, a }


### PR DESCRIPTION
Also fixes options on the sym regressions, which currently is breaking regress1.