### PR TITLE
Fix out-of-bounds vector accesses in the conjecture generator.

### DIFF
--- a/src/theory/quantifiers/conjecture_generator.cpp
+++ b/src/theory/quantifiers/conjecture_generator.cpp
@@ -1089,16 +1089,17 @@ void ConjectureGenerator::getEnumerateUfTerm( Node n, unsigned num, std::vector<
         vec_sum = 0;
         vec.push_back( size_limit );
       }else{
+        int vecindex = (index < vec.size()) ? vec[index] : 0;
         //see if we can iterate current
         if (vec_sum < size_limit
-            && !te->getEnumerateTerm(types[index], vec[index] + 1).isNull())
+            && !te->getEnumerateTerm(types[index], vecindex + 1).isNull())
         {
-          vec[index]++;
+          vec.assign(index, vecindex + 1);
           vec_sum++;
           vec.push_back( size_limit - vec_sum );
         }else{
-          vec_sum -= vec[index];
-          vec[index] = 0;
+          vec_sum -= vecindex;
+          vec.assign(index, 0);
           index++;
           if( index==n.getNumChildren() ){
             success = false;


### PR DESCRIPTION
Fedora recently added -D_GLIBCXX_ASSERTIONS to the default build flags.  On recent versions of glibc, this activates run-time assertions.  One of those assertions is that a vector access is made to a valid vector index.  That particular assertion fails while running the CVC4 1.6 test suite, while processing test/regress/regress1/quantifiers/isaplanner-goal20.smt2.

In ConjectureGenerator::getEnumerateUfTerm, the vector named "vec" starts with no elements, and the variable index is initialized to zero.  As the while loop in the body of the method is executed, the value of index tends to be one beyond the last valid index of "vec".  This commit converts reads beyond the end of "vec" into reads of zero, and uses the "assign" operator to make writes to "vec" be valid.  With this change, the entire test suite runs successfully.