### PR TITLE
Fix incorrectly formatted code as part of #2194

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5251,28 +5251,34 @@ Model* SmtEngine::getModel() {
   return m;
 }
 
-Expr SmtEngine::getHeapExpr() {
+Expr SmtEngine::getHeapExpr()
+{
   NodeManagerScope nms(d_nodeManager);
   Expr heap;
-  Expr nil; // we don't actually use this
+  Expr nil;  // we don't actually use this
   Model* m = getModel();
-  if (m->getHeapModel( heap, nil ))
+  if (m->getHeapModel(heap, nil))
   {
     return heap;
   }
-  InternalError("SmtEngine::getHeapExpr(): failed to obtain heap expression from theory model.");
+  InternalError(
+      "SmtEngine::getHeapExpr(): failed to obtain heap expression from theory "
+      "model.");
 }
 
-Expr SmtEngine::getNilExpr() {
+Expr SmtEngine::getNilExpr()
+{
   NodeManagerScope nms(d_nodeManager);
-  Expr heap; // we don't actually use this
+  Expr heap;  // we don't actually use this
   Expr nil;
   Model* m = getModel();
-  if (m->getHeapModel( heap, nil ))
+  if (m->getHeapModel(heap, nil))
   {
     return nil;
   }
-  InternalError("SmtEngine::getNilExpr(): failed to obtain nil expression from theory model.");
+  InternalError(
+      "SmtEngine::getNilExpr(): failed to obtain nil expression from theory "
+      "model.");
 }
 
 void SmtEngine::checkUnsatCore() {


### PR DESCRIPTION
@aniemetz correctly noticed that commit 9bc90725c49e372f4c0c10444662d7fe608414a4 in #2194 did not adhere to the code style guidelines for CVC4.

This PR corrects that by running git clang-format on the original change-set.