### PR TITLE
Fix bv-abstraction check for AND with non bit-vector atoms.

### DIFF
--- a/src/theory/bv/abstraction.h
+++ b/src/theory/bv/abstraction.h
@@ -155,8 +155,7 @@ class AbstractionModule {
   Node abstractSignatures(TNode assertion);
   Node computeSignature(TNode node);
 
-  bool isConjunctionOfAtoms(TNode node);
-  bool isConjunctionOfAtomsRec(TNode node, TNodeSet& seen);
+  bool isConjunctionOfAtoms(TNode node, TNodeSet& seen);
 
   TNode getGeneralization(TNode term);
   void storeGeneralization(TNode s, TNode t);

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -160,6 +160,7 @@ REG0_TESTS = \
 	regress0/bv/bug440.smt \
 	regress0/bv/bug733.smt2 \
 	regress0/bv/bug734.smt2 \
+	regress0/bv/bv-abstr-bug.smt2 \
 	regress0/bv/bv-int-collapse1.smt2 \
 	regress0/bv/bv-int-collapse2.smt2 \
 	regress0/bv/bv-options1.smt2 \

--- a/test/regress/regress0/bv/bv-abstr-bug.smt2
+++ b/test/regress/regress0/bv/bv-abstr-bug.smt2
@@ -1,0 +1,16 @@
+; COMMAND-LINE: --bv-abstraction --bitblast=eager --no-check-models
+;
+; BV-abstraction should not be applied
+(set-logic QF_BV)
+(set-info :status sat)
+(declare-const a Bool)
+(declare-const b Bool)
+(declare-const c Bool)
+(declare-const d Bool)
+(assert
+ (or
+  (and a b)
+  (and c d)
+ )
+)
+(check-sat)


### PR DESCRIPTION
Checking if BV-abstraction can be applied to an assertion was incorrect since isConjunctionOfAtoms allowed conjunctions of any atoms. However, BV-abstraction expects conjunctions of bit-vector atoms only. This fixes #1995.

Note that node cache 'seen' is now global over all assertions instead of having a cache for each assertion.