### PR TITLE
Avoid ambiguous overloads in BitVector

### DIFF
--- a/src/theory/fp/fp_converter.cpp
+++ b/src/theory/fp/fp_converter.cpp
@@ -275,7 +275,7 @@ symbolicProposition symbolicRoundingMode::valid(void) const
 {
   NodeManager *nm = NodeManager::currentNM();
   Node zero(nm->mkConst(
-      BitVector(SYMFPU_NUMBER_OF_ROUNDING_MODES, (long unsigned int)0)));
+      BitVector(SYMFPU_NUMBER_OF_ROUNDING_MODES, static_cast<uint32_t>(0))));
 
   // Is there a better encoding of this?
   return symbolicProposition(nm->mkNode(
@@ -287,7 +287,7 @@ symbolicProposition symbolicRoundingMode::valid(void) const
                                        *this,
                                        nm->mkConst(BitVector(
                                            SYMFPU_NUMBER_OF_ROUNDING_MODES,
-                                           (long unsigned int)1)))),
+                                           static_cast<uint32_t>(1))))),
                  zero),
       nm->mkNode(kind::BITVECTOR_NOT,
                  nm->mkNode(kind::BITVECTOR_COMP, *this, zero))));

--- a/src/util/bitvector.h
+++ b/src/util/bitvector.h
@@ -19,6 +19,7 @@
 #ifndef __CVC4__BITVECTOR_H
 #define __CVC4__BITVECTOR_H
 
+#include <cstdint>
 #include <iosfwd>
 
 #include "base/exception.h"
@@ -36,12 +37,12 @@ class CVC4_PUBLIC BitVector
 
   BitVector(unsigned size = 0) : d_size(size), d_value(0) {}
 
-  BitVector(unsigned size, unsigned int z) : d_size(size), d_value(z)
+  BitVector(unsigned size, uint32_t z) : d_size(size), d_value(z)
   {
     d_value = d_value.modByPow2(size);
   }
 
-  BitVector(unsigned size, unsigned long int z) : d_size(size), d_value(z)
+  BitVector(unsigned size, uint64_t z) : d_size(size), d_value(z)
   {
     d_value = d_value.modByPow2(size);
   }


### PR DESCRIPTION
`long` is a 32-bit integer on Windows. CVC4's BitVector class had a
constructor for `unsigned int` and `unsigned long`, which lead to issues
with the new CVC4 C++ API because the two constructors were ambiguous
overloads. This commit changes the constructors to use `uint32_t` and
`uint64_t`, which are plattform independent and more explicit (mirroring
the API).