### PR TITLE
Regressions: Support for requiring CVC4 features

### DIFF
--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -433,6 +433,7 @@ REG0_TESTS = \
 	regress0/fmf/sc_bad_model_1221.smt2 \
 	regress0/fmf/syn002-si-real-int.smt2 \
 	regress0/fmf/tail_rec.smt2 \
+	regress0/fp/simple.smt2 \
 	regress0/fuzz_1.smt \
 	regress0/fuzz_3.smt \
 	regress0/get-value-incremental.smt2 \
@@ -601,10 +602,10 @@ REG0_TESTS = \
 	regress0/quantifiers/is-even-pred.smt2 \
 	regress0/quantifiers/is-int.smt2 \
 	regress0/quantifiers/issue1805.smt2 \
+	regress0/quantifiers/issue2033-macro-arith.smt2 \
 	regress0/quantifiers/lra-triv-gn.smt2 \
 	regress0/quantifiers/macros-int-real.smt2 \
 	regress0/quantifiers/macros-real-arg.smt2 \
-	regress0/quantifiers/issue2033-macro-arith.smt2 \
 	regress0/quantifiers/matching-lia-1arg.smt2 \
 	regress0/quantifiers/mix-complete-strat.smt2 \
 	regress0/quantifiers/mix-match.smt2 \

--- a/test/regress/README.md
+++ b/test/regress/README.md
@@ -108,6 +108,19 @@ string `TERM` to make the regression test robust to the actual term printed
 (e.g. there could be multiple non-linear facts and it is ok if any of them is
 printed).
 
+Sometimes, certain benchmarks only apply to certain CVC4
+configurations. The `REQUIRES` directive can be used to only run
+a given benchmark when a feature is supported. For example:
+
+```
+; REQUIRES: symfpu
+```
+
+This benchmark is only run when symfpu has been configured.
+Multiple `REQUIRES` directives are supported. For a list of
+features that can be listed as a requirement, refer to CVC4's
+`--show-config` output.
+
 Sometimes it is useful to keep the directives separate. You can separate the
 benchmark from the output expectations by putting the benchmark in `<benchmark
 file>.smt` and the directives in `<benchmark file>.smt.expect`, which is looked

--- a/test/regress/regress0/fp/simple.smt2
+++ b/test/regress/regress0/fp/simple.smt2
@@ -1,0 +1,6 @@
+; REQUIRES: symfpu
+; EXPECT: unsat
+(set-logic QF_FP)    
+(declare-const x Float32)
+(assert (not (= x (fp.neg (fp.neg x)))))
+(check-sat)


### PR DESCRIPTION
This commit adds supprt for the `REQUIRES` directive in our regression
benchmarks. This directive can be used to enable certain benchmarks only
if CVC4 has been configured with certain features enabled.