### PR TITLE
Remove invalid assertion (#1993).

### DIFF
--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -459,11 +459,6 @@ bool CoreSolver::collectModelInfo(TheoryModel* m, bool fullModel)
 }
 
 Node CoreSolver::getModelValue(TNode var) {
-  // we don't need to evaluate bv expressions and only look at variable values
-  // because this only gets called when the core theory is complete (i.e. no other bv
-  // function symbols are currently asserted)
-  Assert (d_slicer->isCoreTerm(var));
-
   Debug("bitvector-model") << "CoreSolver::getModelValue (" << var <<")";
   Assert (isComplete());
   TNode repr = d_equalityEngine.getRepresentative(var);


### PR DESCRIPTION
The removed assertion is invalid when BV is combined with other theories and the input formula can be solved with no assertions asserted in theory BV (we can have shared terms that have a model value but are not a core term). This is related to issue #1993.