### PR TITLE
Fixes for non-linear check model

### DIFF
--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1685,7 +1685,9 @@ bool NonlinearExtension::simpleCheckModelMsum(const std::map<Node, Node>& msum,
       }
       // whether we will try to minimize/maximize (-1/1) the absolute value
       int setAbs = (set_lower == has_neg_factor) ? 1 : -1;
-      Trace("nl-ext-cms-debug") << "set absolute value to " << (setAbs==1 ? "maximal" : "minimal") << std::endl;
+      Trace("nl-ext-cms-debug")
+          << "set absolute value to " << (setAbs == 1 ? "maximal" : "minimal")
+          << std::endl;
 
       std::vector<Node> vbs;
       Trace("nl-ext-cms-debug") << "set bounds..." << std::endl;
@@ -1697,7 +1699,9 @@ bool NonlinearExtension::simpleCheckModelMsum(const std::map<Node, Node>& msum,
         Node u = us[i];
         bool vc_set_lower;
         int vcsign = signs[i];
-        Trace("nl-ext-cms-debug") << "Bounds for " << vc << " : " << l << ", " << u << ", sign : " << vcsign << ", factor : " << vcfact << std::endl;
+        Trace("nl-ext-cms-debug")
+            << "Bounds for " << vc << " : " << l << ", " << u
+            << ", sign : " << vcsign << ", factor : " << vcfact << std::endl;
         if (l == u)
         {
           // by convention, always say it is lower if they are the same
@@ -1707,12 +1711,12 @@ bool NonlinearExtension::simpleCheckModelMsum(const std::map<Node, Node>& msum,
         }
         else
         {
-          if( vcfact%2==0 )
+          if (vcfact % 2 == 0)
           {
             // minimize or maximize its absolute value
             Rational la = l.getConst<Rational>().abs();
             Rational ua = u.getConst<Rational>().abs();
-            if( la==ua )
+            if (la == ua)
             {
               // by convention, always say it is lower if abs are the same
               vc_set_lower = true;
@@ -1721,7 +1725,7 @@ bool NonlinearExtension::simpleCheckModelMsum(const std::map<Node, Node>& msum,
             }
             else
             {
-              vc_set_lower = (la>ua)==(setAbs==1);
+              vc_set_lower = (la > ua) == (setAbs == 1);
             }
           }
           else if (signs[i] == 0)

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -1056,9 +1056,9 @@ void NonlinearExtension::addCheckModelSubstitution(TNode v, TNode s)
 void NonlinearExtension::addCheckModelBound(TNode v, TNode l, TNode u)
 {
   Assert(!hasCheckModelAssignment(v));
-  Assert( l.isConst() );
-  Assert( u.isConst() );
-  Assert( l.getConst<Rational>()<=u.getConst<Rational>() );
+  Assert(l.isConst());
+  Assert(u.isConst());
+  Assert(l.getConst<Rational>() <= u.getConst<Rational>());
   d_check_model_bounds[v] = std::pair<Node, Node>(l, u);
 }
 
@@ -1297,9 +1297,9 @@ bool NonlinearExtension::solveEqualitySimple(Node eq)
           MULT, coeffa, nm->mkNode(r == 0 ? MINUS : PLUS, negb, val));
       approx = Rewriter::rewrite(approx);
       bounds[r][b] = approx;
-      Assert( approx.isConst() );
+      Assert(approx.isConst());
     }
-    if(bounds[r][0].getConst<Rational>()>bounds[r][1].getConst<Rational>())
+    if (bounds[r][0].getConst<Rational>() > bounds[r][1].getConst<Rational>())
     {
       // ensure bound is (lower, upper)
       Node tmp = bounds[r][0];


### PR DESCRIPTION
I've been using a branch that uses sampling techniques for finding violations in the nonlinear extension's new check model routines.

This caught 3 issues in the non-linear solver.

This PR fixes these issues. Now, the sampling method from https://github.com/ajreynol/CVC4/commits/nlExtSampleTestCheckModel does not find any potential soundness issues in all regressions and SAT benchmarks from QF_NRA that CVC4 solves in <2 seconds.