### PR TITLE
Reenable repair const

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -989,7 +989,7 @@ header = "options/quantifiers_options.h"
   category   = "regular"
   long       = "sygus-repair-const"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "use approach to repair constants in sygus candidate solutions"
 
 [[option]]

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -258,6 +258,9 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   std::vector<Node> candidate_values;
   bool constructed_cand = false;
 
+  // If a module is not trying to repair constants in solutions and the option
+  // sygusRepairConst  is true, we use a default scheme for trying to repair
+  // constants here.
   if (options::sygusRepairConst() && !d_master->usingRepairConst())
   {
     Trace("cegqi-check") << "CegConjuncture : repair previous solution..."

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -258,29 +258,30 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   std::vector<Node> candidate_values;
   bool constructed_cand = false;
 
-  if (options::sygusRepairConst() && !d_master->usingRepairConst())	
-  {	
-    Trace("cegqi-check") << "CegConjuncture : repair previous solution..." << std::endl;
-    // have we tried to repair the previous solution?	
-    // if not, call the repair constant utility	
-    unsigned ninst = d_cinfo[d_candidates[0]].d_inst.size();	
-    if (d_repair_index < ninst)	
-    {	
-      std::vector<Node> fail_cvs;	
-      for (const Node& cprog : d_candidates)	
-      {	
-        Assert(d_repair_index < d_cinfo[cprog].d_inst.size());	
-        fail_cvs.push_back(d_cinfo[cprog].d_inst[d_repair_index]);	
-      }	
-      d_repair_index++;	
-      if (d_sygus_rconst->repairSolution(	
-              d_candidates, fail_cvs, candidate_values))	
-      {	
-        constructed_cand = true;	
-      }	
-    }	
+  if (options::sygusRepairConst() && !d_master->usingRepairConst())
+  {
+    Trace("cegqi-check") << "CegConjuncture : repair previous solution..."
+                         << std::endl;
+    // have we tried to repair the previous solution?
+    // if not, call the repair constant utility
+    unsigned ninst = d_cinfo[d_candidates[0]].d_inst.size();
+    if (d_repair_index < ninst)
+    {
+      std::vector<Node> fail_cvs;
+      for (const Node& cprog : d_candidates)
+      {
+        Assert(d_repair_index < d_cinfo[cprog].d_inst.size());
+        fail_cvs.push_back(d_cinfo[cprog].d_inst[d_repair_index]);
+      }
+      d_repair_index++;
+      if (d_sygus_rconst->repairSolution(
+              d_candidates, fail_cvs, candidate_values))
+      {
+        constructed_cand = true;
+      }
+    }
   }
-  
+
   // get the model value of the relevant terms from the master module
   std::vector<Node> enum_values;
   getModelValues(terms, enum_values);

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -258,6 +258,29 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   std::vector<Node> candidate_values;
   bool constructed_cand = false;
 
+  if (options::sygusRepairConst() && !d_master->usingRepairConst())	
+  {	
+    Trace("cegqi-check") << "CegConjuncture : repair previous solution..." << std::endl;
+    // have we tried to repair the previous solution?	
+    // if not, call the repair constant utility	
+    unsigned ninst = d_cinfo[d_candidates[0]].d_inst.size();	
+    if (d_repair_index < ninst)	
+    {	
+      std::vector<Node> fail_cvs;	
+      for (const Node& cprog : d_candidates)	
+      {	
+        Assert(d_repair_index < d_cinfo[cprog].d_inst.size());	
+        fail_cvs.push_back(d_cinfo[cprog].d_inst[d_repair_index]);	
+      }	
+      d_repair_index++;	
+      if (d_sygus_rconst->repairSolution(	
+              d_candidates, fail_cvs, candidate_values))	
+      {	
+        constructed_cand = true;	
+      }	
+    }	
+  }
+  
   // get the model value of the relevant terms from the master module
   std::vector<Node> enum_values;
   getModelValues(terms, enum_values);

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -397,10 +397,7 @@ void Cegis::registerRefinementLemma(const std::vector<Node>& vars,
   lems.push_back(rlem);
 }
 
-bool Cegis::usingRepairConst()
-{
-  return d_using_gr_repair;
-}
+bool Cegis::usingRepairConst() { return d_using_gr_repair; }
 
 void Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
                                     const std::vector<Node>& ms,

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -397,6 +397,11 @@ void Cegis::registerRefinementLemma(const std::vector<Node>& vars,
   lems.push_back(rlem);
 }
 
+bool Cegis::usingRepairConst()
+{
+  return d_using_gr_repair;
+}
+
 void Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
                                     const std::vector<Node>& ms,
                                     std::vector<Node>& lems)

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -63,7 +63,8 @@ class Cegis : public SygusModule
   virtual void registerRefinementLemma(const std::vector<Node>& vars,
                                        Node lem,
                                        std::vector<Node>& lems) override;
-
+  /** using repair const */
+  virtual bool usingRepairConst() override;
  protected:
   /** the evaluation unfold utility of d_tds */
   SygusEvalUnfold* d_eval_unfold;

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -65,6 +65,7 @@ class Cegis : public SygusModule
                                        std::vector<Node>& lems) override;
   /** using repair const */
   virtual bool usingRepairConst() override;
+
  protected:
   /** the evaluation unfold utility of d_tds */
   SygusEvalUnfold* d_eval_unfold;

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -124,9 +124,8 @@ class SygusModule
   }
   /**
    * Are we trying to repair constants in candidate solutions?
-   * If a module returns false for this and the option sygusRepairConst
-   * is true, we use a default scheme for trying to repair constants in
-   * candidate solutions in CegConjecture.
+   * If we return true for usingRepairConst is true, then this module has
+   * attmepted to repair any solutions returned by constructCandidates.
    */
   virtual bool usingRepairConst() { return false; }
 

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -122,7 +122,13 @@ class SygusModule
   {
     return Node::null();
   }
-
+  /** 
+   * Are we trying to repair constants in candidate solutions?
+   * If a module returns false for this and the option sygusRepairConst
+   * is true, we use a default scheme for trying to repair constants in
+   * candidate solutions in CegConjecture.
+   */
+  virtual bool usingRepairConst() { return false; }
  protected:
   /** reference to quantifier engine */
   QuantifiersEngine* d_qe;

--- a/src/theory/quantifiers/sygus/sygus_module.h
+++ b/src/theory/quantifiers/sygus/sygus_module.h
@@ -122,13 +122,14 @@ class SygusModule
   {
     return Node::null();
   }
-  /** 
+  /**
    * Are we trying to repair constants in candidate solutions?
    * If a module returns false for this and the option sygusRepairConst
    * is true, we use a default scheme for trying to repair constants in
    * candidate solutions in CegConjecture.
    */
   virtual bool usingRepairConst() { return false; }
+
  protected:
   /** reference to quantifier engine */
   QuantifiersEngine* d_qe;

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -164,11 +164,11 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   if (logic.isTheoryEnabled(THEORY_ARITH) && logic.isLinear())
   {
     fo_body = fitToLogic(logic,
-                        fo_body,
-                        candidates,
-                        candidate_skeletons,
-                        sk_vars,
-                        sk_vars_to_subs);
+                         fo_body,
+                         candidates,
+                         candidate_skeletons,
+                         sk_vars,
+                         sk_vars_to_subs);
   }
 
   if (fo_body.isNull() || sk_vars.empty())

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -164,11 +164,11 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   if (logic.isTheoryEnabled(THEORY_ARITH) && logic.isLinear())
   {
     fo_body = fitToLogic(logic,
-                         fo_body,
-                         candidates,
-                         candidate_skeletons,
-                         sk_vars,
-                         sk_vars_to_subs);
+                        fo_body,
+                        candidates,
+                        candidate_skeletons,
+                        sk_vars,
+                        sk_vars_to_subs);
   }
 
   if (fo_body.isNull() || sk_vars.empty())

--- a/test/regress/regress0/expect/scrub.08.sy
+++ b/test/regress/regress0/expect/scrub.08.sy
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --cegqi-si=all --sygus-out=status
+; COMMAND-LINE: --cegqi-si=all --sygus-out=status --no-sygus-repair-const
 ; SCRUBBER: sed -e 's/The fact in question: .*$/The fact in question: TERM/'
 ; EXPECT: (error "A non-linear fact was asserted to arithmetic in a linear logic.
 ; EXPECT: The fact in question: TERM

--- a/test/regress/regress1/quantifiers/horn-simple.smt2
+++ b/test/regress/regress1/quantifiers/horn-simple.smt2
@@ -6,7 +6,7 @@
 
 (assert (forall ((x Int)) (=> (= x 0) (I x))))
 
-(assert (forall ((x Int)) (=> (and (I x) (< x 1)) (I (+ x 1)))))
+(assert (forall ((x Int)) (=> (and (I x) (< x 6)) (I (+ x 1)))))
 
 (assert (forall ((x Int)) (=> (I x) (<= x 10))))
 

--- a/test/regress/regress2/sygus/vcb.sy
+++ b/test/regress/regress2/sygus/vcb.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-out=status
+; COMMAND-LINE: --sygus-out=status --no-sygus-repair-const
 (set-logic LIA)
 
 (synth-fun f1 ((x1 Int) (x2 Int)) Int)


### PR DESCRIPTION
This reenables the previous scheme for sygus modules that don't support repair, and enables the option by default.