### PR TITLE
Move assertion in arrays

### DIFF
--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -668,6 +668,7 @@ void TheoryArrays::preRegisterTermInternal(TNode node)
     {
       d_equalityEngine.addTerm(node);
     }
+    Assert((d_isPreRegistered.insert(node), true));
 
     if (options::arraysLazyRIntro1() && !options::arraysWeakEquivalence()) {
       // Apply RIntro1 rule to any stores equal to store if not done already
@@ -717,7 +718,6 @@ void TheoryArrays::preRegisterTermInternal(TNode node)
       d_reads.push_back(node);
     }
 
-    Assert((d_isPreRegistered.insert(node), true));
     checkRowForIndex(node[1], store);
     break;
   }


### PR DESCRIPTION
It appears as though array's preRegisterInternal( t ) can make a recursive call to preRegisterInternal( t ) for the same term t.  On the recursive call, the method terminates since t has been added to the equality engine. However, we get an assertion failure saying that we haven't preregistered t. However, we are in the process of pre-registering it. To avoid the assertion failure, this PR adds t to the preRegister cache (which is only used in debug) *before* recursive calls to preRegisterInternal.

This fixes #2045.