### PR TITLE
Use evaluator in sygus sampler.

### DIFF
--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -448,13 +448,19 @@ void SygusSampler::addSamplePoint(std::vector<Node>& pt)
 Node SygusSampler::evaluate(Node n, unsigned index)
 {
   Assert(index < d_samples.size());
-  // just a substitution
-  std::vector<Node>& pt = d_samples[index];
-  Node ev = n.substitute(d_vars.begin(), d_vars.end(), pt.begin(), pt.end());
-  Trace("sygus-sample-ev-debug") << "Rewrite : " << ev << std::endl;
-  ev = Rewriter::rewrite(ev);
-  Trace("sygus-sample-ev") << "( " << n << ", " << index << " ) -> " << ev
-                           << std::endl;
+  // use efficient rewrite for substitution + rewrite
+  Node ev = d_eval.eval(n,d_vars,d_samples[index]);
+  Trace("sygus-sample-ev") << "Evaluate ( " << n << ", " << index << " ) -> ";
+  if( !ev.isNull() )
+  {
+    Trace("sygus-sample-ev") << ev << std::endl;
+    return ev;
+  }
+  // substitution + rewrite 
+  std::vector< Node >& pt = d_samples[index];
+  ev = n.substitute(d_vars.begin(),d_vars.end(),pt.begin(), pt.end());
+  ev = Rewriter::rewrite( ev );
+  Trace("sygus-sample-ev") << ev << std::endl;
   return ev;
 }
 

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -449,17 +449,17 @@ Node SygusSampler::evaluate(Node n, unsigned index)
 {
   Assert(index < d_samples.size());
   // use efficient rewrite for substitution + rewrite
-  Node ev = d_eval.eval(n,d_vars,d_samples[index]);
+  Node ev = d_eval.eval(n, d_vars, d_samples[index]);
   Trace("sygus-sample-ev") << "Evaluate ( " << n << ", " << index << " ) -> ";
-  if( !ev.isNull() )
+  if (!ev.isNull())
   {
     Trace("sygus-sample-ev") << ev << std::endl;
     return ev;
   }
-  // substitution + rewrite 
-  std::vector< Node >& pt = d_samples[index];
-  ev = n.substitute(d_vars.begin(),d_vars.end(),pt.begin(), pt.end());
-  ev = Rewriter::rewrite( ev );
+  // substitution + rewrite
+  std::vector<Node>& pt = d_samples[index];
+  ev = n.substitute(d_vars.begin(), d_vars.end(), pt.begin(), pt.end());
+  ev = Rewriter::rewrite(ev);
   Trace("sygus-sample-ev") << ev << std::endl;
   return ev;
 }

--- a/src/theory/quantifiers/sygus_sampler.h
+++ b/src/theory/quantifiers/sygus_sampler.h
@@ -18,6 +18,7 @@
 #define __CVC4__THEORY__QUANTIFIERS__SYGUS_SAMPLER_H
 
 #include <map>
+#include "theory/evaluator.h"
 #include "theory/quantifiers/dynamic_rewrite.h"
 #include "theory/quantifiers/lazy_trie.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
@@ -156,6 +157,8 @@ class SygusSampler : public LazyTrieEvaluator
   TermEnumeration d_tenum;
   /** samples */
   std::vector<std::vector<Node> > d_samples;
+  /** evaluator class */
+  Evaluator d_eval;
   /** data structure to check duplication of sample points */
   class PtTrie
   {


### PR DESCRIPTION
This should make --sygus-rr-synth and --sygus-rr-verify significantly faster for grammars with operators are defined in the evaluator.