### PR TITLE
Changing the arithmetic static learner to use CDHashMap. 

### DIFF
--- a/src/theory/arith/arith_static_learner.h
+++ b/src/theory/arith/arith_static_learner.h
@@ -22,7 +22,7 @@
 
 #include <set>
 
-#include "context/cdtrail_hashmap.h"
+#include "context/cdhashmap.h"
 #include "context/context.h"
 #include "theory/arith/arith_utilities.h"
 #include "util/statistics_registry.h"
@@ -37,7 +37,7 @@ private:
   /**
    * Map from a node to it's minimum and maximum.
    */
-  typedef context::CDTrailHashMap<Node, DeltaRational, NodeHashFunction> CDNodeToMinMaxMap;
+  typedef context::CDHashMap<Node, DeltaRational, NodeHashFunction> CDNodeToMinMaxMap;
   CDNodeToMinMaxMap d_minMap;
   CDNodeToMinMaxMap d_maxMap;
 


### PR DESCRIPTION
This is 2/3 PRs for deprecating CDTrailHashMap.