### PR TITLE
Repair constants using symbolic constructors

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -989,7 +989,7 @@ header = "options/quantifiers_options.h"
   category   = "regular"
   long       = "sygus-repair-const"
   type       = "bool"
-  default    = "true"
+  default    = "false"
   help       = "use approach to repair constants in sygus candidate solutions"
 
 [[option]]

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -1047,16 +1047,22 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
   {
     for (const Node& a : anchors)
     {
-      std::vector<Node> sbl;
-      d_tds->getSymBreakLemmas(a, sbl);
-      for (const Node& lem : sbl)
+      // is this a registered enumerator?
+      if( d_register_st.find(a) != d_register_st.end() )
       {
-        TypeNode tn = d_tds->getTypeForSymBreakLemma(lem);
-        unsigned sz = d_tds->getSizeForSymBreakLemma(lem);
-        registerSymBreakLemma(tn, lem, sz, a, lemmas);
+        // symmetry breaking lemmas should only be for enumerators
+        Assert( d_register_st[a] );
+        std::vector<Node> sbl;
+        d_tds->getSymBreakLemmas(a, sbl);
+        for (const Node& lem : sbl)
+        {
+          TypeNode tn = d_tds->getTypeForSymBreakLemma(lem);
+          unsigned sz = d_tds->getSizeForSymBreakLemma(lem);
+          registerSymBreakLemma(tn, lem, sz, a, lemmas);
+        }
+        d_tds->clearSymBreakLemmas(a);
       }
     }
-    d_tds->clearSymBreakLemmas();
     if (!lemmas.empty())
     {
       return;

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -483,7 +483,7 @@ Node SygusSymBreakNew::getSimpleSymBreakPred( TypeNode tn, int tindex, unsigned 
             }
             // this code adds simple symmetry breaking predicates of the form
             // d.i != d.j, for example if we are considering an ITE constructor,
-            // we enforce that d.1 != d.2 since otherwise the ITE can be 
+            // we enforce that d.1 != d.2 since otherwise the ITE can be
             // simplified.
             for( unsigned i=0; i<deq_child[0].size(); i++ ){
               unsigned c1 = deq_child[0][i];

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -408,7 +408,7 @@ Node SygusSymBreakNew::getSimpleSymBreakPred( TypeNode tn, int tindex, unsigned 
     //symmetry breaking
     Kind nk = d_tds->getConsNumKind( tn, tindex );
     if( options::sygusSymBreak() ){
-      NodeManager * nm = NodeManager::currentNM();
+      NodeManager* nm = NodeManager::currentNM();
       // if less than the maximum depth we consider
       if( depth<2 ){
         //get children
@@ -485,20 +485,24 @@ Node SygusSymBreakNew::getSimpleSymBreakPred( TypeNode tn, int tindex, unsigned 
               unsigned c1 = deq_child[0][i];
               unsigned c2 = deq_child[1][i];
               TypeNode tnc = children[c1].getType();
-              if( tnc==children[c2].getType() && !tnc.getCardinality().isOne() ){
-                Node sym_lem_deq = children[c1].eqNode( children[c2] ).negate();
-                // must guard if there are symbolic constructors 
+              if (tnc == children[c2].getType()
+                  && !tnc.getCardinality().isOne())
+              {
+                Node sym_lem_deq = children[c1].eqNode(children[c2]).negate();
+                // must guard if there are symbolic constructors
                 int anyc_cons_num_c = d_tds->getAnyConstantConsNum(tnc);
-                if( anyc_cons_num_c!=-1 )
+                if (anyc_cons_num_c != -1)
                 {
-                  const Datatype& cdt = static_cast<DatatypeType>(tnc.toType()).getDatatype();
-                  Node guard_val = 
-          nm->mkNode(APPLY_CONSTRUCTOR,
+                  const Datatype& cdt =
+                      static_cast<DatatypeType>(tnc.toType()).getDatatype();
+                  Node guard_val = nm->mkNode(
+                      APPLY_CONSTRUCTOR,
                       Node::fromExpr(cdt[anyc_cons_num_c].getConstructor()));
-                  Node exp = d_tds->getExplain()->getExplanationForEquality(children[c1],guard_val);
-                  sym_lem_deq = nm->mkNode( OR, exp, sym_lem_deq );
+                  Node exp = d_tds->getExplain()->getExplanationForEquality(
+                      children[c1], guard_val);
+                  sym_lem_deq = nm->mkNode(OR, exp, sym_lem_deq);
                 }
-                sbp_conj.push_back( sym_lem_deq );
+                sbp_conj.push_back(sym_lem_deq);
               }
             }
             
@@ -538,9 +542,10 @@ Node SygusSymBreakNew::getSimpleSymBreakPred( TypeNode tn, int tindex, unsigned 
                   Kind nck = d_tds->getConsNumKind(tnc, k);
                   bool red = false;
                   // check if the argument is redundant
-                  if( static_cast<int>(k)==anyc_cons_num )
+                  if (static_cast<int>(k) == anyc_cons_num)
                   {
-                    // check if the any constant constructor is redundant at this argument position
+                    // check if the any constant constructor is redundant at
+                    // this argument position
                     // TODO
                   }
                   else if (nck != UNDEFINED_KIND)
@@ -581,15 +586,15 @@ Node SygusSymBreakNew::getSimpleSymBreakPred( TypeNode tn, int tindex, unsigned 
           // cannot be the "any constant" constructor
           unsigned dt_index_nargs = dt[tindex].getNumArgs();
           int tn_ac = d_tds->getAnyConstantConsNum(tn);
-          if( tn_ac!=-1 && dt_index_nargs>0 )
+          if (tn_ac != -1 && dt_index_nargs > 0)
           {
-            std::vector< Node > exp_all_anyc;
+            std::vector<Node> exp_all_anyc;
             bool success = true;
-            for( unsigned j=0; j<dt_index_nargs; j++ )
+            for (unsigned j = 0; j < dt_index_nargs; j++)
             {
               TypeNode ctn = TypeNode::fromType(dt[tindex].getArgType(j));
               int ctn_ac = d_tds->getAnyConstantConsNum(ctn);
-              if( ctn_ac==-1 )
+              if (ctn_ac == -1)
               {
                 success = false;
                 break;
@@ -598,15 +603,20 @@ Node SygusSymBreakNew::getSimpleSymBreakPred( TypeNode tn, int tindex, unsigned 
               {
                 Node nc = children[j];
                 TypeNode tnc = nc.getType();
-                const Datatype& cdt = static_cast<DatatypeType>(tnc.toType()).getDatatype();
-                exp_all_anyc.push_back( DatatypesRewriter::mkTester(nc, ctn_ac, cdt) );
+                const Datatype& cdt =
+                    static_cast<DatatypeType>(tnc.toType()).getDatatype();
+                exp_all_anyc.push_back(
+                    DatatypesRewriter::mkTester(nc, ctn_ac, cdt));
               }
             }
-            if( success )
+            if (success)
             {
-              Node expaan = exp_all_anyc.size()==1 ? exp_all_anyc[0] : nm->mkNode(AND,exp_all_anyc);
+              Node expaan = exp_all_anyc.size() == 1
+                                ? exp_all_anyc[0]
+                                : nm->mkNode(AND, exp_all_anyc);
               expaan = expaan.negate();
-              Trace("sygus-sb-simple-debug") << "Ensure not all any constant: " << expaan << std::endl;
+              Trace("sygus-sb-simple-debug")
+                  << "Ensure not all any constant: " << expaan << std::endl;
               sbp_conj.push_back(expaan);
             }
           }

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -845,12 +845,14 @@ void SygusSymBreakNew::addSymBreakLemmasFor( TypeNode tn, Node t, unsigned d, st
 void SygusSymBreakNew::addSymBreakLemmasFor( TypeNode tn, Node t, unsigned d, Node a, std::vector< Node >& lemmas ) {
   Assert( t.getType()==tn );
   Assert( !a.isNull() );
+  Trace("sygus-sb-debug2") << "add sym break lemmas for " << t << " " << d << " " << a << std::endl;
   std::map< TypeNode, std::map< unsigned, std::vector< Node > > >::iterator its = d_cache[a].d_sb_lemmas.find( tn );
   if( its != d_cache[a].d_sb_lemmas.end() ){
     TNode x = getFreeVar( tn );
     //get symmetry breaking lemmas for this term 
     unsigned csz = getSearchSizeForAnchor( a );
     int max_sz = ((int)csz) - ((int)d);
+    Trace("sygus-sb-debug2") << "add lemmas up to size " << max_sz << ", which is (search_size) " << csz << " - (depth) " << d << std::endl;
     for( std::map< unsigned, std::vector< Node > >::iterator it = its->second.begin(); it != its->second.end(); ++it ){
       if( (int)it->first<=max_sz ){
         for( unsigned k=0; k<it->second.size(); k++ ){
@@ -860,6 +862,7 @@ void SygusSymBreakNew::addSymBreakLemmasFor( TypeNode tn, Node t, unsigned d, No
       }
     }
   }
+  Trace("sygus-sb-debug2") << "...finished." << std::endl;
 }
 
 void SygusSymBreakNew::addSymBreakLemma(Node lem,

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -845,14 +845,17 @@ void SygusSymBreakNew::addSymBreakLemmasFor( TypeNode tn, Node t, unsigned d, st
 void SygusSymBreakNew::addSymBreakLemmasFor( TypeNode tn, Node t, unsigned d, Node a, std::vector< Node >& lemmas ) {
   Assert( t.getType()==tn );
   Assert( !a.isNull() );
-  Trace("sygus-sb-debug2") << "add sym break lemmas for " << t << " " << d << " " << a << std::endl;
+  Trace("sygus-sb-debug2") << "add sym break lemmas for " << t << " " << d
+                           << " " << a << std::endl;
   std::map< TypeNode, std::map< unsigned, std::vector< Node > > >::iterator its = d_cache[a].d_sb_lemmas.find( tn );
   if( its != d_cache[a].d_sb_lemmas.end() ){
     TNode x = getFreeVar( tn );
     //get symmetry breaking lemmas for this term 
     unsigned csz = getSearchSizeForAnchor( a );
     int max_sz = ((int)csz) - ((int)d);
-    Trace("sygus-sb-debug2") << "add lemmas up to size " << max_sz << ", which is (search_size) " << csz << " - (depth) " << d << std::endl;
+    Trace("sygus-sb-debug2")
+        << "add lemmas up to size " << max_sz << ", which is (search_size) "
+        << csz << " - (depth) " << d << std::endl;
     for( std::map< unsigned, std::vector< Node > >::iterator it = its->second.begin(); it != its->second.end(); ++it ){
       if( (int)it->first<=max_sz ){
         for( unsigned k=0; k<it->second.size(); k++ ){
@@ -1051,10 +1054,10 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
     for (const Node& a : anchors)
     {
       // is this a registered enumerator?
-      if( d_register_st.find(a) != d_register_st.end() )
+      if (d_register_st.find(a) != d_register_st.end())
       {
         // symmetry breaking lemmas should only be for enumerators
-        Assert( d_register_st[a] );
+        Assert(d_register_st[a]);
         std::vector<Node> sbl;
         d_tds->getSymBreakLemmas(a, sbl);
         for (const Node& lem : sbl)

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.h
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.h
@@ -23,11 +23,6 @@
 
 namespace CVC4 {
 namespace theory {
-
-namespace arith {
-  class TheoryArith;
-}
-
 namespace quantifiers {
 
 class CegqiOutput {

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -258,30 +258,6 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   std::vector<Node> candidate_values;
   bool constructed_cand = false;
 
-  /*
-  if (options::sygusRepairConst())
-  {
-    // have we tried to repair the previous solution?
-    // if not, call the repair constant utility
-    unsigned ninst = d_cinfo[d_candidates[0]].d_inst.size();
-    if (d_repair_index < ninst)
-    {
-      std::vector<Node> fail_cvs;
-      for (const Node& cprog : d_candidates)
-      {
-        Assert(d_repair_index < d_cinfo[cprog].d_inst.size());
-        fail_cvs.push_back(d_cinfo[cprog].d_inst[d_repair_index]);
-      }
-      d_repair_index++;
-      if (d_sygus_rconst->repairSolution(
-              d_candidates, fail_cvs, candidate_values))
-      {
-        constructed_cand = true;
-      }
-    }
-  }
-  */
-
   // get the model value of the relevant terms from the master module
   std::vector<Node> enum_values;
   getModelValues(terms, enum_values);

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -258,6 +258,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   std::vector<Node> candidate_values;
   bool constructed_cand = false;
 
+  /*
   if (options::sygusRepairConst())
   {
     // have we tried to repair the previous solution?
@@ -279,6 +280,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
       }
     }
   }
+  */
 
   // get the model value of the relevant terms from the master module
   std::vector<Node> enum_values;

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -72,11 +72,11 @@ bool Cegis::processInitialize(Node n,
   {
     Trace("cegis") << "...register enumerator " << candidates[i];
     bool do_repair_const = false;
-    if( options::sygusRepairConst() )
+    if (options::sygusRepairConst())
     {
       TypeNode ctn = candidates[i].getType();
       d_tds->registerSygusType(ctn);
-      if( d_tds->hasSubtermSymbolicCons(ctn))
+      if (d_tds->hasSubtermSymbolicCons(ctn))
       {
         do_repair_const = true;
         // remember that we are doing grammar-based repair
@@ -85,7 +85,8 @@ bool Cegis::processInitialize(Node n,
       }
     }
     Trace("cegis") << std::endl;
-    d_tds->registerEnumerator(candidates[i], candidates[i], d_parent, false, do_repair_const);
+    d_tds->registerEnumerator(
+        candidates[i], candidates[i], d_parent, false, do_repair_const);
   }
   return true;
 }
@@ -173,15 +174,15 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
     }
   }
   // if we are using grammar-based repair
-  if( d_using_gr_repair )
+  if (d_using_gr_repair)
   {
     SygusRepairConst* src = d_parent->getRepairConst();
     Assert(src != nullptr);
     // check if any enum_values have symbolic terms that must be repaired
     bool mustRepair = false;
-    for( const Node& c : enum_values )
+    for (const Node& c : enum_values)
     {
-      if( SygusRepairConst::mustRepair(c) )
+      if (SygusRepairConst::mustRepair(c))
       {
         mustRepair = true;
         break;
@@ -189,30 +190,33 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
     }
     Trace("cegis") << "...must repair is: " << mustRepair << std::endl;
     // if the solution contains a subterm that must be repaired
-    if( mustRepair )
+    if (mustRepair)
     {
       std::vector<Node> fail_cvs = enum_values;
       Assert(candidates.size() == fail_cvs.size());
-      if( src->repairSolution(candidates, fail_cvs, candidate_values) )
+      if (src->repairSolution(candidates, fail_cvs, candidate_values))
       {
         return true;
       }
       else
       {
-        // repair solution didn't work, exclude this solution 
-        std::vector< Node > exp;
-        for( unsigned i=0, size = enums.size(); i<size; i++ )
+        // repair solution didn't work, exclude this solution
+        std::vector<Node> exp;
+        for (unsigned i = 0, size = enums.size(); i < size; i++)
         {
-          d_tds->getExplain()->getExplanationForEquality(enums[i],enum_values[i], exp);
+          d_tds->getExplain()->getExplanationForEquality(
+              enums[i], enum_values[i], exp);
         }
-        Assert( !exp.empty() );
-        Node expn = exp.size()==1 ? exp[0] : NodeManager::currentNM()->mkNode( AND, exp );
-        lems.push_back( expn.negate() );
+        Assert(!exp.empty());
+        Node expn = exp.size() == 1
+                        ? exp[0]
+                        : NodeManager::currentNM()->mkNode(AND, exp);
+        lems.push_back(expn.negate());
         return false;
       }
     }
   }
-  
+
   // evaluate on refinement lemmas
   bool addedEvalLemmas = addEvalLemmas(enums, enum_values);
 
@@ -240,7 +244,7 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
   }
   return true;
 }
-  
+
 bool Cegis::processConstructCandidates(const std::vector<Node>& enums,
                                        const std::vector<Node>& enum_values,
                                        const std::vector<Node>& candidates,

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -206,9 +206,8 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
             enums[i], enum_values[i], exp);
       }
       Assert(!exp.empty());
-      Node expn = exp.size() == 1
-                      ? exp[0]
-                      : NodeManager::currentNM()->mkNode(AND, exp);
+      Node expn =
+          exp.size() == 1 ? exp[0] : NodeManager::currentNM()->mkNode(AND, exp);
       lems.push_back(expn.negate());
       return false;
     }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -198,22 +198,19 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
       {
         return true;
       }
-      else
+      // repair solution didn't work, exclude this solution
+      std::vector<Node> exp;
+      for (unsigned i = 0, size = enums.size(); i < size; i++)
       {
-        // repair solution didn't work, exclude this solution
-        std::vector<Node> exp;
-        for (unsigned i = 0, size = enums.size(); i < size; i++)
-        {
-          d_tds->getExplain()->getExplanationForEquality(
-              enums[i], enum_values[i], exp);
-        }
-        Assert(!exp.empty());
-        Node expn = exp.size() == 1
-                        ? exp[0]
-                        : NodeManager::currentNM()->mkNode(AND, exp);
-        lems.push_back(expn.negate());
-        return false;
+        d_tds->getExplain()->getExplanationForEquality(
+            enums[i], enum_values[i], exp);
       }
+      Assert(!exp.empty());
+      Node expn = exp.size() == 1
+                      ? exp[0]
+                      : NodeManager::currentNM()->mkNode(AND, exp);
+      lems.push_back(expn.negate());
+      return false;
     }
   }
 

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -29,7 +29,7 @@ namespace theory {
 namespace quantifiers {
 
 Cegis::Cegis(QuantifiersEngine* qe, CegConjecture* p)
-    : SygusModule(qe, p), d_eval_unfold(nullptr)
+    : SygusModule(qe, p), d_eval_unfold(nullptr), d_using_gr_repair(false)
 {
   if (options::sygusEvalUnfold())
   {
@@ -66,10 +66,26 @@ bool Cegis::processInitialize(Node n,
                               const std::vector<Node>& candidates,
                               std::vector<Node>& lemmas)
 {
+  Trace("cegis") << "Initialize cegis..." << std::endl;
   // initialize an enumerator for each candidate
   for (unsigned i = 0; i < candidates.size(); i++)
   {
-    d_tds->registerEnumerator(candidates[i], candidates[i], d_parent);
+    Trace("cegis") << "...register enumerator " << candidates[i];
+    bool do_repair_const = false;
+    if( options::sygusRepairConst() )
+    {
+      TypeNode ctn = candidates[i].getType();
+      d_tds->registerSygusType(ctn);
+      if( d_tds->hasSubtermSymbolicCons(ctn))
+      {
+        do_repair_const = true;
+        // remember that we are doing grammar-based repair
+        d_using_gr_repair = true;
+        Trace("cegis") << " (using repair)";
+      }
+    }
+    Trace("cegis") << std::endl;
+    d_tds->registerEnumerator(candidates[i], candidates[i], d_parent, false, do_repair_const);
   }
   return true;
 }
@@ -156,6 +172,47 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
       Trace("cegis") << ss.str() << std::endl;
     }
   }
+  // if we are using grammar-based repair
+  if( d_using_gr_repair )
+  {
+    SygusRepairConst* src = d_parent->getRepairConst();
+    Assert(src != nullptr);
+    // check if any enum_values have symbolic terms that must be repaired
+    bool mustRepair = false;
+    for( const Node& c : enum_values )
+    {
+      if( SygusRepairConst::mustRepair(c) )
+      {
+        mustRepair = true;
+        break;
+      }
+    }
+    Trace("cegis") << "...must repair is: " << mustRepair << std::endl;
+    // if the solution contains a subterm that must be repaired
+    if( mustRepair )
+    {
+      std::vector<Node> fail_cvs = enum_values;
+      Assert(candidates.size() == fail_cvs.size());
+      if( src->repairSolution(candidates, fail_cvs, candidate_values) )
+      {
+        return true;
+      }
+      else
+      {
+        // repair solution didn't work, exclude this solution 
+        std::vector< Node > exp;
+        for( unsigned i=0, size = enums.size(); i<size; i++ )
+        {
+          d_tds->getExplain()->getExplanationForEquality(enums[i],enum_values[i], exp);
+        }
+        Assert( !exp.empty() );
+        Node expn = exp.size()==1 ? exp[0] : NodeManager::currentNM()->mkNode( AND, exp );
+        lems.push_back( expn.negate() );
+        return false;
+      }
+    }
+  }
+  
   // evaluate on refinement lemmas
   bool addedEvalLemmas = addEvalLemmas(enums, enum_values);
 
@@ -183,7 +240,7 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
   }
   return true;
 }
-
+  
 bool Cegis::processConstructCandidates(const std::vector<Node>& enums,
                                        const std::vector<Node>& enum_values,
                                        const std::vector<Node>& candidates,
@@ -196,14 +253,6 @@ bool Cegis::processConstructCandidates(const std::vector<Node>& enums,
     candidate_values.insert(
         candidate_values.end(), enum_values.begin(), enum_values.end());
     return true;
-  }
-  SygusRepairConst* src = d_parent->getRepairConst();
-  if (src != nullptr)
-  {
-    // it may be repairable
-    std::vector<Node> fail_cvs = enum_values;
-    Assert(candidates.size() == fail_cvs.size());
-    return src->repairSolution(candidates, fail_cvs, candidate_values);
   }
   return false;
 }

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -166,9 +166,13 @@ class Cegis : public SygusModule
   std::unordered_set<unsigned> d_cegis_sample_refine;
 
   //---------------------------------for sygus repair
-  /** are we using grammar-based repair? */
+  /** are we using grammar-based repair? 
+   * 
+   * This flag is set ot true if at least one of the enumerators allocated
+   * by this class has been configured to allow model values with symbolic
+   * constructors, such as the "any constant" constructor.
+   */
   bool d_using_gr_repair;
-
   //---------------------------------end for sygus repair
 };
 

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -79,7 +79,7 @@ class Cegis : public SygusModule
   virtual bool processInitialize(Node n,
                                  const std::vector<Node>& candidates,
                                  std::vector<Node>& lemmas);
-  /** do cegis-implementation-specific construct candidate
+  /** do cegis-implementation-specific post-processing for construct candidate
    *
    * satisfiedRl is whether all refinement lemmas are satisfied under the
    * substitution { enums -> enum_values }.
@@ -164,6 +164,12 @@ class Cegis : public SygusModule
    * added as refinement lemmas.
    */
   std::unordered_set<unsigned> d_cegis_sample_refine;
+  
+  //---------------------------------for sygus repair
+  /** are we using grammar-based repair? */
+  bool d_using_gr_repair;
+  
+  //---------------------------------end for sygus repair
 };
 
 } /* CVC4::theory::quantifiers namespace */

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -164,11 +164,11 @@ class Cegis : public SygusModule
    * added as refinement lemmas.
    */
   std::unordered_set<unsigned> d_cegis_sample_refine;
-  
+
   //---------------------------------for sygus repair
   /** are we using grammar-based repair? */
   bool d_using_gr_repair;
-  
+
   //---------------------------------end for sygus repair
 };
 

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -166,8 +166,8 @@ class Cegis : public SygusModule
   std::unordered_set<unsigned> d_cegis_sample_refine;
 
   //---------------------------------for sygus repair
-  /** are we using grammar-based repair? 
-   * 
+  /** are we using grammar-based repair?
+   *
    * This flag is set ot true if at least one of the enumerators allocated
    * by this class has been configured to allow model values with symbolic
    * constructors, such as the "any constant" constructor.

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -110,7 +110,8 @@ void SygusGrammarNorm::TypeObject::buildDatatype(SygusGrammarNorm* sygus_norm,
     TypeNode sygus_type = TypeNode::fromType(dt.getSygusType());
     // must be handled by counterexample-guided instantiation
     // don't do it for Boolean (not worth the trouble)
-    if (CegInstantiator::isCbqiSort(sygus_type) >= CEG_HANDLED && !sygus_type.isBoolean())
+    if (CegInstantiator::isCbqiSort(sygus_type) >= CEG_HANDLED
+        && !sygus_type.isBoolean())
     {
       Trace("sygus-grammar-normalize") << "...add any constant constructor.\n";
       // add an "any constant" proxy variable

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -109,7 +109,10 @@ void SygusGrammarNorm::TypeObject::buildDatatype(SygusGrammarNorm* sygus_norm,
   {
     TypeNode sygus_type = TypeNode::fromType(dt.getSygusType());
     // must be handled by counterexample-guided instantiation
-    // don't do it for Boolean (not worth the trouble)
+    // don't do it for Boolean (not worth the trouble, since it has only
+    // minimal gain (1 any constant vs 2 constructors for true/false), and
+    // we need to do a lot of special symmetry breaking, e.g. for ensuring
+    // any constant constructors are not the 1st children of ITEs.
     if (CegInstantiator::isCbqiSort(sygus_type) >= CEG_HANDLED
         && !sygus_type.isBoolean())
     {

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -20,11 +20,11 @@
 #include "printer/sygus_print_callback.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
+#include "theory/quantifiers/cegqi/ceg_instantiator.h"
 #include "theory/quantifiers/sygus/ce_guided_conjecture.h"
 #include "theory/quantifiers/sygus/sygus_grammar_red.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
-#include "theory/quantifiers/cegqi/ceg_instantiator.h"
 
 #include <numeric>  // for std::iota
 
@@ -113,25 +113,23 @@ void SygusGrammarNorm::TypeObject::buildDatatype(SygusGrammarNorm* sygus_norm,
                              d_pc[i],
                              d_weight[i]);
   }
-  if( dt.getSygusAllowConst() )
+  if (dt.getSygusAllowConst())
   {
-    TypeNode sygus_type = TypeNode::fromType( dt.getSygusType() );
+    TypeNode sygus_type = TypeNode::fromType(dt.getSygusType());
     // must be handled by counterexample-guided instantiation
-    if( CegInstantiator::isCbqiSort( sygus_type )>=CEG_HANDLED )
+    if (CegInstantiator::isCbqiSort(sygus_type) >= CEG_HANDLED)
     {
       Trace("sygus-grammar-normalize") << "...add any constant constructor.\n";
       // add an "any constant" proxy variable
-      Node av = NodeManager::currentNM()->mkSkolem("_any_constant",sygus_type);
+      Node av = NodeManager::currentNM()->mkSkolem("_any_constant", sygus_type);
       // mark that it represents any constant
       SygusAnyConstAttribute saca;
-      av.setAttribute(saca,true);
+      av.setAttribute(saca, true);
       std::stringstream ss;
       ss << d_unres_tn << "_any_constant";
       std::string cname(ss.str());
       std::vector<Type> empty_arg_types;
-      d_dt.addSygusConstructor(av.toExpr(),
-                              cname,
-                              empty_arg_types);
+      d_dt.addSygusConstructor(av.toExpr(), cname, empty_arg_types);
     }
   }
   Trace("sygus-grammar-normalize") << "...built datatype " << d_dt << " ";

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.h
@@ -36,6 +36,10 @@ namespace quantifiers {
 
 class SygusGrammarNorm;
 
+/** Attribute true for variables that represent any constant */
+struct SygusAnyConstAttributeId {};
+typedef expr::Attribute< SygusAnyConstAttributeId, bool > SygusAnyConstAttribute;
+
 /** Operator position trie class
  *
  * This data structure stores an unresolved type corresponding to the

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.h
@@ -37,8 +37,10 @@ namespace quantifiers {
 class SygusGrammarNorm;
 
 /** Attribute true for variables that represent any constant */
-struct SygusAnyConstAttributeId {};
-typedef expr::Attribute< SygusAnyConstAttributeId, bool > SygusAnyConstAttribute;
+struct SygusAnyConstAttributeId
+{
+};
+typedef expr::Attribute<SygusAnyConstAttributeId, bool> SygusAnyConstAttribute;
 
 /** Operator position trie class
  *

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -218,7 +218,7 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
     std::vector<Node> sk_sygus_m;
     for (const Node& v : sk_vars)
     {
-      Assert( d_sk_to_fo.find(v)!=d_sk_to_fo.end());
+      Assert(d_sk_to_fo.find(v) != d_sk_to_fo.end());
       Node fov = d_sk_to_fo[v];
       Node fov_m = Node::fromExpr(repcChecker.getValue(fov.toExpr()));
       Trace("sygus-repair-const") << "  " << fov << " = " << fov_m << std::endl;
@@ -415,7 +415,7 @@ Node SygusRepairConst::getFoQuery(const std::vector<Node>& candidates,
   Trace("sygus-repair-const-debug") << "  ...got : " << body << std::endl;
 
   Trace("sygus-repair-const") << "  Introduce first-order vars..." << std::endl;
-  for( const Node& v : sk_vars )
+  for (const Node& v : sk_vars)
   {
     std::map<Node, Node>::iterator itf = d_sk_to_fo.find(v);
     if (itf == d_sk_to_fo.end())
@@ -451,7 +451,7 @@ Node SygusRepairConst::getFoQuery(const std::vector<Node>& candidates,
         if (std::find(sk_vars.begin(), sk_vars.end(), v) != sk_vars.end())
         {
           std::map<Node, Node>::iterator itf = d_sk_to_fo.find(v);
-          Assert (itf != d_sk_to_fo.end());
+          Assert(itf != d_sk_to_fo.end());
           visited[cur] = itf->second;
         }
       }
@@ -558,15 +558,15 @@ bool SygusRepairConst::getFitToLogicExcludeVar(LogicInfo& logic,
     {
       visited.insert(cur);
       Kind ck = cur.getKind();
-      if (restrictLA && (ck == NONLINEAR_MULT || ck==DIVISION))
+      if (restrictLA && (ck == NONLINEAR_MULT || ck == DIVISION))
       {
-        for( unsigned j=0, size=cur.getNumChildren(); j<size; j++ )
+        for (unsigned j = 0, size = cur.getNumChildren(); j < size; j++)
         {
           Node ccur = cur[j];
           std::map<Node, Node>::iterator itf = d_fo_to_sk.find(ccur);
           if (itf != d_fo_to_sk.end())
           {
-            if( ck == NONLINEAR_MULT || ( ck == DIVISION && j==1 ) )
+            if (ck == NONLINEAR_MULT || (ck == DIVISION && j == 1))
             {
               exvar = itf->second;
               return true;

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -20,8 +20,8 @@
 #include "smt/smt_engine_scope.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/quantifiers/cegqi/ceg_instantiator.h"
-#include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/sygus/sygus_grammar_norm.h"
+#include "theory/quantifiers/sygus/term_database_sygus.h"
 
 using namespace CVC4::kind;
 
@@ -115,7 +115,8 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   for (unsigned i = 0, size = candidates.size(); i < size; i++)
   {
     Node cv = candidate_values[i];
-    Node skeleton = getSkeleton(cv, free_var_count, sk_vars, sk_vars_to_subs, useConstants);
+    Node skeleton =
+        getSkeleton(cv, free_var_count, sk_vars, sk_vars_to_subs, useConstants);
     if (Trace.isOn("sygus-repair-const"))
     {
       Printer* p = Printer::getPrinter(options::outputLanguage());
@@ -253,28 +254,31 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   return false;
 }
 
-bool SygusRepairConst::mustRepair(Node n) 
+bool SygusRepairConst::mustRepair(Node n)
 {
   std::unordered_set<TNode, TNodeHashFunction> visited;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
-    if (visited.find(cur) == visited.end()) {
+    if (visited.find(cur) == visited.end())
+    {
       visited.insert(cur);
-      Assert( cur.getKind()==APPLY_CONSTRUCTOR );
-      if( isRepairable(cur,false) )
+      Assert(cur.getKind() == APPLY_CONSTRUCTOR);
+      if (isRepairable(cur, false))
       {
         return true;
       }
-      for (const Node& cn : cur ){
+      for (const Node& cn : cur)
+      {
         visit.push_back(cn);
       }
     }
   } while (!visit.empty());
-  
+
   return false;
 }
 
@@ -288,14 +292,14 @@ bool SygusRepairConst::isRepairable(Node n, bool useConstantsAsHoles)
   Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Assert(dt.isSygus());
-  Node op = n.getOperator();    
+  Node op = n.getOperator();
   unsigned cindex = Datatype::indexOf(op.toExpr());
   if (dt[cindex].getNumArgs() > 0)
   {
     return false;
   }
   Node sygusOp = Node::fromExpr(dt[cindex].getSygusOp());
-  if( sygusOp.getAttribute(SygusAnyConstAttribute()) )
+  if (sygusOp.getAttribute(SygusAnyConstAttribute()))
   {
     // if it represents "any constant" then it is repairable
     return true;

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -85,7 +85,7 @@ void SygusRepairConst::registerSygusType(TypeNode tn,
 bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
                                       const std::vector<Node>& candidate_values,
                                       std::vector<Node>& repair_cv,
-                                      bool useConstants)
+                                      bool useConstantsAsHoles)
 {
   Assert(candidates.size() == candidate_values.size());
 
@@ -116,7 +116,7 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   {
     Node cv = candidate_values[i];
     Node skeleton =
-        getSkeleton(cv, free_var_count, sk_vars, sk_vars_to_subs, useConstants);
+        getSkeleton(cv, free_var_count, sk_vars, sk_vars_to_subs, useConstantsAsHoles);
     if (Trace.isOn("sygus-repair-const"))
     {
       Printer* p = Printer::getPrinter(options::outputLanguage());

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -33,7 +33,7 @@ class CegConjecture;
  * This module is used to repair portions of candidate solutions. In particular,
  * given a synthesis conjecture:
  *   exists f. forall x. P( f, x )
- * and a candidate solution f = \x. t[x,r] where c are repairable terms, this
+ * and a candidate solution f = \x. t[x,r] where r are repairable terms, this
  * function checks whether there exists a term of the form \x. t[x,c'] for some
  * constants c' such that:
  *   forall x. P( (\x. t[x,c']), x )  [***]

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -76,7 +76,7 @@ class SygusRepairConst
   bool repairSolution(const std::vector<Node>& candidates,
                       const std::vector<Node>& candidate_values,
                       std::vector<Node>& repair_cv,
-                      bool useConstantsAsHoles=true
+                      bool useConstantsAsHoles=false
                      );
   /** must repair? 
    * 
@@ -112,19 +112,14 @@ class SygusRepairConst
    * already registered types.
    */
   void registerSygusType(TypeNode tn, std::map<TypeNode, bool>& tprocessed);
-  /**
-   * Returns true if n is a term of a sygus datatype type that allows all
-   * constants, and n encodes a constant. The term n must have a sygus datatype
-   * type.
-   */
-  inline bool isRepairableConstant(Node n) const;
   /** is repairable? 
    * 
    * This returns true if n can be repaired by this class. In particular, we
-   * return true if n is an "any constant" constructor, or it is a constant
-   * in a type that allows all constants and useConstantsAsHoles is true.
+   * return true if n is an "any constant" constructor, or it is a constructor
+   * for a constant in a type that allows all constants and useConstantsAsHoles 
+   * is true.
    */
-  inline bool isRepairable(Node n, bool useConstantsAsHoles=true) const;
+  static bool isRepairable(Node n, bool useConstantsAsHoles);
   /** get skeleton
    *
    * Returns a skeleton for sygus datatype value n, where the subterms of n that

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -33,9 +33,9 @@ class CegConjecture;
  * This module is used to repair portions of candidate solutions. In particular,
  * given a synthesis conjecture:
  *   exists f. forall x. P( f, x )
- * and a candidate solution f = \x. t[x,c] where c are constants, this function
- * checks whether there exists a term of the form \x. t[x,c'] for some constants
- * c' such that:
+ * and a candidate solution f = \x. t[x,r] where c are repairable terms, this
+ * function checks whether there exists a term of the form \x. t[x,c'] for some
+ * constants c' such that:
  *   forall x. P( (\x. t[x,c']), x )  [***]
  * is satisfiable, where notice that the above formula after beta-reduction may
  * be one in pure first-order logic in a decidable theory (say linear
@@ -68,11 +68,15 @@ class SygusRepairConst
    * is a solution for the synthesis conjecture associated with this class.
    * Moreover, it is the case that
    *    repair_cv[j] != candidate_values[j], for at least one j.
+   * We always consider applications of the "any constant" constructors in 
+   * candidate_values to be repairable. In addition, if the flag 
+   * useConstantsAsHoles is true, we consider all constants whose (sygus) type
+   * admit alls constants to be repairable.
    */
   bool repairSolution(const std::vector<Node>& candidates,
                       const std::vector<Node>& candidate_values,
                       std::vector<Node>& repair_cv,
-                      bool useConstants=true
+                      bool useConstantsAsHoles=true
                      );
   /** must repair? 
    * 
@@ -118,24 +122,25 @@ class SygusRepairConst
    * 
    * This returns true if n can be repaired by this class. In particular, we
    * return true if n is an "any constant" constructor, or it is a constant
-   * in a type that allows all constants and useConstants is true.
+   * in a type that allows all constants and useConstantsAsHoles is true.
    */
-  inline bool isRepairable(Node n, bool useConstants=true) const;
+  inline bool isRepairable(Node n, bool useConstantsAsHoles=true) const;
   /** get skeleton
    *
-   * Returns a skeleton for n, where the subterms of n that are repairable
-   * constants are replaced by free variables. Since we are interested in
+   * Returns a skeleton for sygus datatype value n, where the subterms of n that
+   * are repairable are replaced by free variables. Since we are interested in
    * returning canonical skeletons, the free variables we use in this
    * replacement are taken from TermDbSygus, where we track indices
    * in free_var_count. Variables we introduce in this way are added to sk_vars.
    * The mapping sk_vars_to_subs contains entries v -> c, where v is a
-   * variable in sk_vars, and c is the term in n that it replaced.
+   * variable in sk_vars, and c is the term in n that it replaced. The flag
+   * useConstantsAsHoles affects which terms we consider to be repairable.
    */
   Node getSkeleton(Node n,
                    std::map<TypeNode, int>& free_var_count,
                    std::vector<Node>& sk_vars,
                    std::map<Node, Node>& sk_vars_to_subs,
-                      bool useConstants);
+                   bool useConstantsAsHoles);
   /** get first-order query
    *
    * This function returns a formula that is equivalent to the negation of the

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -68,23 +68,23 @@ class SygusRepairConst
    * is a solution for the synthesis conjecture associated with this class.
    * Moreover, it is the case that
    *    repair_cv[j] != candidate_values[j], for at least one j.
-   * We always consider applications of the "any constant" constructors in 
-   * candidate_values to be repairable. In addition, if the flag 
+   * We always consider applications of the "any constant" constructors in
+   * candidate_values to be repairable. In addition, if the flag
    * useConstantsAsHoles is true, we consider all constants whose (sygus) type
    * admit alls constants to be repairable.
    */
   bool repairSolution(const std::vector<Node>& candidates,
                       const std::vector<Node>& candidate_values,
                       std::vector<Node>& repair_cv,
-                      bool useConstantsAsHoles=false
-                     );
-  /** must repair? 
-   * 
+                      bool useConstantsAsHoles = false);
+  /** must repair?
+   *
    * This returns true if n must be repaired for it to be a valid solution.
    * This corresponds to whether n contains a subterm that is a symbolic
    * constructor like the "any constant" constructor.
    */
   static bool mustRepair(Node n);
+
  private:
   /** reference to quantifier engine */
   QuantifiersEngine* d_qe;
@@ -112,11 +112,11 @@ class SygusRepairConst
    * already registered types.
    */
   void registerSygusType(TypeNode tn, std::map<TypeNode, bool>& tprocessed);
-  /** is repairable? 
-   * 
+  /** is repairable?
+   *
    * This returns true if n can be repaired by this class. In particular, we
    * return true if n is an "any constant" constructor, or it is a constructor
-   * for a constant in a type that allows all constants and useConstantsAsHoles 
+   * for a constant in a type that allows all constants and useConstantsAsHoles
    * is true.
    */
   static bool isRepairable(Node n, bool useConstantsAsHoles);

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -71,8 +71,16 @@ class SygusRepairConst
    */
   bool repairSolution(const std::vector<Node>& candidates,
                       const std::vector<Node>& candidate_values,
-                      std::vector<Node>& repair_cv);
-
+                      std::vector<Node>& repair_cv,
+                      bool useConstants=true
+                     );
+  /** must repair? 
+   * 
+   * This returns true if n must be repaired for it to be a valid solution.
+   * This corresponds to whether n contains a subterm that is a symbolic
+   * constructor like the "any constant" constructor.
+   */
+  static bool mustRepair(Node n);
  private:
   /** reference to quantifier engine */
   QuantifiersEngine* d_qe;
@@ -105,7 +113,14 @@ class SygusRepairConst
    * constants, and n encodes a constant. The term n must have a sygus datatype
    * type.
    */
-  bool isRepairableConstant(Node n);
+  inline bool isRepairableConstant(Node n) const;
+  /** is repairable? 
+   * 
+   * This returns true if n can be repaired by this class. In particular, we
+   * return true if n is an "any constant" constructor, or it is a constant
+   * in a type that allows all constants and useConstants is true.
+   */
+  inline bool isRepairable(Node n, bool useConstants=true) const;
   /** get skeleton
    *
    * Returns a skeleton for n, where the subterms of n that are repairable
@@ -119,7 +134,8 @@ class SygusRepairConst
   Node getSkeleton(Node n,
                    std::map<TypeNode, int>& free_var_count,
                    std::vector<Node>& sk_vars,
-                   std::map<Node, Node>& sk_vars_to_subs);
+                   std::map<Node, Node>& sk_vars_to_subs,
+                      bool useConstants);
   /** get first-order query
    *
    * This function returns a formula that is equivalent to the negation of the

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -813,8 +813,8 @@ void TermDbSygus::registerEnumerator(Node e,
     d_enum_to_active_guard[e] = eg;
   }
 
-  // if not using symbolic constants, introduce symmetry breaking lemma
-  // templates for each relevant subtype of the grammar
+  // depending on if we are using symbolic constructors, introduce symmetry
+  // breaking lemma templates for each relevant subtype of the grammar
   std::map<TypeNode, std::map<TypeNode, unsigned> >::iterator it =
       d_min_type_depth.find(et);
   Assert(it != d_min_type_depth.end());
@@ -836,7 +836,7 @@ void TermDbSygus::registerEnumerator(Node e,
       }
       else
       {
-        // can remove all other concrete constant constructors?
+        // can remove all other concrete constant constructors
         for (unsigned i = 0, ncons = dt.getNumConstructors(); i < ncons; i++)
         {
           if (i != itsa->second)

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -698,7 +698,8 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
             TypeNode ctn = TypeNode::fromType(dt[i].getArgType(j));
             registerSygusType(ctn);
             // carry type attributes
-            if( d_has_subterm_sym_cons.find(ctn)!=d_has_subterm_sym_cons.end() )
+            if (d_has_subterm_sym_cons.find(ctn)
+                != d_has_subterm_sym_cons.end())
             {
               d_has_subterm_sym_cons[tn] = true;
             }
@@ -735,8 +736,8 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
                   << std::endl;
             }
           }
-          // symbolic constructors 
-          if( n.getAttribute(SygusAnyConstAttribute()) )
+          // symbolic constructors
+          if (n.getAttribute(SygusAnyConstAttribute()))
           {
             d_sym_cons_any_constant[tn] = i;
             d_has_subterm_sym_cons[tn] = true;
@@ -759,7 +760,7 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
               << " encodes terms that are not of type " << btn << std::endl;
         }
         // compute min type depth information
-        computeMinTypeDepthInternal( tn, tn, 0 );
+        computeMinTypeDepthInternal(tn, tn, 0);
       }
     }
   }
@@ -782,44 +783,53 @@ void TermDbSygus::registerEnumerator(Node e,
   registerSygusType(et);
   d_enum_to_conjecture[e] = conj;
   d_enum_to_synth_fun[e] = f;
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   if( mkActiveGuard ){
     // make the guard
-    Node eg = Rewriter::rewrite( nm->mkSkolem( "eG", nm->booleanType() ) );
+    Node eg = Rewriter::rewrite(nm->mkSkolem("eG", nm->booleanType()));
     eg = d_quantEngine->getValuation().ensureLiteral( eg );
     AlwaysAssert( !eg.isNull() );
     d_quantEngine->getOutputChannel().requirePhase( eg, true );
     //add immediate lemma
-    Node lem = nm->mkNode( OR, eg, eg.negate() );
+    Node lem = nm->mkNode(OR, eg, eg.negate());
     Trace("cegqi-lemma") << "Cegqi::Lemma : enumerator : " << lem << std::endl;
     d_quantEngine->getOutputChannel().lemma( lem );
     d_enum_to_active_guard[e] = eg;
   }
-  if( !useSymbolicCons )
+  if (!useSymbolicCons)
   {
     // if not using symbolic constants, introduce symmetry breaking lemma
     // templates for each relevant subtype of the grammar
-    std::map<TypeNode, std::map<TypeNode, unsigned> >::iterator it = d_min_type_depth.find(et);
-    Assert( it!=d_min_type_depth.end() );
-    // for each type of subterm of this enumerator 
-    for( const std::pair<const TypeNode, unsigned>& st : it->second )
+    std::map<TypeNode, std::map<TypeNode, unsigned> >::iterator it =
+        d_min_type_depth.find(et);
+    Assert(it != d_min_type_depth.end());
+    // for each type of subterm of this enumerator
+    for (const std::pair<const TypeNode, unsigned>& st : it->second)
     {
       TypeNode stn = st.first;
-      std::map<TypeNode, unsigned >::iterator itsa = d_sym_cons_any_constant.find(stn);
-      if( itsa!=d_sym_cons_any_constant.end() )
+      std::map<TypeNode, unsigned>::iterator itsa =
+          d_sym_cons_any_constant.find(stn);
+      if (itsa != d_sym_cons_any_constant.end())
       {
-        Assert( stn.isDatatype() );
-        const Datatype& dt = static_cast<DatatypeType>(stn.toType()).getDatatype();
+        Assert(stn.isDatatype());
+        const Datatype& dt =
+            static_cast<DatatypeType>(stn.toType()).getDatatype();
         // make the apply-constructor corresponding to an application of the
         // "any constant" constructor
-        Node exc_val = nm->mkNode( APPLY_CONSTRUCTOR, Node::fromExpr( dt[itsa->second].getConstructor() ) );
+        Node exc_val =
+            nm->mkNode(APPLY_CONSTRUCTOR,
+                       Node::fromExpr(dt[itsa->second].getConstructor()));
         // should not include the constuctor in any subterm
         Node x = getFreeVar(stn, 0);
-        Trace("sygus-db") << "Construct symmetry breaking lemma from " << x << " == " << exc_val << std::endl;
+        Trace("sygus-db") << "Construct symmetry breaking lemma from " << x
+                          << " == " << exc_val << std::endl;
         Node lem = getExplain()->getExplanationForEquality(x, exc_val);
         lem = lem.negate();
-        Trace("cegqi-lemma") << "Cegqi::Lemma : exclude symbolic cons lemma (template) : " << lem << std::endl;
-        // the size of the subterm we are blocking is the weight of the constructor (usually zero)
+        Trace("cegqi-lemma")
+            << "Cegqi::Lemma : exclude symbolic cons lemma (template) : " << lem
+            << std::endl;
+        // the size of the subterm we are blocking is the weight of the
+        // constructor (usually zero)
         registerSymBreakLemma(e, lem, stn, dt[itsa->second].getWeight());
       }
     }
@@ -919,10 +929,7 @@ unsigned TermDbSygus::getSizeForSymBreakLemma(Node lem) const
   return it->second;
 }
 
-void TermDbSygus::clearSymBreakLemmas(Node e)
-{
-  d_enum_to_sb_lemmas.erase(e);
-}
+void TermDbSygus::clearSymBreakLemmas(Node e) { d_enum_to_sb_lemmas.erase(e); }
 
 bool TermDbSygus::isRegistered( TypeNode tn ) {
   return d_register.find( tn )!=d_register.end();
@@ -1155,7 +1162,7 @@ bool TermDbSygus::isTypeMatch( const DatatypeConstructor& c1, const DatatypeCons
 
 bool TermDbSygus::hasSubtermSymbolicCons(TypeNode tn) const
 {
-  return d_has_subterm_sym_cons.find(tn)!=d_has_subterm_sym_cons.end();
+  return d_has_subterm_sym_cons.find(tn) != d_has_subterm_sym_cons.end();
 }
 
 Node TermDbSygus::minimizeBuiltinTerm( Node n ) {
@@ -1389,7 +1396,7 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
       cc.insert( cc.end(), args.begin(), args.end() );
       pre[j] = NodeManager::currentNM()->mkNode( kind::APPLY_UF, cc );
     }
-    Node ret = mkGeneric( dt, i, pre );
+    Node ret = mkGeneric(dt, i, pre);
     // if it is a variable, apply the substitution
     if( ret.getKind()==kind::BOUND_VARIABLE ){
       Assert( ret.hasAttribute(SygusVarNumAttribute()) );

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -695,7 +695,13 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
         {
           for (unsigned j = 0, nargs = dt[i].getNumArgs(); j < nargs; j++)
           {
-            registerSygusType(getArgType(dt[i], j));
+            TypeNode ctn = TypeNode::fromType(dt[i].getArgType(j));
+            registerSygusType(ctn);
+            // carry type attributes
+            if( d_has_subterm_sym_cons.find(ctn)!=d_has_subterm_sym_cons.end() )
+            {
+              d_has_subterm_sym_cons[tn] = true;
+            }
           }
         }
         //iterate over constructors
@@ -733,6 +739,7 @@ void TermDbSygus::registerSygusType( TypeNode tn ) {
           if( n.getAttribute(SygusAnyConstAttribute()) )
           {
             d_sym_cons_any_constant[tn] = i;
+            d_has_subterm_sym_cons[tn] = true;
           }
           // TODO (as part of #1170): we still do not properly catch type
           // errors in sygus grammars for arguments of builtin operators.
@@ -1144,6 +1151,11 @@ bool TermDbSygus::isTypeMatch( const DatatypeConstructor& c1, const DatatypeCons
     }
     return true;
   }
+}
+
+bool TermDbSygus::hasSubtermSymbolicCons(TypeNode tn) const
+{
+  return d_has_subterm_sym_cons.find(tn)!=d_has_subterm_sym_cons.end();
 }
 
 Node TermDbSygus::minimizeBuiltinTerm( Node n ) {

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -196,10 +196,13 @@ typedef expr::Attribute<SygusToBuiltinAttributeId, Node>
 
 Node TermDbSygus::sygusToBuiltin( Node n, TypeNode tn ) {
   std::map<TypeNode, int> var_count;
-  return sygusToBuiltin(n,tn,var_count);
+  return sygusToBuiltin(n, tn, var_count);
 }
 
-Node TermDbSygus::sygusToBuiltin( Node n, TypeNode tn, std::map<TypeNode, int>& var_count ) {
+Node TermDbSygus::sygusToBuiltin(Node n,
+                                 TypeNode tn,
+                                 std::map<TypeNode, int>& var_count)
+{
   Assert( n.getType()==tn );
   Assert( tn.isDatatype() );
 
@@ -220,16 +223,17 @@ Node TermDbSygus::sygusToBuiltin( Node n, TypeNode tn, std::map<TypeNode, int>& 
     for (unsigned j = 0, size = n.getNumChildren(); j < size; j++)
     {
       // if the child is a symbolic constructor, do not include it
-      if( !isSymbolicConsApp(n[j]) )
+      if (!isSymbolicConsApp(n[j]))
       {
-        pre[j] = sygusToBuiltin(n[j], TypeNode::fromType(dt[i].getArgType(j)), var_count);
+        pre[j] = sygusToBuiltin(
+            n[j], TypeNode::fromType(dt[i].getArgType(j)), var_count);
       }
     }
     Node ret = mkGeneric(dt, i, var_count, pre);
     Trace("sygus-db-debug")
         << "SygusToBuiltin : Generic is " << ret << std::endl;
     // cache if we had a fresh variable count
-    if( var_count_empty )
+    if (var_count_empty)
     {
       n.setAttribute(SygusToBuiltinAttribute(), ret);
     }
@@ -817,16 +821,15 @@ void TermDbSygus::registerEnumerator(Node e,
   // for each type of subterm of this enumerator
   for (const std::pair<const TypeNode, unsigned>& st : it->second)
   {
-    std::vector< unsigned > rm_indices;
+    std::vector<unsigned> rm_indices;
     TypeNode stn = st.first;
     Assert(stn.isDatatype());
-    const Datatype& dt =
-        static_cast<DatatypeType>(stn.toType()).getDatatype();
+    const Datatype& dt = static_cast<DatatypeType>(stn.toType()).getDatatype();
     std::map<TypeNode, unsigned>::iterator itsa =
         d_sym_cons_any_constant.find(stn);
     if (itsa != d_sym_cons_any_constant.end())
     {
-      if( !useSymbolicCons )
+      if (!useSymbolicCons)
       {
         // do not use the symbolic constructor
         rm_indices.push_back(itsa->second);
@@ -834,12 +837,12 @@ void TermDbSygus::registerEnumerator(Node e,
       else
       {
         // can remove all other concrete constant constructors?
-        for( unsigned i=0, ncons = dt.getNumConstructors(); i<ncons; i++ )
+        for (unsigned i = 0, ncons = dt.getNumConstructors(); i < ncons; i++)
         {
-          if( i!=itsa->second )
+          if (i != itsa->second)
           {
-            Node c_op = getConsNumConst(stn,i);
-            if( !c_op.isNull() )
+            Node c_op = getConsNumConst(stn, i);
+            if (!c_op.isNull())
             {
               rm_indices.push_back(i);
             }
@@ -847,13 +850,12 @@ void TermDbSygus::registerEnumerator(Node e,
         }
       }
     }
-    for( unsigned& rindex : rm_indices )
+    for (unsigned& rindex : rm_indices)
     {
       // make the apply-constructor corresponding to an application of the
       // "any constant" constructor
-      Node exc_val =
-          nm->mkNode(APPLY_CONSTRUCTOR,
-                      Node::fromExpr(dt[rindex].getConstructor()));
+      Node exc_val = nm->mkNode(APPLY_CONSTRUCTOR,
+                                Node::fromExpr(dt[rindex].getConstructor()));
       // should not include the constuctor in any subterm
       Node x = getFreeVar(stn, 0);
       Trace("sygus-db") << "Construct symmetry breaking lemma from " << x
@@ -965,7 +967,8 @@ unsigned TermDbSygus::getSizeForSymBreakLemma(Node lem) const
 
 void TermDbSygus::clearSymBreakLemmas(Node e) { d_enum_to_sb_lemmas.erase(e); }
 
-bool TermDbSygus::isRegistered( TypeNode tn ) const {
+bool TermDbSygus::isRegistered(TypeNode tn) const
+{
   return d_register.find( tn )!=d_register.end();
 }
 
@@ -1194,16 +1197,18 @@ bool TermDbSygus::isTypeMatch( const DatatypeConstructor& c1, const DatatypeCons
   }
 }
 
-int TermDbSygus::getAnyConstantConsNum( TypeNode tn ) const
+int TermDbSygus::getAnyConstantConsNum(TypeNode tn) const
 {
-  Assert( isRegistered( tn ) );
-  std::map< TypeNode, unsigned >::const_iterator itt = d_sym_cons_any_constant.find( tn );
-  if( itt!=d_sym_cons_any_constant.end() ){
+  Assert(isRegistered(tn));
+  std::map<TypeNode, unsigned>::const_iterator itt =
+      d_sym_cons_any_constant.find(tn);
+  if (itt != d_sym_cons_any_constant.end())
+  {
     return static_cast<int>(itt->second);
   }
   return -1;
 }
-  
+
 bool TermDbSygus::hasSubtermSymbolicCons(TypeNode tn) const
 {
   return d_has_subterm_sym_cons.find(tn) != d_has_subterm_sym_cons.end();
@@ -1211,7 +1216,7 @@ bool TermDbSygus::hasSubtermSymbolicCons(TypeNode tn) const
 
 bool TermDbSygus::isSymbolicConsApp(Node n) const
 {
-  if( n.getKind()!=APPLY_CONSTRUCTOR )
+  if (n.getKind() != APPLY_CONSTRUCTOR)
   {
     return false;
   }

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -812,8 +812,8 @@ void TermDbSygus::registerEnumerator(Node e,
         Node lem = getExplain()->getExplanationForEquality(x, exc_val);
         lem = lem.negate();
         Trace("cegqi-lemma") << "Cegqi::Lemma : exclude symbolic cons lemma (template) : " << lem << std::endl;
-        // the size of the subterm we are blocking is zero (any_constant is a nullary constructor)
-        registerSymBreakLemma(e, lem, stn, 0);
+        // the size of the subterm we are blocking is the weight of the constructor (usually zero)
+        registerSymBreakLemma(e, lem, stn, dt[itsa->second].getWeight());
       }
     }
   }

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -170,8 +170,13 @@ class TermDbSygus {
    *
    * Given a sygus datatype term n of type tn, this function returns its analog,
    * that is, the term that n encodes.
+   * 
+   * Notice that each occurrence of a symbolic constructor application is
+   * replaced by a unique variable. To track counters for introducing unique
+   * variables, we use the var_count map.
    */
   Node sygusToBuiltin(Node n, TypeNode tn);
+  Node sygusToBuiltin(Node n, TypeNode tn, std::map<TypeNode, int>& var_count);
   /** same as above, but without tn */
   Node sygusToBuiltin(Node n) { return sygusToBuiltin(n, n.getType()); }
   /** evaluate builtin
@@ -317,7 +322,7 @@ class TermDbSygus {
   std::map<TypeNode, bool> d_has_subterm_sym_cons;
 
  public:  // general sygus utilities
-  bool isRegistered( TypeNode tn );
+  bool isRegistered( TypeNode tn ) const;
   // get the minimum depth of type in its parent grammar
   unsigned getMinTypeDepth( TypeNode root_tn, TypeNode tn );
   // get the minimum size for a constructor term
@@ -344,11 +349,18 @@ class TermDbSygus {
   int getFirstArgOccurrence( const DatatypeConstructor& c, TypeNode tn );
   /** is type match */
   bool isTypeMatch( const DatatypeConstructor& c1, const DatatypeConstructor& c2 );
+  /**
+   * Get the index of the "any constant" constructor of type tn if it has one,
+   * or returns -1 otherwise.
+   */
+  int getAnyConstantConsNum( TypeNode tn ) const;
   /** has subterm symbolic constructor
    *
    * Returns true if any subterm of type tn can be a symbolic constructor.
    */
   bool hasSubtermSymbolicCons(TypeNode tn) const;
+  /** return whether n is an application of a symbolic constructor */
+  bool isSymbolicConsApp(Node n) const;
 
   TypeNode getSygusTypeForVar( Node v );
   Node sygusSubstituted( TypeNode tn, Node n, std::vector< Node >& args );

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -113,7 +113,7 @@ class TermDbSygus {
   TypeNode getTypeForSymBreakLemma(Node lem) const;
   /** Get the minimum size of terms symmetry breaking lemma lem applies to */
   unsigned getSizeForSymBreakLemma(Node lem) const;
-  /** Clear information about symmetry breaking lemmas for e */
+  /** Clear information about symmetry breaking lemmas for enumerator e */
   void clearSymBreakLemmas(Node e);
   //------------------------------end enumerators
 

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -170,7 +170,7 @@ class TermDbSygus {
    *
    * Given a sygus datatype term n of type tn, this function returns its analog,
    * that is, the term that n encodes.
-   * 
+   *
    * Notice that each occurrence of a symbolic constructor application is
    * replaced by a unique variable. To track counters for introducing unique
    * variables, we use the var_count map.
@@ -322,7 +322,7 @@ class TermDbSygus {
   std::map<TypeNode, bool> d_has_subterm_sym_cons;
 
  public:  // general sygus utilities
-  bool isRegistered( TypeNode tn ) const;
+  bool isRegistered(TypeNode tn) const;
   // get the minimum depth of type in its parent grammar
   unsigned getMinTypeDepth( TypeNode root_tn, TypeNode tn );
   // get the minimum size for a constructor term
@@ -353,7 +353,7 @@ class TermDbSygus {
    * Get the index of the "any constant" constructor of type tn if it has one,
    * or returns -1 otherwise.
    */
-  int getAnyConstantConsNum( TypeNode tn ) const;
+  int getAnyConstantConsNum(TypeNode tn) const;
   /** has subterm symbolic constructor
    *
    * Returns true if any subterm of type tn can be a symbolic constructor.

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -113,8 +113,8 @@ class TermDbSygus {
   TypeNode getTypeForSymBreakLemma(Node lem) const;
   /** Get the minimum size of terms symmetry breaking lemma lem applies to */
   unsigned getSizeForSymBreakLemma(Node lem) const;
-  /** Clear information about symmetry breaking lemmas */
-  void clearSymBreakLemmas();
+  /** Clear information about symmetry breaking lemmas for e */
+  void clearSymBreakLemmas(Node e);
   //------------------------------end enumerators
 
   //-----------------------------conversion from sygus to builtin

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -310,6 +310,12 @@ private:
    * has one. 
    */
   std::map<TypeNode, unsigned > d_sym_cons_any_constant;
+  /** 
+   * Whether any subterm of this type contains a symbolic constructor. This
+   * corresponds to whether sygus repair techniques will ever have any effect
+   * for this type.
+   */
+  std::map< TypeNode, bool > d_has_subterm_sym_cons;
 
  public:  // general sygus utilities
   bool isRegistered( TypeNode tn );
@@ -339,6 +345,11 @@ private:
   int getFirstArgOccurrence( const DatatypeConstructor& c, TypeNode tn );
   /** is type match */
   bool isTypeMatch( const DatatypeConstructor& c1, const DatatypeConstructor& c2 );
+  /** has subterm symbolic constructor 
+   * 
+   * Returns true if any subterm of type tn can be a symbolic constructor.
+   */
+  bool hasSubtermSymbolicCons(TypeNode tn) const;
 
   TypeNode getSygusTypeForVar( Node v );
   Node sygusSubstituted( TypeNode tn, Node n, std::vector< Node >& args );

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -75,8 +75,7 @@ class TermDbSygus {
                           Node f,
                           CegConjecture* conj,
                           bool mkActiveGuard = false,
-                          bool useSymbolicCons = false
-                         );
+                          bool useSymbolicCons = false);
   /** is e an enumerator registered with this class? */
   bool isEnumerator(Node e) const;
   /** return the conjecture e is associated with */
@@ -305,17 +304,17 @@ class TermDbSygus {
   std::map<TypeNode, std::map<unsigned, unsigned> > d_min_cons_term_size;
   /** a cache for getSelectorWeight */
   std::map<TypeNode, std::map<Node, unsigned> > d_sel_weight;
-  /** 
+  /**
    * For each sygus type, the index of the "any constant" constructor, if it
-   * has one. 
+   * has one.
    */
-  std::map<TypeNode, unsigned > d_sym_cons_any_constant;
-  /** 
+  std::map<TypeNode, unsigned> d_sym_cons_any_constant;
+  /**
    * Whether any subterm of this type contains a symbolic constructor. This
    * corresponds to whether sygus repair techniques will ever have any effect
    * for this type.
    */
-  std::map< TypeNode, bool > d_has_subterm_sym_cons;
+  std::map<TypeNode, bool> d_has_subterm_sym_cons;
 
  public:  // general sygus utilities
   bool isRegistered( TypeNode tn );
@@ -345,8 +344,8 @@ class TermDbSygus {
   int getFirstArgOccurrence( const DatatypeConstructor& c, TypeNode tn );
   /** is type match */
   bool isTypeMatch( const DatatypeConstructor& c1, const DatatypeConstructor& c2 );
-  /** has subterm symbolic constructor 
-   * 
+  /** has subterm symbolic constructor
+   *
    * Returns true if any subterm of type tn can be a symbolic constructor.
    */
   bool hasSubtermSymbolicCons(TypeNode tn) const;

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -271,7 +271,7 @@ class TermDbSygus {
   Node d_true;
   Node d_false;
 
-private:
+ private:
   /** computes the map d_min_type_depth */
   void computeMinTypeDepthInternal( TypeNode root_tn, TypeNode tn, unsigned type_depth );
   bool involvesDivByZero( Node n, std::map< Node, bool >& visited );

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -406,7 +406,6 @@ REG0_TESTS = \
 	regress0/expect/scrub.03.smt2 \
 	regress0/expect/scrub.04.smt2 \
 	regress0/expect/scrub.06.cvc \
-	regress0/expect/scrub.07.sy \
 	regress0/expect/scrub.08.sy \
 	regress0/expect/scrub.09.p \
 	regress0/flet.smt \
@@ -1974,7 +1973,6 @@ TESTS_EXPECT = \
 	regress0/decision/wchains010ue.smt.expect \
 	regress0/expect/scrub.01.smt.expect \
 	regress0/expect/scrub.03.smt2.expect \
-	regress0/expect/scrub.07.sy.expect \
 	regress0/quantifiers/bug291.smt2.expect \
 	regress0/uflia/check02.smt2.expect \
 	regress0/uflia/check03.smt2.expect \

--- a/test/regress/regress0/expect/scrub.07.sy
+++ b/test/regress/regress0/expect/scrub.07.sy
@@ -1,7 +1,0 @@
-; COMMAND-LINE: --cegqi-si=all --sygus-out=status
-(set-logic LIA)
-(declare-var n Int)
-
-(synth-fun f ((n Int)) Int)
-(constraint (= (/ n n) 1))
-(check-synth)

--- a/test/regress/regress0/expect/scrub.07.sy.expect
+++ b/test/regress/regress0/expect/scrub.07.sy.expect
@@ -1,5 +1,0 @@
-% SCRUBBER: sed -e 's/The fact in question: .*$/The fact in question: TERM/'
-% EXPECT: (error "A non-linear fact was asserted to arithmetic in a linear logic.
-% EXPECT: The fact in question: TERM
-% EXPECT: ")
-% EXIT: 1

--- a/test/regress/regress2/sygus/ex23.sy
+++ b/test/regress/regress2/sygus/ex23.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-out=status
+; COMMAND-LINE: --sygus-out=status --sygus-repair-const
 (set-logic LIA)
 
 (synth-inv inv-f ((y Int) (z Int) (c Int)))
@@ -19,5 +19,7 @@
 (not (and (< c 36) (or (< z 0) (>= z 4608)))))
 
 (inv-constraint inv-f pre-f trans-f post-f)
+
+; needs --sygus-repair-const, since easy solution involves the constant 4608
 
 (check-synth)


### PR DESCRIPTION
This generalizes the repair constant utility of sygus so that the task of enumerating templates is done at the grammar level. This makes it so that we don't prune instantiations of repairable templates.

I am disabling the option by default since it will need further testing.

This fixes the timeout in regress2.