### PR TITLE
Exclude Boolean connectives from ITE conditions in SygusUnifStrat

### DIFF
--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -1141,6 +1141,12 @@ Expr DatatypeConstructor::getSelector(std::string name) const {
   return (*this)[name].getSelector();
 }
 
+Type DatatypeConstructor::getArgType(unsigned index) const
+{
+  PrettyCheckArgument(index < getNumArgs(), index, "index out of bounds");
+  return static_cast<SelectorType>((*this)[index].getType()).getRangeType();
+}
+
 bool DatatypeConstructor::involvesExternalType() const{
   for(const_iterator i = begin(); i != end(); ++i) {
     if(! SelectorType((*i).getSelector().getType()).getRangeType().isDatatype()) {

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -390,6 +390,11 @@ class CVC4_PUBLIC DatatypeConstructor {
    * is returned.
    */
   Expr getSelector(std::string name) const;
+  /** 
+   * Get argument type. Returns the return type of the i^th selector of this
+   * constructor.
+   */
+  Type getArgType(unsigned i) const;
 
   /** get selector internal
    *

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -390,7 +390,7 @@ class CVC4_PUBLIC DatatypeConstructor {
    * is returned.
    */
   Expr getSelector(std::string name) const;
-  /** 
+  /**
    * Get argument type. Returns the return type of the i^th selector of this
    * constructor.
    */

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -179,16 +179,16 @@ bool CegConjecturePbe::initialize(Node n,
     std::map<Node, std::vector<Node>> strategy_lemmas;
     d_sygus_unif[c].initialize(
         d_qe, singleton_c, d_candidate_to_enum[c], strategy_lemmas);
-    // collect lemmas from all strategies
+    Assert(!d_candidate_to_enum[c].empty());
+    Trace("sygus-pbe") << "Initialize " << d_candidate_to_enum[c].size()
+                       << " enumerators for " << c << "..." << std::endl;
+    // collect list per type of strategy points with strategy lemmas
     std::map<TypeNode, std::vector<Node>> tn_to_strategy_pt;
     for (const std::pair<const Node, std::vector<Node>>& p : strategy_lemmas)
     {
       TypeNode tnsp = p.first.getType();
       tn_to_strategy_pt[tnsp].push_back(p.first);
     }
-    Assert(!d_candidate_to_enum[c].empty());
-    Trace("sygus-pbe") << "Initialize " << d_candidate_to_enum[c].size()
-                       << " enumerators for " << c << "..." << std::endl;
     // initialize the enumerators
     NodeManager* nm = NodeManager::currentNM();
     for (const Node& e : d_candidate_to_enum[c])
@@ -200,6 +200,9 @@ bool CegConjecturePbe::initialize(Node n,
       d_enum_to_candidate[e] = c;
       TNode te = e;
       // initialize static symmetry breaking lemmas for it
+      // we register only one "master" enumerator per type
+      // thus, the strategy lemmas (which are for individual strategy points)
+      // are applicable (disjunctively) to the master enumerator
       std::map<TypeNode, std::vector<Node>>::iterator itt =
           tn_to_strategy_pt.find(etn);
       if (itt != tn_to_strategy_pt.end())

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -180,20 +180,49 @@ bool CegConjecturePbe::initialize(Node n,
     d_sygus_unif[c].initialize(
         d_qe, singleton_c, d_candidate_to_enum[c], strategy_lemmas);
     // collect lemmas from all strategies
+    std::map<TypeNode, std::vector< Node > > tn_to_strategy_pt;
     for (const std::pair<const Node, std::vector<Node>>& p : strategy_lemmas)
     {
-      lemmas.insert(lemmas.end(), p.second.begin(), p.second.end());
+      TypeNode tnsp = p.first.getType();
+      tn_to_strategy_pt[tnsp].push_back( p.first );
     }
     Assert(!d_candidate_to_enum[c].empty());
     Trace("sygus-pbe") << "Initialize " << d_candidate_to_enum[c].size()
                        << " enumerators for " << c << "..." << std::endl;
     // initialize the enumerators
+                       NodeManager * nm = NodeManager::currentNM();
     for (const Node& e : d_candidate_to_enum[c])
     {
+      TypeNode etn = e.getType();
       d_tds->registerEnumerator(e, c, d_parent, true);
       Node g = d_tds->getActiveGuardForEnumerator(e);
       d_enum_to_active_guard[e] = g;
       d_enum_to_candidate[e] = c;
+      TNode te = e;
+      // initialize static symmetry breaking lemmas for it
+      std::map<TypeNode, std::vector< Node > >::iterator itt = tn_to_strategy_pt.find(etn);
+      if( itt!=tn_to_strategy_pt.end() )
+      {
+        std::vector< Node > disj;
+        for( const Node& sp : itt->second )
+        {
+          std::map<Node, std::vector<Node>>::iterator itsl = strategy_lemmas.find(sp);
+          Assert( itsl!=strategy_lemmas.end() );
+          if( !itsl->second.empty() )
+          {
+            TNode tsp = sp;
+            Node lem = itsl->second.size()==1 ? itsl->second[0] : nm->mkNode( AND, itsl->second );
+            if( tsp!=te )
+            {
+              lem = lem.substitute(tsp,te);
+            }
+            disj.push_back(lem);
+          }
+        }
+        Node lem = disj.size()==1 ? disj[0] : nm->mkNode( OR, disj );
+        Trace("sygus-pbe") << "  static redundant op lemma : " << lem << std::endl;
+        lemmas.push_back(lem);
+      }
     }
     Trace("sygus-pbe") << "Initialize " << d_examples[c].size()
                        << " example points for " << c << "..." << std::endl;

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -180,17 +180,17 @@ bool CegConjecturePbe::initialize(Node n,
     d_sygus_unif[c].initialize(
         d_qe, singleton_c, d_candidate_to_enum[c], strategy_lemmas);
     // collect lemmas from all strategies
-    std::map<TypeNode, std::vector< Node > > tn_to_strategy_pt;
+    std::map<TypeNode, std::vector<Node>> tn_to_strategy_pt;
     for (const std::pair<const Node, std::vector<Node>>& p : strategy_lemmas)
     {
       TypeNode tnsp = p.first.getType();
-      tn_to_strategy_pt[tnsp].push_back( p.first );
+      tn_to_strategy_pt[tnsp].push_back(p.first);
     }
     Assert(!d_candidate_to_enum[c].empty());
     Trace("sygus-pbe") << "Initialize " << d_candidate_to_enum[c].size()
                        << " enumerators for " << c << "..." << std::endl;
     // initialize the enumerators
-                       NodeManager * nm = NodeManager::currentNM();
+    NodeManager* nm = NodeManager::currentNM();
     for (const Node& e : d_candidate_to_enum[c])
     {
       TypeNode etn = e.getType();
@@ -200,27 +200,31 @@ bool CegConjecturePbe::initialize(Node n,
       d_enum_to_candidate[e] = c;
       TNode te = e;
       // initialize static symmetry breaking lemmas for it
-      std::map<TypeNode, std::vector< Node > >::iterator itt = tn_to_strategy_pt.find(etn);
-      if( itt!=tn_to_strategy_pt.end() )
+      std::map<TypeNode, std::vector<Node>>::iterator itt =
+          tn_to_strategy_pt.find(etn);
+      if (itt != tn_to_strategy_pt.end())
       {
-        std::vector< Node > disj;
-        for( const Node& sp : itt->second )
+        std::vector<Node> disj;
+        for (const Node& sp : itt->second)
         {
-          std::map<Node, std::vector<Node>>::iterator itsl = strategy_lemmas.find(sp);
-          Assert( itsl!=strategy_lemmas.end() );
-          if( !itsl->second.empty() )
+          std::map<Node, std::vector<Node>>::iterator itsl =
+              strategy_lemmas.find(sp);
+          Assert(itsl != strategy_lemmas.end());
+          if (!itsl->second.empty())
           {
             TNode tsp = sp;
-            Node lem = itsl->second.size()==1 ? itsl->second[0] : nm->mkNode( AND, itsl->second );
-            if( tsp!=te )
+            Node lem = itsl->second.size() == 1 ? itsl->second[0]
+                                                : nm->mkNode(AND, itsl->second);
+            if (tsp != te)
             {
-              lem = lem.substitute(tsp,te);
+              lem = lem.substitute(tsp, te);
             }
             disj.push_back(lem);
           }
         }
-        Node lem = disj.size()==1 ? disj[0] : nm->mkNode( OR, disj );
-        Trace("sygus-pbe") << "  static redundant op lemma : " << lem << std::endl;
+        Node lem = disj.size() == 1 ? disj[0] : nm->mkNode(OR, disj);
+        Trace("sygus-pbe") << "  static redundant op lemma : " << lem
+                           << std::endl;
         lemmas.push_back(lem);
       }
     }

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -760,7 +760,8 @@ void SygusUnifStrategy::staticLearnRedundantOps(
   {
     return;
   }
-  Trace("sygus-strat-slearn") << "Learn redundant operators " << e << " " << nrole << "..." << std::endl;
+  Trace("sygus-strat-slearn") << "Learn redundant operators " << e << " "
+                              << nrole << "..." << std::endl;
   visited[e][nrole] = true;
   EnumInfo& ei = getEnumInfo(e);
   if (ei.isTemplated())
@@ -821,7 +822,6 @@ void SygusUnifStrategy::staticLearnRedundantOps(
       }
     }
   }
-
 
   // all other constructors are needed
   for (unsigned j = 0, size = dt.getNumConstructors(); j < size; j++)

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -760,6 +760,7 @@ void SygusUnifStrategy::staticLearnRedundantOps(
   {
     return;
   }
+  Trace("sygus-strat-slearn") << "Learn redundant operators " << e << " " << nrole << "..." << std::endl;
   visited[e][nrole] = true;
   EnumInfo& ei = getEnumInfo(e);
   if (ei.isTemplated())
@@ -821,14 +822,7 @@ void SygusUnifStrategy::staticLearnRedundantOps(
     }
   }
 
-  // get the master enumerator for the type of this enumerator
-  std::map<TypeNode, Node>::iterator itse = d_master_enum.find(etn);
-  if (itse == d_master_enum.end())
-  {
-    return;
-  }
-  Node em = itse->second;
-  Assert(!em.isNull());
+
   // all other constructors are needed
   for (unsigned j = 0, size = dt.getNumConstructors(); j < size; j++)
   {
@@ -838,15 +832,15 @@ void SygusUnifStrategy::staticLearnRedundantOps(
     }
   }
   // update the constructors that the master enumerator needs
-  if (needs_cons.find(em) == needs_cons.end())
+  if (needs_cons.find(e) == needs_cons.end())
   {
-    needs_cons[em] = needs_cons_curr;
+    needs_cons[e] = needs_cons_curr;
   }
   else
   {
     for (unsigned j = 0, size = dt.getNumConstructors(); j < size; j++)
     {
-      needs_cons[em][j] = needs_cons[em][j] || needs_cons_curr[j];
+      needs_cons[e][j] = needs_cons[e][j] || needs_cons_curr[j];
     }
   }
 }

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -784,28 +784,28 @@ void SygusUnifStrategy::staticLearnRedundantOps(
   // get the current datatype
   const Datatype& dt = static_cast<DatatypeType>(etn.toType()).getDatatype();
   // do not use recursive Boolean connectives for conditions of ITEs
-  if( nrole==enum_ite_condition )
+  if (nrole == enum_ite_condition)
   {
     for (unsigned j = 0, size = dt.getNumConstructors(); j < size; j++)
     {
       Node op = Node::fromExpr(dt[j].getSygusOp());
-      if( op.getKind() == kind::BUILTIN )
+      if (op.getKind() == kind::BUILTIN)
       {
-        Kind k = NodeManager::operatorToKind( op );
-        if( k==NOT || k==OR || k==AND )
+        Kind k = NodeManager::operatorToKind(op);
+        if (k == NOT || k == OR || k == AND)
         {
           // can eliminate if their argument types are simple loops to this type
           bool type_ok = true;
-          for( unsigned k=0, nargs = dt[j].getNumArgs(); k<nargs; k++ )
+          for (unsigned k = 0, nargs = dt[j].getNumArgs(); k < nargs; k++)
           {
-            TypeNode tn = TypeNode::fromType( dt[j].getArgType(k) );
-            if( tn!=etn )
+            TypeNode tn = TypeNode::fromType(dt[j].getArgType(k));
+            if (tn != etn)
             {
               type_ok = false;
               break;
             }
           }
-          if( type_ok )
+          if (type_ok)
           {
             needs_cons_curr[j] = false;
           }
@@ -813,7 +813,7 @@ void SygusUnifStrategy::staticLearnRedundantOps(
       }
     }
   }
-  
+
   // get the master enumerator for the type of this enumerator
   std::map<TypeNode, Node>::iterator itse = d_master_enum.find(etn);
   if (itse == d_master_enum.end())

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -780,7 +780,8 @@ void SygusUnifStrategy::staticLearnRedundantOps(
     EnumTypeInfoStrat* etis = snode.d_strats[j];
     int cindex = Datatype::indexOf(etis->d_cons.toExpr());
     Assert(cindex != -1);
-    Trace("sygus-strat-slearn") << "...by strategy, can exclude operator " << etis->d_cons << std::endl;
+    Trace("sygus-strat-slearn")
+        << "...by strategy, can exclude operator " << etis->d_cons << std::endl;
     needs_cons_curr[static_cast<unsigned>(cindex)] = false;
     for (std::pair<Node, NodeRole>& cec : etis->d_cenum)
     {
@@ -795,7 +796,8 @@ void SygusUnifStrategy::staticLearnRedundantOps(
     for (unsigned j = 0, size = dt.getNumConstructors(); j < size; j++)
     {
       Node op = Node::fromExpr(dt[j].getSygusOp());
-      Trace("sygus-strat-slearn") << "...for ite condition, look at operator : " << op << std::endl;
+      Trace("sygus-strat-slearn")
+          << "...for ite condition, look at operator : " << op << std::endl;
       if (op.getKind() == kind::BUILTIN)
       {
         Kind k = NodeManager::operatorToKind(op);
@@ -814,7 +816,9 @@ void SygusUnifStrategy::staticLearnRedundantOps(
           }
           if (type_ok)
           {
-            Trace("sygus-strat-slearn") << "...for ite condition, can exclude Boolean connective : " << op << std::endl;
+            Trace("sygus-strat-slearn")
+                << "...for ite condition, can exclude Boolean connective : "
+                << op << std::endl;
             needs_cons_curr[j] = false;
           }
         }

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -1010,7 +1010,8 @@ bool TermDbSygus::isConstArg( TypeNode tn, int i ) {
 TypeNode TermDbSygus::getArgType(const DatatypeConstructor& c, unsigned i) const
 {
   Assert(i < c.getNumArgs());
-  return TypeNode::fromType( static_cast<SelectorType>(c[i].getType()).getRangeType() );
+  return TypeNode::fromType(
+      static_cast<SelectorType>(c[i].getType()).getRangeType());
 }
 
 /** get first occurrence */

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -1007,10 +1007,10 @@ bool TermDbSygus::isConstArg( TypeNode tn, int i ) {
   }
 }
 
-TypeNode TermDbSygus::getArgType(const DatatypeConstructor& c, unsigned i)
+TypeNode TermDbSygus::getArgType(const DatatypeConstructor& c, unsigned i) const
 {
   Assert(i < c.getNumArgs());
-  return TypeNode::fromType( ((SelectorType)c[i].getType()).getRangeType() );
+  return TypeNode::fromType( static_cast<SelectorType>(c[i].getType()).getRangeType() );
 }
 
 /** get first occurrence */

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -259,7 +259,7 @@ private:
   bool isKindArg( TypeNode tn, int i );
   bool isConstArg( TypeNode tn, int i );
   /** get arg type */
-  TypeNode getArgType(const DatatypeConstructor& c, unsigned i);
+  TypeNode getArgType(const DatatypeConstructor& c, unsigned i) const;
   /** get first occurrence */
   int getFirstArgOccurrence( const DatatypeConstructor& c, TypeNode tn );
   /** is type match */


### PR DESCRIPTION
Removes some PBE-specific policies from SygusUnifStrat as well.