### PR TITLE
exportTo only if needed for --sygus-rr-synth-check

### DIFF
--- a/src/expr/expr_manager_template.cpp
+++ b/src/expr/expr_manager_template.cpp
@@ -1023,6 +1023,16 @@ TypeNode exportTypeInternal(TypeNode n, NodeManager* from, NodeManager* to, Expr
   } else if(n.getKind() == kind::BITVECTOR_TYPE) {
     return to->mkBitVectorType(n.getConst<BitVectorSize>());
   }
+  else if (n.getKind() == kind::FLOATINGPOINT_TYPE)
+  {
+    return to->mkFloatingPointType(n.getConst<FloatingPointSize>());
+  }
+  else if (n.getNumChildren() == 0)
+  {
+    std::stringstream msg;
+    msg << "export of type " << n << " not supported";
+    throw ExportUnsupportedException(msg.str().c_str());
+  }
   Type from_t = from->toType(n);
   Type& to_t = vmap.d_typeMap[from_t];
   if(! to_t.isNull()) {

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -248,8 +248,11 @@ public:
         children.push_back(exportInternal(*i));
       }
       if(Debug.isOn("export")) {
-        ExprManagerScope ems(*to);
         Debug("export") << "children for export from " << n << std::endl;
+
+        // `n` belongs to the `from` ExprManager, so begin ExprManagerScope
+        // after printing `n`
+        ExprManagerScope ems(*to);
         for(std::vector<Node>::iterator i = children.begin(), i_end = children.end(); i != i_end; ++i) {
           Debug("export") << "  child: " << *i << std::endl;
         }

--- a/src/expr/type_node.cpp
+++ b/src/expr/type_node.cpp
@@ -342,6 +342,7 @@ TypeNode TypeNode::commonTypeNode(TypeNode t0, TypeNode t1, bool isLeast) {
   // t1.getKind() == kind::TYPE_CONSTANT
   switch(t0.getKind()) {
   case kind::BITVECTOR_TYPE:
+  case kind::FLOATINGPOINT_TYPE:
   case kind::SORT_TYPE:
   case kind::CONSTRUCTOR_TYPE:
   case kind::SELECTOR_TYPE:


### PR DESCRIPTION
With this commit, we only use an SmtEngine with a separate ExprManager
for --sygus-rr-synth-check if necessary (currently, this is only the
case when --sygus-rr-synth-check-timeout is active). The reason for
this is that we do not support exportTo for all kinds. Additionally,
this commit adds support for exporting floating-point types and adds a
check that throws an exception if an unsupported type is being
exported (previously, it just crashed). Finally, it fixes a minor
issue with -d export, where an expression was printed while the wrong
ExprManager was active, leading to an assertion failure when getting
the types of expressions (which is required for operators like
equality where the sort of the children is not fixed).