### PR TITLE
Fix nl regression for unsat cores

### DIFF
--- a/test/regress/regress1/nl/approx-sqrt-unsat.smt2
+++ b/test/regress/regress1/nl/approx-sqrt-unsat.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --nl-ext-tplanes
+; EXPECT: unsat
 (set-logic QF_NRA)
 (set-info :status unsat)
 (declare-fun x () Real)


### PR DESCRIPTION
I believe this was caused by the fact that --check-unsat-cores disables certain simplifications that make this problem easier. This adds an additional option to this benchmark that makes it solvable regardless of whether unsat cores are used.