### PR TITLE
Small change for more sensible line breaking in the output of get-model

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1951,7 +1951,7 @@ static void toStream(std::ostream& out,
       const Datatype& d = i->getDatatype();
       out << "(";
       toStream(out, d);
-      out << ")" << endl;
+      out << ")";
     }
     out << ")";
   }
@@ -1966,11 +1966,11 @@ static void toStream(std::ostream& out,
       const Datatype& d = i->getDatatype();
       out << "(" << maybeQuoteSymbol(d.getName()) << " ";
       toStream(out, d);
-      out << ")" << endl;
+      out << ")";
     }
     out << ")";
   }
-  out << ")";
+  out << ")" << endl;
 }
 
 static void toStream(std::ostream& out, const CommentCommand* c, Variant v)


### PR DESCRIPTION
This appears to turn stuff like this:

```
(model
(declare-datatypes () ((tuple0 (Tuple0))
))
(declare-sort us_private 0)
```

Into:

```
(model
(declare-datatypes () ((tuple0 (Tuple0))))
(declare-sort us_private 0)
```