### PR TITLE
fix bv-to-bool and bool-to-bv warnings

### DIFF
--- a/src/preprocessing/passes/bool_to_bv.h
+++ b/src/preprocessing/passes/bool_to_bv.h
@@ -52,10 +52,10 @@ class BoolToBV : public PreprocessingPass
   Node getLowerCache(TNode term) const;
   bool hasLowerCache(TNode term) const;
   Node lowerNode(TNode current, bool topLevel = false);
-  Statistics d_statistics;
   NodeNodeMap d_lowerCache;
   Node d_one;
   Node d_zero;
+  Statistics d_statistics;
 };  // class
 }  // namespace passes
 }  // namespace preprocessing

--- a/src/preprocessing/passes/bv_to_bool.h
+++ b/src/preprocessing/passes/bv_to_bool.h
@@ -65,11 +65,11 @@ class BVToBool : public PreprocessingPass
   void liftBvToBool(const std::vector<Node>& assertions,
                     std::vector<Node>& new_assertions);
 
-  Statistics d_statistics;
   NodeNodeMap d_liftCache;
   NodeNodeMap d_boolCache;
   Node d_one;
   Node d_zero;
+  Statistics d_statistics;
 };
 
 }  // namespace passes


### PR DESCRIPTION
The members did not appear in the class declaration in the same order as in the initialization list. fixed by changing the order in the class declaration.