### PR TITLE
Add missing include

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -111,6 +111,7 @@
 #include "theory/quantifiers/sygus/ce_guided_instantiation.h"
 #include "theory/quantifiers/sygus_inference.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/rewriter.h"
 #include "theory/sort_inference.h"
 #include "theory/strings/theory_strings.h"
 #include "theory/substitutions.h"


### PR DESCRIPTION
`theory/rewriter.h` is currently being included indirectly via `theory/bv/theory_bv_rewriter.h`