### PR TITLE
Fix equality conflicts reported by FP

### DIFF
--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -907,8 +907,9 @@ bool TheoryFp::handlePropagation(TNode node) {
 
   bool stat = d_out->propagate(node);
 
-  if (!stat) handleConflict(node);
-
+  if (!stat) {
+    d_conflict = true;
+  }
   return stat;
 }
 

--- a/src/theory/fp/theory_fp.cpp
+++ b/src/theory/fp/theory_fp.cpp
@@ -907,7 +907,8 @@ bool TheoryFp::handlePropagation(TNode node) {
 
   bool stat = d_out->propagate(node);
 
-  if (!stat) {
+  if (!stat)
+  {
     d_conflict = true;
   }
   return stat;

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -1557,7 +1557,8 @@ REG1_TESTS = \
 	regress1/uflia/microwave21.ec.minimized.smt2 \
 	regress1/uflia/simple_cyclic2.smt2 \
 	regress1/uflia/speed2_e8_449_e8_517.ec.smt2 \
-	regress1/uflia/stalmark_e7_27_e7_31.ec.smt2
+	regress1/uflia/stalmark_e7_27_e7_31.ec.smt2 \
+	regress1/wrong-qfabvfp-smtcomp2018.smt2
 
 REG2_TESTS = \
 	regress2/DTP_k2_n35_c175_s15.smt2 \

--- a/test/regress/regress1/wrong-qfabvfp-smtcomp2018.smt2
+++ b/test/regress/regress1/wrong-qfabvfp-smtcomp2018.smt2
@@ -1,0 +1,15 @@
+; REQUIRES: symfpu
+; COMMAND-LINE: --decision=internal
+; COMMAND-LINE: --decision=justification
+; EXPECT: sat
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BVFP)
+(declare-fun a () (_ BitVec 64))
+(declare-fun b () (_ BitVec 64))
+(assert (fp.leq ((_ to_fp 11 53) a) ((_ to_fp 11 53) (_ bv4626322717216342016 64))))
+(assert (not (fp.isNaN ((_ to_fp 11 53) b))))
+(declare-fun k2 () (_ BitVec 64))
+(assert (or (= k2 b) (= k2 a)))
+(assert
+(or (fp.isNaN ((_ to_fp 11 53) k2)) (fp.gt ((_ to_fp 11 53) k2) ((_ to_fp 11 53) (_ bv4626322717216342016 64))) ))
+(check-sat)


### PR DESCRIPTION
This fixes a soundness issue in FP where it would report unsound unit conflicts when a conflict was found by propagation from the equality engine of FP.

This changes FP to mimic the behavior of other theories, which set a flag to indicate that there is a conflict but do not report the propagating (dis)equality as a standalone conflict. Here are examples of what other theories do in this case:
https://github.com/CVC4/CVC4/blob/master/src/theory/datatypes/theory_datatypes.cpp#L677
https://github.com/CVC4/CVC4/blob/master/src/theory/sets/theory_sets_private.cpp#L2099
https://github.com/CVC4/CVC4/blob/master/src/theory/uf/theory_uf.cpp#L286
