### PR TITLE
Add option for timeout for rewrite candidate check

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1218,6 +1218,13 @@ header = "options/quantifiers_options.h"
   default    = "false"
   help       = "use satisfiability check to verify correctness of candidate rewrites"
 
+[[option]]
+  name       = "sygusRewSynthCheckTimeout"
+  category   = "regular"
+  long       = "sygus-rr-synth-check-timeout"
+  type       = "unsigned long"
+  help       = "timeout (in milliseconds) for the satisfiability check to verify correctness of candidate rewrites"
+
 # CEGQI applied to general quantified formulas
 
 [[option]]


### PR DESCRIPTION
This commit adds the option `--sygus-rr-synth-check-timeout` to specify
a timeout for each rewrite candidate check. Rewrites that could not be
checked within the time limit will have a `candidate-` prefix in the
output.