### PR TITLE
Fixes for quantifiers + incremental

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2093,6 +2093,11 @@ void SmtEngine::setDefaults() {
     if( !options::rewriteDivk.wasSetByUser()) {
       options::rewriteDivk.set( true );
     }
+    if( options::incrementalSolving() )
+    {
+      // cannot do nested quantifier elimination in incremental mode
+      options::cbqiNestedQE.set(false);
+    }
     if (d_logic.isPure(THEORY_ARITH) || d_logic.isPure(THEORY_BV))
     {
       options::cbqiAll.set( false );

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2093,7 +2093,7 @@ void SmtEngine::setDefaults() {
     if( !options::rewriteDivk.wasSetByUser()) {
       options::rewriteDivk.set( true );
     }
-    if( options::incrementalSolving() )
+    if (options::incrementalSolving())
     {
       // cannot do nested quantifier elimination in incremental mode
       options::cbqiNestedQE.set(false);

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -357,25 +357,28 @@ void InstStrategyCbqi::checkOwnership(Node q)
 
 void InstStrategyCbqi::preRegisterQuantifier(Node q)
 {
-  //mark all nested quantifiers with id
-  if( options::cbqiNestedQE() ){
-    std::map< Node, Node > visited;
-    Node mq = getIdMarkedQuantNode( q[1], visited );
-    if( mq!=q[1] ){
+  // mark all nested quantifiers with id
+  if (options::cbqiNestedQE())
+  {
+    std::map<Node, Node> visited;
+    Node mq = getIdMarkedQuantNode(q[1], visited);
+    if (mq != q[1])
+    {
       // do not do cbqi, we are reducing this quantified formula to a marked
       // one
       d_do_cbqi[q] = CEG_UNHANDLED;
-      //instead do reduction
-      std::vector< Node > qqc;
-      qqc.push_back( q[0] );
-      qqc.push_back( mq );
-      if( q.getNumChildren()==3 ){
-        qqc.push_back( q[2] );
+      // instead do reduction
+      std::vector<Node> qqc;
+      qqc.push_back(q[0]);
+      qqc.push_back(mq);
+      if (q.getNumChildren() == 3)
+      {
+        qqc.push_back(q[2]);
       }
-      Node qq = NodeManager::currentNM()->mkNode( FORALL, qqc );
-      Node mlem = NodeManager::currentNM()->mkNode( IMPLIES, q, qq );
+      Node qq = NodeManager::currentNM()->mkNode(FORALL, qqc);
+      Node mlem = NodeManager::currentNM()->mkNode(IMPLIES, q, qq);
       Trace("cbqi-lemma") << "Mark quant id lemma : " << mlem << std::endl;
-      d_quantEngine->addLemma( mlem );
+      d_quantEngine->addLemma(mlem);
     }
   }
   if( doCbqi( q ) ){

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -358,9 +358,9 @@ void InstStrategyCbqi::checkOwnership(Node q)
 void InstStrategyCbqi::preRegisterQuantifier(Node q)
 {
   // mark all nested quantifiers with id
-  if( d_quantEngine->getOwner(q)==this )
+  if (options::cbqiNestedQE())
   {
-    if (options::cbqiNestedQE())
+    if( d_quantEngine->getOwner(q)==this )
     {
       std::map<Node, Node> visited;
       Node mq = getIdMarkedQuantNode(q[1], visited);

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -358,27 +358,30 @@ void InstStrategyCbqi::checkOwnership(Node q)
 void InstStrategyCbqi::preRegisterQuantifier(Node q)
 {
   // mark all nested quantifiers with id
-  if (options::cbqiNestedQE())
+  if( d_quantEngine->getOwner(q)==this )
   {
-    std::map<Node, Node> visited;
-    Node mq = getIdMarkedQuantNode(q[1], visited);
-    if (mq != q[1])
+    if (options::cbqiNestedQE())
     {
-      // do not do cbqi, we are reducing this quantified formula to a marked
-      // one
-      d_do_cbqi[q] = CEG_UNHANDLED;
-      // instead do reduction
-      std::vector<Node> qqc;
-      qqc.push_back(q[0]);
-      qqc.push_back(mq);
-      if (q.getNumChildren() == 3)
+      std::map<Node, Node> visited;
+      Node mq = getIdMarkedQuantNode(q[1], visited);
+      if (mq != q[1])
       {
-        qqc.push_back(q[2]);
+        // do not do cbqi, we are reducing this quantified formula to a marked
+        // one
+        d_do_cbqi[q] = CEG_UNHANDLED;
+        // instead do reduction
+        std::vector<Node> qqc;
+        qqc.push_back(q[0]);
+        qqc.push_back(mq);
+        if (q.getNumChildren() == 3)
+        {
+          qqc.push_back(q[2]);
+        }
+        Node qq = NodeManager::currentNM()->mkNode(FORALL, qqc);
+        Node mlem = NodeManager::currentNM()->mkNode(IMPLIES, q, qq);
+        Trace("cbqi-lemma") << "Mark quant id lemma : " << mlem << std::endl;
+        d_quantEngine->addLemma(mlem);
       }
-      Node qq = NodeManager::currentNM()->mkNode(FORALL, qqc);
-      Node mlem = NodeManager::currentNM()->mkNode(IMPLIES, q, qq);
-      Trace("cbqi-lemma") << "Mark quant id lemma : " << mlem << std::endl;
-      d_quantEngine->addLemma(mlem);
     }
   }
   if( doCbqi( q ) ){

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -344,7 +344,7 @@ Node InstStrategyCbqi::getIdMarkedQuantNode( Node n, std::map< Node, Node >& vis
   }
 }
 
-void InstStrategyCbqi::preRegisterQuantifier( Node q ) {
+void InstStrategyCbqi::checkOwnership( Node q ) {
   if( d_quantEngine->getOwner( q )==NULL && doCbqi( q ) ){
     if (d_do_cbqi[q] == CEG_HANDLED)
     {
@@ -376,7 +376,7 @@ void InstStrategyCbqi::preRegisterQuantifier( Node q ) {
   }
 }
 
-void InstStrategyCbqi::registerQuantifier( Node q ) {
+void InstStrategyCbqi::preRegisterQuantifier( Node q ) {
   if( doCbqi( q ) ){
     if( registerCbqiLemma( q ) ){
       Trace("cbqi") << "Registered cbqi lemma for quantifier : " << q << std::endl;
@@ -673,7 +673,7 @@ CegInstantiator * InstStrategyCegqi::getInstantiator( Node q ) {
   }
 }
 
-void InstStrategyCegqi::registerQuantifier( Node q ) {
+void InstStrategyCegqi::preRegisterQuantifier( Node q ) {
   if( doCbqi( q ) ){
     // get the instantiator  
     if( options::cbqiPreRegInst() ){

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -351,34 +351,33 @@ void InstStrategyCbqi::checkOwnership(Node q)
     {
       //take full ownership of the quantified formula
       d_quantEngine->setOwner( q, this );
-      
-      //mark all nested quantifiers with id
-      if( options::cbqiNestedQE() ){
-        std::map< Node, Node > visited;
-        Node mq = getIdMarkedQuantNode( q[1], visited );
-        if( mq!=q[1] ){
-          // do not do cbqi, we are reducing this quantified formula to a marked
-          // one
-          d_do_cbqi[q] = CEG_UNHANDLED;
-          //instead do reduction
-          std::vector< Node > qqc;
-          qqc.push_back( q[0] );
-          qqc.push_back( mq );
-          if( q.getNumChildren()==3 ){
-            qqc.push_back( q[2] );
-          }
-          Node qq = NodeManager::currentNM()->mkNode( FORALL, qqc );
-          Node mlem = NodeManager::currentNM()->mkNode( IMPLIES, q, qq );
-          Trace("cbqi-lemma") << "Mark quant id lemma : " << mlem << std::endl;
-          d_quantEngine->getOutputChannel().lemma( mlem );
-        }
-      }
     }
   }
 }
 
 void InstStrategyCbqi::preRegisterQuantifier(Node q)
 {
+  //mark all nested quantifiers with id
+  if( options::cbqiNestedQE() ){
+    std::map< Node, Node > visited;
+    Node mq = getIdMarkedQuantNode( q[1], visited );
+    if( mq!=q[1] ){
+      // do not do cbqi, we are reducing this quantified formula to a marked
+      // one
+      d_do_cbqi[q] = CEG_UNHANDLED;
+      //instead do reduction
+      std::vector< Node > qqc;
+      qqc.push_back( q[0] );
+      qqc.push_back( mq );
+      if( q.getNumChildren()==3 ){
+        qqc.push_back( q[2] );
+      }
+      Node qq = NodeManager::currentNM()->mkNode( FORALL, qqc );
+      Node mlem = NodeManager::currentNM()->mkNode( IMPLIES, q, qq );
+      Trace("cbqi-lemma") << "Mark quant id lemma : " << mlem << std::endl;
+      d_quantEngine->addLemma( mlem );
+    }
+  }
   if( doCbqi( q ) ){
     if( registerCbqiLemma( q ) ){
       Trace("cbqi") << "Registered cbqi lemma for quantifier : " << q << std::endl;

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.cpp
@@ -344,7 +344,8 @@ Node InstStrategyCbqi::getIdMarkedQuantNode( Node n, std::map< Node, Node >& vis
   }
 }
 
-void InstStrategyCbqi::checkOwnership( Node q ) {
+void InstStrategyCbqi::checkOwnership(Node q)
+{
   if( d_quantEngine->getOwner( q )==NULL && doCbqi( q ) ){
     if (d_do_cbqi[q] == CEG_HANDLED)
     {
@@ -376,7 +377,8 @@ void InstStrategyCbqi::checkOwnership( Node q ) {
   }
 }
 
-void InstStrategyCbqi::preRegisterQuantifier( Node q ) {
+void InstStrategyCbqi::preRegisterQuantifier(Node q)
+{
   if( doCbqi( q ) ){
     if( registerCbqiLemma( q ) ){
       Trace("cbqi") << "Registered cbqi lemma for quantifier : " << q << std::endl;
@@ -673,7 +675,8 @@ CegInstantiator * InstStrategyCegqi::getInstantiator( Node q ) {
   }
 }
 
-void InstStrategyCegqi::preRegisterQuantifier( Node q ) {
+void InstStrategyCegqi::preRegisterQuantifier(Node q)
+{
   if( doCbqi( q ) ){
     // get the instantiator  
     if( options::cbqiPreRegInst() ){

--- a/src/theory/quantifiers/cegqi/inst_strategy_cbqi.h
+++ b/src/theory/quantifiers/cegqi/inst_strategy_cbqi.h
@@ -103,8 +103,8 @@ class InstStrategyCbqi : public QuantifiersModule {
   void check(Theory::Effort e, QEffort quant_e) override;
   bool checkComplete() override;
   bool checkCompleteFor(Node q) override;
+  void checkOwnership(Node q) override;
   void preRegisterQuantifier(Node q) override;
-  void registerQuantifier(Node q) override;
   /** get next decision request */
   Node getNextDecisionRequest(unsigned& priority) override;
 };
@@ -147,8 +147,8 @@ class InstStrategyCegqi : public InstStrategyCbqi {
 
   //get instantiator for quantifier
   CegInstantiator * getInstantiator( Node q );
-  //register quantifier
-  void registerQuantifier(Node q) override;
+  /** pre-register quantifier */
+  void preRegisterQuantifier(Node q) override;
   //presolve
   void presolve() override;
 };

--- a/src/theory/quantifiers/conjecture_generator.cpp
+++ b/src/theory/quantifiers/conjecture_generator.cpp
@@ -923,14 +923,6 @@ unsigned ConjectureGenerator::flushWaitingConjectures( unsigned& addedLemmas, in
   return addedLemmas;
 }
 
-void ConjectureGenerator::registerQuantifier( Node q ) {
-
-}
-
-void ConjectureGenerator::assertNode( Node n ) {
-
-}
-
 bool ConjectureGenerator::considerTermCanon( Node ln, bool genRelevant ){
   if( !ln.isNull() ){
     //do not consider if it is non-canonical, and either:

--- a/src/theory/quantifiers/conjecture_generator.h
+++ b/src/theory/quantifiers/conjecture_generator.h
@@ -428,9 +428,6 @@ public:
   void reset_round(Theory::Effort e) override;
   /* Call during quantifier engine's check */
   void check(Theory::Effort e, QEffort quant_e) override;
-  /* Called for new quantifiers */
-  void registerQuantifier(Node q) override;
-  void assertNode(Node n) override;
   /** Identify this module (for debugging, dynamic configuration, etc..) */
   std::string identify() const override { return "ConjectureGenerator"; }
   // options

--- a/src/theory/quantifiers/ematching/instantiation_engine.cpp
+++ b/src/theory/quantifiers/ematching/instantiation_engine.cpp
@@ -157,7 +157,7 @@ bool InstantiationEngine::checkCompleteFor( Node q ) {
   return false;
 }
 
-void InstantiationEngine::preRegisterQuantifier( Node q ) {
+void InstantiationEngine::checkOwnership( Node q ) {
   if( options::strictTriggers() && q.getNumChildren()==3 ){
     //if strict triggers, take ownership of this quantified formula
     bool hasPat = false;

--- a/src/theory/quantifiers/ematching/instantiation_engine.cpp
+++ b/src/theory/quantifiers/ematching/instantiation_engine.cpp
@@ -157,7 +157,8 @@ bool InstantiationEngine::checkCompleteFor( Node q ) {
   return false;
 }
 
-void InstantiationEngine::checkOwnership( Node q ) {
+void InstantiationEngine::checkOwnership(Node q)
+{
   if( options::strictTriggers() && q.getNumChildren()==3 ){
     //if strict triggers, take ownership of this quantified formula
     bool hasPat = false;

--- a/src/theory/quantifiers/ematching/instantiation_engine.h
+++ b/src/theory/quantifiers/ematching/instantiation_engine.h
@@ -81,7 +81,7 @@ class InstantiationEngine : public QuantifiersModule {
   void reset_round(Theory::Effort e) override;
   void check(Theory::Effort e, QEffort quant_e) override;
   bool checkCompleteFor(Node q) override;
-  void preRegisterQuantifier(Node q) override;
+  void checkOwnership(Node q) override;
   void registerQuantifier(Node q) override;
   Node explain(TNode n) { return Node::null(); }
   /** add user pattern */

--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -384,10 +384,11 @@ void BoundedIntegers::setBoundedVar( Node q, Node v, unsigned bound_type ) {
   Trace("bound-int-var") << "Bound variable #" << d_set_nums[q][v] << " : " << v << std::endl; 
 }
 
-void BoundedIntegers::checkOwnership( Node f ) {
+void BoundedIntegers::checkOwnership(Node f)
+{
   //this needs to be done at preregister since it affects e.g. QuantDSplit's preregister
   Trace("bound-int") << "check ownership quantifier " << f << std::endl;
-  
+
   bool success;
   do{
     std::map< Node, unsigned > bound_lit_type_map;

--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -547,10 +547,6 @@ void BoundedIntegers::checkOwnership(Node f)
   }
 }
 
-void BoundedIntegers::registerQuantifier( Node q ) {
-
-}
-
 void BoundedIntegers::assertNode( Node n ) {
   Trace("bound-int-assert") << "Assert " << n << std::endl;
   Node nlit = n.getKind()==NOT ? n[0] : n;

--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -384,9 +384,9 @@ void BoundedIntegers::setBoundedVar( Node q, Node v, unsigned bound_type ) {
   Trace("bound-int-var") << "Bound variable #" << d_set_nums[q][v] << " : " << v << std::endl; 
 }
 
-void BoundedIntegers::preRegisterQuantifier( Node f ) {
+void BoundedIntegers::checkOwnership( Node f ) {
   //this needs to be done at preregister since it affects e.g. QuantDSplit's preregister
-  Trace("bound-int") << "preRegister quantifier " << f << std::endl;
+  Trace("bound-int") << "check ownership quantifier " << f << std::endl;
   
   bool success;
   do{

--- a/src/theory/quantifiers/fmf/bounded_integers.h
+++ b/src/theory/quantifiers/fmf/bounded_integers.h
@@ -146,7 +146,6 @@ public:
   void presolve() override;
   bool needsCheck(Theory::Effort e) override;
   void check(Theory::Effort e, QEffort quant_e) override;
-  void registerQuantifier(Node q) override;
   void checkOwnership(Node q) override;
   void assertNode(Node n) override;
   Node getNextDecisionRequest(unsigned& priority) override;

--- a/src/theory/quantifiers/fmf/bounded_integers.h
+++ b/src/theory/quantifiers/fmf/bounded_integers.h
@@ -147,7 +147,7 @@ public:
   bool needsCheck(Theory::Effort e) override;
   void check(Theory::Effort e, QEffort quant_e) override;
   void registerQuantifier(Node q) override;
-  void preRegisterQuantifier(Node q) override;
+  void checkOwnership(Node q) override;
   void assertNode(Node n) override;
   Node getNextDecisionRequest(unsigned& priority) override;
   bool isBoundVar( Node q, Node v ) { return std::find( d_set[q].begin(), d_set[q].end(), v )!=d_set[q].end(); }

--- a/src/theory/quantifiers/inst_strategy_enumerative.cpp
+++ b/src/theory/quantifiers/inst_strategy_enumerative.cpp
@@ -295,7 +295,6 @@ bool InstStrategyEnum::process(Node f, bool fullEffort)
   return false;
 }
 
-void InstStrategyEnum::registerQuantifier(Node q) {}
 } /* CVC4::theory::quantifiers namespace */
 } /* CVC4::theory namespace */
 } /* CVC4 namespace */

--- a/src/theory/quantifiers/inst_strategy_enumerative.h
+++ b/src/theory/quantifiers/inst_strategy_enumerative.h
@@ -72,8 +72,6 @@ class InstStrategyEnum : public QuantifiersModule
    * quantified formulas via calls to process(...)
    */
   void check(Theory::Effort e, QEffort quant_e) override;
-  /** Register quantifier. */
-  void registerQuantifier(Node q) override;
   /** Identify. */
   std::string identify() const override
   {

--- a/src/theory/quantifiers/local_theory_ext.cpp
+++ b/src/theory/quantifiers/local_theory_ext.cpp
@@ -32,7 +32,8 @@ QuantifiersModule( qe ), d_wasInvoked( false ), d_needsCheck( false ){
 }
 
 /** add quantifier */
-void LtePartialInst::checkOwnership( Node q ) {
+void LtePartialInst::checkOwnership(Node q)
+{
   if( !q.getAttribute(LtePartialInstAttribute()) ){
     if( d_do_inst.find( q )!=d_do_inst.end() ){
       if( d_do_inst[q] ){

--- a/src/theory/quantifiers/local_theory_ext.cpp
+++ b/src/theory/quantifiers/local_theory_ext.cpp
@@ -32,7 +32,7 @@ QuantifiersModule( qe ), d_wasInvoked( false ), d_needsCheck( false ){
 }
 
 /** add quantifier */
-void LtePartialInst::preRegisterQuantifier( Node q ) {
+void LtePartialInst::checkOwnership( Node q ) {
   if( !q.getAttribute(LtePartialInstAttribute()) ){
     if( d_do_inst.find( q )!=d_do_inst.end() ){
       if( d_do_inst[q] ){

--- a/src/theory/quantifiers/local_theory_ext.h
+++ b/src/theory/quantifiers/local_theory_ext.h
@@ -64,11 +64,8 @@ public:
   bool needsCheck(Theory::Effort e) override;
   /* Call during quantifier engine's check */
   void check(Theory::Effort e, QEffort quant_e) override;
-  /* Called for new quantifiers */
-  void registerQuantifier(Node q) override {}
   /* check complete */
   bool checkComplete() override { return !d_wasInvoked; }
-  void assertNode(Node n) override {}
   /** Identify this module (for debugging, dynamic configuration, etc..) */
   std::string identify() const override { return "LtePartialInst"; }
 };

--- a/src/theory/quantifiers/local_theory_ext.h
+++ b/src/theory/quantifiers/local_theory_ext.h
@@ -56,7 +56,7 @@ private:
 public:
   LtePartialInst( QuantifiersEngine * qe, context::Context* c );
   /** determine whether this quantified formula will be reduced */
-  void preRegisterQuantifier(Node q) override;
+  void checkOwnership(Node q) override;
   /** was invoked */
   bool wasInvoked() { return d_wasInvoked; }
   

--- a/src/theory/quantifiers/quant_split.cpp
+++ b/src/theory/quantifiers/quant_split.cpp
@@ -31,8 +31,7 @@ QuantifiersModule( qe ), d_added_split( qe->getUserContext() ){
 
 }
 
-/** pre register quantifier */
-void QuantDSplit::preRegisterQuantifier( Node q ) {
+void QuantDSplit::checkOwnership( Node q ) {
   int max_index = -1;
   int max_score = -1;
   if( q.getNumChildren()==3 ){

--- a/src/theory/quantifiers/quant_split.cpp
+++ b/src/theory/quantifiers/quant_split.cpp
@@ -31,7 +31,8 @@ QuantifiersModule( qe ), d_added_split( qe->getUserContext() ){
 
 }
 
-void QuantDSplit::checkOwnership( Node q ) {
+void QuantDSplit::checkOwnership(Node q)
+{
   int max_index = -1;
   int max_score = -1;
   if( q.getNumChildren()==3 ){

--- a/src/theory/quantifiers/quant_split.h
+++ b/src/theory/quantifiers/quant_split.h
@@ -34,7 +34,7 @@ private:
 public:
   QuantDSplit( QuantifiersEngine * qe, context::Context* c );
   /** determine whether this quantified formula will be reduced */
-  void preRegisterQuantifier(Node q) override;
+  void checkOwnership(Node q) override;
 
   /* whether this module needs to check this round */
   bool needsCheck(Theory::Effort e) override;

--- a/src/theory/quantifiers/quant_util.h
+++ b/src/theory/quantifiers/quant_util.h
@@ -113,21 +113,21 @@ class QuantifiersModule {
    * Called once for new quantified formulas that are
    * pre-registered by the quantifiers theory.
    */
-  virtual void checkOwnership( Node q ) { }
+  virtual void checkOwnership(Node q) {}
   /** Register quantifier
    *
-   * Called once for new quantified formulas q that are pre-registered by the 
-   * quantifiers theory, after internal ownership of quantified formulas is 
+   * Called once for new quantified formulas q that are pre-registered by the
+   * quantifiers theory, after internal ownership of quantified formulas is
    * finalized. This does context-dependent initialization of this module.
    */
-  virtual void registerQuantifier( Node q ) {}
+  virtual void registerQuantifier(Node q) {}
   /** Pre-register quantifier
    *
    * Called once for new quantified formulas that are
    * pre-registered by the quantifiers theory, after
    * internal ownership of quantified formulas is finalized.
    */
-  virtual void preRegisterQuantifier( Node q ) {}
+  virtual void preRegisterQuantifier(Node q) {}
   /** Assert node.
    *
    * Called when a quantified formula q is asserted to the quantifiers theory

--- a/src/theory/quantifiers/quant_util.h
+++ b/src/theory/quantifiers/quant_util.h
@@ -113,14 +113,21 @@ class QuantifiersModule {
    * Called once for new quantified formulas that are
    * pre-registered by the quantifiers theory.
    */
-  virtual void preRegisterQuantifier( Node q ) { }
+  virtual void checkOwnership( Node q ) { }
   /** Register quantifier
+   *
+   * Called once for new quantified formulas q that are pre-registered by the 
+   * quantifiers theory, after internal ownership of quantified formulas is 
+   * finalized. This does context-dependent initialization of this module.
+   */
+  virtual void registerQuantifier( Node q ) {}
+  /** Pre-register quantifier
    *
    * Called once for new quantified formulas that are
    * pre-registered by the quantifiers theory, after
    * internal ownership of quantified formulas is finalized.
    */
-  virtual void registerQuantifier( Node q ) = 0;
+  virtual void preRegisterQuantifier( Node q ) {}
   /** Assert node.
    *
    * Called when a quantified formula q is asserted to the quantifiers theory

--- a/src/theory/quantifiers/quant_util.h
+++ b/src/theory/quantifiers/quant_util.h
@@ -108,10 +108,11 @@ class QuantifiersModule {
    * we are incomplete for other reasons.
    */
   virtual bool checkCompleteFor( Node q ) { return false; }
-  /** Pre register quantifier.
+  /** Check ownership
    *
-   * Called once for new quantified formulas that are
-   * pre-registered by the quantifiers theory.
+   * Called once for new quantified formulas that are registered by the
+   * quantifiers theory. The primary purpose of this function is to establish
+   * if this module is the owner of quantified formula q.
    */
   virtual void checkOwnership(Node q) {}
   /** Register quantifier

--- a/src/theory/quantifiers/theory_quantifiers.cpp
+++ b/src/theory/quantifiers/theory_quantifiers.cpp
@@ -83,13 +83,19 @@ void TheoryQuantifiers::finishInit()
 }
 
 void TheoryQuantifiers::preRegisterTerm(TNode n) {
-  Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() " << n << endl;
-  if( n.getKind()==FORALL ){
-    if( !options::cbqi() || options::recurseCbqi() || !TermUtil::hasInstConstAttr(n) ){
-      getQuantifiersEngine()->registerQuantifier( n );
-      Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() done " << n << endl;
-    }
+  if( n.getKind()!=FORALL ){
+    return;
   }
+  Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() " << n << endl;
+  if( options::cbqi() && !options::recurseCbqi() && TermUtil::hasInstConstAttr(n) ){
+    Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() done, unused " << n << endl;
+    return;
+  }
+  // Preregister the quantified formula.
+  // This initializes the modules used for handling n in this user context.
+  getQuantifiersEngine()->preRegisterQuantifier( n );
+  Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() done " << n << endl;
+
 }
 
 

--- a/src/theory/quantifiers/theory_quantifiers.cpp
+++ b/src/theory/quantifiers/theory_quantifiers.cpp
@@ -83,19 +83,23 @@ void TheoryQuantifiers::finishInit()
 }
 
 void TheoryQuantifiers::preRegisterTerm(TNode n) {
-  if( n.getKind()!=FORALL ){
+  if (n.getKind() != FORALL)
+  {
     return;
   }
   Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() " << n << endl;
-  if( options::cbqi() && !options::recurseCbqi() && TermUtil::hasInstConstAttr(n) ){
-    Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() done, unused " << n << endl;
+  if (options::cbqi() && !options::recurseCbqi()
+      && TermUtil::hasInstConstAttr(n))
+  {
+    Debug("quantifiers-prereg")
+        << "TheoryQuantifiers::preRegisterTerm() done, unused " << n << endl;
     return;
   }
   // Preregister the quantified formula.
   // This initializes the modules used for handling n in this user context.
-  getQuantifiersEngine()->preRegisterQuantifier( n );
-  Debug("quantifiers-prereg") << "TheoryQuantifiers::preRegisterTerm() done " << n << endl;
-
+  getQuantifiersEngine()->preRegisterQuantifier(n);
+  Debug("quantifiers-prereg")
+      << "TheoryQuantifiers::preRegisterTerm() done " << n << endl;
 }
 
 

--- a/src/theory/quantifiers/theory_quantifiers.h
+++ b/src/theory/quantifiers/theory_quantifiers.h
@@ -65,9 +65,6 @@ class TheoryQuantifiers : public Theory {
   void assertUniversal( Node n );
   void assertExistential( Node n );
   void computeCareGraph() override;
-
-  using BoolMap = context::CDHashMap<Node, bool, NodeHashFunction>;
-
   /** number of instantiations */
   int d_numInstantiations;
   int d_baseDecLevel;

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -754,17 +754,18 @@ void QuantifiersEngine::registerQuantifierInternal(Node f)
 
     for (QuantifiersModule*& mdl : d_modules)
     {
-      Trace("quant-debug") << "check ownership with "
-                           << mdl->identify() << "..." << std::endl;
+      Trace("quant-debug") << "check ownership with " << mdl->identify()
+                           << "..." << std::endl;
       mdl->checkOwnership(f);
     }
     QuantifiersModule* qm = getOwner(f);
-    Trace("quant") << " Owner : " << (qm==nullptr ? "[none]" : qm->identify()) << std::endl;
+    Trace("quant") << " Owner : " << (qm == nullptr ? "[none]" : qm->identify())
+                   << std::endl;
     // register with each module
     for (QuantifiersModule*& mdl : d_modules)
     {
-      Trace("quant-debug") << "register with " << mdl->identify()
-                           << "..." << std::endl;
+      Trace("quant-debug") << "register with " << mdl->identify() << "..."
+                           << std::endl;
       mdl->registerQuantifier(f);
       // since this is context-independent, we should not add any lemmas during
       // this call

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -76,6 +76,7 @@ QuantifiersEngine::QuantifiersEngine(context::Context* c,
       d_term_enum(new quantifiers::TermEnumeration),
       d_conflict_c(c, false),
       // d_quants(u),
+      d_quants_prereg(u),
       d_quants_red(u),
       d_lemmas_produced_c(u),
       d_ierCounter_c(c),
@@ -734,52 +735,62 @@ bool QuantifiersEngine::reduceQuantifier( Node q ) {
   }
 }
 
-bool QuantifiersEngine::registerQuantifier( Node f ){
+void QuantifiersEngine::registerQuantifierInternal( Node f ){
   std::map< Node, bool >::iterator it = d_quants.find( f );
   if( it==d_quants.end() ){
+    // Assert( d_lemmas_waiting.empty() );
     Trace("quant") << "QuantifiersEngine : Register quantifier ";
     Trace("quant") << " : " << f << std::endl;
     ++(d_statistics.d_num_quant);
     Assert( f.getKind()==FORALL );
-
-    //check whether we should apply a reduction
-    if( reduceQuantifier( f ) ){
-      Trace("quant") << "...reduced." << std::endl;
-      d_quants[f] = false;
-      return false;
-    }else{
-      // register with utilities
-      for (unsigned i = 0; i < d_util.size(); i++)
-      {
-        d_util[i]->registerQuantifier(f);
-      }
-      // compute attributes
-      d_quant_attr->computeAttributes(f);
-
-      for( unsigned i=0; i<d_modules.size(); i++ ){
-        Trace("quant-debug") << "pre-register with " << d_modules[i]->identify() << "..." << std::endl;
-        d_modules[i]->preRegisterQuantifier( f );
-      }
-      QuantifiersModule * qm = getOwner( f );
-      if( qm!=NULL ){
-        Trace("quant") << "   Owner : " << qm->identify() << std::endl;
-      }
-      //register with each module
-      for( unsigned i=0; i<d_modules.size(); i++ ){
-        Trace("quant-debug") << "register with " << d_modules[i]->identify() << "..." << std::endl;
-        d_modules[i]->registerQuantifier( f );
-      }
-      //TODO: remove this
-      Node ceBody = d_term_util->getInstConstantBody( f );
-      Trace("quant-debug")  << "...finish." << std::endl;
-      d_quants[f] = true;
-      // flush lemmas
-      flushLemmas();
-      return true;
+    // register with utilities
+    for (unsigned i = 0; i < d_util.size(); i++)
+    {
+      d_util[i]->registerQuantifier(f);
     }
-  }else{
-    return (*it).second;
+    // compute attributes
+    d_quant_attr->computeAttributes(f);
+
+    for( unsigned i=0; i<d_modules.size(); i++ ){
+      Trace("quant-debug") << "check ownership with " << d_modules[i]->identify() << "..." << std::endl;
+      d_modules[i]->checkOwnership( f );
+    }
+    QuantifiersModule * qm = getOwner( f );
+    if( qm!=NULL ){
+      Trace("quant") << "   Owner : " << qm->identify() << std::endl;
+    }
+    //register with each module
+    for( unsigned i=0; i<d_modules.size(); i++ ){
+      Trace("quant-debug") << "register with " << d_modules[i]->identify() << "..." << std::endl;
+      d_modules[i]->registerQuantifier( f );
+    }
+    //TODO: remove this
+    Node ceBody = d_term_util->getInstConstantBody( f );
+    Trace("quant-debug")  << "...finish." << std::endl;
+    d_quants[f] = true;
+    // since this is context-independent, we should not add any lemmas during 
+    // this call
+    // Assert( d_lemmas_waiting.empty() );
   }
+}
+
+void QuantifiersEngine::preRegisterQuantifier( Node q )
+{
+  NodeSet::const_iterator it = d_quants_prereg.find( q );
+  if( it!=d_quants_prereg.end() ){
+    return;
+  }
+  d_quants_prereg.insert(q);
+  // ensure that it is registered
+  registerQuantifierInternal(q);
+  //register with each module
+  for (QuantifiersModule*& mdl : d_modules)
+  {
+    Trace("quant-debug") << "pre-register with " << mdl->identify() << "..." << std::endl;
+    mdl->preRegisterQuantifier( q );
+  }
+  // flush the lemmas
+  flushLemmas();
 }
 
 void QuantifiersEngine::registerPattern( std::vector<Node> & pattern) {
@@ -790,31 +801,32 @@ void QuantifiersEngine::registerPattern( std::vector<Node> & pattern) {
 }
 
 void QuantifiersEngine::assertQuantifier( Node f, bool pol ){
-  if( !pol ){
-    //if not reduced
-    if( !reduceQuantifier( f ) ){
-      //do skolemization
-      Node lem = d_skolemize->process(f);
-      if (!lem.isNull())
-      {
-        if( Trace.isOn("quantifiers-sk-debug") ){
-          Node slem = Rewriter::rewrite( lem );
-          Trace("quantifiers-sk-debug") << "Skolemize lemma : " << slem << std::endl;
-        }
-        getOutputChannel().lemma( lem, false, true );
-      }
-    }
-  }else{
-    //assert to modules TODO : also for !pol?
-    //register the quantifier, assert it to each module
-    if( registerQuantifier( f ) ){
-      d_model->assertQuantifier( f );
-      for( unsigned i=0; i<d_modules.size(); i++ ){
-        d_modules[i]->assertNode( f );
-      }
-      addTermToDatabase( d_term_util->getInstConstantBody( f ), true );
-    }
+  if( reduceQuantifier( f ) ){
+    // if we can reduce it, nothing left to do
+    return;
   }
+  if( !pol ){
+    //do skolemization
+    Node lem = d_skolemize->process(f);
+    if (!lem.isNull())
+    {
+      if( Trace.isOn("quantifiers-sk-debug") ){
+        Node slem = Rewriter::rewrite( lem );
+        Trace("quantifiers-sk-debug") << "Skolemize lemma : " << slem << std::endl;
+      }
+      getOutputChannel().lemma( lem, false, true );
+    }
+    return;
+  }
+  // ensure the quantified formula is registered
+  registerQuantifierInternal( f );
+  // assert it to each module
+  d_model->assertQuantifier( f );
+  for (QuantifiersModule*& mdl : d_modules)
+  {
+    mdl->assertNode( f );
+  }
+  addTermToDatabase( d_term_util->getInstConstantBody( f ), true );
 }
 
 void QuantifiersEngine::propagate( Theory::Effort level ){

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -735,7 +735,8 @@ bool QuantifiersEngine::reduceQuantifier( Node q ) {
   }
 }
 
-void QuantifiersEngine::registerQuantifierInternal( Node f ){
+void QuantifiersEngine::registerQuantifierInternal(Node f)
+{
   std::map< Node, bool >::iterator it = d_quants.find( f );
   if( it==d_quants.end() ){
     // Assert( d_lemmas_waiting.empty() );
@@ -751,43 +752,50 @@ void QuantifiersEngine::registerQuantifierInternal( Node f ){
     // compute attributes
     d_quant_attr->computeAttributes(f);
 
-    for( unsigned i=0; i<d_modules.size(); i++ ){
-      Trace("quant-debug") << "check ownership with " << d_modules[i]->identify() << "..." << std::endl;
-      d_modules[i]->checkOwnership( f );
+    for (unsigned i = 0; i < d_modules.size(); i++)
+    {
+      Trace("quant-debug") << "check ownership with "
+                           << d_modules[i]->identify() << "..." << std::endl;
+      d_modules[i]->checkOwnership(f);
     }
-    QuantifiersModule * qm = getOwner( f );
-    if( qm!=NULL ){
+    QuantifiersModule* qm = getOwner(f);
+    if (qm != NULL)
+    {
       Trace("quant") << "   Owner : " << qm->identify() << std::endl;
     }
-    //register with each module
-    for( unsigned i=0; i<d_modules.size(); i++ ){
-      Trace("quant-debug") << "register with " << d_modules[i]->identify() << "..." << std::endl;
-      d_modules[i]->registerQuantifier( f );
+    // register with each module
+    for (unsigned i = 0; i < d_modules.size(); i++)
+    {
+      Trace("quant-debug") << "register with " << d_modules[i]->identify()
+                           << "..." << std::endl;
+      d_modules[i]->registerQuantifier(f);
     }
-    //TODO: remove this
-    Node ceBody = d_term_util->getInstConstantBody( f );
-    Trace("quant-debug")  << "...finish." << std::endl;
+    // TODO: remove this
+    Node ceBody = d_term_util->getInstConstantBody(f);
+    Trace("quant-debug") << "...finish." << std::endl;
     d_quants[f] = true;
-    // since this is context-independent, we should not add any lemmas during 
+    // since this is context-independent, we should not add any lemmas during
     // this call
     // Assert( d_lemmas_waiting.empty() );
   }
 }
 
-void QuantifiersEngine::preRegisterQuantifier( Node q )
+void QuantifiersEngine::preRegisterQuantifier(Node q)
 {
-  NodeSet::const_iterator it = d_quants_prereg.find( q );
-  if( it!=d_quants_prereg.end() ){
+  NodeSet::const_iterator it = d_quants_prereg.find(q);
+  if (it != d_quants_prereg.end())
+  {
     return;
   }
   d_quants_prereg.insert(q);
   // ensure that it is registered
   registerQuantifierInternal(q);
-  //register with each module
+  // register with each module
   for (QuantifiersModule*& mdl : d_modules)
   {
-    Trace("quant-debug") << "pre-register with " << mdl->identify() << "..." << std::endl;
-    mdl->preRegisterQuantifier( q );
+    Trace("quant-debug") << "pre-register with " << mdl->identify() << "..."
+                         << std::endl;
+    mdl->preRegisterQuantifier(q);
   }
   // flush the lemmas
   flushLemmas();
@@ -801,32 +809,35 @@ void QuantifiersEngine::registerPattern( std::vector<Node> & pattern) {
 }
 
 void QuantifiersEngine::assertQuantifier( Node f, bool pol ){
-  if( reduceQuantifier( f ) ){
+  if (reduceQuantifier(f))
+  {
     // if we can reduce it, nothing left to do
     return;
   }
   if( !pol ){
-    //do skolemization
+    // do skolemization
     Node lem = d_skolemize->process(f);
     if (!lem.isNull())
     {
-      if( Trace.isOn("quantifiers-sk-debug") ){
-        Node slem = Rewriter::rewrite( lem );
-        Trace("quantifiers-sk-debug") << "Skolemize lemma : " << slem << std::endl;
+      if (Trace.isOn("quantifiers-sk-debug"))
+      {
+        Node slem = Rewriter::rewrite(lem);
+        Trace("quantifiers-sk-debug")
+            << "Skolemize lemma : " << slem << std::endl;
       }
-      getOutputChannel().lemma( lem, false, true );
+      getOutputChannel().lemma(lem, false, true);
     }
     return;
   }
   // ensure the quantified formula is registered
-  registerQuantifierInternal( f );
+  registerQuantifierInternal(f);
   // assert it to each module
-  d_model->assertQuantifier( f );
+  d_model->assertQuantifier(f);
   for (QuantifiersModule*& mdl : d_modules)
   {
-    mdl->assertNode( f );
+    mdl->assertNode(f);
   }
-  addTermToDatabase( d_term_util->getInstConstantBody( f ), true );
+  addTermToDatabase(d_term_util->getInstConstantBody(f), true);
 }
 
 void QuantifiersEngine::propagate( Theory::Effort level ){

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -771,13 +771,13 @@ void QuantifiersEngine::registerQuantifierInternal(Node f)
       d_modules[i]->registerQuantifier(f);
       // since this is context-independent, we should not add any lemmas during
       // this call
-      Assert( d_lemmas_waiting.size()==prev_lemma_waiting );
+      Assert(d_lemmas_waiting.size() == prev_lemma_waiting);
     }
     // TODO: remove this
     Node ceBody = d_term_util->getInstConstantBody(f);
     Trace("quant-debug") << "...finish." << std::endl;
     d_quants[f] = true;
-    AlwaysAssert( d_lemmas_waiting.size()==prev_lemma_waiting );
+    AlwaysAssert(d_lemmas_waiting.size() == prev_lemma_waiting);
   }
 }
 
@@ -801,7 +801,7 @@ void QuantifiersEngine::preRegisterQuantifier(Node q)
   }
   // flush the lemmas
   flushLemmas();
-  Trace("quant-debug") << "...finish pre-register " << q<< "..." << std::endl;
+  Trace("quant-debug") << "...finish pre-register " << q << "..." << std::endl;
 }
 
 void QuantifiersEngine::registerPattern( std::vector<Node> & pattern) {

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -739,9 +739,9 @@ void QuantifiersEngine::registerQuantifierInternal(Node f)
 {
   std::map< Node, bool >::iterator it = d_quants.find( f );
   if( it==d_quants.end() ){
-    // Assert( d_lemmas_waiting.empty() );
     Trace("quant") << "QuantifiersEngine : Register quantifier ";
     Trace("quant") << " : " << f << std::endl;
+    unsigned prev_lemma_waiting = d_lemmas_waiting.size();
     ++(d_statistics.d_num_quant);
     Assert( f.getKind()==FORALL );
     // register with utilities
@@ -769,14 +769,15 @@ void QuantifiersEngine::registerQuantifierInternal(Node f)
       Trace("quant-debug") << "register with " << d_modules[i]->identify()
                            << "..." << std::endl;
       d_modules[i]->registerQuantifier(f);
+      // since this is context-independent, we should not add any lemmas during
+      // this call
+      Assert( d_lemmas_waiting.size()==prev_lemma_waiting );
     }
     // TODO: remove this
     Node ceBody = d_term_util->getInstConstantBody(f);
     Trace("quant-debug") << "...finish." << std::endl;
     d_quants[f] = true;
-    // since this is context-independent, we should not add any lemmas during
-    // this call
-    // Assert( d_lemmas_waiting.empty() );
+    AlwaysAssert( d_lemmas_waiting.size()==prev_lemma_waiting );
   }
 }
 
@@ -787,6 +788,7 @@ void QuantifiersEngine::preRegisterQuantifier(Node q)
   {
     return;
   }
+  Trace("quant-debug") << "QuantifiersEngine : Pre-register " << q << std::endl;
   d_quants_prereg.insert(q);
   // ensure that it is registered
   registerQuantifierInternal(q);
@@ -799,6 +801,7 @@ void QuantifiersEngine::preRegisterQuantifier(Node q)
   }
   // flush the lemmas
   flushLemmas();
+  Trace("quant-debug") << "...finish pre-register " << q<< "..." << std::endl;
 }
 
 void QuantifiersEngine::registerPattern( std::vector<Node> & pattern) {

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -752,28 +752,25 @@ void QuantifiersEngine::registerQuantifierInternal(Node f)
     // compute attributes
     d_quant_attr->computeAttributes(f);
 
-    for (unsigned i = 0; i < d_modules.size(); i++)
+    for (QuantifiersModule*& mdl : d_modules)
     {
       Trace("quant-debug") << "check ownership with "
-                           << d_modules[i]->identify() << "..." << std::endl;
-      d_modules[i]->checkOwnership(f);
+                           << mdl->identify() << "..." << std::endl;
+      mdl->checkOwnership(f);
     }
     QuantifiersModule* qm = getOwner(f);
-    if (qm != NULL)
-    {
-      Trace("quant") << "   Owner : " << qm->identify() << std::endl;
-    }
+    Trace("quant") << " Owner : " << (qm==nullptr ? "[none]" : qm->identify()) << std::endl;
     // register with each module
-    for (unsigned i = 0; i < d_modules.size(); i++)
+    for (QuantifiersModule*& mdl : d_modules)
     {
-      Trace("quant-debug") << "register with " << d_modules[i]->identify()
+      Trace("quant-debug") << "register with " << mdl->identify()
                            << "..." << std::endl;
-      d_modules[i]->registerQuantifier(f);
+      mdl->registerQuantifier(f);
       // since this is context-independent, we should not add any lemmas during
       // this call
       Assert(d_lemmas_waiting.size() == prev_lemma_waiting);
     }
-    // TODO: remove this
+    // TODO (#2020): remove this
     Node ceBody = d_term_util->getInstConstantBody(f);
     Trace("quant-debug") << "...finish." << std::endl;
     d_quants[f] = true;

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -306,6 +306,7 @@ private:
  bool reduceQuantifier(Node q);
  /** flush lemmas */
  void flushLemmas();
+
 public:
   /** add lemma lem */
   bool addLemma( Node lem, bool doCache = true, bool doRewrite = true );

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -298,8 +298,8 @@ private:
   *
   * This is called when a quantified formula q is pre-registered to the
   * quantifiers theory, and updates the modules in this class with
-  * context-dependent information about how to handle q.
-  * This includes basic information such as which module owns it.
+  * context-independent information about how to handle q. This includes basic
+  * information such as which module owns q.
   */
  void registerQuantifierInternal(Node q);
  /** reduceQuantifier, return true if reduced */

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -173,6 +173,8 @@ private:
  private:
   /** list of all quantifiers seen */
   std::map< Node, bool > d_quants;
+  /** quantifiers pre-registered */
+  NodeSet d_quants_prereg;
   /** quantifiers reduced */
   BoolMap d_quants_red;
   std::map< Node, Node > d_quants_red_lem;
@@ -277,8 +279,12 @@ public:
   void check( Theory::Effort e );
   /** notify that theories were combined */
   void notifyCombineTheories();
-  /** register quantifier */
-  bool registerQuantifier( Node f );
+  /** preRegister quantifier 
+   * 
+   * This function is called after registerQuantifier for quantified formulas
+   * that are pre-registered to the quantifiers theory.
+   */
+  void preRegisterQuantifier( Node q );
   /** register quantifier */
   void registerPattern( std::vector<Node> & pattern);
   /** assert universal quantifier */
@@ -288,6 +294,14 @@ public:
   /** get next decision request */
   Node getNextDecisionRequest( unsigned& priority );
 private:
+  /** (context-indepentent) register quantifier internal
+   * 
+   * This is called when a quantified formula q is pre-registered to the
+   * quantifiers theory, and updates the modules in this class with
+   * context-dependent information about how to handle q.
+   * This includes basic information such as which module owns it.
+   */
+  void registerQuantifierInternal( Node q );
   /** reduceQuantifier, return true if reduced */
   bool reduceQuantifier( Node q );
   /** flush lemmas */

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -279,12 +279,12 @@ public:
   void check( Theory::Effort e );
   /** notify that theories were combined */
   void notifyCombineTheories();
-  /** preRegister quantifier 
-   * 
+  /** preRegister quantifier
+   *
    * This function is called after registerQuantifier for quantified formulas
    * that are pre-registered to the quantifiers theory.
    */
-  void preRegisterQuantifier( Node q );
+  void preRegisterQuantifier(Node q);
   /** register quantifier */
   void registerPattern( std::vector<Node> & pattern);
   /** assert universal quantifier */
@@ -294,18 +294,18 @@ public:
   /** get next decision request */
   Node getNextDecisionRequest( unsigned& priority );
 private:
-  /** (context-indepentent) register quantifier internal
-   * 
-   * This is called when a quantified formula q is pre-registered to the
-   * quantifiers theory, and updates the modules in this class with
-   * context-dependent information about how to handle q.
-   * This includes basic information such as which module owns it.
-   */
-  void registerQuantifierInternal( Node q );
-  /** reduceQuantifier, return true if reduced */
-  bool reduceQuantifier( Node q );
-  /** flush lemmas */
-  void flushLemmas();
+ /** (context-indepentent) register quantifier internal
+  *
+  * This is called when a quantified formula q is pre-registered to the
+  * quantifiers theory, and updates the modules in this class with
+  * context-dependent information about how to handle q.
+  * This includes basic information such as which module owns it.
+  */
+ void registerQuantifierInternal(Node q);
+ /** reduceQuantifier, return true if reduced */
+ bool reduceQuantifier(Node q);
+ /** flush lemmas */
+ void flushLemmas();
 public:
   /** add lemma lem */
   bool addLemma( Node lem, bool doCache = true, bool doRewrite = true );


### PR DESCRIPTION
This distinguishes context-independent "registration" and user-context-dependent "pre-registration" in quantifiers modules. 

Previously, the quantifiers module InstStrategyCbqi (and derived InstStrategyCegqi) were adding lemmas during registration, which is a context-independent method. However, adding lemmas is user-context dependent. Thus, we had potential coherence issues in incremental mode.  This was the cause of #2001. 

This PR changes the name of QuantifiersModule::preRegisterQuantifier to QuantifiersModule::checkOwnership, adds a preRegistration functionality to QuantifiersModules, and updates InstStrategyCbqi/InstStrategyCegqi's registerQuantifier to be preRegisterQuantifier.

This fixes #2001.

Note: the indentation in registerQuantifier changed, although only minor changes were made to this method, namely, reduceQuantifier (which also should be user-context-dependent) was moved to preRegisterQuantifier.

