### PR TITLE
Support multiple sets of command line args in regs

### DIFF
--- a/test/regress/README.md
+++ b/test/regress/README.md
@@ -87,6 +87,9 @@ executing CVC4, for example:
 % COMMAND-LINE: --incremental
 ```
 
+If multiple `COMMAND-LINE` directives are used, the regression is run with each
+set of options separately.
+
 Sometimes, the expected output or error output may need some processing. This
 is done with the `SCRUBBER` and `ERROR-SCRUBBER` directives. The command
 specified by the `SCRUBBER`/`ERROR-SCRUBBER` directive is applied to the output


### PR DESCRIPTION
This commit adds support for multiple sets of command line arguments for
regressions. Each use of a `COMMAND-LINE` directive is interpreted as a
separate set of command line arguments.