### PR TITLE
Normalize negated bit-vector terms over equalities.

### DIFF
--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -757,6 +757,10 @@ Node TheoryBV::ppRewrite(TNode t)
   } else if (RewriteRule<ZeroExtendEqConst>::applies(t)) {
     res = RewriteRule<ZeroExtendEqConst>::run<false>(t);
   }
+  else if (RewriteRule<NormalizeEqPlusNeg>::applies(t))
+  {
+    res = RewriteRule<NormalizeEqPlusNeg>::run<false>(t);
+  }
 
   // if(t.getKind() == kind::EQUAL &&
   //    ((t[0].getKind() == kind::BITVECTOR_MULT && t[1].getKind() ==

--- a/src/theory/bv/theory_bv_rewrite_rules.h
+++ b/src/theory/bv/theory_bv_rewrite_rules.h
@@ -31,7 +31,8 @@ namespace CVC4 {
 namespace theory {
 namespace bv {
 
-enum RewriteRuleId {
+enum RewriteRuleId
+{
 
   /// core normalization rules
   EmptyRule,
@@ -175,6 +176,7 @@ enum RewriteRuleId {
   OrSimplify,
   XorSimplify,
   BitwiseSlicing,
+  NormalizeEqPlusNeg,
   // rules to simplify bitblasting
   BBPlusNeg,
   UltPlusOne,
@@ -321,6 +323,7 @@ inline std::ostream& operator << (std::ostream& out, RewriteRuleId ruleId) {
   case ConcatToMult: out << "ConcatToMult"; return out;
   case IsPowerOfTwo: out << "IsPowerOfTwo"; return out;
   case MultSltMult: out << "MultSltMult"; return out;
+  case NormalizeEqPlusNeg: out << "NormalizeEqPlusNeg"; return out;
   default:
     Unreachable();
   }
@@ -548,6 +551,7 @@ struct AllRewriteRules {
   RewriteRule<SignExtendUltConst> rule126;
   RewriteRule<ZeroExtendUltConst> rule127;
   RewriteRule<MultSltMult> rule128;
+  RewriteRule<NormalizeEqPlusNeg> rule129;
 };
 
 template<> inline

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -1502,8 +1502,6 @@ inline Node RewriteRule<NormalizeEqPlusNeg>::apply(TNode node)
 
   Node lhs = nb_lhs.getNumChildren() == 1 ? nb_lhs[0] : nb_lhs.constructNode();
   Node rhs = nb_rhs.getNumChildren() == 1 ? nb_rhs[0] : nb_rhs.constructNode();
-  std::cout << node << std::endl;
-  std::cout << lhs.eqNode(rhs) << std::endl;
   return nm->mkNode(node.getKind(), lhs, rhs);
 }
 

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -1462,7 +1462,8 @@ inline bool RewriteRule<NormalizeEqPlusNeg>::applies(TNode node)
 template <>
 inline Node RewriteRule<NormalizeEqPlusNeg>::apply(TNode node)
 {
-  Debug("bv-rewrite") << "RewriteRule<>(" << node << ")" << std::endl;
+  Debug("bv-rewrite") << "RewriteRule<NormalizeEqPlusNeg>(" << node << ")"
+                      << std::endl;
 
   NodeBuilder<> nb_lhs(kind::BITVECTOR_PLUS);
   NodeBuilder<> nb_rhs(kind::BITVECTOR_PLUS);

--- a/src/theory/bv/theory_bv_rewrite_rules_normalization.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_normalization.h
@@ -1497,11 +1497,34 @@ inline Node RewriteRule<NormalizeEqPlusNeg>::apply(TNode node)
   {
     nb_rhs << node[1];
   }
-  Assert(nb_rhs.getNumChildren() > 0);
-  Assert(nb_lhs.getNumChildren() > 0);
 
-  Node lhs = nb_lhs.getNumChildren() == 1 ? nb_lhs[0] : nb_lhs.constructNode();
-  Node rhs = nb_rhs.getNumChildren() == 1 ? nb_rhs[0] : nb_rhs.constructNode();
+  Node zero = utils::mkZero(utils::getSize(node[0]));
+
+  Node lhs, rhs;
+  if (nb_lhs.getNumChildren() == 0)
+  {
+    lhs = zero;
+  }
+  else if (nb_lhs.getNumChildren() == 1)
+  {
+    lhs = nb_lhs[0];
+  }
+  else
+  {
+    lhs = nb_lhs.constructNode();
+  }
+  if (nb_rhs.getNumChildren() == 0)
+  {
+    rhs = zero;
+  }
+  else if (nb_rhs.getNumChildren() == 1)
+  {
+    rhs = nb_rhs[0];
+  }
+  else
+  {
+    rhs = nb_rhs.constructNode();
+  }
   return nm->mkNode(node.getKind(), lhs, rhs);
 }
 

--- a/src/theory/bv/theory_bv_rewriter.cpp
+++ b/src/theory/bv/theory_bv_rewriter.cpp
@@ -642,14 +642,6 @@ RewriteResponse TheoryBVRewriter::RewriteEqual(TNode node, bool prerewrite) {
         return RewriteResponse(REWRITE_AGAIN_FULL, resultNode);
       }
     }
-    if (RewriteRule<NormalizeEqPlusNeg>::applies(resultNode))
-    {
-      resultNode = RewriteRule<NormalizeEqPlusNeg>::run<false>(resultNode);
-      if (resultNode != node)
-      {
-        return RewriteResponse(REWRITE_AGAIN_FULL, resultNode);
-      }
-    }
     return RewriteResponse(REWRITE_DONE, resultNode); 
   }
 }

--- a/src/theory/bv/theory_bv_rewriter.cpp
+++ b/src/theory/bv/theory_bv_rewriter.cpp
@@ -642,6 +642,14 @@ RewriteResponse TheoryBVRewriter::RewriteEqual(TNode node, bool prerewrite) {
         return RewriteResponse(REWRITE_AGAIN_FULL, resultNode);
       }
     }
+    if (RewriteRule<NormalizeEqPlusNeg>::applies(resultNode))
+    {
+      resultNode = RewriteRule<NormalizeEqPlusNeg>::run<false>(resultNode);
+      if (resultNode != node)
+      {
+        return RewriteResponse(REWRITE_AGAIN_FULL, resultNode);
+      }
+    }
     return RewriteResponse(REWRITE_DONE, resultNode); 
   }
 }


### PR DESCRIPTION
Push negated terms to other side of equality to eliminated negations. This solves +53 additional benchmarks. #2015 