### PR TITLE
Builtin evaluation functions for sygus

### DIFF
--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -72,11 +72,13 @@ const Datatype& Datatype::datatypeOf(Expr item) {
 
 size_t Datatype::indexOf(Expr item) {
   ExprManagerScope ems(item);
+  /*
   PrettyCheckArgument(item.getType().isConstructor() ||
                 item.getType().isTester() ||
                 item.getType().isSelector(),
                 item,
                 "arg must be a datatype constructor, selector, or tester");
+                */
   TNode n = Node::fromExpr(item);
   if( item.getKind()==kind::APPLY_TYPE_ASCRIPTION ){
     return indexOf( item[0] );
@@ -88,9 +90,11 @@ size_t Datatype::indexOf(Expr item) {
 
 size_t Datatype::cindexOf(Expr item) {
   ExprManagerScope ems(item);
+  /*
   PrettyCheckArgument(item.getType().isSelector(),
                 item,
                 "arg must be a datatype selector");
+                */
   TNode n = Node::fromExpr(item);
   if( item.getKind()==kind::APPLY_TYPE_ASCRIPTION ){
     return cindexOf( item[0] );

--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -72,13 +72,15 @@ const Datatype& Datatype::datatypeOf(Expr item) {
 
 size_t Datatype::indexOf(Expr item) {
   ExprManagerScope ems(item);
-  /*
   PrettyCheckArgument(item.getType().isConstructor() ||
                 item.getType().isTester() ||
                 item.getType().isSelector(),
                 item,
                 "arg must be a datatype constructor, selector, or tester");
-                */
+  return indexOfInternal(item);
+}
+
+size_t Datatype::indexOfInternal(Expr item) {
   TNode n = Node::fromExpr(item);
   if( item.getKind()==kind::APPLY_TYPE_ASCRIPTION ){
     return indexOf( item[0] );
@@ -90,11 +92,12 @@ size_t Datatype::indexOf(Expr item) {
 
 size_t Datatype::cindexOf(Expr item) {
   ExprManagerScope ems(item);
-  /*
   PrettyCheckArgument(item.getType().isSelector(),
                 item,
                 "arg must be a datatype selector");
-                */
+  return cindexOfInternal(item);
+}
+size_t Datatype::cindexOfInternal(Expr item) {
   TNode n = Node::fromExpr(item);
   if( item.getKind()==kind::APPLY_TYPE_ASCRIPTION ){
     return cindexOf( item[0] );

--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -80,7 +80,8 @@ size_t Datatype::indexOf(Expr item) {
   return indexOfInternal(item);
 }
 
-size_t Datatype::indexOfInternal(Expr item) {
+size_t Datatype::indexOfInternal(Expr item)
+{
   TNode n = Node::fromExpr(item);
   if( item.getKind()==kind::APPLY_TYPE_ASCRIPTION ){
     return indexOf( item[0] );
@@ -97,7 +98,8 @@ size_t Datatype::cindexOf(Expr item) {
                 "arg must be a datatype selector");
   return cindexOfInternal(item);
 }
-size_t Datatype::cindexOfInternal(Expr item) {
+size_t Datatype::cindexOfInternal(Expr item)
+{
   TNode n = Node::fromExpr(item);
   if( item.getKind()==kind::APPLY_TYPE_ASCRIPTION ){
     return cindexOf( item[0] );

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -614,12 +614,12 @@ public:
    * always the first index.)
    */
   static size_t cindexOf(Expr item) CVC4_PUBLIC;
-  
-  /** 
-   * Same as above, but without checks. These methods should be used by 
+
+  /**
+   * Same as above, but without checks. These methods should be used by
    * internal (Node-level) code.
    */
-  static size_t indexOfInternal(Expr item);  
+  static size_t indexOfInternal(Expr item);
   static size_t cindexOfInternal(Expr item);
 
   /** The type for iterators over constructors. */

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -614,6 +614,13 @@ public:
    * always the first index.)
    */
   static size_t cindexOf(Expr item) CVC4_PUBLIC;
+  
+  /** 
+   * Same as above, but without checks. These methods should be used by 
+   * internal (Node-level) code.
+   */
+  static size_t indexOfInternal(Expr item);  
+  static size_t cindexOfInternal(Expr item);
 
   /** The type for iterators over constructors. */
   typedef DatatypeConstructorIterator iterator;

--- a/src/options/datatypes_options.toml
+++ b/src/options/datatypes_options.toml
@@ -175,3 +175,12 @@ header = "options/datatypes_options.h"
   default    = "-1"
   read_only  = true
   help       = "tells enumerative sygus to only consider solutions up to term size N (-1 == no limit, default)"
+
+[[option]]
+  name       = "sygusEvalBuiltin"
+  category   = "regular"
+  long       = "sygus-eval-builtin"
+  type       = "bool"
+  default    = "false"
+  read_only  = true
+  help       = "use builtin kind for evaluation functions in sygus"

--- a/src/options/datatypes_options.toml
+++ b/src/options/datatypes_options.toml
@@ -181,6 +181,6 @@ header = "options/datatypes_options.h"
   category   = "regular"
   long       = "sygus-eval-builtin"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   read_only  = true
   help       = "use builtin kind for evaluation functions in sygus"

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -665,9 +665,8 @@ unsigned DatatypesRewriter::indexOf(Node n)
 {
   if (!n.hasAttribute(DtIndexAttribute()))
   {
-    Assert(n.getType().isConstructor() ||
-                n.getType().isTester() ||
-                n.getType().isSelector());
+    Assert(n.getType().isConstructor() || n.getType().isTester()
+           || n.getType().isSelector());
     unsigned index = Datatype::indexOfInternal(n.toExpr());
     n.setAttribute(DtIndexAttribute(), index);
     return index;

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -671,7 +671,7 @@ unsigned DatatypesRewriter::indexOf(Node n)
 {
   if( !n.hasAttribute(DtIndexAttribute()) )
   {
-    unsigned index = Datatype::indexOf(n.toExpr());
+    unsigned index = Datatype::indexOfInternal(n.toExpr());
     n.setAttribute(DtIndexAttribute(),index);
     return index;
   }

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -110,8 +110,8 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
   }
   else if (k==kind::DT_SYGUS_EVAL)
   {
-        return RewriteResponse(REWRITE_DONE, in);
-    // rewrite if all constant
+        //return RewriteResponse(REWRITE_DONE, in);
+    // only rewrite if all constant
     for( const Node& inc : in )
     {
       if( !inc.isConst() )

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -459,8 +459,7 @@ RewriteResponse DatatypesRewriter::rewriteTester(TNode in)
 {
   if (in[0].getKind() == kind::APPLY_CONSTRUCTOR)
   {
-    bool result = indexOf(in.getOperator())
-                  == indexOf(in[0].getOperator());
+    bool result = indexOf(in.getOperator()) == indexOf(in[0].getOperator());
     Trace("datatypes-rewrite") << "DatatypesRewriter::postRewrite: "
                                << "Rewrite trivial tester " << in << " "
                                << result << std::endl;
@@ -668,15 +667,14 @@ typedef expr::Attribute<DtIndexAttributeId, uint64_t> DtIndexAttribute;
 
 unsigned DatatypesRewriter::indexOf(Node n)
 {
-  if( !n.hasAttribute(DtIndexAttribute()) )
+  if (!n.hasAttribute(DtIndexAttribute()))
   {
     unsigned index = Datatype::indexOfInternal(n.toExpr());
-    n.setAttribute(DtIndexAttribute(),index);
+    n.setAttribute(DtIndexAttribute(), index);
     return index;
   }
   return n.getAttribute(DtIndexAttribute());
 }
-
 
 Node DatatypesRewriter::mkTester(Node n, int i, const Datatype& dt)
 {

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -108,11 +108,11 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
       return RewriteResponse(REWRITE_AGAIN_FULL, res);
     }
   }
-  else if (k == kind::DT_SYGUS_EVAL)
+  else if (k == DT_SYGUS_EVAL)
   {
     // sygus evaluation function
     Node ev = in[0];
-    if (ev.getKind() == kind::APPLY_CONSTRUCTOR)
+    if (ev.getKind() == APPLY_CONSTRUCTOR)
     {
       Trace("dt-sygus-util") << "Rewrite " << in << " by unfolding...\n";
       const Datatype& dt =
@@ -126,7 +126,6 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
         Assert(ev[0].getType().isComparableTo(in.getType()));
         return RewriteResponse(REWRITE_AGAIN_FULL, ev[0]);
       }
-      NodeManager* nm = NodeManager::currentNM();
       std::vector<Node> args;
       for (unsigned j = 1, nchild = in.getNumChildren(); j < nchild; j++)
       {
@@ -139,11 +138,11 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
         std::vector<Node> cc;
         cc.push_back(evc);
         cc.insert(cc.end(), args.begin(), args.end());
-        children.push_back(nm->mkNode(kind::DT_SYGUS_EVAL, cc));
+        children.push_back(nm->mkNode(DT_SYGUS_EVAL, cc));
       }
       Node ret = mkSygusTerm(dt, i, children);
       // if it is a variable, apply the substitution
-      if (ret.getKind() == kind::BOUND_VARIABLE)
+      if (ret.getKind() == BOUND_VARIABLE)
       {
         Assert(ret.hasAttribute(SygusVarNumAttribute()));
         int vn = ret.getAttribute(SygusVarNumAttribute());
@@ -218,7 +217,7 @@ Kind getOperatorKindForSygusBuiltin(Node op)
 
 Node DatatypesRewriter::mkSygusTerm(const Datatype& dt,
                                     unsigned i,
-                                    std::vector<Node>& children)
+                                    const std::vector<Node>& children)
 {
   Trace("dt-sygus-util") << "Make sygus term " << dt.getName() << "[" << i
                          << "] with children: " << children << std::endl;
@@ -257,7 +256,7 @@ Node DatatypesRewriter::mkSygusTerm(const Datatype& dt,
   Trace("dt-sygus-util") << "...return " << ret << std::endl;
   return ret;
 }
-Node DatatypesRewriter::mkSygusEvalApp(std::vector<Node>& children)
+Node DatatypesRewriter::mkSygusEvalApp(const std::vector<Node>& children)
 {
   if (options::sygusEvalBuiltin())
   {
@@ -666,6 +665,9 @@ unsigned DatatypesRewriter::indexOf(Node n)
 {
   if (!n.hasAttribute(DtIndexAttribute()))
   {
+    Assert(n.getType().isConstructor() ||
+                n.getType().isTester() ||
+                n.getType().isSelector());
     unsigned index = Datatype::indexOfInternal(n.toExpr());
     n.setAttribute(DtIndexAttribute(), index);
     return index;

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -245,18 +245,17 @@ Node DatatypesRewriter::mkSygusTerm(const Datatype& dt,
   if (op.getKind() == BUILTIN)
   {
     ret = NodeManager::currentNM()->mkNode(op, schildren);
+    Trace("dt-sygus-util") << "...return (builtin) " << ret << std::endl;
+    return ret;
+  }
+  Kind ok = getOperatorKindForSygusBuiltin(op);
+  if (schildren.size() == 1 && ok == kind::UNDEFINED_KIND)
+  {
+    ret = schildren[0];
   }
   else
   {
-    Kind ok = getOperatorKindForSygusBuiltin(op);
-    if (schildren.size() == 1 && ok == kind::UNDEFINED_KIND)
-    {
-      ret = schildren[0];
-    }
-    else
-    {
-      ret = NodeManager::currentNM()->mkNode(ok, schildren);
-    }
+    ret = NodeManager::currentNM()->mkNode(ok, schildren);
   }
   Trace("dt-sygus-util") << "...return " << ret << std::endl;
   return ret;

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -227,6 +227,35 @@ Node DatatypesRewriter::mkSygusTerm(const Datatype& dt,
   }
   return ret;
 }
+Node DatatypesRewriter::mkSygusEvalApp(const Datatype& dt,
+                    std::vector< Node >& children)
+{
+  Assert( dt.isSygus() );
+  std::vector< Node > schildren;
+  schildren.push_back(Node::fromExpr(dt.getSygusEvaluationFunc()));
+  schildren.insert(schildren.end(),children.begin(),children.end());
+  return NodeManager::currentNM()->mkNode(APPLY_UF,schildren);
+}
+
+bool DatatypesRewriter::isSygusEvalApp(Node n)
+{
+  if (n.getKind() != APPLY_UF || n.getNumChildren() == 0)
+  {
+    return false;
+  }
+  TypeNode tn = n[0].getType();
+  if (!tn.isDatatype())
+  {
+    return false;
+  }
+  const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
+  if (!dt.isSygus())
+  {
+    return false;
+  }
+  Node eval_op = Node::fromExpr(dt.getSygusEvaluationFunc());
+  return eval_op == n.getOperator();
+}
 
 RewriteResponse DatatypesRewriter::preRewrite(TNode in)
 {

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -196,27 +196,24 @@ Kind getOperatorKindForSygusBuiltin(Node op)
     // does beta-reduction but does not for APPLY
     return APPLY_UF;
   }
-  else
+  TypeNode tn = op.getType();
+  if (tn.isConstructor())
   {
-    TypeNode tn = op.getType();
-    if (tn.isConstructor())
-    {
-      return APPLY_CONSTRUCTOR;
-    }
-    else if (tn.isSelector())
-    {
-      return APPLY_SELECTOR;
-    }
-    else if (tn.isTester())
-    {
-      return APPLY_TESTER;
-    }
-    else if (tn.isFunction())
-    {
-      return APPLY_UF;
-    }
-    return NodeManager::operatorToKind(op);
+    return APPLY_CONSTRUCTOR;
   }
+  else if (tn.isSelector())
+  {
+    return APPLY_SELECTOR;
+  }
+  else if (tn.isTester())
+  {
+    return APPLY_TESTER;
+  }
+  else if (tn.isFunction())
+  {
+    return APPLY_UF;
+  }
+  return NodeManager::operatorToKind(op);
 }
 
 Node DatatypesRewriter::mkSygusTerm(const Datatype& dt,

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -26,6 +26,11 @@
 
 namespace CVC4 {
 namespace theory {
+  
+/** sygus var num */
+struct SygusVarNumAttributeId {};
+typedef expr::Attribute<SygusVarNumAttributeId, uint64_t> SygusVarNumAttribute;
+
 namespace datatypes {
 
 class DatatypesRewriter {
@@ -102,7 +107,14 @@ public:
   *   C( x, y ) and z
   */
  static bool checkClash(Node n1, Node n2, std::vector<Node>& rew);
-
+  /** make sygus term
+   *
+   * This function returns a builtin term f( children[0], ..., children[n] ) 
+   * where f is the builtin op of the i^th constructor of sygus datatype dt.
+   */
+  static Node mkSygusTerm(const Datatype& dt,
+                          unsigned i,
+                          std::vector< Node >& children);
 private:
  /** rewrite constructor term in */
  static RewriteResponse rewriteConstructor(TNode in);

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -119,6 +119,7 @@ public:
   /** make sygus evaluation function application */
   static Node mkSygusEvalApp(const Datatype& dt,
                           std::vector< Node >& children);
+  static Node mkSygusEvalApp(std::vector< Node >& children);
   /** is sygus evaluation function */
   static bool isSygusEvalApp(Node n);
 private:

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -110,11 +110,17 @@ public:
   /** make sygus term
    *
    * This function returns a builtin term f( children[0], ..., children[n] ) 
-   * where f is the builtin op of the i^th constructor of sygus datatype dt.
+   * where f is the builtin op that the i^th constructor of sygus datatype dt
+   * encodes.
    */
   static Node mkSygusTerm(const Datatype& dt,
                           unsigned i,
                           std::vector< Node >& children);
+  /** make sygus evaluation function application */
+  static Node mkSygusEvalApp(const Datatype& dt,
+                          std::vector< Node >& children);
+  /** is sygus evaluation function */
+  static bool isSygusEvalApp(Node n);
 private:
  /** rewrite constructor term in */
  static RewriteResponse rewriteConstructor(TNode in);

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -129,15 +129,15 @@ public:
   */
  static Node mkSygusTerm(const Datatype& dt,
                          unsigned i,
-                         std::vector<Node>& children);
+                         const std::vector<Node>& children);
  /** make sygus evaluation function application */
- static Node mkSygusEvalApp(std::vector<Node>& children);
+ static Node mkSygusEvalApp(const std::vector<Node>& children);
  /** is sygus evaluation function */
  static bool isSygusEvalApp(Node n);
  /**
   * Get the builtin sygus operator for constructor term n of sygus datatype
   * type. For example, if n is the term C_+( d1, d2 ) where C_+ is a sygus
-  * constructorwhose sygus op is the builtin operator +, this method returns +.
+  * constructor whose sygus op is the builtin operator +, this method returns +.
   */
  static Node getSygusOpForCTerm(Node n);
 

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -26,9 +26,11 @@
 
 namespace CVC4 {
 namespace theory {
-  
+
 /** sygus var num */
-struct SygusVarNumAttributeId {};
+struct SygusVarNumAttributeId
+{
+};
 typedef expr::Attribute<SygusVarNumAttributeId, uint64_t> SygusVarNumAttribute;
 
 /** Attribute true for variables that represent any constant */
@@ -113,25 +115,26 @@ public:
   *   C( x, y ) and z
   */
  static bool checkClash(Node n1, Node n2, std::vector<Node>& rew);
-  /** make sygus term
-   *
-   * This function returns a builtin term f( children[0], ..., children[n] ) 
-   * where f is the builtin op that the i^th constructor of sygus datatype dt
-   * encodes.
-   */
-  static Node mkSygusTerm(const Datatype& dt,
-                          unsigned i,
-                          std::vector< Node >& children);
-  /** make sygus evaluation function application */
-  static Node mkSygusEvalApp(std::vector< Node >& children);
-  /** is sygus evaluation function */
-  static bool isSygusEvalApp(Node n);
-  /** 
-   * Get the builtin sygus operator for constructor term n of sygus datatype 
-   * type. For example, if n is the term C_+( d1, d2 ) where C_+ is a sygus
-   * constructorwhose sygus op is the builtin operator +, this method returns +.
-   */
-  static Node getSygusOpForCTerm(Node n);
+ /** make sygus term
+  *
+  * This function returns a builtin term f( children[0], ..., children[n] )
+  * where f is the builtin op that the i^th constructor of sygus datatype dt
+  * encodes.
+  */
+ static Node mkSygusTerm(const Datatype& dt,
+                         unsigned i,
+                         std::vector<Node>& children);
+ /** make sygus evaluation function application */
+ static Node mkSygusEvalApp(std::vector<Node>& children);
+ /** is sygus evaluation function */
+ static bool isSygusEvalApp(Node n);
+ /**
+  * Get the builtin sygus operator for constructor term n of sygus datatype
+  * type. For example, if n is the term C_+( d1, d2 ) where C_+ is a sygus
+  * constructorwhose sygus op is the builtin operator +, this method returns +.
+  */
+ static Node getSygusOpForCTerm(Node n);
+
 private:
  /** rewrite constructor term in */
  static RewriteResponse rewriteConstructor(TNode in);

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -31,6 +31,12 @@ namespace theory {
 struct SygusVarNumAttributeId {};
 typedef expr::Attribute<SygusVarNumAttributeId, uint64_t> SygusVarNumAttribute;
 
+/** Attribute true for variables that represent any constant */
+struct SygusAnyConstAttributeId
+{
+};
+typedef expr::Attribute<SygusAnyConstAttributeId, bool> SygusAnyConstAttribute;
+
 namespace datatypes {
 
 class DatatypesRewriter {
@@ -120,6 +126,12 @@ public:
   static Node mkSygusEvalApp(std::vector< Node >& children);
   /** is sygus evaluation function */
   static bool isSygusEvalApp(Node n);
+  /** 
+   * Get the builtin sygus operator for constructor term n of sygus datatype 
+   * type. For example, if n is the term C_+( d1, d2 ) where C_+ is a sygus
+   * constructorwhose sygus op is the builtin operator +, this method returns +.
+   */
+  static Node getSygusOpForCTerm(Node n);
 private:
  /** rewrite constructor term in */
  static RewriteResponse rewriteConstructor(TNode in);

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -73,10 +73,10 @@ public:
  /** is tester, same as above but does not update an argument */
  static int isTester(Node n);
  /**
-   * Get the index of a constructor or tester in its datatype, or the
-   * index of a selector in its constructor.  (Zero is always the
-   * first index.)
-   */
+  * Get the index of a constructor or tester in its datatype, or the
+  * index of a selector in its constructor.  (Zero is always the
+  * first index.)
+  */
  static unsigned indexOf(Node n);
  /** make tester is-C( n ), where C is the i^{th} constructor of dt */
  static Node mkTester(Node n, int i, const Datatype& dt);

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -117,8 +117,6 @@ public:
                           unsigned i,
                           std::vector< Node >& children);
   /** make sygus evaluation function application */
-  static Node mkSygusEvalApp(const Datatype& dt,
-                          std::vector< Node >& children);
   static Node mkSygusEvalApp(std::vector< Node >& children);
   /** is sygus evaluation function */
   static bool isSygusEvalApp(Node n);

--- a/src/theory/datatypes/datatypes_rewriter.h
+++ b/src/theory/datatypes/datatypes_rewriter.h
@@ -72,6 +72,12 @@ public:
  static int isTester(Node n, Node& a);
  /** is tester, same as above but does not update an argument */
  static int isTester(Node n);
+ /**
+   * Get the index of a constructor or tester in its datatype, or the
+   * index of a selector in its constructor.  (Zero is always the
+   * first index.)
+   */
+ static unsigned indexOf(Node n);
  /** make tester is-C( n ), where C is the i^{th} constructor of dt */
  static Node mkTester(Node n, int i, const Datatype& dt);
  /** make tester split

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -297,7 +297,8 @@ void SygusSymBreakNew::assertTesterInternal( int tindex, TNode n, Node exp, std:
         sb_lemmas.push_back(ipred);
       }
       // static conjecture-dependent symmetry breaking
-      Trace("sygus-sb-debug") << "  conjecture-dependent symmetry breaking...\n";
+      Trace("sygus-sb-debug")
+          << "  conjecture-dependent symmetry breaking...\n";
       std::map<Node, quantifiers::CegConjecture*>::iterator itc =
           d_anchor_to_conj.find(a);
       if (itc != d_anchor_to_conj.end())
@@ -401,19 +402,21 @@ Node SygusSymBreakNew::getSimpleSymBreakPred(TypeNode tn,
   {
     return it->second;
   }
-  Assert( tn.isDatatype() );
+  Assert(tn.isDatatype());
   NodeManager* nm = NodeManager::currentNM();
   Node n = getFreeVar(tn);
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  Assert( dt.isSygus() );
+  Assert(dt.isSygus());
   Assert(tindex >= 0 && tindex < static_cast<int>(dt.getNumConstructors()));
-  
-  Trace("sygus-sb-simple-debug") << "Simple symmetry breaking for " << dt.getName() << ", constructor " << dt[tindex].getName() << ", at depth " << depth << std::endl;
-  
+
+  Trace("sygus-sb-simple-debug")
+      << "Simple symmetry breaking for " << dt.getName() << ", constructor "
+      << dt[tindex].getName() << ", at depth " << depth << std::endl;
+
   // if we are the "any constant" constructor, we do no symmetry breaking
   // only do simple symmetry breaking up to depth 2
   Node sop = Node::fromExpr(dt[tindex].getSygusOp());
-  if (sop.getAttribute(SygusAnyConstAttribute()) || depth>2)
+  if (sop.getAttribute(SygusAnyConstAttribute()) || depth > 2)
   {
     d_simple_sb_pred[tn][tindex][usingSymCons][depth] = Node::null();
     return Node::null();
@@ -441,7 +444,7 @@ Node SygusSymBreakNew::getSimpleSymBreakPred(TypeNode tn,
   {
     // the number of (sygus) arguments
     unsigned dt_index_nargs = dt[tindex].getNumArgs();
-    
+
     // builtin type
     TypeNode tnb = TypeNode::fromType(dt.getSygusType());
     // get children
@@ -478,7 +481,8 @@ Node SygusSymBreakNew::getSimpleSymBreakPred(TypeNode tn,
     {
       if (nk != UNDEFINED_KIND)
       {
-        Trace("sygus-sb-simple-debug") << "  Equality reasoning about children..." << std::endl;
+        Trace("sygus-sb-simple-debug")
+            << "  Equality reasoning about children..." << std::endl;
         // commutative operators
         if (quantifiers::TermUtil::isComm(nk))
         {
@@ -562,8 +566,9 @@ Node SygusSymBreakNew::getSimpleSymBreakPred(TypeNode tn,
             {
               const Datatype& cdt =
                   static_cast<DatatypeType>(tnc.toType()).getDatatype();
-              Node fv = d_tds->getFreeVar(tnc,0);
-              Node guard_val = datatypes::DatatypesRewriter::getInstCons(fv,cdt,anyc_cons_num_c);
+              Node fv = d_tds->getFreeVar(tnc, 0);
+              Node guard_val = datatypes::DatatypesRewriter::getInstCons(
+                  fv, cdt, anyc_cons_num_c);
               Node exp = d_tds->getExplain()->getExplanationForEquality(
                   children[c1], guard_val);
               sym_lem_deq = nm->mkNode(OR, exp, sym_lem_deq);
@@ -572,7 +577,8 @@ Node SygusSymBreakNew::getSimpleSymBreakPred(TypeNode tn,
           }
         }
 
-        Trace("sygus-sb-simple-debug") << "  Redundant operators..." << std::endl;
+        Trace("sygus-sb-simple-debug")
+            << "  Redundant operators..." << std::endl;
         // singular arguments (e.g. 0 for mult)
         // redundant arguments (e.g. 0 for plus, 1 for mult)
         // right-associativity
@@ -735,37 +741,43 @@ void SygusSymBreakNew::registerSearchTerm( TypeNode tn, unsigned d, Node n, bool
   }
 }
 
-Node SygusSymBreakNew::registerSearchValue( Node a, Node n, Node nv, unsigned d, std::vector< Node >& lemmas ) {
+Node SygusSymBreakNew::registerSearchValue(
+    Node a, Node n, Node nv, unsigned d, std::vector<Node>& lemmas)
+{
   Assert( n.getType()==nv.getType() );
-  TypeNode tn = n.getType(); 
-  if( !tn.isDatatype() )
+  TypeNode tn = n.getType();
+  if (!tn.isDatatype())
   {
-    // don't register non-(sygus-)datatype terms, instead we return the 
+    // don't register non-(sygus-)datatype terms, instead we return the
     // selector chain n.
     return n;
   }
-  Assert( nv.getKind()==APPLY_CONSTRUCTOR );
-  NodeManager * nm = NodeManager::currentNM();
+  Assert(nv.getKind() == APPLY_CONSTRUCTOR);
+  NodeManager* nm = NodeManager::currentNM();
   // currently bottom-up, could be top-down?
   if( nv.getNumChildren()>0 ){
     const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
     unsigned cindex = Datatype::indexOf( nv.getOperator().toExpr() );
-    std::vector< Node > rcons_children;
+    std::vector<Node> rcons_children;
     rcons_children.push_back(nv.getOperator());
     bool childrenChanged = false;
     for( unsigned i=0; i<nv.getNumChildren(); i++ ){
-      Node sel = nm->mkNode( APPLY_SELECTOR_TOTAL, Node::fromExpr( dt[cindex].getSelectorInternal( tn.toType(), i ) ), n );
-      Node nvc = registerSearchValue( a, sel, nv[i], d+1, lemmas );
-      if( nvc.isNull() ){
+      Node sel = nm->mkNode(
+          APPLY_SELECTOR_TOTAL,
+          Node::fromExpr(dt[cindex].getSelectorInternal(tn.toType(), i)),
+          n);
+      Node nvc = registerSearchValue(a, sel, nv[i], d + 1, lemmas);
+      if (nvc.isNull())
+      {
         return Node::null();
       }
       rcons_children.push_back(nvc);
-      childrenChanged = childrenChanged || nvc!=nv[i];
+      childrenChanged = childrenChanged || nvc != nv[i];
     }
     // reconstruct the value, which may be a skeleton
-    if( childrenChanged )
+    if (childrenChanged)
     {
-      nv = nm->mkNode(APPLY_CONSTRUCTOR,rcons_children);
+      nv = nm->mkNode(APPLY_CONSTRUCTOR, rcons_children);
     }
   }
   Trace("sygus-sb-debug2") << "Registering search value " << n << " -> " << nv << std::endl;
@@ -1216,8 +1228,9 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
   for( std::map< Node, bool >::iterator it = d_register_st.begin(); it != d_register_st.end(); ++it ){
     if( it->second ){
       Node prog = it->first;
-      Trace("dt-sygus-debug") << "Checking model value of " << prog << "..." << std::endl;
-      Assert( prog.getType().isDatatype() );
+      Trace("dt-sygus-debug")
+          << "Checking model value of " << prog << "..." << std::endl;
+      Assert(prog.getType().isDatatype());
       Node progv = d_td->getValuation().getModel()->getValue( prog );
       if (Trace.isOn("dt-sygus"))
       {
@@ -1253,8 +1266,9 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
         
         // register the search value ( prog -> progv ), this may invoke symmetry breaking 
         if( options::sygusSymBreakDynamic() ){
-          Node rsv = registerSearchValue( prog, prog, progv, 0, lemmas );
-          if( rsv.isNull() ){
+          Node rsv = registerSearchValue(prog, prog, progv, 0, lemmas);
+          if (rsv.isNull())
+          {
             Trace("sygus-sb") << "  SygusSymBreakNew::check: ...added new symmetry breaking lemma for " << prog << "." << std::endl;
           }
           else
@@ -1292,10 +1306,10 @@ bool SygusSymBreakNew::checkTesters(Node n,
                                     int ind,
                                     std::vector<Node>& lemmas)
 {
-  if( vn.getKind()!=kind::APPLY_CONSTRUCTOR )
+  if (vn.getKind() != kind::APPLY_CONSTRUCTOR)
   {
     // all datatype terms should be constant here
-    Assert( !vn.getType().isDatatype() );
+    Assert(!vn.getType().isDatatype());
     return true;
   }
   if( Trace.isOn("sygus-sb-warn") ){

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -215,20 +215,21 @@ bool SygusSymBreakNew::computeTopLevel( TypeNode tn, Node n ){
 
 void SygusSymBreakNew::assertTesterInternal( int tindex, TNode n, Node exp, std::vector< Node >& lemmas ) {
   TypeNode ntn = n.getType();
-  if( !ntn.isDatatype() )
+  if (!ntn.isDatatype())
   {
     // nothing to do for non-datatype types
     return;
-  } 
+  }
   const Datatype& dt = static_cast<DatatypeType>(ntn.toType()).getDatatype();
-  if( !dt.isSygus() )
+  if (!dt.isSygus())
   {
     // nothing to do for non-sygus-datatype type
     return;
   }
-  d_active_terms.insert( n );
-  Trace("sygus-sb-debug2") << "Sygus : activate term : " << n << " : " << exp << std::endl; 
-  
+  d_active_terms.insert(n);
+  Trace("sygus-sb-debug2") << "Sygus : activate term : " << n << " : " << exp
+                           << std::endl;
+
   // get the search size for this
   Assert( d_term_to_anchor.find( n )!=d_term_to_anchor.end() );
   Node a = d_term_to_anchor[n];
@@ -755,7 +756,7 @@ void SygusSymBreakNew::registerSearchTerm( TypeNode tn, unsigned d, Node n, bool
 Node SygusSymBreakNew::registerSearchValue(
     Node a, Node n, Node nv, unsigned d, std::vector<Node>& lemmas)
 {
-  Assert( n.getType().isComparableTo( nv.getType() ) );
+  Assert(n.getType().isComparableTo(nv.getType()));
   TypeNode tn = n.getType();
   if (!tn.isDatatype())
   {
@@ -768,11 +769,12 @@ Node SygusSymBreakNew::registerSearchValue(
   // currently bottom-up, could be top-down?
   if( nv.getNumChildren()>0 ){
     const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
-    unsigned cindex = DatatypesRewriter::indexOf( nv.getOperator() );
+    unsigned cindex = DatatypesRewriter::indexOf(nv.getOperator());
     std::vector<Node> rcons_children;
     rcons_children.push_back(nv.getOperator());
     bool childrenChanged = false;
-    for( unsigned i=0, nchild = nv.getNumChildren(); i<nchild; i++ ){
+    for (unsigned i = 0, nchild = nv.getNumChildren(); i < nchild; i++)
+    {
       Node sel = nm->mkNode(
           APPLY_SELECTOR_TOTAL,
           Node::fromExpr(dt[cindex].getSelectorInternal(tn.toType(), i)),
@@ -1333,7 +1335,7 @@ bool SygusSymBreakNew::checkTesters(Node n,
   }
   TypeNode tn = n.getType();
   const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
-  int cindex = DatatypesRewriter::indexOf( vn.getOperator() );
+  int cindex = DatatypesRewriter::indexOf(vn.getOperator());
   Node tst = DatatypesRewriter::mkTester( n, cindex, dt );
   bool hastst = d_td->getValuation().getModel()->hasTerm( tst );
   Node tstrep = d_td->getValuation().getModel()->getRepresentative( tst );

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -760,15 +760,21 @@ Node SygusSymBreakNew::registerSearchValue(
   TypeNode tn = n.getType();
   if (!tn.isDatatype())
   {
-    // don't register non-(sygus-)datatype terms, instead we return the
+    // don't register non-datatype terms, instead we return the
     // selector chain n.
+    return n;
+  }
+  const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
+  if( !dt.isSygus() )
+  {
+    // don't register non-sygus-datatype terms
     return n;
   }
   Assert(nv.getKind() == APPLY_CONSTRUCTOR);
   NodeManager* nm = NodeManager::currentNM();
-  // currently bottom-up, could be top-down?
+  // we call the body of this function in a bottom-up fashion
+  // this ensures that the "abstraction" of the model value is available
   if( nv.getNumChildren()>0 ){
-    const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
     unsigned cindex = DatatypesRewriter::indexOf(nv.getOperator());
     std::vector<Node> rcons_children;
     rcons_children.push_back(nv.getOperator());

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -589,8 +589,8 @@ Node SygusSymBreakNew::getSimpleSymBreakPred(TypeNode tn,
           }
         }
 
-        Trace("sygus-sb-simple-debug")
-            << "  Redundant operators..." << std::endl;
+        Trace("sygus-sb-simple-debug") << "  Redundant operators..."
+                                       << std::endl;
         // singular arguments (e.g. 0 for mult)
         // redundant arguments (e.g. 0 for plus, 1 for mult)
         // right-associativity
@@ -765,7 +765,7 @@ Node SygusSymBreakNew::registerSearchValue(
     return n;
   }
   const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
-  if( !dt.isSygus() )
+  if (!dt.isSygus())
   {
     // don't register non-sygus-datatype terms
     return n;
@@ -1247,8 +1247,8 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
   for( std::map< Node, bool >::iterator it = d_register_st.begin(); it != d_register_st.end(); ++it ){
     if( it->second ){
       Node prog = it->first;
-      Trace("dt-sygus-debug")
-          << "Checking model value of " << prog << "..." << std::endl;
+      Trace("dt-sygus-debug") << "Checking model value of " << prog << "..."
+                              << std::endl;
       Assert(prog.getType().isDatatype());
       Node progv = d_td->getValuation().getModel()->getValue( prog );
       if (Trace.isOn("dt-sygus"))

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -219,10 +219,15 @@ void SygusSymBreakNew::assertTesterInternal( int tindex, TNode n, Node exp, std:
   {
     // nothing to do for non-datatype types
     return;
+  } 
+  const Datatype& dt = static_cast<DatatypeType>(ntn.toType()).getDatatype();
+  if( !dt.isSygus() )
+  {
+    // nothing to do for non-sygus-datatype type
+    return;
   }
   d_active_terms.insert( n );
-  Trace("sygus-sb-debug2") << "Sygus : activate term : " << n << " : " << exp << std::endl;  
-  const Datatype& dt = ((DatatypeType)ntn.toType()).getDatatype();
+  Trace("sygus-sb-debug2") << "Sygus : activate term : " << n << " : " << exp << std::endl; 
   
   // get the search size for this
   Assert( d_term_to_anchor.find( n )!=d_term_to_anchor.end() );

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -412,6 +412,7 @@ Node SygusSymBreakNew::getSimpleSymBreakPred(TypeNode tn,
   {
     return it->second;
   }
+  // this function is only called on sygus datatype types
   Assert(tn.isDatatype());
   NodeManager* nm = NodeManager::currentNM();
   Node n = getFreeVar(tn);
@@ -771,7 +772,7 @@ Node SygusSymBreakNew::registerSearchValue(
     std::vector<Node> rcons_children;
     rcons_children.push_back(nv.getOperator());
     bool childrenChanged = false;
-    for( unsigned i=0; i<nv.getNumChildren(); i++ ){
+    for( unsigned i=0, nchild = nv.getNumChildren(); i<nchild; i++ ){
       Node sel = nm->mkNode(
           APPLY_SELECTOR_TOTAL,
           Node::fromExpr(dt[cindex].getSelectorInternal(tn.toType(), i)),

--- a/src/theory/datatypes/datatypes_sygus.h
+++ b/src/theory/datatypes/datatypes_sygus.h
@@ -290,7 +290,11 @@ private:
    * contains occurrences of the "any constant" constructor. For example, if
    * nv is C_+( C_x(), C_{any_constant}( 5 ) ), then the return value of this
    * function will either be null, or C_+( C_x(), C_{any_constant}( n.1.0 ) ),
-   * where n.1.0 is the appropriate selector chain applied to n.
+   * where n.1.0 is the appropriate selector chain applied to n. We build this
+   * abstraction since the semantics of C_{any_constant} is "any constant" and
+   * not "some constant". Thus, we should consider the subterm 
+   * C_{any_constant}( 5 ) above to be an unconstrained variable (as represented
+   * by a selector chain), instead of the concrete value 5.
    */
   Node registerSearchValue(
       Node a, Node n, Node nv, unsigned d, std::vector<Node>& lemmas);

--- a/src/theory/datatypes/datatypes_sygus.h
+++ b/src/theory/datatypes/datatypes_sygus.h
@@ -283,7 +283,7 @@ private:
    * z -> t for all terms t of appropriate depth, including d.
    * This function strengthens blocking clauses using generalization techniques
    * described in Reynolds et al SYNT 2017.
-   * 
+   *
    * The return value of this function is an abstraction of model assignment
    * of nv to n, or null if we wish to exclude the model assignment nv to n.
    * The return value of this method is different from nv itself, e.g. if it
@@ -292,7 +292,8 @@ private:
    * function will either be null, or C_+( C_x(), C_{any_constant}( n.1.0 ) ),
    * where n.1.0 is the appropriate selector chain applied to n.
    */
-  Node registerSearchValue( Node a, Node n, Node nv, unsigned d, std::vector< Node >& lemmas );
+  Node registerSearchValue(
+      Node a, Node n, Node nv, unsigned d, std::vector<Node>& lemmas);
   /** Register symmetry breaking lemma
    *
    * This function adds the symmetry breaking lemma template lem for terms of

--- a/src/theory/datatypes/datatypes_sygus.h
+++ b/src/theory/datatypes/datatypes_sygus.h
@@ -290,7 +290,7 @@ private:
    * contains occurrences of the "any constant" constructor. For example, if
    * nv is C_+( C_x(), C_{any_constant}( 5 ) ), then the return value of this
    * function will either be null, or C_+( C_x(), C_{any_constant}( n.1.0 ) ),
-   * where n.2.1 is the appropriate selector chain applied to n.
+   * where n.1.0 is the appropriate selector chain applied to n.
    */
   Node registerSearchValue( Node a, Node n, Node nv, unsigned d, std::vector< Node >& lemmas );
   /** Register symmetry breaking lemma

--- a/src/theory/datatypes/datatypes_sygus.h
+++ b/src/theory/datatypes/datatypes_sygus.h
@@ -292,7 +292,7 @@ private:
    * function will either be null, or C_+( C_x(), C_{any_constant}( n.1.0 ) ),
    * where n.1.0 is the appropriate selector chain applied to n. We build this
    * abstraction since the semantics of C_{any_constant} is "any constant" and
-   * not "some constant". Thus, we should consider the subterm 
+   * not "some constant". Thus, we should consider the subterm
    * C_{any_constant}( 5 ) above to be an unconstrained variable (as represented
    * by a selector chain), instead of the concrete value 5.
    */

--- a/src/theory/datatypes/datatypes_sygus.h
+++ b/src/theory/datatypes/datatypes_sygus.h
@@ -283,8 +283,16 @@ private:
    * z -> t for all terms t of appropriate depth, including d.
    * This function strengthens blocking clauses using generalization techniques
    * described in Reynolds et al SYNT 2017.
+   * 
+   * The return value of this function is an abstraction of model assignment
+   * of nv to n, or null if we wish to exclude the model assignment nv to n.
+   * The return value of this method is different from nv itself, e.g. if it
+   * contains occurrences of the "any constant" constructor. For example, if
+   * nv is C_+( C_x(), C_{any_constant}( 5 ) ), then the return value of this
+   * function will either be null, or C_+( C_x(), C_{any_constant}( n.1.0 ) ),
+   * where n.2.1 is the appropriate selector chain applied to n.
    */
-  bool registerSearchValue( Node a, Node n, Node nv, unsigned d, std::vector< Node >& lemmas );
+  Node registerSearchValue( Node a, Node n, Node nv, unsigned d, std::vector< Node >& lemmas );
   /** Register symmetry breaking lemma
    *
    * This function adds the symmetry breaking lemma template lem for terms of

--- a/src/theory/datatypes/kinds
+++ b/src/theory/datatypes/kinds
@@ -114,4 +114,7 @@ typerule DT_SIZE_BOUND ::CVC4::theory::datatypes::DtBoundTypeRule
 operator DT_SYGUS_BOUND 2 "datatypes sygus bound"
 typerule DT_SYGUS_BOUND ::CVC4::theory::datatypes::DtSygusBoundTypeRule
 
+operator DT_SYGUS_EVAL 1: "datatypes sygus evaluation function"
+typerule DT_SYGUS_EVAL ::CVC4::theory::datatypes::DtSyguEvalTypeRule
+
 endtheory

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -65,8 +65,6 @@ TheoryDatatypes::TheoryDatatypes(Context* c, UserContext* u, OutputChannel& out,
   d_equalityEngine.addFunctionKind(kind::APPLY_SELECTOR_TOTAL);
   //d_equalityEngine.addFunctionKind(kind::DT_SIZE);
   //d_equalityEngine.addFunctionKind(kind::DT_HEIGHT_BOUND);
-  //d_equalityEngine.addFunctionKind(kind::DT_SYGUS_TERM_ORDER);
-  //d_equalityEngine.addFunctionKind(kind::DT_SYGUS_IS_CONST);
   d_equalityEngine.addFunctionKind(kind::APPLY_TESTER);
   //d_equalityEngine.addFunctionKind(kind::APPLY_UF);
 
@@ -530,6 +528,8 @@ void TheoryDatatypes::finishInit() {
     quantifiers::TermDbSygus * tds = getQuantifiersEngine()->getTermDatabaseSygus();
     Assert( tds!=NULL );
     d_sygus_sym_break = new SygusSymBreakNew( this, tds, getSatContext() );
+    // do congruence on evaluation functions
+    d_equalityEngine.addFunctionKind(kind::DT_SYGUS_EVAL);
   }
 }
 

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -961,7 +961,7 @@ Node TheoryDatatypes::getLabel( Node n ) {
 
 int TheoryDatatypes::getLabelIndex( EqcInfo* eqc, Node n ){
   if( eqc && !eqc->d_constructor.get().isNull() ){
-    return DatatypesRewriter::indexOf( eqc->d_constructor.get().getOperator() );
+    return DatatypesRewriter::indexOf(eqc->d_constructor.get().getOperator());
   }else{
     Node lbl = getLabel( n );
     if( lbl.isNull() ){
@@ -2260,7 +2260,8 @@ std::pair<bool, Node> TheoryDatatypes::entailmentCheck(TNode lit, const Entailme
       Node r = d_equalityEngine.getRepresentative( n );
       EqcInfo * ei = getOrMakeEqcInfo( r, false );
       int l_index = getLabelIndex( ei, r );
-      int t_index = static_cast<int>(DatatypesRewriter::indexOf( atom.getOperator()));
+      int t_index =
+          static_cast<int>(DatatypesRewriter::indexOf(atom.getOperator()));
       Trace("dt-entail") << "  Tester indices are " << t_index << " and " << l_index << std::endl;
       if( l_index!=-1 && (l_index==t_index)==pol ){
         std::vector< TNode > exp_c;

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -546,7 +546,7 @@ Node TheoryDatatypes::expandDefinition(LogicRequest &logicRequest, Node n) {
     Node selector_use;
     TypeNode ndt = n[0].getType();
     if( options::dtSharedSelectors() ){
-      size_t selectorIndex = Datatype::indexOf(selectorExpr);
+      size_t selectorIndex = DatatypesRewriter::indexOf(selector);
       Trace("dt-expand") << "...selector index = " << selectorIndex << std::endl;
       Assert( selectorIndex<c.getNumArgs() );
       selector_use = Node::fromExpr( c.getSelectorInternal( ndt.toType(), selectorIndex ) );
@@ -961,7 +961,7 @@ Node TheoryDatatypes::getLabel( Node n ) {
 
 int TheoryDatatypes::getLabelIndex( EqcInfo* eqc, Node n ){
   if( eqc && !eqc->d_constructor.get().isNull() ){
-    return Datatype::indexOf( eqc->d_constructor.get().getOperator().toExpr() );
+    return DatatypesRewriter::indexOf( eqc->d_constructor.get().getOperator() );
   }else{
     Node lbl = getLabel( n );
     if( lbl.isNull() ){
@@ -970,7 +970,6 @@ int TheoryDatatypes::getLabelIndex( EqcInfo* eqc, Node n ){
       int tindex = DatatypesRewriter::isTester( lbl );
       Assert( tindex!=-1 );
       return tindex;
-      //return Datatype::indexOf( getLabel( n ).getOperator().toExpr() );
     }
   }
 }
@@ -998,7 +997,6 @@ void TheoryDatatypes::getPossibleCons( EqcInfo* eqc, Node n, std::vector< bool >
       for( int i=0; i<n_lbl; i++ ){
         Node t = d_labels_data[n][i];
         Assert( t.getKind()==NOT );
-        //pcons[ Datatype::indexOf( t[0].getOperator().toExpr() ) ] = false;
         int tindex = DatatypesRewriter::isTester( t[0] );
         Assert( tindex!=-1 );
         pcons[ tindex ] = false;
@@ -1077,7 +1075,6 @@ void TheoryDatatypes::addTester( int ttindex, Node t, EqcInfo* eqc, Node n, Node
       Assert( ti.getKind()==NOT );
       j = ti;
       jt = j[0];
-      //int jtindex = Datatype::indexOf( jt.getOperator().toExpr() );
       int jtindex = DatatypesRewriter::isTester( jt );
       Assert( jtindex!=-1 );
       if( jtindex==ttindex ){
@@ -1212,7 +1209,7 @@ void TheoryDatatypes::addConstructor( Node c, EqcInfo* eqc, Node n ){
   //check labels
   NodeIntMap::iterator lbl_i = d_labels.find( n );
   if( lbl_i != d_labels.end() ){
-    size_t constructorIndex = Datatype::indexOf(c.getOperator().toExpr());
+    size_t constructorIndex = DatatypesRewriter::indexOf(c.getOperator());
     int n_lbl = (*lbl_i).second;
     for( int i=0; i<n_lbl; i++ ){
       Node t = d_labels_data[n][i];
@@ -1296,7 +1293,7 @@ void TheoryDatatypes::collapseSelector( Node s, Node c ) {
   }
   if( s.getKind()==kind::APPLY_SELECTOR_TOTAL ){
     Expr selectorExpr = s.getOperator().toExpr();
-    size_t constructorIndex = Datatype::indexOf(c.getOperator().toExpr());
+    size_t constructorIndex = DatatypesRewriter::indexOf(c.getOperator());
     const Datatype& dt = Datatype::datatypeOf(selectorExpr);
     const DatatypeConstructor& dtc = dt[constructorIndex];
     int selectorIndex = dtc.getSelectorIndexInternal( selectorExpr );
@@ -1305,10 +1302,6 @@ void TheoryDatatypes::collapseSelector( Node s, Node c ) {
     //if( wrong ){
     //  return;
     //}
-    //if( Datatype::indexOf(c.getOperator().toExpr())!=Datatype::cindexOf(s.getOperator().toExpr()) ){
-    //  mkExpDefSkolem( s.getOperator(), s[0].getType(), s.getType() );
-    //  r = NodeManager::currentNM()->mkNode( kind::APPLY_UF, d_exp_def_skolem[s.getOperator().toExpr()], s[0] );
-    //}else{
     r = NodeManager::currentNM()->mkNode( kind::APPLY_SELECTOR_TOTAL, s.getOperator(), c );
     if( options::dtRefIntro() ){
       use_s = NodeManager::currentNM()->mkNode( kind::APPLY_SELECTOR_TOTAL, s.getOperator(), use_s );
@@ -2267,7 +2260,7 @@ std::pair<bool, Node> TheoryDatatypes::entailmentCheck(TNode lit, const Entailme
       Node r = d_equalityEngine.getRepresentative( n );
       EqcInfo * ei = getOrMakeEqcInfo( r, false );
       int l_index = getLabelIndex( ei, r );
-      int t_index = (int)Datatype::indexOf( atom.getOperator().toExpr() );
+      int t_index = static_cast<int>(DatatypesRewriter::indexOf( atom.getOperator()));
       Trace("dt-entail") << "  Tester indices are " << t_index << " and " << l_index << std::endl;
       if( l_index!=-1 && (l_index==t_index)==pol ){
         std::vector< TNode > exp_c;

--- a/src/theory/datatypes/theory_datatypes_type_rules.h
+++ b/src/theory/datatypes/theory_datatypes_type_rules.h
@@ -359,6 +359,46 @@ class DtSygusBoundTypeRule {
   }
 }; /* class DtSygusBoundTypeRule */
 
+class DtSyguEvalTypeRule {
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
+                                     bool check) {
+    TypeNode headType = n[0].getType(check);
+    if (!headType.isDatatype()) {
+      throw TypeCheckingExceptionPrivate(
+          n, "datatype sygus eval takes a datatype head");
+    }
+    const Datatype& dt =
+                  static_cast<DatatypeType>(headType.toType()).getDatatype();
+    if( !dt.isSygus() )
+    {
+      throw TypeCheckingExceptionPrivate(
+          n, "datatype sygus eval must have a datatype head that is sygus");
+      
+    }
+    if (check) 
+    {
+      Node svl = Node::fromExpr( dt.getSygusVarList() );
+      if( svl.getNumChildren()+1!=n.getNumChildren() )
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "wrong number of arguments to a datatype sygus evaluation function");
+      }
+      for( unsigned i=0, nvars = svl.getNumChildren(); i<nvars; i++ )
+      {
+        TypeNode vtype = svl[i].getType(check);
+        TypeNode atype = n[i+1].getType(check);
+        if( !vtype.isComparableTo(atype) )
+        {
+          throw TypeCheckingExceptionPrivate(
+            n, "argument type mismatch in a datatype sygus evaluation function");
+        }
+      }
+    }
+    return TypeNode::fromType( dt.getSygusType() );
+  }
+}; /* class DtSygusBoundTypeRule */
+
 } /* CVC4::theory::datatypes namespace */
 } /* CVC4::theory namespace */
 } /* CVC4 namespace */

--- a/src/theory/datatypes/theory_datatypes_type_rules.h
+++ b/src/theory/datatypes/theory_datatypes_type_rules.h
@@ -359,43 +359,49 @@ class DtSygusBoundTypeRule {
   }
 }; /* class DtSygusBoundTypeRule */
 
-class DtSyguEvalTypeRule {
+class DtSyguEvalTypeRule
+{
  public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
     TypeNode headType = n[0].getType(check);
-    if (!headType.isDatatype()) {
+    if (!headType.isDatatype())
+    {
       throw TypeCheckingExceptionPrivate(
           n, "datatype sygus eval takes a datatype head");
     }
     const Datatype& dt =
-                  static_cast<DatatypeType>(headType.toType()).getDatatype();
-    if( !dt.isSygus() )
+        static_cast<DatatypeType>(headType.toType()).getDatatype();
+    if (!dt.isSygus())
     {
       throw TypeCheckingExceptionPrivate(
           n, "datatype sygus eval must have a datatype head that is sygus");
-      
     }
-    if (check) 
+    if (check)
     {
-      Node svl = Node::fromExpr( dt.getSygusVarList() );
-      if( svl.getNumChildren()+1!=n.getNumChildren() )
+      Node svl = Node::fromExpr(dt.getSygusVarList());
+      if (svl.getNumChildren() + 1 != n.getNumChildren())
       {
-        throw TypeCheckingExceptionPrivate(
-            n, "wrong number of arguments to a datatype sygus evaluation function");
+        throw TypeCheckingExceptionPrivate(n,
+                                           "wrong number of arguments to a "
+                                           "datatype sygus evaluation "
+                                           "function");
       }
-      for( unsigned i=0, nvars = svl.getNumChildren(); i<nvars; i++ )
+      for (unsigned i = 0, nvars = svl.getNumChildren(); i < nvars; i++)
       {
         TypeNode vtype = svl[i].getType(check);
-        TypeNode atype = n[i+1].getType(check);
-        if( !vtype.isComparableTo(atype) )
+        TypeNode atype = n[i + 1].getType(check);
+        if (!vtype.isComparableTo(atype))
         {
           throw TypeCheckingExceptionPrivate(
-            n, "argument type mismatch in a datatype sygus evaluation function");
+              n,
+              "argument type mismatch in a datatype sygus evaluation function");
         }
       }
     }
-    return TypeNode::fromType( dt.getSygusType() );
+    return TypeNode::fromType(dt.getSygusType());
   }
 }; /* class DtSygusBoundTypeRule */
 

--- a/src/theory/datatypes/type_enumerator.cpp
+++ b/src/theory/datatypes/type_enumerator.cpp
@@ -188,7 +188,7 @@ Node DatatypesEnumerator::getTermEnum( TypeNode tn, unsigned i ){
      Debug("dt-enum-debug") << "done : " << t << std::endl;
      Assert( t.getKind()==kind::APPLY_CONSTRUCTOR );
      // start with the constructor for which a ground term is constructed
-     d_zeroCtor = Datatype::indexOf( t.getOperator().toExpr() );
+     d_zeroCtor = datatypes::DatatypesRewriter::indexOf( t.getOperator() );
      d_has_debruijn = 0;
    }
    Debug("dt-enum") << "zero ctor : " << d_zeroCtor << std::endl;

--- a/src/theory/datatypes/type_enumerator.cpp
+++ b/src/theory/datatypes/type_enumerator.cpp
@@ -188,7 +188,7 @@ Node DatatypesEnumerator::getTermEnum( TypeNode tn, unsigned i ){
      Debug("dt-enum-debug") << "done : " << t << std::endl;
      Assert( t.getKind()==kind::APPLY_CONSTRUCTOR );
      // start with the constructor for which a ground term is constructed
-     d_zeroCtor = datatypes::DatatypesRewriter::indexOf( t.getOperator() );
+     d_zeroCtor = datatypes::DatatypesRewriter::indexOf(t.getOperator());
      d_has_debruijn = 0;
    }
    Debug("dt-enum") << "zero ctor : " << d_zeroCtor << std::endl;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -240,7 +240,6 @@ void CegConjecture::doBasicCheck(std::vector< Node >& lems) {
 }
 
 bool CegConjecture::needsRefinement() const { return d_set_ce_sk_vars; }
-
 void CegConjecture::doCheck(std::vector<Node>& lems)
 {
   Assert(d_master != nullptr);

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -430,8 +430,7 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   Trace("cegqi-refine-debug")
       << "  For counterexample skolems : " << d_ce_sk_vars << std::endl;
   Node base_lem;
-  if (d_base_inst.getKind() == kind::NOT
-      && d_base_inst[0].getKind() == kind::FORALL)
+  if (d_base_inst.getKind() == NOT && d_base_inst[0].getKind() == FORALL)
   {
     base_lem = d_base_inst[0][1];
   }

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -276,7 +276,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
       }
       d_repair_index++;
       if (d_sygus_rconst->repairSolution(
-              d_candidates, fail_cvs, candidate_values))
+              d_candidates, fail_cvs, candidate_values, true))
       {
         constructed_cand = true;
       }

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -23,7 +23,6 @@
 #include "theory/quantifiers/first_order_model.h"
 #include "theory/quantifiers/instantiate.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
-#include "theory/quantifiers/skolemize.h"
 #include "theory/quantifiers/sygus/ce_guided_instantiation.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
@@ -46,6 +45,7 @@ CegConjecture::CegConjecture(QuantifiersEngine* qe)
       d_ceg_cegis(new Cegis(qe, this)),
       d_ceg_cegisUnif(new CegisUnif(qe, this)),
       d_master(nullptr),
+      d_set_ce_sk_vars(false),
       d_repair_index(0),
       d_refine_count(0),
       d_syntax_guided(false)
@@ -239,8 +239,8 @@ void CegConjecture::doBasicCheck(std::vector< Node >& lems) {
   }
 }
 
-bool CegConjecture::needsRefinement() { 
-  return !d_ce_sk.empty();
+bool CegConjecture::needsRefinement() const { 
+  return d_set_ce_sk_vars;
 }
 
 void CegConjecture::doCheck(std::vector<Node>& lems)
@@ -305,7 +305,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
       recordInstantiation(candidate_values);
       return;
     }
-    Assert( d_ce_sk.empty() );
+    Assert( !d_set_ce_sk_vars );
   }else{
     if( !constructed_cand ){
       return;
@@ -313,33 +313,39 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   }
   
   //immediately skolemize inner existentials
-  Node instr = Rewriter::rewrite(inst);
+  d_set_ce_sk_vars = sk_refine;
   Node lem;
-  if (instr.getKind() == NOT && instr[0].getKind() == FORALL)
+  if (inst.getKind() == NOT && inst[0].getKind() == FORALL)
   {
+    // introduce the skolem variables
+    std::vector< Node > sks;
     if (constructed_cand)
     {
-      lem = d_qe->getSkolemize()->getSkolemizedBody(instr[0]).negate();
+      std::vector< Node > vars;
+      for( const Node& v : inst[0][0] )
+      {
+        Node sk = nm->mkSkolem("rsk",v.getType());
+        sks.push_back(sk);
+        vars.push_back(v);
+      }
+      lem = inst[0][1].substitute(vars.begin(),vars.end(),sks.begin(),sks.end());
+      lem = lem.negate();
     }
     if (sk_refine)
     {
-      Assert(!isGround());
-      d_ce_sk.push_back(instr[0]);
+      d_ce_sk_vars.insert(d_ce_sk_vars.end(),sks.begin(),sks.end());
     }
+    Assert(!isGround());
   }
   else
   {
     if (constructed_cand)
     {
       // use the instance itself
-      lem = instr;
+      lem = inst;
     }
-    if (sk_refine)
-    {
-      // we add null so that one test of the conjecture for the empty
-      // substitution is checked
-      d_ce_sk.push_back(Node::null());
-    }
+    // we add null so that one test of the conjecture for the empty
+    // substitution is checked
   }
   if (!lem.isNull())
   {
@@ -372,22 +378,19 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
         
 void CegConjecture::doRefine( std::vector< Node >& lems ){
   Assert( lems.empty() );
-  Assert( d_ce_sk.size()==1 );
+  Assert( d_set_ce_sk_vars );
 
   //first, make skolem substitution
   Trace("cegqi-refine") << "doRefine : construct skolem substitution..." << std::endl;
   std::vector< Node > sk_vars;
   std::vector< Node > sk_subs;
   //collect the substitution over all disjuncts
-  Node ce_q = d_ce_sk[0];
-  if (!ce_q.isNull())
+  if (!d_ce_sk_vars.empty())
   {
-    Trace("cegqi-refine") << "Get skolem constants for : " << ce_q << std::endl;
-    std::vector<Node> skolems;
-    d_qe->getSkolemize()->getSkolemConstants(ce_q, skolems);
-    Assert(d_inner_vars.size() == skolems.size());
+    Trace("cegqi-refine") << "Get model values for skolems..." << std::endl;
+    Assert(d_inner_vars.size() == d_ce_sk_vars.size());
     std::vector<Node> model_values;
-    getModelValues(skolems, model_values);
+    getModelValues(d_ce_sk_vars, model_values);
     sk_vars.insert(sk_vars.end(), d_inner_vars.begin(), d_inner_vars.end());
     sk_subs.insert(sk_subs.end(), model_values.begin(), model_values.end());
   }
@@ -399,12 +402,10 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   std::vector< Node > lem_c;
   Trace("cegqi-refine") << "doRefine : Construct refinement lemma..." << std::endl;
   Trace("cegqi-refine-debug")
-      << "  For counterexample point : " << ce_q << std::endl;
+      << "  For counterexample skolems : " << d_ce_sk_vars << std::endl;
   Node base_lem;
-  if (!ce_q.isNull())
+  if (d_base_inst.getKind() == kind::NOT && d_base_inst[0].getKind() == kind::FORALL)
   {
-    Assert(d_base_inst.getKind() == kind::NOT
-           && d_base_inst[0].getKind() == kind::FORALL);
     base_lem = d_base_inst[0][1];
   }
   else
@@ -421,7 +422,8 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   Trace("cegqi-refine") << "doRefine : register refinement lemma " << base_lem << "..." << std::endl;
   d_master->registerRefinementLemma(sk_vars, base_lem, lems);
   Trace("cegqi-refine") << "doRefine : finished" << std::endl;
-  d_ce_sk.clear();
+  d_set_ce_sk_vars = false;
+  d_ce_sk_vars.clear();
 }
 
 void CegConjecture::preregisterConjecture( Node q ) {
@@ -458,15 +460,8 @@ Node CegConjecture::getModelValue( Node n ) {
 
 void CegConjecture::debugPrint( const char * c ) {
   Trace(c) << "Synthesis conjecture : " << d_embed_quant << std::endl;
-  Trace(c) << "  * Candidate program/output symbol : ";
-  for( unsigned i=0; i<d_candidates.size(); i++ ){
-    Trace(c) << d_candidates[i] << " ";
-  }
-  Trace(c) << std::endl;
-  Trace(c) << "  * Candidate ce skolems : ";
-  for( unsigned i=0; i<d_ce_sk.size(); i++ ){
-    Trace(c) << d_ce_sk[i] << " ";
-  }
+  Trace(c) << "  * Candidate programs : " << d_candidates << std::endl;
+  Trace(c) << "  * Counterexample skolems : " << d_ce_sk_vars << std::endl;
 }
 
 Node CegConjecture::getCurrentStreamGuard() const {
@@ -579,7 +574,8 @@ void CegConjecture::printAndContinueStream()
 
   // We will not refine the current candidate solution since it is a solution
   // thus, we clear information regarding the current refinement
-  d_ce_sk.clear();
+  d_set_ce_sk_vars = false;
+  d_ce_sk_vars.clear();
   // However, we need to exclude the current solution using an explicit
   // blocking clause, so that we proceed to the next solution.
   std::vector<Node> terms;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -382,6 +382,7 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   Node ce_q = d_ce_sk[0];
   if (!ce_q.isNull())
   {
+    Trace("cegqi-refine") << "Get skolem constants for : " << ce_q << std::endl;
     std::vector<Node> skolems;
     d_qe->getSkolemize()->getSkolemConstants(ce_q, skolems);
     Assert(d_inner_vars.size() == skolems.size());
@@ -413,12 +414,13 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
 
   Assert( sk_vars.size()==sk_subs.size() );
 
-  Trace("cegqi-refine") << "doRefine : construct and finalize lemmas..." << std::endl;
-
+  Trace("cegqi-refine") << "doRefine : substitute..." << std::endl;
   base_lem = base_lem.substitute( sk_vars.begin(), sk_vars.end(), sk_subs.begin(), sk_subs.end() );
+  Trace("cegqi-refine") << "doRefine : rewrite..." << std::endl;
   base_lem = Rewriter::rewrite( base_lem );
+  Trace("cegqi-refine") << "doRefine : register refinement lemma " << base_lem << "..." << std::endl;
   d_master->registerRefinementLemma(sk_vars, base_lem, lems);
-
+  Trace("cegqi-refine") << "doRefine : finished" << std::endl;
   d_ce_sk.clear();
 }
 

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.cpp
@@ -239,9 +239,7 @@ void CegConjecture::doBasicCheck(std::vector< Node >& lems) {
   }
 }
 
-bool CegConjecture::needsRefinement() const { 
-  return d_set_ce_sk_vars;
-}
+bool CegConjecture::needsRefinement() const { return d_set_ce_sk_vars; }
 
 void CegConjecture::doCheck(std::vector<Node>& lems)
 {
@@ -305,7 +303,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
       recordInstantiation(candidate_values);
       return;
     }
-    Assert( !d_set_ce_sk_vars );
+    Assert(!d_set_ce_sk_vars);
   }else{
     if( !constructed_cand ){
       return;
@@ -318,22 +316,23 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
   if (inst.getKind() == NOT && inst[0].getKind() == FORALL)
   {
     // introduce the skolem variables
-    std::vector< Node > sks;
+    std::vector<Node> sks;
     if (constructed_cand)
     {
-      std::vector< Node > vars;
-      for( const Node& v : inst[0][0] )
+      std::vector<Node> vars;
+      for (const Node& v : inst[0][0])
       {
-        Node sk = nm->mkSkolem("rsk",v.getType());
+        Node sk = nm->mkSkolem("rsk", v.getType());
         sks.push_back(sk);
         vars.push_back(v);
       }
-      lem = inst[0][1].substitute(vars.begin(),vars.end(),sks.begin(),sks.end());
+      lem = inst[0][1].substitute(
+          vars.begin(), vars.end(), sks.begin(), sks.end());
       lem = lem.negate();
     }
     if (sk_refine)
     {
-      d_ce_sk_vars.insert(d_ce_sk_vars.end(),sks.begin(),sks.end());
+      d_ce_sk_vars.insert(d_ce_sk_vars.end(), sks.begin(), sks.end());
     }
     Assert(!isGround());
   }
@@ -378,7 +377,7 @@ void CegConjecture::doCheck(std::vector<Node>& lems)
         
 void CegConjecture::doRefine( std::vector< Node >& lems ){
   Assert( lems.empty() );
-  Assert( d_set_ce_sk_vars );
+  Assert(d_set_ce_sk_vars);
 
   //first, make skolem substitution
   Trace("cegqi-refine") << "doRefine : construct skolem substitution..." << std::endl;
@@ -404,7 +403,8 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   Trace("cegqi-refine-debug")
       << "  For counterexample skolems : " << d_ce_sk_vars << std::endl;
   Node base_lem;
-  if (d_base_inst.getKind() == kind::NOT && d_base_inst[0].getKind() == kind::FORALL)
+  if (d_base_inst.getKind() == kind::NOT
+      && d_base_inst[0].getKind() == kind::FORALL)
   {
     base_lem = d_base_inst[0][1];
   }
@@ -419,7 +419,8 @@ void CegConjecture::doRefine( std::vector< Node >& lems ){
   base_lem = base_lem.substitute( sk_vars.begin(), sk_vars.end(), sk_subs.begin(), sk_subs.end() );
   Trace("cegqi-refine") << "doRefine : rewrite..." << std::endl;
   base_lem = Rewriter::rewrite( base_lem );
-  Trace("cegqi-refine") << "doRefine : register refinement lemma " << base_lem << "..." << std::endl;
+  Trace("cegqi-refine") << "doRefine : register refinement lemma " << base_lem
+                        << "..." << std::endl;
   d_master->registerRefinementLemma(sk_vars, base_lem, lems);
   Trace("cegqi-refine") << "doRefine : finished" << std::endl;
   d_set_ce_sk_vars = false;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -173,12 +173,16 @@ private:
   /** list of variables on inner quantification */
   std::vector< Node > d_inner_vars;
   /**
-   * The set of current existentially quantified formulas whose couterexamples
-   * we must refine. This may be added to during calls to doCheck(). The model
-   * values for skolems of these formulas are analyzed during doRefine().
+   * The set of skolems for the current "verification" lemma, if one exists. 
+   * This may be added to during calls to doCheck(). The model values for these
+   * skolems are analyzed during doRefine().
+   */
+  std::vector<Node> d_ce_sk_vars;
+  /** 
+   * Whether the above vector has been set. We have this flag since the above
+   * vector may be set to empty (e.g. for ground synthesis conjectures).
    */
   bool d_set_ce_sk_vars;
-  std::vector<Node> d_ce_sk_vars;
 
   /** the asserted (negated) conjecture */
   Node d_quant;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -60,7 +60,7 @@ public:
   /** whether the conjecture is waiting for a call to doCheck below */
   bool needsCheck( std::vector< Node >& lem );
   /** whether the conjecture is waiting for a call to doRefine below */
-  bool needsRefinement();
+  bool needsRefinement() const;
   /** do single invocation check 
   * This updates Gamma for an iteration of step 2 of Figure 1 of Reynolds et al CAV 2015.
   */
@@ -177,7 +177,8 @@ private:
    * we must refine. This may be added to during calls to doCheck(). The model
    * values for skolems of these formulas are analyzed during doRefine().
    */
-  std::vector<Node> d_ce_sk;
+  bool d_set_ce_sk_vars;
+  std::vector<Node> d_ce_sk_vars;
 
   /** the asserted (negated) conjecture */
   Node d_quant;

--- a/src/theory/quantifiers/sygus/ce_guided_conjecture.h
+++ b/src/theory/quantifiers/sygus/ce_guided_conjecture.h
@@ -173,12 +173,12 @@ private:
   /** list of variables on inner quantification */
   std::vector< Node > d_inner_vars;
   /**
-   * The set of skolems for the current "verification" lemma, if one exists. 
+   * The set of skolems for the current "verification" lemma, if one exists.
    * This may be added to during calls to doCheck(). The model values for these
    * skolems are analyzed during doRefine().
    */
   std::vector<Node> d_ce_sk_vars;
-  /** 
+  /**
    * Whether the above vector has been set. We have this flag since the above
    * vector may be set to empty (e.g. for ground synthesis conjectures).
    */

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv_sol.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv_sol.cpp
@@ -1211,7 +1211,7 @@ Node CegConjectureSingleInvSol::builtinToSygusConst(Node c,
   Node sc;
   d_builtin_const_to_sygus[tn][c] = sc;
   Assert(c.isConst());
-  if(!tn.isDatatype())
+  if (!tn.isDatatype())
   {
     // if we've traversed to a builtin type, simply return c
     d_builtin_const_to_sygus[tn][c] = c;
@@ -1220,7 +1220,7 @@ Node CegConjectureSingleInvSol::builtinToSygusConst(Node c,
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Trace("csi-rcons-debug") << "Try to reconstruct " << c << " in "
                            << dt.getName() << std::endl;
-  if(!dt.isSygus())
+  if (!dt.isSygus())
   {
     // if we've traversed to a builtin datatype type, simply return c
     d_builtin_const_to_sygus[tn][c] = c;

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv_sol.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv_sol.cpp
@@ -1211,11 +1211,21 @@ Node CegConjectureSingleInvSol::builtinToSygusConst(Node c,
   Node sc;
   d_builtin_const_to_sygus[tn][c] = sc;
   Assert(c.isConst());
-  Assert(tn.isDatatype());
+  if(!tn.isDatatype())
+  {
+    // if we've traversed to a builtin type, simply return c
+    d_builtin_const_to_sygus[tn][c] = c;
+    return c;
+  }
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Trace("csi-rcons-debug") << "Try to reconstruct " << c << " in "
                            << dt.getName() << std::endl;
-  Assert(dt.isSygus());
+  if(!dt.isSygus())
+  {
+    // if we've traversed to a builtin datatype type, simply return c
+    d_builtin_const_to_sygus[tn][c] = c;
+    return c;
+  }
   // if we are not interested in reconstructing constants, or the grammar allows
   // them, return a proxy
   if (!options::cegqiSingleInvReconstructConst() || dt.getSygusAllowConst())
@@ -1496,9 +1506,7 @@ Node CegConjectureSingleInvSol::getGenericBase(TypeNode tn,
   }
   TermDbSygus* tds = d_qe->getTermDatabaseSygus();
   Assert(tds->isRegistered(tn));
-  std::map<TypeNode, int> var_count;
-  std::map<int, Node> pre;
-  Node g = tds->mkGeneric(dt, c, var_count, pre);
+  Node g = tds->mkGeneric(dt, c);
   Trace("csi-sol-debug") << "Generic is " << g << std::endl;
   Node gr = Rewriter::rewrite(g);
   Trace("csi-sol-debug") << "Generic rewritten is " << gr << std::endl;

--- a/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
+++ b/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
@@ -31,6 +31,11 @@ SygusEvalUnfold::SygusEvalUnfold(TermDbSygus* tds) : d_tds(tds) {}
 void SygusEvalUnfold::registerEvalTerm(Node n)
 {
   Assert(options::sygusEvalUnfold());
+  // is this a sygus evaluation function application?
+  if( !datatypes::DatatypesRewriter::isSygusEvalApp(n) )
+  {
+    return;
+  }
   if (d_eval_processed.find(n) != d_eval_processed.end())
   {
     return;
@@ -38,12 +43,6 @@ void SygusEvalUnfold::registerEvalTerm(Node n)
   Trace("sygus-eval-unfold")
       << "SygusEvalUnfold: register eval term : " << n << std::endl;
   d_eval_processed.insert(n);
-  
-  // is this a sygus evaluation function application?
-  if( !datatypes::DatatypesRewriter::isSygusEvalApp(n) )
-  {
-    return;
-  }
   TypeNode tn = n[0].getType();
   Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
@@ -122,7 +121,6 @@ void SygusEvalUnfold::registerModelValue(Node a,
       }
       // evaluation children
       std::vector<Node> eval_children;
-      eval_children.push_back(Node::fromExpr(dt.getSygusEvaluationFunc()));
       eval_children.push_back(n);
       // for each evaluation
       for (unsigned i = start; i < curr_size; i++)
@@ -147,8 +145,8 @@ void SygusEvalUnfold::registerModelValue(Node a,
           vtm[n] = vn;
           eval_children.insert(
               eval_children.end(), it->second[i].begin(), it->second[i].end());
-          Node eval_fun = nm->mkNode(APPLY_UF, eval_children);
-          eval_children.resize(2);
+          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,eval_children);
+          eval_children.resize(1);
           res = d_tds->unfold(eval_fun, vtm, exp);
           expn = exp.size() == 1 ? exp[0] : nm->mkNode(AND, exp);
         }
@@ -157,13 +155,13 @@ void SygusEvalUnfold::registerModelValue(Node a,
           EvalSygusInvarianceTest esit;
           eval_children.insert(
               eval_children.end(), it->second[i].begin(), it->second[i].end());
-          Node conj = nm->mkNode(APPLY_UF, eval_children);
-          eval_children[1] = vn;
-          Node eval_fun = nm->mkNode(APPLY_UF, eval_children);
+          Node conj = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,eval_children);
+          eval_children[0] = vn;
+          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,eval_children);
           res = d_tds->evaluateWithUnfolding(eval_fun);
           esit.init(conj, n, res);
-          eval_children.resize(2);
-          eval_children[1] = n;
+          eval_children.resize(1);
+          eval_children[0] = n;
 
           // evaluate with minimal explanation
           std::vector<Node> mexp;

--- a/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
+++ b/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
@@ -15,8 +15,8 @@
 #include "theory/quantifiers/sygus/sygus_eval_unfold.h"
 
 #include "options/quantifiers_options.h"
-#include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/datatypes/datatypes_rewriter.h"
+#include "theory/quantifiers/sygus/term_database_sygus.h"
 
 using namespace std;
 using namespace CVC4::kind;
@@ -32,7 +32,7 @@ void SygusEvalUnfold::registerEvalTerm(Node n)
 {
   Assert(options::sygusEvalUnfold());
   // is this a sygus evaluation function application?
-  if( !datatypes::DatatypesRewriter::isSygusEvalApp(n) )
+  if (!datatypes::DatatypesRewriter::isSygusEvalApp(n))
   {
     return;
   }
@@ -50,7 +50,7 @@ void SygusEvalUnfold::registerEvalTerm(Node n)
   if (n[0].getKind() == APPLY_CONSTRUCTOR)
   {
     // constructors should be unfolded and reduced already
-    Assert( false );
+    Assert(false);
     return;
   }
   // register this evaluation term with its head
@@ -145,7 +145,8 @@ void SygusEvalUnfold::registerModelValue(Node a,
           vtm[n] = vn;
           eval_children.insert(
               eval_children.end(), it->second[i].begin(), it->second[i].end());
-          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
+          Node eval_fun =
+              datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
           eval_children.resize(1);
           res = d_tds->unfold(eval_fun, vtm, exp);
           expn = exp.size() == 1 ? exp[0] : nm->mkNode(AND, exp);
@@ -155,9 +156,11 @@ void SygusEvalUnfold::registerModelValue(Node a,
           EvalSygusInvarianceTest esit;
           eval_children.insert(
               eval_children.end(), it->second[i].begin(), it->second[i].end());
-          Node conj = datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
+          Node conj =
+              datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
           eval_children[0] = vn;
-          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
+          Node eval_fun =
+              datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
           res = d_tds->evaluateWithUnfolding(eval_fun);
           esit.init(conj, n, res);
           eval_children.resize(1);

--- a/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
+++ b/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
@@ -44,6 +44,7 @@ void SygusEvalUnfold::registerEvalTerm(Node n)
       << "SygusEvalUnfold: register eval term : " << n << std::endl;
   d_eval_processed.insert(n);
   TypeNode tn = n[0].getType();
+  // since n[0] is an evaluation head, we know tn is a sygus datatype
   Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Assert(dt.isSygus());
@@ -101,6 +102,7 @@ void SygusEvalUnfold::registerModelValue(Node a,
           antec_exp.size() == 1 ? antec_exp[0] : nm->mkNode(AND, antec_exp);
       // Node antec = n.eqNode( vn );
       TypeNode tn = n.getType();
+      // n occurs as an evaluation head, thus it has sygus datatype type
       Assert(tn.isDatatype());
       const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
       Assert(dt.isSygus());

--- a/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
+++ b/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
@@ -45,9 +45,9 @@ void SygusEvalUnfold::registerEvalTerm(Node n)
     return;
   }
   TypeNode tn = n[0].getType();
-  Assert(!tn.isDatatype());
+  Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  Assert(!dt.isSygus());
+  Assert(dt.isSygus());
   if (n[0].getKind() == APPLY_CONSTRUCTOR)
   {
     // constructors should be unfolded and reduced already

--- a/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
+++ b/src/theory/quantifiers/sygus/sygus_eval_unfold.cpp
@@ -145,7 +145,7 @@ void SygusEvalUnfold::registerModelValue(Node a,
           vtm[n] = vn;
           eval_children.insert(
               eval_children.end(), it->second[i].begin(), it->second[i].end());
-          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,eval_children);
+          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
           eval_children.resize(1);
           res = d_tds->unfold(eval_fun, vtm, exp);
           expn = exp.size() == 1 ? exp[0] : nm->mkNode(AND, exp);
@@ -155,9 +155,9 @@ void SygusEvalUnfold::registerModelValue(Node a,
           EvalSygusInvarianceTest esit;
           eval_children.insert(
               eval_children.end(), it->second[i].begin(), it->second[i].end());
-          Node conj = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,eval_children);
+          Node conj = datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
           eval_children[0] = vn;
-          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,eval_children);
+          Node eval_fun = datatypes::DatatypesRewriter::mkSygusEvalApp(eval_children);
           res = d_tds->evaluateWithUnfolding(eval_fun);
           esit.init(conj, n, res);
           eval_children.resize(1);

--- a/src/theory/quantifiers/sygus/sygus_explain.cpp
+++ b/src/theory/quantifiers/sygus/sygus_explain.cpp
@@ -129,9 +129,9 @@ void SygusExplain::getExplanationForEquality(Node n,
     return;
   }
   TypeNode tn = n.getType();
-  if(!tn.isDatatype())
+  if (!tn.isDatatype())
   {
-    // sygus datatype fields that are not sygus datatypes are treated as 
+    // sygus datatype fields that are not sygus datatypes are treated as
     // abstractions only, hence we disregard this field
     return;
   }
@@ -185,9 +185,9 @@ void SygusExplain::getExplanationFor(TermRecBuild& trb,
   Assert(vnr.isNull() || vn != vnr);
   Assert(n.getType() == vn.getType());
   TypeNode ntn = n.getType();
-  if( !ntn.isDatatype() )
+  if (!ntn.isDatatype())
   {
-    // sygus datatype fields that are not sygus datatypes are treated as 
+    // sygus datatype fields that are not sygus datatypes are treated as
     // abstractions only, hence we disregard this field
     return;
   }

--- a/src/theory/quantifiers/sygus/sygus_explain.cpp
+++ b/src/theory/quantifiers/sygus/sygus_explain.cpp
@@ -137,7 +137,7 @@ void SygusExplain::getExplanationForEquality(Node n,
   }
   Assert(vn.getKind() == kind::APPLY_CONSTRUCTOR);
   const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
-  int i = Datatype::indexOf(vn.getOperator().toExpr());
+  int i = datatypes::DatatypesRewriter::indexOf(vn.getOperator());
   Node tst = datatypes::DatatypesRewriter::mkTester(n, i, dt);
   exp.push_back(tst);
   for (unsigned j = 0; j < vn.getNumChildren(); j++)
@@ -221,7 +221,7 @@ void SygusExplain::getExplanationFor(TermRecBuild& trb,
     }
   }
   const Datatype& dt = ((DatatypeType)ntn.toType()).getDatatype();
-  int cindex = Datatype::indexOf(vn.getOperator().toExpr());
+  int cindex = datatypes::DatatypesRewriter::indexOf(vn.getOperator());
   Assert(cindex >= 0 && cindex < (int)dt.getNumConstructors());
   Node tst = datatypes::DatatypesRewriter::mkTester(n, cindex, dt);
   exp.push_back(tst);

--- a/src/theory/quantifiers/sygus/sygus_explain.cpp
+++ b/src/theory/quantifiers/sygus/sygus_explain.cpp
@@ -123,7 +123,9 @@ void SygusExplain::getExplanationForEquality(Node n,
                                              std::vector<Node>& exp,
                                              std::map<unsigned, bool>& cexc)
 {
-  Assert(n.getType() == vn.getType());
+  // since builtin types occur in grammar, types are comparable but not
+  // necessarily equal
+  Assert(n.getType().isComparableTo(n.getType()));
   if (n == vn)
   {
     return;
@@ -183,7 +185,7 @@ void SygusExplain::getExplanationFor(TermRecBuild& trb,
                                      int& sz)
 {
   Assert(vnr.isNull() || vn != vnr);
-  Assert(n.getType() == vn.getType());
+  Assert(n.getType().isComparableTo(vn.getType()));
   TypeNode ntn = n.getType();
   if (!ntn.isDatatype())
   {

--- a/src/theory/quantifiers/sygus/sygus_explain.cpp
+++ b/src/theory/quantifiers/sygus/sygus_explain.cpp
@@ -128,9 +128,14 @@ void SygusExplain::getExplanationForEquality(Node n,
   {
     return;
   }
-  Assert(vn.getKind() == kind::APPLY_CONSTRUCTOR);
   TypeNode tn = n.getType();
-  Assert(tn.isDatatype());
+  if(!tn.isDatatype())
+  {
+    // sygus datatype fields that are not sygus datatypes are treated as 
+    // abstractions only, hence we disregard this field
+    return;
+  }
+  Assert(vn.getKind() == kind::APPLY_CONSTRUCTOR);
   const Datatype& dt = ((DatatypeType)tn.toType()).getDatatype();
   int i = Datatype::indexOf(vn.getOperator().toExpr());
   Node tst = datatypes::DatatypesRewriter::mkTester(n, i, dt);
@@ -178,10 +183,16 @@ void SygusExplain::getExplanationFor(TermRecBuild& trb,
                                      int& sz)
 {
   Assert(vnr.isNull() || vn != vnr);
-  Assert(vn.getKind() == APPLY_CONSTRUCTOR);
-  Assert(vnr.isNull() || vnr.getKind() == APPLY_CONSTRUCTOR);
   Assert(n.getType() == vn.getType());
   TypeNode ntn = n.getType();
+  if( !ntn.isDatatype() )
+  {
+    // sygus datatype fields that are not sygus datatypes are treated as 
+    // abstractions only, hence we disregard this field
+    return;
+  }
+  Assert(vn.getKind() == APPLY_CONSTRUCTOR);
+  Assert(vnr.isNull() || vnr.getKind() == APPLY_CONSTRUCTOR);
   std::map<unsigned, bool> cexc;
   // for each child, 
   // check whether replacing that child by a fresh variable

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -18,12 +18,12 @@
 
 #include "expr/datatype.h"
 #include "options/quantifiers_options.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/quantifiers/sygus/ce_guided_conjecture.h"
-#include "theory/quantifiers/sygus/sygus_process_conj.h"
 #include "theory/quantifiers/sygus/sygus_grammar_norm.h"
+#include "theory/quantifiers/sygus/sygus_process_conj.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
-#include "theory/datatypes/datatypes_rewriter.h"
 
 using namespace CVC4::kind;
 
@@ -311,7 +311,8 @@ Node CegGrammarConstructor::convertToEmbedding( Node n, std::map< Node, Node >& 
           makeEvalFun = true;
         }
       }
-      if( !makeEvalFun ){
+      if (!makeEvalFun)
+      {
         // otherwise, we apply the previous operator
         if( cur.getMetaKind() == kind::metakind::PARAMETERIZED ){
           children.push_back( cur.getOperator() );
@@ -324,7 +325,7 @@ Node CegGrammarConstructor::convertToEmbedding( Node n, std::map< Node, Node >& 
         childChanged = childChanged || cur[i] != it->second;
         children.push_back(it->second);
       }
-      if( makeEvalFun )
+      if (makeEvalFun)
       {
         // will make into an application of an evaluation function
         ret = datatypes::DatatypesRewriter::mkSygusEvalApp(children);

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -326,11 +326,8 @@ Node CegGrammarConstructor::convertToEmbedding( Node n, std::map< Node, Node >& 
       }
       if( makeEvalFun )
       {
-        TypeNode tn = children[0].getType();
-        Assert( tn.isDatatype() );
         // will make into an application of an evaluation function
-        const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-        ret = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,children);
+        ret = datatypes::DatatypesRewriter::mkSygusEvalApp(children);
       }
       else if (childChanged)
       {

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -20,12 +20,12 @@
 #include "printer/sygus_print_callback.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/quantifiers/cegqi/ceg_instantiator.h"
 #include "theory/quantifiers/sygus/ce_guided_conjecture.h"
 #include "theory/quantifiers/sygus/sygus_grammar_red.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
-#include "theory/datatypes/datatypes_rewriter.h"
 
 #include <numeric>  // for std::iota
 
@@ -131,7 +131,7 @@ void SygusGrammarNorm::TypeObject::buildDatatype(SygusGrammarNorm* sygus_norm,
       // we add this constructor first since we use left associative chains
       // and our symmetry breaking should group any constants together
       // beneath the same application
-      // we set its weight to zero since it should not be 
+      // we set its weight to zero since it should not be
       d_dt.addSygusConstructor(av.toExpr(), cname, builtin_arg, nullptr, 0);
     }
   }

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -131,7 +131,8 @@ void SygusGrammarNorm::TypeObject::buildDatatype(SygusGrammarNorm* sygus_norm,
       // we add this constructor first since we use left associative chains
       // and our symmetry breaking should group any constants together
       // beneath the same application
-      // we set its weight to zero since it should not be
+      // we set its weight to zero since it should be considered at the
+      // same level as constants.
       d_dt.addSygusConstructor(av.toExpr(), cname, builtin_arg, nullptr, 0);
     }
   }

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -25,6 +25,7 @@
 #include "theory/quantifiers/sygus/sygus_grammar_red.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 
 #include <numeric>  // for std::iota
 
@@ -125,11 +126,13 @@ void SygusGrammarNorm::TypeObject::buildDatatype(SygusGrammarNorm* sygus_norm,
       std::stringstream ss;
       ss << d_unres_tn << "_any_constant";
       std::string cname(ss.str());
-      std::vector<Type> empty_arg_types;
+      std::vector<Type> builtin_arg;
+      builtin_arg.push_back(dt.getSygusType());
       // we add this constructor first since we use left associative chains
       // and our symmetry breaking should group any constants together
       // beneath the same application
-      d_dt.addSygusConstructor(av.toExpr(), cname, empty_arg_types);
+      // we set its weight to zero since it should not be 
+      d_dt.addSygusConstructor(av.toExpr(), cname, builtin_arg, nullptr, 0);
     }
   }
   for (unsigned i = 0, size_d_ops = d_ops.size(); i < size_d_ops; ++i)

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.h
@@ -36,12 +36,6 @@ namespace quantifiers {
 
 class SygusGrammarNorm;
 
-/** Attribute true for variables that represent any constant */
-struct SygusAnyConstAttributeId
-{
-};
-typedef expr::Attribute<SygusAnyConstAttributeId, bool> SygusAnyConstAttribute;
-
 /** Operator position trie class
  *
  * This data structure stores an unresolved type corresponding to the

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -47,7 +47,7 @@ void CegConjecturePbe::collectExamples( Node n, std::map< Node, bool >& visited,
     visited[n] = true;
     Node neval;
     Node n_output;
-    if( n.getKind()==APPLY_UF && n.getNumChildren()>0 ){
+    if( datatypes::DatatypesRewriter::isSygusEvalApp(n) ){
       neval = n;
       if( hasPol ){
         n_output = !pol ? d_true : d_false;

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -47,55 +47,54 @@ void CegConjecturePbe::collectExamples( Node n, std::map< Node, bool >& visited,
     visited[n] = true;
     Node neval;
     Node n_output;
+    bool neval_is_evalapp = false;
     if( datatypes::DatatypesRewriter::isSygusEvalApp(n) ){
       neval = n;
       if( hasPol ){
         n_output = !pol ? d_true : d_false;
       }
+      neval_is_evalapp = true;
     }else if( n.getKind()==EQUAL && hasPol && !pol ){
       for( unsigned r=0; r<2; r++ ){
-        if( n[r].getKind()==APPLY_UF && n[r].getNumChildren()>0 ){
+        if( datatypes::DatatypesRewriter::isSygusEvalApp(n[r]) ){
           neval = n[r];
           if( n[1-r].isConst() ){
             n_output = n[1-r];
           }
+          neval_is_evalapp = true;
         }
       }
     }
-    if( !neval.isNull() ){
-      if( neval.getKind()==APPLY_UF && neval.getNumChildren()>0 ){
-        // is it an evaluation function?
-        if( d_examples.find( neval[0] )!=d_examples.end() ){
-          std::map< Node, bool >::iterator itx = d_examples_invalid.find( neval[0] );
-          if( itx==d_examples_invalid.end() ){
-            //collect example
-            bool success = true;
-            std::vector< Node > ex;
-            for( unsigned j=1; j<neval.getNumChildren(); j++ ){
-              if( !neval[j].isConst() ){
-                success = false;
-                break;
-              }else{
-                ex.push_back( neval[j] );
-              }
-            }
-            if( success ){
-              d_examples[neval[0]].push_back( ex );
-              d_examples_out[neval[0]].push_back( n_output );
-              d_examples_term[neval[0]].push_back( neval );
-              if( n_output.isNull() ){
-                d_examples_out_invalid[neval[0]] = true;
-              }else{
-                Assert( n_output.isConst() );
-              }
-              //finished processing this node
-              return;
-            }else{
-              d_examples_invalid[neval[0]] = true;
-              d_examples_out_invalid[neval[0]] = true;
-            }
+    // is it an evaluation function?
+    if( neval_is_evalapp && d_examples.find( neval[0] )!=d_examples.end() ){
+      // get the evaluation head
+      Node eh = neval[0];
+      std::map< Node, bool >::iterator itx = d_examples_invalid.find( eh );
+      if( itx==d_examples_invalid.end() ){
+        //collect example
+        bool success = true;
+        std::vector< Node > ex;
+        for( unsigned j=1, nchild = neval.getNumChildren(); j<nchild; j++ ){
+          if( !neval[j].isConst() ){
+            success = false;
+            break;
           }
+          ex.push_back( neval[j] );
         }
+        if( success ){
+          d_examples[eh].push_back( ex );
+          d_examples_out[eh].push_back( n_output );
+          d_examples_term[eh].push_back( neval );
+          if( n_output.isNull() ){
+            d_examples_out_invalid[eh] = true;
+          }else{
+            Assert( n_output.isConst() );
+          }
+          //finished processing this node
+          return;
+        }
+        d_examples_invalid[eh] = true;
+        d_examples_out_invalid[eh] = true;
       }
     }
     for( unsigned i=0; i<n.getNumChildren(); i++ ){

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -48,7 +48,8 @@ void CegConjecturePbe::collectExamples( Node n, std::map< Node, bool >& visited,
     Node neval;
     Node n_output;
     bool neval_is_evalapp = false;
-    if( datatypes::DatatypesRewriter::isSygusEvalApp(n) ){
+    if (datatypes::DatatypesRewriter::isSygusEvalApp(n))
+    {
       neval = n;
       if( hasPol ){
         n_output = !pol ? d_true : d_false;
@@ -56,7 +57,8 @@ void CegConjecturePbe::collectExamples( Node n, std::map< Node, bool >& visited,
       neval_is_evalapp = true;
     }else if( n.getKind()==EQUAL && hasPol && !pol ){
       for( unsigned r=0; r<2; r++ ){
-        if( datatypes::DatatypesRewriter::isSygusEvalApp(n[r]) ){
+        if (datatypes::DatatypesRewriter::isSygusEvalApp(n[r]))
+        {
           neval = n[r];
           if( n[1-r].isConst() ){
             n_output = n[1-r];
@@ -66,31 +68,39 @@ void CegConjecturePbe::collectExamples( Node n, std::map< Node, bool >& visited,
       }
     }
     // is it an evaluation function?
-    if( neval_is_evalapp && d_examples.find( neval[0] )!=d_examples.end() ){
+    if (neval_is_evalapp && d_examples.find(neval[0]) != d_examples.end())
+    {
       // get the evaluation head
       Node eh = neval[0];
-      std::map< Node, bool >::iterator itx = d_examples_invalid.find( eh );
-      if( itx==d_examples_invalid.end() ){
-        //collect example
+      std::map<Node, bool>::iterator itx = d_examples_invalid.find(eh);
+      if (itx == d_examples_invalid.end())
+      {
+        // collect example
         bool success = true;
-        std::vector< Node > ex;
-        for( unsigned j=1, nchild = neval.getNumChildren(); j<nchild; j++ ){
-          if( !neval[j].isConst() ){
+        std::vector<Node> ex;
+        for (unsigned j = 1, nchild = neval.getNumChildren(); j < nchild; j++)
+        {
+          if (!neval[j].isConst())
+          {
             success = false;
             break;
           }
-          ex.push_back( neval[j] );
+          ex.push_back(neval[j]);
         }
-        if( success ){
-          d_examples[eh].push_back( ex );
-          d_examples_out[eh].push_back( n_output );
-          d_examples_term[eh].push_back( neval );
-          if( n_output.isNull() ){
+        if (success)
+        {
+          d_examples[eh].push_back(ex);
+          d_examples_out[eh].push_back(n_output);
+          d_examples_term[eh].push_back(neval);
+          if (n_output.isNull())
+          {
             d_examples_out_invalid[eh] = true;
-          }else{
-            Assert( n_output.isConst() );
           }
-          //finished processing this node
+          else
+          {
+            Assert(n_output.isConst());
+          }
+          // finished processing this node
           return;
         }
         d_examples_invalid[eh] = true;

--- a/src/theory/quantifiers/sygus/sygus_process_conj.cpp
+++ b/src/theory/quantifiers/sygus/sygus_process_conj.cpp
@@ -17,9 +17,9 @@
 #include <stack>
 
 #include "expr/datatype.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
-#include "theory/datatypes/datatypes_rewriter.h"
 
 using namespace CVC4::kind;
 using namespace std;

--- a/src/theory/quantifiers/sygus/sygus_process_conj.cpp
+++ b/src/theory/quantifiers/sygus/sygus_process_conj.cpp
@@ -19,6 +19,7 @@
 #include "expr/datatype.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 
 using namespace CVC4::kind;
 using namespace std;

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -300,7 +300,10 @@ bool SygusRepairConst::isRepairable(Node n, bool useConstantsAsHoles)
   TypeNode tn = n.getType();
   Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  Assert(dt.isSygus());
+  if(!dt.isSygus())
+  {
+    return false;
+  }
   Node op = n.getOperator();
   unsigned cindex = datatypes::DatatypesRewriter::indexOf(op);
   Node sygusOp = Node::fromExpr(dt[cindex].getSygusOp());

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -19,10 +19,10 @@
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
 #include "smt/smt_statistics_registry.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/quantifiers/cegqi/ceg_instantiator.h"
 #include "theory/quantifiers/sygus/sygus_grammar_norm.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
-#include "theory/datatypes/datatypes_rewriter.h"
 
 using namespace CVC4::kind;
 
@@ -78,7 +78,7 @@ void SygusRepairConst::registerSygusType(TypeNode tn,
       {
         TypeNode tnc = d_tds->getArgType(dtc, j);
         // avoid recursing on non-sygus-datatype children
-        if( tnc.isDatatype() )
+        if (tnc.isDatatype())
         {
           registerSygusType(tnc, tprocessed);
         }
@@ -450,7 +450,7 @@ Node SygusRepairConst::getFoQuery(const std::vector<Node>& candidates,
     if (it == visited.end())
     {
       visited[cur] = Node::null();
-      if( datatypes::DatatypesRewriter::isSygusEvalApp(cur) )
+      if (datatypes::DatatypesRewriter::isSygusEvalApp(cur))
       {
         Node v = cur[0];
         if (std::find(sk_vars.begin(), sk_vars.end(), v) != sk_vars.end())

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -22,6 +22,7 @@
 #include "theory/quantifiers/cegqi/ceg_instantiator.h"
 #include "theory/quantifiers/sygus/sygus_grammar_norm.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 
 using namespace CVC4::kind;
 
@@ -445,7 +446,7 @@ Node SygusRepairConst::getFoQuery(const std::vector<Node>& candidates,
     if (it == visited.end())
     {
       visited[cur] = Node::null();
-      if (cur.getKind() == APPLY_UF && cur.getNumChildren() > 0)
+      if( datatypes::DatatypesRewriter::isSygusEvalApp(cur) )
       {
         Node v = cur[0];
         if (std::find(sk_vars.begin(), sk_vars.end(), v) != sk_vars.end())

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -62,14 +62,14 @@ void SygusRepairConst::registerSygusType(TypeNode tn,
   if (tprocessed.find(tn) == tprocessed.end())
   {
     tprocessed[tn] = true;
-    if(!tn.isDatatype())
+    if (!tn.isDatatype())
     {
       // may have recursed to a non-datatype, e.g. in the case that we have
       // "any constant" constructors
       return;
     }
     const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-    if(!dt.isSygus())
+    if (!dt.isSygus())
     {
       // may have recursed to a non-sygus-datatype
       return;
@@ -302,7 +302,7 @@ bool SygusRepairConst::isRepairable(Node n, bool useConstantsAsHoles)
   TypeNode tn = n.getType();
   Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  if(!dt.isSygus())
+  if (!dt.isSygus())
   {
     return false;
   }

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -62,10 +62,16 @@ void SygusRepairConst::registerSygusType(TypeNode tn,
   if (tprocessed.find(tn) == tprocessed.end())
   {
     tprocessed[tn] = true;
-    Assert(tn.isDatatype());
+    if(!tn.isDatatype())
+    {
+      // may have recursed to a non-datatype, e.g. in the case that we have
+      // "any constant" constructors
+      return;
+    }
     const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
     if(!dt.isSygus())
     {
+      // may have recursed to a non-sygus-datatype
       return;
     }
     // check if this datatype allows all constants
@@ -80,11 +86,7 @@ void SygusRepairConst::registerSygusType(TypeNode tn,
       for (unsigned j = 0, nargs = dtc.getNumArgs(); j < nargs; j++)
       {
         TypeNode tnc = d_tds->getArgType(dtc, j);
-        // avoid recursing on non-sygus-datatype children
-        if (tnc.isDatatype())
-        {
-          registerSygusType(tnc, tprocessed);
-        }
+        registerSygusType(tnc, tprocessed);
       }
     }
   }

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -64,7 +64,10 @@ void SygusRepairConst::registerSygusType(TypeNode tn,
     tprocessed[tn] = true;
     Assert(tn.isDatatype());
     const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-    Assert(dt.isSygus());
+    if(!dt.isSygus())
+    {
+      return;
+    }
     // check if this datatype allows all constants
     if (dt.getSygusAllowConst())
     {
@@ -299,7 +302,7 @@ bool SygusRepairConst::isRepairable(Node n, bool useConstantsAsHoles)
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Assert(dt.isSygus());
   Node op = n.getOperator();
-  unsigned cindex = Datatype::indexOf(op.toExpr());
+  unsigned cindex = datatypes::DatatypesRewriter::indexOf(op);
   Node sygusOp = Node::fromExpr(dt[cindex].getSygusOp());
   if (sygusOp.getAttribute(SygusAnyConstAttribute()))
   {

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -77,7 +77,11 @@ void SygusRepairConst::registerSygusType(TypeNode tn,
       for (unsigned j = 0, nargs = dtc.getNumArgs(); j < nargs; j++)
       {
         TypeNode tnc = d_tds->getArgType(dtc, j);
-        registerSygusType(tnc, tprocessed);
+        // avoid recursing on non-sygus-datatype children
+        if( tnc.isDatatype() )
+        {
+          registerSygusType(tnc, tprocessed);
+        }
       }
     }
   }
@@ -296,15 +300,15 @@ bool SygusRepairConst::isRepairable(Node n, bool useConstantsAsHoles)
   Assert(dt.isSygus());
   Node op = n.getOperator();
   unsigned cindex = Datatype::indexOf(op.toExpr());
-  if (dt[cindex].getNumArgs() > 0)
-  {
-    return false;
-  }
   Node sygusOp = Node::fromExpr(dt[cindex].getSygusOp());
   if (sygusOp.getAttribute(SygusAnyConstAttribute()))
   {
     // if it represents "any constant" then it is repairable
     return true;
+  }
+  if (dt[cindex].getNumArgs() > 0)
+  {
+    return false;
   }
   if (useConstantsAsHoles && dt.getSygusAllowConst())
   {

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -19,6 +19,7 @@
 #include "printer/printer.h"
 #include "theory/quantifiers/sygus/ce_guided_conjecture.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 
 using namespace CVC4::kind;
 
@@ -80,7 +81,7 @@ Node SygusUnifRl::purifyLemma(Node n,
   // We retrive model value now because purified node may not have a value
   Node nv = n;
   // Whether application of a function-to-synthesize
-  bool fapp = k == APPLY_UF && size > 0;
+  bool fapp = datatypes::DatatypesRewriter::isSygusEvalApp(n);
   bool u_fapp = false;
   bool nu_fapp = false;
   if (fapp)

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -138,8 +138,8 @@ Node SygusUnifRl::purifyLemma(Node n,
   {
     if (n.getMetaKind() == metakind::PARAMETERIZED)
     {
-      Trace("sygus-unif-rl-purify-debug")
-          << "Node " << n << " is parameterized\n";
+      Trace("sygus-unif-rl-purify-debug") << "Node " << n
+                                          << " is parameterized\n";
       children.insert(children.begin(), n.getOperator());
     }
     if (Trace.isOn("sygus-unif-rl-purify-debug"))
@@ -192,8 +192,8 @@ Node SygusUnifRl::purifyLemma(Node n,
       // replace first child and rebulid node
       Assert(children.size() > 0);
       children[0] = new_f;
-      Trace("sygus-unif-rl-purify-debug")
-          << "Make sygus eval app " << children << std::endl;
+      Trace("sygus-unif-rl-purify-debug") << "Make sygus eval app " << children
+                                          << std::endl;
       np = datatypes::DatatypesRewriter::mkSygusEvalApp(children);
       d_app_to_purified[nb] = np;
     }
@@ -846,8 +846,8 @@ Node SygusUnifRl::DecisionTreeInfo::PointSeparator::evaluate(Node n,
   // compute the result
   if (Trace.isOn("sygus-unif-rl-sep"))
   {
-    Trace("sygus-unif-rl-sep")
-        << "Evaluate cond " << builtin_cond << " on pt " << n << " ( ";
+    Trace("sygus-unif-rl-sep") << "Evaluate cond " << builtin_cond << " on pt "
+                               << n << " ( ";
     for (const Node& pti : pt)
     {
       Trace("sygus-unif-rl-sep") << pti << " ";

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -195,9 +195,9 @@ Node SygusUnifRl::purifyLemma(Node n,
         Trace("sygus-unif-rl-purify-debug") << ")\n";
       }
       // replace first child and rebulid node
-      children[1] = new_f;
+      children[0] = new_f;
       Assert(children.size() > 1);
-      np = NodeManager::currentNM()->mkNode(k, children);
+      np = datatypes::DatatypesRewriter::mkSygusEvalApp(children);
       d_app_to_purified[nb] = np;
     }
     else

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -17,9 +17,9 @@
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "printer/printer.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/quantifiers/sygus/ce_guided_conjecture.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
-#include "theory/datatypes/datatypes_rewriter.h"
 
 using namespace CVC4::kind;
 
@@ -136,10 +136,10 @@ Node SygusUnifRl::purifyLemma(Node n,
   Node nb;
   if (childChanged)
   {
-    if (n.getMetaKind()==metakind::PARAMETERIZED )
+    if (n.getMetaKind() == metakind::PARAMETERIZED)
     {
-      Trace("sygus-unif-rl-purify-debug") << "Node " << n
-                                          << " is parameterized\n";
+      Trace("sygus-unif-rl-purify-debug")
+          << "Node " << n << " is parameterized\n";
       children.insert(children.begin(), n.getOperator());
     }
     if (Trace.isOn("sygus-unif-rl-purify-debug"))
@@ -192,7 +192,8 @@ Node SygusUnifRl::purifyLemma(Node n,
       // replace first child and rebulid node
       Assert(children.size() > 0);
       children[0] = new_f;
-      Trace("sygus-unif-rl-purify-debug") << "Make sygus eval app " << children << std::endl;
+      Trace("sygus-unif-rl-purify-debug")
+          << "Make sygus eval app " << children << std::endl;
       np = datatypes::DatatypesRewriter::mkSygusEvalApp(children);
       d_app_to_purified[nb] = np;
     }
@@ -845,8 +846,8 @@ Node SygusUnifRl::DecisionTreeInfo::PointSeparator::evaluate(Node n,
   // compute the result
   if (Trace.isOn("sygus-unif-rl-sep"))
   {
-    Trace("sygus-unif-rl-sep") << "Evaluate cond "
-                               << builtin_cond << " on pt " << n << " ( ";
+    Trace("sygus-unif-rl-sep")
+        << "Evaluate cond " << builtin_cond << " on pt " << n << " ( ";
     for (const Node& pti : pt)
     {
       Trace("sygus-unif-rl-sep") << pti << " ";

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -252,7 +252,7 @@ void SygusUnifStrategy::buildStrategyGraph(TypeNode tn, NodeRole nrole)
     {
       echildren.push_back(sbv);
     }
-    Node eut = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,echildren);
+    Node eut = datatypes::DatatypesRewriter::mkSygusEvalApp(echildren);
     Trace("sygus-unif-debug2") << "  Test evaluation of " << eut << "..."
                                << std::endl;
     eut = d_qe->getTermDatabaseSygus()->unfold(eut);
@@ -291,12 +291,10 @@ void SygusUnifStrategy::buildStrategyGraph(TypeNode tn, NodeRole nrole)
       for (unsigned k = 0, sksize = sks.size(); k < sksize; k++)
       {
         Assert(sks[k].getType().isDatatype());
-        const Datatype& cdt =
-            static_cast<DatatypeType>(sks[k].getType().toType()).getDatatype();
         echildren[0] = sks[k];
         Trace("sygus-unif-debug2") << "...set eval dt to " << sks[k]
                                    << std::endl;
-        Node esk = datatypes::DatatypesRewriter::mkSygusEvalApp(cdt,echildren);
+        Node esk = datatypes::DatatypesRewriter::mkSygusEvalApp(echildren);
         vs.push_back(esk);
         Node tvar = nm->mkSkolem("templ", esk.getType());
         templ_var_index[tvar] = k;

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -208,6 +208,8 @@ void SygusUnifStrategy::buildStrategyGraph(TypeNode tn, NodeRole nrole)
   }
 
   // look at information on how we will construct solutions for this type
+  // we know this is a sygus datatype since it is either the top-level type
+  // in the strategy graph, or was recursed by a strategy we inferred.
   Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Assert(dt.isSygus());

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -246,14 +246,13 @@ void SygusUnifStrategy::buildStrategyGraph(TypeNode tn, NodeRole nrole)
     }
     Node ut = nm->mkNode(APPLY_CONSTRUCTOR, utchildren);
     std::vector<Node> echildren;
-    echildren.push_back(Node::fromExpr(dt.getSygusEvaluationFunc()));
     echildren.push_back(ut);
     Node sbvl = Node::fromExpr(dt.getSygusVarList());
     for (const Node& sbv : sbvl)
     {
       echildren.push_back(sbv);
     }
-    Node eut = nm->mkNode(APPLY_UF, echildren);
+    Node eut = datatypes::DatatypesRewriter::mkSygusEvalApp(dt,echildren);
     Trace("sygus-unif-debug2") << "  Test evaluation of " << eut << "..."
                                << std::endl;
     eut = d_qe->getTermDatabaseSygus()->unfold(eut);
@@ -294,11 +293,10 @@ void SygusUnifStrategy::buildStrategyGraph(TypeNode tn, NodeRole nrole)
         Assert(sks[k].getType().isDatatype());
         const Datatype& cdt =
             static_cast<DatatypeType>(sks[k].getType().toType()).getDatatype();
-        echildren[0] = Node::fromExpr(cdt.getSygusEvaluationFunc());
-        echildren[1] = sks[k];
+        echildren[0] = sks[k];
         Trace("sygus-unif-debug2") << "...set eval dt to " << sks[k]
                                    << std::endl;
-        Node esk = nm->mkNode(APPLY_UF, echildren);
+        Node esk = datatypes::DatatypesRewriter::mkSygusEvalApp(cdt,echildren);
         vs.push_back(esk);
         Node tvar = nm->mkSkolem("templ", esk.getType());
         templ_var_index[tvar] = k;

--- a/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_strat.cpp
@@ -799,8 +799,7 @@ void SygusUnifStrategy::staticLearnRedundantOps(
       continue;
     }
     EnumTypeInfoStrat* etis = snode.d_strats[j];
-    unsigned cindex =
-        static_cast<unsigned>(Datatype::indexOf(etis->d_cons.toExpr()));
+    unsigned cindex = datatypes::DatatypesRewriter::indexOf(etis->d_cons);
     // constructors that correspond to strategies are not needed
     // the intuition is that the strategy itself is responsible for constructing
     // all terms that use the given constructor

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -17,6 +17,7 @@
 #include "base/cvc4_check.h"
 #include "options/quantifiers_options.h"
 #include "theory/arith/arith_msum.h"
+#include "theory/datatypes/datatypes_rewriter.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/sygus/sygus_grammar_norm.h"
 #include "theory/quantifiers/term_database.h"
@@ -146,12 +147,12 @@ Node TermDbSygus::mkGeneric(const Datatype& dt,
   Trace("sygus-db-debug") << "mkGeneric " << dt.getName() << " " << op << " " << op.getKind() << "..." << std::endl;
   for (unsigned i = 0, nargs = dt[c].getNumArgs(); i < nargs; i++)
   {
-    TypeNode tna = getArgType( dt[c], i );
     Node a;
     std::map< int, Node >::iterator it = pre.find( i );
     if( it!=pre.end() ){
       a = it->second;
     }else{
+      TypeNode tna = TypeNode::fromType(dt[c].getArgType(i));
       a = getFreeVarInc( tna, var_count, true );
     }
     Trace("sygus-db-debug")
@@ -1443,7 +1444,6 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
     for( unsigned j=0; j<dt[i].getNumArgs(); j++ ){
       std::vector< Node > cc;
       //get the evaluation argument for the selector
-      Type rt = dt[i][j].getRangeType();
       const Datatype & ad = ((DatatypeType)dt[i][j].getRangeType()).getDatatype();
       cc.push_back( Node::fromExpr( ad.getSygusEvaluationFunc() ) );
       Node s;

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -1549,7 +1549,11 @@ Node TermDbSygus::evaluateWithUnfolding( Node n ) {
 
 bool TermDbSygus::isEvaluationPoint(Node n) const
 {
-  if (n.getKind() != APPLY_UF || n.getNumChildren() == 0 || !n[0].isVar())
+  if( !datatypes::DatatypesRewriter::isSygusEvalApp(n) )
+  {
+    return false;
+  }
+  if (!n[0].isVar())
   {
     return false;
   }
@@ -1560,18 +1564,7 @@ bool TermDbSygus::isEvaluationPoint(Node n) const
       return false;
     }
   }
-  TypeNode tn = n[0].getType();
-  if (!tn.isDatatype())
-  {
-    return false;
-  }
-  const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  if (!dt.isSygus())
-  {
-    return false;
-  }
-  Node eval_op = Node::fromExpr(dt.getSygusEvaluationFunc());
-  return eval_op == n.getOperator();
+  return true;
 }
 
 }/* CVC4::theory::quantifiers namespace */

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -194,7 +194,7 @@ Node TermDbSygus::sygusToBuiltin(Node n, TypeNode tn)
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   if (n.getKind() == APPLY_CONSTRUCTOR)
   {
-    unsigned i = Datatype::indexOf(n.getOperator().toExpr());
+    unsigned i = datatypes::DatatypesRewriter::indexOf(n.getOperator());
     Assert(n.getNumChildren() == dt[i].getNumArgs());
     std::map<int, Node> pre;
     for (unsigned j = 0, size = n.getNumChildren(); j < size; j++)
@@ -238,7 +238,7 @@ unsigned TermDbSygus::getSygusTermSize( Node n ){
     sum += getSygusTermSize(n[i]);
   }
   const Datatype& dt = Datatype::datatypeOf(n.getOperator().toExpr());
-  int cindex = Datatype::indexOf(n.getOperator().toExpr());
+  int cindex = datatypes::DatatypesRewriter::indexOf(n.getOperator());
   Assert(cindex >= 0 && cindex < (int)dt.getNumConstructors());
   unsigned weight = dt[cindex].getWeight();
   return weight + sum;
@@ -1218,7 +1218,7 @@ bool TermDbSygus::isSymbolicConsApp(Node n) const
   TypeNode tn = n.getType();
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Assert(dt.isSygus());
-  unsigned cindex = Datatype::indexOf(n.getOperator().toExpr());
+  unsigned cindex = datatypes::DatatypesRewriter::indexOf(n.getOperator());
   Node sygusOp = Node::fromExpr(dt[cindex].getSygusOp());
   // it is symbolic if it represents "any constant"
   return sygusOp.getAttribute(SygusAnyConstAttribute());
@@ -1409,7 +1409,7 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
   Type headType = en[0].getType().toType();
   NodeManager* nm = NodeManager::currentNM();
   const Datatype& dt = static_cast<DatatypeType>(headType).getDatatype();
-  unsigned i = Datatype::indexOf(ev.getOperator().toExpr());
+  unsigned i = datatypes::DatatypesRewriter::indexOf(ev.getOperator());
   if (track_exp)
   {
     // explanation

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -1422,8 +1422,8 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
   Node sop = Node::fromExpr(dt[i].getSygusOp());
   if (sop.getAttribute(SygusAnyConstAttribute()))
   {
-    Trace("sygus-db-debug")
-        << "...it is an any-constant constructor" << std::endl;
+    Trace("sygus-db-debug") << "...it is an any-constant constructor"
+                            << std::endl;
     Assert(dt[i].getNumArgs() == 1);
     if (en[0].getKind() == APPLY_CONSTRUCTOR)
     {
@@ -1483,7 +1483,7 @@ Node TermDbSygus::unfold(Node en)
   std::vector<Node> exp;
   return unfold(en, vtm, exp, false);
 }
-    
+
 Node TermDbSygus::getEagerUnfold( Node n, std::map< Node, Node >& visited ) {
   std::map< Node, Node >::iterator itv = visited.find( n );
   if( itv==visited.end() ){

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -1399,7 +1399,6 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
       std::vector< Node > cc;
       //get the evaluation argument for the selector
       const Datatype & ad = ((DatatypeType)dt[i][j].getRangeType()).getDatatype();
-      cc.push_back( Node::fromExpr( ad.getSygusEvaluationFunc() ) );
       Node s;
       if( en[0].getKind()==kind::APPLY_CONSTRUCTOR ){
         s = en[0][j];
@@ -1412,7 +1411,7 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
         vtm[s] = ev[j];
       }
       cc.insert( cc.end(), args.begin(), args.end() );
-      pre[j] = NodeManager::currentNM()->mkNode( kind::APPLY_UF, cc );
+      pre[j] = datatypes::DatatypesRewriter::mkSygusEvalApp(ad,cc);
     }
     Node ret = mkGeneric(dt, i, pre);
     // if it is a variable, apply the substitution

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -1220,6 +1220,7 @@ bool TermDbSygus::isSymbolicConsApp(Node n) const
     return false;
   }
   TypeNode tn = n.getType();
+  Assert(tn.isDatatype());
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
   Assert(dt.isSygus());
   unsigned cindex = datatypes::DatatypesRewriter::indexOf(n.getOperator());

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -831,10 +831,6 @@ void TermDbSygus::registerEnumerator(Node e,
         }
       }
     }
-    if (rm_indices.empty())
-    {
-      continue;
-    }
     for (unsigned& rindex : rm_indices)
     {
       // make the apply-constructor corresponding to an application of the
@@ -1393,13 +1389,10 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
   if (track_exp)
   {
     std::map<Node, Node>::iterator itv = vtm.find(en[0]);
+    Assert(itv != vtm.end());
     if (itv != vtm.end())
     {
       ev = itv->second;
-    }
-    else
-    {
-      Assert(false);
     }
     Assert(en[0].getType() == ev.getType());
     Assert(ev.isConst());
@@ -1449,8 +1442,11 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
   {
     std::vector<Node> cc;
     Node s;
+    // get the j^th subfield of en
     if (en[0].getKind() == kind::APPLY_CONSTRUCTOR)
     {
+      // if it is a concrete constructor application, as an optimization,
+      // just return the argument
       s = en[0][j];
     }
     else
@@ -1481,7 +1477,13 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
   return ret;
 }
 
-
+Node TermDbSygus::unfold(Node en)
+{
+  std::map<Node, Node> vtm;
+  std::vector<Node> exp;
+  return unfold(en, vtm, exp, false);
+}
+    
 Node TermDbSygus::getEagerUnfold( Node n, std::map< Node, Node >& visited ) {
   std::map< Node, Node >::iterator itv = visited.find( n );
   if( itv==visited.end() ){

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -192,6 +192,10 @@ Node TermDbSygus::sygusToBuiltin(Node n, TypeNode tn)
   Trace("sygus-db-debug") << "SygusToBuiltin : compute for " << n
                           << ", type = " << tn << std::endl;
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
+  if( !dt.isSygus() )
+  {
+    return n;
+  }
   if (n.getKind() == APPLY_CONSTRUCTOR)
   {
     unsigned i = datatypes::DatatypesRewriter::indexOf(n.getOperator());

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -192,7 +192,7 @@ Node TermDbSygus::sygusToBuiltin(Node n, TypeNode tn)
   Trace("sygus-db-debug") << "SygusToBuiltin : compute for " << n
                           << ", type = " << tn << std::endl;
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  if( !dt.isSygus() )
+  if (!dt.isSygus())
   {
     return n;
   }

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -139,7 +139,8 @@ Node TermDbSygus::mkGeneric(const Datatype& dt,
   Assert( dt.isSygus() );
   Assert( !dt[c].getSygusOp().isNull() );
   std::vector< Node > children;
-  Trace("sygus-db-debug") << "mkGeneric " << dt.getName() << " " << c << "..." << std::endl;
+  Trace("sygus-db-debug") << "mkGeneric " << dt.getName() << " " << c << "..."
+                          << std::endl;
   for (unsigned i = 0, nargs = dt[c].getNumArgs(); i < nargs; i++)
   {
     Node a;
@@ -155,7 +156,7 @@ Node TermDbSygus::mkGeneric(const Datatype& dt,
     Assert( !a.isNull() );
     children.push_back( a );
   }
-  return datatypes::DatatypesRewriter::mkSygusTerm(dt,c,children);
+  return datatypes::DatatypesRewriter::mkSygusTerm(dt, c, children);
 }
 
 Node TermDbSygus::mkGeneric(const Datatype& dt, int c, std::map<int, Node>& pre)
@@ -176,11 +177,10 @@ struct SygusToBuiltinAttributeId
 typedef expr::Attribute<SygusToBuiltinAttributeId, Node>
     SygusToBuiltinAttribute;
 
-Node TermDbSygus::sygusToBuiltin(Node n,
-                                 TypeNode tn)
+Node TermDbSygus::sygusToBuiltin(Node n, TypeNode tn)
 {
   Assert( n.getType()==tn );
-  if( !tn.isDatatype() )
+  if (!tn.isDatatype())
   {
     return n;
   }
@@ -228,13 +228,14 @@ Node TermDbSygus::sygusSubstituted( TypeNode tn, Node n, std::vector< Node >& ar
 }
 
 unsigned TermDbSygus::getSygusTermSize( Node n ){
-  if(n.getKind() != APPLY_CONSTRUCTOR)
+  if (n.getKind() != APPLY_CONSTRUCTOR)
   {
     return 0;
   }
   unsigned sum = 0;
-  for( unsigned i=0; i<n.getNumChildren(); i++ ){
-    sum += getSygusTermSize( n[i] );
+  for (unsigned i = 0; i < n.getNumChildren(); i++)
+  {
+    sum += getSygusTermSize(n[i]);
   }
   const Datatype& dt = Datatype::datatypeOf(n.getOperator().toExpr());
   int cindex = Datatype::indexOf(n.getOperator().toExpr());
@@ -786,7 +787,8 @@ void TermDbSygus::registerEnumerator(Node e,
     d_enum_to_active_guard[e] = eg;
   }
 
-  Trace("sygus-db") << "  registering symmetry breaking clauses..." << std::endl;
+  Trace("sygus-db") << "  registering symmetry breaking clauses..."
+                    << std::endl;
   // depending on if we are using symbolic constructors, introduce symmetry
   // breaking lemma templates for each relevant subtype of the grammar
   std::map<TypeNode, std::map<TypeNode, unsigned> >::iterator it =
@@ -824,7 +826,7 @@ void TermDbSygus::registerEnumerator(Node e,
         }
       }
     }
-    if( rm_indices.empty() )
+    if (rm_indices.empty())
     {
       continue;
     }
@@ -835,8 +837,8 @@ void TermDbSygus::registerEnumerator(Node e,
       // we call getInstCons since in the case of any constant constructors, it
       // is necessary to generate a term of the form any_constant( x.0 ) for a
       // fresh variable x.0.
-      Node fv = getFreeVar(stn,0);
-      Node exc_val = datatypes::DatatypesRewriter::getInstCons(fv,dt,rindex);
+      Node fv = getFreeVar(stn, 0);
+      Node exc_val = datatypes::DatatypesRewriter::getInstCons(fv, dt, rindex);
       // should not include the constuctor in any subterm
       Node x = getFreeVar(stn, 0);
       Trace("sygus-db") << "Construct symmetry breaking lemma from " << x
@@ -968,7 +970,7 @@ TypeNode TermDbSygus::sygusToBuiltinType( TypeNode tn ) {
 void TermDbSygus::computeMinTypeDepthInternal( TypeNode root_tn, TypeNode tn, unsigned type_depth ) {
   std::map< TypeNode, unsigned >::iterator it = d_min_type_depth[root_tn].find( tn );
   if( it==d_min_type_depth[root_tn].end() || type_depth<it->second ){
-    if( !tn.isDatatype() )
+    if (!tn.isDatatype())
     {
       // do not recurse to non-datatype types
       return;
@@ -1375,79 +1377,98 @@ unsigned TermDbSygus::getAnchorDepth( Node n ) {
 }
 
 Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Node >& exp, bool track_exp ) {
-  if( !datatypes::DatatypesRewriter::isSygusEvalApp(en) ){
-    Assert( en.isConst() );
+  if (!datatypes::DatatypesRewriter::isSygusEvalApp(en))
+  {
+    Assert(en.isConst());
     return en;
   }
   Trace("sygus-db-debug") << "Unfold : " << en << std::endl;
   Node ev = en[0];
-  if( track_exp ){
-    std::map< Node, Node >::iterator itv = vtm.find( en[0] );
-    if( itv!=vtm.end() ){
+  if (track_exp)
+  {
+    std::map<Node, Node>::iterator itv = vtm.find(en[0]);
+    if (itv != vtm.end())
+    {
       ev = itv->second;
-    }else{
-      Assert( false );
     }
-    Assert( en[0].getType()==ev.getType() );
-    Assert( ev.isConst() );
+    else
+    {
+      Assert(false);
+    }
+    Assert(en[0].getType() == ev.getType());
+    Assert(ev.isConst());
   }
-  Assert( ev.getKind()==kind::APPLY_CONSTRUCTOR );
-  std::vector< Node > args;
-  for( unsigned i=1, nchild = en.getNumChildren(); i<nchild; i++ ){
-    args.push_back( en[i] );
+  Assert(ev.getKind() == kind::APPLY_CONSTRUCTOR);
+  std::vector<Node> args;
+  for (unsigned i = 1, nchild = en.getNumChildren(); i < nchild; i++)
+  {
+    args.push_back(en[i]);
   }
-  
+
   Type headType = en[0].getType().toType();
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   const Datatype& dt = static_cast<DatatypeType>(headType).getDatatype();
-  unsigned i = Datatype::indexOf( ev.getOperator().toExpr() );
-  if( track_exp ){
-    //explanation
-    Node ee = nm->mkNode( kind::APPLY_TESTER, Node::fromExpr( dt[i].getTester() ), en[0] );
-    if( std::find( exp.begin(), exp.end(), ee )==exp.end() ){
-      exp.push_back( ee );
+  unsigned i = Datatype::indexOf(ev.getOperator().toExpr());
+  if (track_exp)
+  {
+    // explanation
+    Node ee = nm->mkNode(
+        kind::APPLY_TESTER, Node::fromExpr(dt[i].getTester()), en[0]);
+    if (std::find(exp.begin(), exp.end(), ee) == exp.end())
+    {
+      exp.push_back(ee);
     }
   }
   // if we are a symbolic constructor, unfolding returns the subterm itself
-  Node sop = Node::fromExpr( dt[i].getSygusOp() );
-  if( sop.getAttribute(SygusAnyConstAttribute()) )
+  Node sop = Node::fromExpr(dt[i].getSygusOp());
+  if (sop.getAttribute(SygusAnyConstAttribute()))
   {
-    Trace("sygus-db-debug") << "...it is an any-constant constructor" << std::endl;
-    Assert( dt[i].getNumArgs()==1 );
-    if( en[0].getKind()==APPLY_CONSTRUCTOR )
+    Trace("sygus-db-debug")
+        << "...it is an any-constant constructor" << std::endl;
+    Assert(dt[i].getNumArgs() == 1);
+    if (en[0].getKind() == APPLY_CONSTRUCTOR)
     {
       return en[0][0];
     }
     else
     {
-      return nm->mkNode( APPLY_SELECTOR_TOTAL, dt[i].getSelectorInternal( headType, 0 ), en[0] );
+      return nm->mkNode(
+          APPLY_SELECTOR_TOTAL, dt[i].getSelectorInternal(headType, 0), en[0]);
     }
   }
-  
-  Assert( !dt.isParametric() );
-  std::map< int, Node > pre;
-  for( unsigned j=0, nargs = dt[i].getNumArgs(); j<nargs; j++ ){
-    std::vector< Node > cc;
+
+  Assert(!dt.isParametric());
+  std::map<int, Node> pre;
+  for (unsigned j = 0, nargs = dt[i].getNumArgs(); j < nargs; j++)
+  {
+    std::vector<Node> cc;
     Node s;
-    if( en[0].getKind()==kind::APPLY_CONSTRUCTOR ){
+    if (en[0].getKind() == kind::APPLY_CONSTRUCTOR)
+    {
       s = en[0][j];
-    }else{
-      s = nm->mkNode( kind::APPLY_SELECTOR_TOTAL, dt[i].getSelectorInternal( headType, j ), en[0] );
     }
-    cc.push_back( s );
-    if( track_exp ){
-      //update vtm map
+    else
+    {
+      s = nm->mkNode(kind::APPLY_SELECTOR_TOTAL,
+                     dt[i].getSelectorInternal(headType, j),
+                     en[0]);
+    }
+    cc.push_back(s);
+    if (track_exp)
+    {
+      // update vtm map
       vtm[s] = ev[j];
     }
-    cc.insert( cc.end(), args.begin(), args.end() );
+    cc.insert(cc.end(), args.begin(), args.end());
     pre[j] = datatypes::DatatypesRewriter::mkSygusEvalApp(cc);
   }
   Node ret = mkGeneric(dt, i, pre);
   // if it is a variable, apply the substitution
-  if( ret.getKind()==kind::BOUND_VARIABLE ){
-    Assert( ret.hasAttribute(SygusVarNumAttribute()) );
+  if (ret.getKind() == kind::BOUND_VARIABLE)
+  {
+    Assert(ret.hasAttribute(SygusVarNumAttribute()));
     int i = ret.getAttribute(SygusVarNumAttribute());
-    Assert( Node::fromExpr( dt.getSygusVarList() )[i]==ret );
+    Assert(Node::fromExpr(dt.getSygusVarList())[i] == ret);
     return args[i];
   }
   ret = Rewriter::rewrite(ret);
@@ -1460,7 +1481,8 @@ Node TermDbSygus::getEagerUnfold( Node n, std::map< Node, Node >& visited ) {
   if( itv==visited.end() ){
     Trace("cegqi-eager-debug") << "getEagerUnfold " << n << std::endl;
     Node ret;
-    if( datatypes::DatatypesRewriter::isSygusEvalApp(n) ){
+    if (datatypes::DatatypesRewriter::isSygusEvalApp(n))
+    {
       TypeNode tn = n[0].getType();
       Trace("cegqi-eager-debug") << "check " << n[0].getType() << std::endl;
       if( tn.isDatatype() ){
@@ -1537,7 +1559,9 @@ Node TermDbSygus::evaluateWithUnfolding(
       visited.find(n);
   if( it==visited.end() ){
     Node ret = n;
-    while( datatypes::DatatypesRewriter::isSygusEvalApp(ret) && ret[0].getKind()==APPLY_CONSTRUCTOR ){
+    while (datatypes::DatatypesRewriter::isSygusEvalApp(ret)
+           && ret[0].getKind() == APPLY_CONSTRUCTOR)
+    {
       ret = unfold( ret );
     }    
     if( ret.getNumChildren()>0 ){
@@ -1570,7 +1594,7 @@ Node TermDbSygus::evaluateWithUnfolding( Node n ) {
 
 bool TermDbSygus::isEvaluationPoint(Node n) const
 {
-  if( !datatypes::DatatypesRewriter::isSygusEvalApp(n) )
+  if (!datatypes::DatatypesRewriter::isSygusEvalApp(n))
   {
     return false;
   }

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -1413,7 +1413,6 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
   for( unsigned j=0, nargs = dt[i].getNumArgs(); j<nargs; j++ ){
     std::vector< Node > cc;
     //get the evaluation argument for the selector
-    const Datatype & ad = static_cast<DatatypeType>(dt[i].getArgType(j)).getDatatype();
     Node s;
     if( en[0].getKind()==kind::APPLY_CONSTRUCTOR ){
       s = en[0][j];
@@ -1426,7 +1425,7 @@ Node TermDbSygus::unfold( Node en, std::map< Node, Node >& vtm, std::vector< Nod
       vtm[s] = ev[j];
     }
     cc.insert( cc.end(), args.begin(), args.end() );
-    pre[j] = datatypes::DatatypesRewriter::mkSygusEvalApp(ad,cc);
+    pre[j] = datatypes::DatatypesRewriter::mkSygusEvalApp(cc);
   }
   Node ret = mkGeneric(dt, i, pre);
   // if it is a variable, apply the substitution

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -389,29 +389,30 @@ public: // for symmetry breaking
   bool considerConst( TypeNode tn, TypeNode tnp, Node c, Kind pk, int arg );
   bool considerConst( const Datatype& pdt, TypeNode tnp, Node c, Kind pk, int arg );
   int solveForArgument( TypeNode tnp, unsigned cindex, unsigned arg );
+
  public:
-  /** unfold 
-   * 
-   * This method returns the one-step unfolding of an evaluation function 
+  /** unfold
+   *
+   * This method returns the one-step unfolding of an evaluation function
    * application. An example of a one step unfolding is:
    *    eval( C_+( d1, d2 ), t ) ---> +( eval( d1, t ), eval( d2, t ) )
-   * 
+   *
    * This function does this unfolding for a (possibly symbolic) evaluation
    * head, where the argument "variable to model" vtm stores the model value of
    * variables from this head. This allows us to track an explanation of the
    * unfolding in the vector exp when track_exp is true.
-   * 
+   *
    * For example, if vtm[d] = C_+( C_x(), C_0() ) and track_exp is true, then
-   * this method applied to eval( d, t ) will return 
+   * this method applied to eval( d, t ) will return
    * +( eval( d.0, t ), eval( d.1, t ) ), and is-C_+( d ) is added to exp.
    */
   Node unfold(Node en,
               std::map<Node, Node>& vtm,
               std::vector<Node>& exp,
               bool track_exp = true);
-  /** 
+  /**
    * Same as above, but without explanation tracking. This is used for concrete
-   * evaluation heads 
+   * evaluation heads
    */
   Node unfold(Node en);
   Node getEagerUnfold( Node n, std::map< Node, Node >& visited );

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -390,13 +390,6 @@ public: // for symmetry breaking
   bool considerConst( const Datatype& pdt, TypeNode tnp, Node c, Kind pk, int arg );
   int solveForArgument( TypeNode tnp, unsigned cindex, unsigned arg );
 public:
- /** unfold
-  *
-  * This method
-  *
-  * TODO
-  *
-  */
  Node unfold(Node en,
              std::map<Node, Node>& vtm,
              std::vector<Node>& exp,

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -378,10 +378,6 @@ class TermDbSygus {
   Node getSemanticSkolem( TypeNode tn, Node n, bool doMk = true );
   /** involves div-by-zero */
   bool involvesDivByZero( Node n );
-  
-  /** get operator kind */
-  static Kind getOperatorKind( Node op );
-
   /** get anchor */
   static Node getAnchor( Node n );
   static unsigned getAnchorDepth( Node n );

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -389,17 +389,31 @@ public: // for symmetry breaking
   bool considerConst( TypeNode tn, TypeNode tnp, Node c, Kind pk, int arg );
   bool considerConst( const Datatype& pdt, TypeNode tnp, Node c, Kind pk, int arg );
   int solveForArgument( TypeNode tnp, unsigned cindex, unsigned arg );
-public:
- Node unfold(Node en,
-             std::map<Node, Node>& vtm,
-             std::vector<Node>& exp,
-             bool track_exp = true);
- Node unfold(Node en)
- {
-   std::map<Node, Node> vtm;
-   std::vector<Node> exp;
-   return unfold(en, vtm, exp, false);
-  }
+ public:
+  /** unfold 
+   * 
+   * This method returns the one-step unfolding of an evaluation function 
+   * application. An example of a one step unfolding is:
+   *    eval( C_+( d1, d2 ), t ) ---> +( eval( d1, t ), eval( d2, t ) )
+   * 
+   * This function does this unfolding for a (possibly symbolic) evaluation
+   * head, where the argument "variable to model" vtm stores the model value of
+   * variables from this head. This allows us to track an explanation of the
+   * unfolding in the vector exp when track_exp is true.
+   * 
+   * For example, if vtm[d] = C_+( C_x(), C_0() ) and track_exp is true, then
+   * this method applied to eval( d, t ) will return 
+   * +( eval( d.0, t ), eval( d.1, t ) ), and is-C_+( d ) is added to exp.
+   */
+  Node unfold(Node en,
+              std::map<Node, Node>& vtm,
+              std::vector<Node>& exp,
+              bool track_exp = true);
+  /** 
+   * Same as above, but without explanation tracking. This is used for concrete
+   * evaluation heads 
+   */
+  Node unfold(Node en);
   Node getEagerUnfold( Node n, std::map< Node, Node >& visited );
 };
 

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -390,18 +390,22 @@ public: // for symmetry breaking
   bool considerConst( const Datatype& pdt, TypeNode tnp, Node c, Kind pk, int arg );
   int solveForArgument( TypeNode tnp, unsigned cindex, unsigned arg );
 public:
-  /** unfold 
-   * 
-   * This method 
-   *
-   * TODO 
-   * 
-   */
-  Node unfold( Node en, std::map< Node, Node >& vtm, std::vector< Node >& exp, bool track_exp = true );
-  Node unfold( Node en ){
-    std::map< Node, Node > vtm;
-    std::vector< Node > exp;
-    return unfold( en, vtm, exp, false );
+ /** unfold
+  *
+  * This method
+  *
+  * TODO
+  *
+  */
+ Node unfold(Node en,
+             std::map<Node, Node>& vtm,
+             std::vector<Node>& exp,
+             bool track_exp = true);
+ Node unfold(Node en)
+ {
+   std::map<Node, Node> vtm;
+   std::vector<Node> exp;
+   return unfold(en, vtm, exp, false);
   }
   Node getEagerUnfold( Node n, std::map< Node, Node >& visited );
 };

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -172,13 +172,8 @@ class TermDbSygus {
    *
    * Given a sygus datatype term n of type tn, this function returns its analog,
    * that is, the term that n encodes.
-   *
-   * Notice that each occurrence of a symbolic constructor application is
-   * replaced by a unique variable. To track counters for introducing unique
-   * variables, we use the var_count map.
    */
   Node sygusToBuiltin(Node n, TypeNode tn);
-  Node sygusToBuiltin(Node n, TypeNode tn, std::map<TypeNode, int>& var_count);
   /** same as above, but without tn */
   Node sygusToBuiltin(Node n) { return sygusToBuiltin(n, n.getType()); }
   /** evaluate builtin
@@ -395,6 +390,13 @@ public: // for symmetry breaking
   bool considerConst( const Datatype& pdt, TypeNode tnp, Node c, Kind pk, int arg );
   int solveForArgument( TypeNode tnp, unsigned cindex, unsigned arg );
 public:
+  /** unfold 
+   * 
+   * This method 
+   *
+   * TODO 
+   * 
+   */
   Node unfold( Node en, std::map< Node, Node >& vtm, std::vector< Node >& exp, bool track_exp = true );
   Node unfold( Node en ){
     std::map< Node, Node > vtm;

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -605,9 +605,15 @@ Node SygusSampler::getSygusRandomValue(TypeNode tn,
                                        double rinc,
                                        unsigned depth)
 {
-  Assert(tn.isDatatype());
+  if(!tn.isDatatype())
+  {
+    return getRandomValue(tn);
+  }
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  Assert(dt.isSygus());
+  if(!dt.isSygus())
+  {
+    return getRandomValue(tn);
+  }
   Assert(d_rvalue_cindices.find(tn) != d_rvalue_cindices.end());
   Trace("sygus-sample-grammar")
       << "Sygus random value " << tn << ", depth = " << depth
@@ -671,9 +677,15 @@ void SygusSampler::registerSygusType(TypeNode tn)
   if (d_rvalue_cindices.find(tn) == d_rvalue_cindices.end())
   {
     d_rvalue_cindices[tn].clear();
-    Assert(tn.isDatatype());
+    if(!tn.isDatatype())
+    {
+      return;
+    }
     const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-    Assert(dt.isSygus());
+    if(!dt.isSygus())
+    {
+      return;
+    }
     for (unsigned i = 0, ncons = dt.getNumConstructors(); i < ncons; i++)
     {
       const DatatypeConstructor& dtc = dt[i];

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -605,12 +605,12 @@ Node SygusSampler::getSygusRandomValue(TypeNode tn,
                                        double rinc,
                                        unsigned depth)
 {
-  if(!tn.isDatatype())
+  if (!tn.isDatatype())
   {
     return getRandomValue(tn);
   }
   const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-  if(!dt.isSygus())
+  if (!dt.isSygus())
   {
     return getRandomValue(tn);
   }
@@ -677,12 +677,12 @@ void SygusSampler::registerSygusType(TypeNode tn)
   if (d_rvalue_cindices.find(tn) == d_rvalue_cindices.end())
   {
     d_rvalue_cindices[tn].clear();
-    if(!tn.isDatatype())
+    if (!tn.isDatatype())
     {
       return;
     }
     const Datatype& dt = static_cast<DatatypeType>(tn.toType()).getDatatype();
-    if(!dt.isSygus())
+    if (!dt.isSygus())
     {
       return;
     }

--- a/src/theory/quantifiers/term_util.h
+++ b/src/theory/quantifiers/term_util.h
@@ -76,10 +76,6 @@ typedef expr::Attribute<AbsTypeFunDefAttributeId, bool> AbsTypeFunDefAttribute;
 struct QuantIdNumAttributeId {};
 typedef expr::Attribute< QuantIdNumAttributeId, uint64_t > QuantIdNumAttribute;
 
-/** sygus var num */
-struct SygusVarNumAttributeId {};
-typedef expr::Attribute<SygusVarNumAttributeId, uint64_t> SygusVarNumAttribute;
-
 /** Attribute to mark Skolems as virtual terms */
 struct VirtualTermSkolemAttributeId {};
 typedef expr::Attribute< VirtualTermSkolemAttributeId, bool > VirtualTermSkolemAttribute;

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -914,9 +914,7 @@ Node TheoryEngineModelBuilder::normalize(TheoryModel* m, TNode r, bool evalOnly)
     if (childrenConst)
     {
       retNode = Rewriter::rewrite(retNode);
-      Trace("model-builder-debug") << "Rewritten : " << retNode << std::endl;
       Assert(retNode.getKind() == kind::APPLY_UF
-            || retNode.getKind() == kind::DT_SYGUS_EVAL
              || !retNode.getType().isFirstClass()
              || retNode.isConst());
     }

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -914,7 +914,9 @@ Node TheoryEngineModelBuilder::normalize(TheoryModel* m, TNode r, bool evalOnly)
     if (childrenConst)
     {
       retNode = Rewriter::rewrite(retNode);
+      Trace("model-builder-debug") << "Rewritten : " << retNode << std::endl;
       Assert(retNode.getKind() == kind::APPLY_UF
+            || retNode.getKind() == kind::DT_SYGUS_EVAL
              || !retNode.getType().isFirstClass()
              || retNode.isConst());
     }


### PR DESCRIPTION
This PR contains three core improvements to sygus/datatypes:

(1) It makes sygus evaluation functions use a builtin kind DT_SYGUS_EVAL by default. This eliminates the need for the UF solver during sygus solving.

(2) It makes "any constant" constructors take the builtin argument they encode, e.g. an any constant constructor for integers for sygus datatype D is of type Int -> D, whereas previously it had just been D. This ensures that DT_SYGUS_EVAL can be given a complete interpretation via:
(DT_SYGUS_EVAL (any_constant k) t1...tn)  ---> k

(3) It updates the implementation of sygus to use an internal "indexOf" utility in DatatypesRewriter. This eliminates a ~9% overhead from sygus solving.

It also properly reenables constant repair for sygus modules that don't support repair (there was a typo in the code that caused repair not to be run).