### PR TITLE
Cache isInterpretedFinite

### DIFF
--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -66,41 +66,59 @@ Cardinality TypeNode::getCardinality() const {
   return kind::getCardinality(*this);
 }
 
-bool TypeNode::isInterpretedFinite() const {
-  if( getCardinality().isFinite() ){
-    return true;
-  }else{
-    if( options::finiteModelFind() ){
+/** Attribute true for types that are interpreted as finite */
+struct IsInterpretedFiniteTag { };
+struct IsInterpretedFiniteComputedTag { };
+typedef expr::Attribute<IsInterpretedFiniteTag, bool> IsInterpretedFiniteAttr;
+typedef expr::Attribute<IsInterpretedFiniteComputedTag, bool> IsInterpretedFiniteComputedAttr;
+
+bool TypeNode::isInterpretedFinite() {
+  // TODO: cache 
+  if( !getAttribute(IsInterpretedFiniteComputedAttr()) )
+  {
+    bool isInterpretedFinite = false;
+    if( getCardinality().isFinite() ){
+      isInterpretedFinite = true;
+    }
+    else if( options::finiteModelFind() )
+    {
       if( isSort() ){
-        return true;
+        isInterpretedFinite = true;
       }else if( isDatatype() ){
         TypeNode tn = *this;
         const Datatype& dt = getDatatype();
-        return dt.isInterpretedFinite( tn.toType() );
+        isInterpretedFinite = dt.isInterpretedFinite( tn.toType() );
       }else if( isArray() ){
-        return getArrayIndexType().isInterpretedFinite() && getArrayConstituentType().isInterpretedFinite();
+        isInterpretedFinite = getArrayIndexType().isInterpretedFinite() && getArrayConstituentType().isInterpretedFinite();
       }else if( isSet() ) {
-        return getSetElementType().isInterpretedFinite();
+        isInterpretedFinite = getSetElementType().isInterpretedFinite();
       }
       else if (isFunction())
       {
+        isInterpretedFinite = true;
         if (!getRangeType().isInterpretedFinite())
         {
-          return false;
+          isInterpretedFinite = false;
         }
-        std::vector<TypeNode> argTypes = getArgTypes();
-        for (unsigned i = 0, nargs = argTypes.size(); i < nargs; i++)
+        else
         {
-          if (!argTypes[i].isInterpretedFinite())
+          std::vector<TypeNode> argTypes = getArgTypes();
+          for (unsigned i = 0, nargs = argTypes.size(); i < nargs; i++)
           {
-            return false;
+            if (!argTypes[i].isInterpretedFinite())
+            {
+              isInterpretedFinite = false;
+              break;
+            }
           }
         }
-        return true;
       }
     }
-    return false;
+    setAttribute(IsInterpretedFiniteAttr(), isInterpretedFinite);
+    setAttribute(IsInterpretedFiniteComputedAttr(), true);
+    return isInterpretedFinite;
   }
+  return getAttribute(IsInterpretedFiniteAttr());
 }
 
 bool TypeNode::isFirstClass() const {

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -73,7 +73,7 @@ typedef expr::Attribute<IsInterpretedFiniteTag, bool> IsInterpretedFiniteAttr;
 typedef expr::Attribute<IsInterpretedFiniteComputedTag, bool> IsInterpretedFiniteComputedAttr;
 
 bool TypeNode::isInterpretedFinite() {
-  // TODO: cache 
+  // check it is already cached
   if( !getAttribute(IsInterpretedFiniteComputedAttr()) )
   {
     bool isInterpretedFinite = false;

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -67,29 +67,38 @@ Cardinality TypeNode::getCardinality() const {
 }
 
 /** Attribute true for types that are interpreted as finite */
-struct IsInterpretedFiniteTag { };
-struct IsInterpretedFiniteComputedTag { };
+struct IsInterpretedFiniteTag
+{
+};
+struct IsInterpretedFiniteComputedTag
+{
+};
 typedef expr::Attribute<IsInterpretedFiniteTag, bool> IsInterpretedFiniteAttr;
-typedef expr::Attribute<IsInterpretedFiniteComputedTag, bool> IsInterpretedFiniteComputedAttr;
+typedef expr::Attribute<IsInterpretedFiniteComputedTag, bool>
+    IsInterpretedFiniteComputedAttr;
 
-bool TypeNode::isInterpretedFinite() {
+bool TypeNode::isInterpretedFinite()
+{
   // check it is already cached
-  if( !getAttribute(IsInterpretedFiniteComputedAttr()) )
+  if (!getAttribute(IsInterpretedFiniteComputedAttr()))
   {
     bool isInterpretedFinite = false;
-    if( getCardinality().isFinite() ){
+    if (getCardinality().isFinite())
+    {
       isInterpretedFinite = true;
     }
-    else if( options::finiteModelFind() )
+    else if (options::finiteModelFind())
     {
       if( isSort() ){
         isInterpretedFinite = true;
       }else if( isDatatype() ){
         TypeNode tn = *this;
         const Datatype& dt = getDatatype();
-        isInterpretedFinite = dt.isInterpretedFinite( tn.toType() );
+        isInterpretedFinite = dt.isInterpretedFinite(tn.toType());
       }else if( isArray() ){
-        isInterpretedFinite = getArrayIndexType().isInterpretedFinite() && getArrayConstituentType().isInterpretedFinite();
+        isInterpretedFinite =
+            getArrayIndexType().isInterpretedFinite()
+            && getArrayConstituentType().isInterpretedFinite();
       }else if( isSet() ) {
         isInterpretedFinite = getSetElementType().isInterpretedFinite();
       }

--- a/src/expr/type_node.h
+++ b/src/expr/type_node.h
@@ -429,7 +429,6 @@ public:
    */
   bool isInterpretedFinite();
 
-
   /**
    * Is this a first-class type?
    * First-class types are types for which:

--- a/src/expr/type_node.h
+++ b/src/expr/type_node.h
@@ -427,7 +427,7 @@ public:
    * If finite model finding is enabled, this assumes all uninterpreted sorts 
    *   are interpreted as finite.
    */
-  bool isInterpretedFinite() const;
+  bool isInterpretedFinite();
 
 
   /**


### PR DESCRIPTION
Recent profiling found that computing whether the cardinality of a type is finite can take upwards of 20% of the runtime for sygus. This caches and eliminates this.