### PR TITLE
Fix rewriter for lambda

### DIFF
--- a/src/theory/builtin/theory_builtin_rewriter.cpp
+++ b/src/theory/builtin/theory_builtin_rewriter.cpp
@@ -88,7 +88,7 @@ RewriteResponse TheoryBuiltinRewriter::postRewrite(TNode node) {
         Trace("builtin-rewrite") << "  array rep : " << anode << ", constant = " << anode.isConst() << std::endl;
         Assert( anode.isConst()==retNode.isConst() );
         Assert( retNode.getType()==node.getType() );
-        Assert( node.hasFreeVar()==retNode.hasFreeVar() );
+        Assert(node.hasFreeVar() == retNode.hasFreeVar());
         return RewriteResponse(REWRITE_DONE, retNode);
       } 
     }else{
@@ -193,10 +193,12 @@ Node TheoryBuiltinRewriter::getLambdaForArrayRepresentation( TNode a, TNode bvl 
   }
 }
 
-Node TheoryBuiltinRewriter::getArrayRepresentationForLambdaRec( TNode n, TypeNode retType ){
+Node TheoryBuiltinRewriter::getArrayRepresentationForLambdaRec(TNode n,
+                                                               TypeNode retType)
+{
   Assert( n.getKind()==kind::LAMBDA );
   Trace("builtin-rewrite-debug") << "Get array representation for : " << n << std::endl;
-  
+
   Node first_arg = n[0][0];
   Node rec_bvl;
   if( n[0].getNumChildren()>1 ){
@@ -231,7 +233,9 @@ Node TheoryBuiltinRewriter::getArrayRepresentationForLambdaRec( TNode n, TypeNod
       // non-equality condition
       Trace("builtin-rewrite-debug2") << "  ...non-equality condition." << std::endl;
       return Node::null();
-    }else if( Rewriter::rewrite( index_eq )!=index_eq ){
+    }
+    else if (Rewriter::rewrite(index_eq) != index_eq)
+    {
       // equality must be oriented correctly based on rewriter
       Trace("builtin-rewrite-debug2") << "  ...equality not oriented properly." << std::endl;
       return Node::null();
@@ -242,7 +246,8 @@ Node TheoryBuiltinRewriter::getArrayRepresentationForLambdaRec( TNode n, TypeNod
       Node arg = index_eq[r];
       Node val = index_eq[1-r];
       if( arg==first_arg ){
-        if( !val.isConst() ){
+        if (!val.isConst())
+        {
           // non-constant value
           Trace("builtin-rewrite-debug2") << "  ...non-constant value." << std::endl;
           return Node::null();
@@ -256,7 +261,7 @@ Node TheoryBuiltinRewriter::getArrayRepresentationForLambdaRec( TNode n, TypeNod
     if( !curr_index.isNull() ){
       if( !rec_bvl.isNull() ){
         curr_val = NodeManager::currentNM()->mkNode( kind::LAMBDA, rec_bvl, curr_val );
-        curr_val = getArrayRepresentationForLambdaRec( curr_val, retType );
+        curr_val = getArrayRepresentationForLambdaRec(curr_val, retType);
         if( curr_val.isNull() ){
           Trace("builtin-rewrite-debug2") << "  ...non-constant value." << std::endl;
           return Node::null();
@@ -275,7 +280,7 @@ Node TheoryBuiltinRewriter::getArrayRepresentationForLambdaRec( TNode n, TypeNod
   }
   if( !rec_bvl.isNull() ){
     curr = NodeManager::currentNM()->mkNode( kind::LAMBDA, rec_bvl, curr );
-    curr = getArrayRepresentationForLambdaRec( curr, retType );
+    curr = getArrayRepresentationForLambdaRec(curr, retType);
   }
   if( !curr.isNull() && curr.isConst() ){
     // compute the return type
@@ -303,11 +308,12 @@ Node TheoryBuiltinRewriter::getArrayRepresentationForLambdaRec( TNode n, TypeNod
   }
 }
 
-Node TheoryBuiltinRewriter::getArrayRepresentationForLambda( TNode n ){
+Node TheoryBuiltinRewriter::getArrayRepresentationForLambda(TNode n)
+{
   Assert( n.getKind()==kind::LAMBDA );
   // must carry the overall return type to deal with cases like (lambda ((x Int)(y Int)) (ite (= x _) 0.5 0.0)),
   //  where the inner construction for the else case about should be (arraystoreall (Array Int Real) 0.0)
-  return getArrayRepresentationForLambdaRec( n, n[1].getType() );
+  return getArrayRepresentationForLambdaRec(n, n[1].getType());
 }
 
 }/* CVC4::theory::builtin namespace */

--- a/src/theory/builtin/theory_builtin_rewriter.h
+++ b/src/theory/builtin/theory_builtin_rewriter.h
@@ -117,6 +117,8 @@ private:
    * that is, arrays of the form:
    *   (store ... (store (storeall _ b) i1 e1) ... in en)
    * where b, i1, e1, ..., in, en are constants.
+   * Notice however that the return value of this form need not be a (canonical)
+   * array constant.
    *
    * If it is not possible to construct an array of this form that corresponds
    * to n, this method returns null.

--- a/src/theory/builtin/theory_builtin_rewriter.h
+++ b/src/theory/builtin/theory_builtin_rewriter.h
@@ -60,64 +60,64 @@ private:
   static Node getLambdaForArrayRepresentationRec( TNode a, TNode bvl, unsigned bvlIndex, 
                                                   std::unordered_map< TNode, Node, TNodeHashFunction >& visited );
   /** recursive helper for getArrayRepresentationForLambda */
-  static Node getArrayRepresentationForLambdaRec( TNode n, TypeNode retType );
-public:
- /** Get function type for array type
-  *
-  * This returns the function type of terms returned by the function
-  * getLambdaForArrayRepresentation( t, bvl ),
-  * where t.getType()=atn.
-  *
-  * bvl should be a bound variable list whose variables correspond in-order
-  * to the index types of the (curried) Array type. For example, a bound
-  * variable list bvl whose variables have types (Int, Real) can be given as
-  * input when paired with atn = (Array Int (Array Real Bool)), or (Array Int
-  * (Array Real (Array Bool Bool))). This function returns (-> Int Real Bool)
-  * and (-> Int Real (Array Bool Bool)) respectively in these cases.
-  * On the other hand, the above bvl is not a proper input for
-  * atn = (Array Int (Array Bool Bool)) or (Array Int Int).
-  * If the types of bvl and atn do not match, we throw an assertion failure.
-  */
- static TypeNode getFunctionTypeForArrayType(TypeNode atn, Node bvl);
- /** Get array type for function type
-  *
-  * This returns the array type of terms returned by
-  * getArrayRepresentationForLambda( t ), where t.getType()=ftn.
-  */
- static TypeNode getArrayTypeForFunctionType(TypeNode ftn);
- /**
-  * Given an array constant a, returns a lambda expression that it corresponds
-  * to, with bound variable list bvl.
-  * Examples:
-  *
-  * (store (storeall (Array Int Int) 2) 0 1)
-  * becomes
-  * ((lambda x. (ite (= x 0) 1 2))
-  *
-  * (store (storeall (Array Int (Array Int Int)) (storeall (Array Int Int) 4)) 0
-  * (store (storeall (Array Int Int) 3) 1 2))
-  * becomes
-  * (lambda xy. (ite (= x 0) (ite (= x 1) 2 3) 4))
-  *
-  * (store (store (storeall (Array Int Bool) false) 2 true) 1 true)
-  * becomes
-  * (lambda x. (ite (= x 1) true (ite (= x 2) true false)))
-  *
-  * Notice that the return body of the lambda is rewritten to ensure that the
-  * representation is canonical. Hence the last
-  * example will in fact be returned as:
-  * (lambda x. (ite (= x 1) true (= x 2)))
-  */
- static Node getLambdaForArrayRepresentation(TNode a, TNode bvl);
- /** 
-  * Given a lambda expression n, returns an array term that corresponds to n.
-  * This does the opposite direction of the examples described above.
-  *
-  * We limit the return values of this method to be a constant. If it is not
-  * possible to construct an array constant that corresponds to n, this method
-  * returns null.
-  */
- static Node getArrayRepresentationForLambda(TNode n);
+  static Node getArrayRepresentationForLambdaRec(TNode n, TypeNode retType);
+
+ public:
+  /** Get function type for array type
+   *
+   * This returns the function type of terms returned by the function
+   * getLambdaForArrayRepresentation( t, bvl ),
+   * where t.getType()=atn.
+   *
+   * bvl should be a bound variable list whose variables correspond in-order
+   * to the index types of the (curried) Array type. For example, a bound
+   * variable list bvl whose variables have types (Int, Real) can be given as
+   * input when paired with atn = (Array Int (Array Real Bool)), or (Array Int
+   * (Array Real (Array Bool Bool))). This function returns (-> Int Real Bool)
+   * and (-> Int Real (Array Bool Bool)) respectively in these cases.
+   * On the other hand, the above bvl is not a proper input for
+   * atn = (Array Int (Array Bool Bool)) or (Array Int Int).
+   * If the types of bvl and atn do not match, we throw an assertion failure.
+   */
+  static TypeNode getFunctionTypeForArrayType(TypeNode atn, Node bvl);
+  /** Get array type for function type
+   *
+   * This returns the array type of terms returned by
+   * getArrayRepresentationForLambda( t ), where t.getType()=ftn.
+   */
+  static TypeNode getArrayTypeForFunctionType(TypeNode ftn);
+  /**
+   * Given an array constant a, returns a lambda expression that it corresponds
+   * to, with bound variable list bvl.
+   * Examples:
+   *
+   * (store (storeall (Array Int Int) 2) 0 1)
+   * becomes
+   * ((lambda x. (ite (= x 0) 1 2))
+   *
+   * (store (storeall (Array Int (Array Int Int)) (storeall (Array Int Int) 4))
+   * 0 (store (storeall (Array Int Int) 3) 1 2)) becomes (lambda xy. (ite (= x
+   * 0) (ite (= x 1) 2 3) 4))
+   *
+   * (store (store (storeall (Array Int Bool) false) 2 true) 1 true)
+   * becomes
+   * (lambda x. (ite (= x 1) true (ite (= x 2) true false)))
+   *
+   * Notice that the return body of the lambda is rewritten to ensure that the
+   * representation is canonical. Hence the last
+   * example will in fact be returned as:
+   * (lambda x. (ite (= x 1) true (= x 2)))
+   */
+  static Node getLambdaForArrayRepresentation(TNode a, TNode bvl);
+  /**
+   * Given a lambda expression n, returns an array term that corresponds to n.
+   * This does the opposite direction of the examples described above.
+   *
+   * We limit the return values of this method to be a constant. If it is not
+   * possible to construct an array constant that corresponds to n, this method
+   * returns null.
+   */
+  static Node getArrayRepresentationForLambda(TNode n);
 };/* class TheoryBuiltinRewriter */
 
 }/* CVC4::theory::builtin namespace */

--- a/src/theory/builtin/theory_builtin_rewriter.h
+++ b/src/theory/builtin/theory_builtin_rewriter.h
@@ -113,9 +113,13 @@ private:
    * Given a lambda expression n, returns an array term that corresponds to n.
    * This does the opposite direction of the examples described above.
    *
-   * We limit the return values of this method to be a constant. If it is not
-   * possible to construct an array constant that corresponds to n, this method
-   * returns null.
+   * We limit the return values of this method to be almost constant functions,
+   * that is, arrays of the form:
+   *   (store ... (store (storeall _ b) i1 e1) ... in en)
+   * where b, i1, e1, ..., in, en are constants.
+   *
+   * If it is not possible to construct an array of this form that corresponds
+   * to n, this method returns null.
    */
   static Node getArrayRepresentationForLambda(TNode n);
 };/* class TheoryBuiltinRewriter */

--- a/src/theory/builtin/theory_builtin_rewriter.h
+++ b/src/theory/builtin/theory_builtin_rewriter.h
@@ -60,7 +60,7 @@ private:
   static Node getLambdaForArrayRepresentationRec( TNode a, TNode bvl, unsigned bvlIndex, 
                                                   std::unordered_map< TNode, Node, TNodeHashFunction >& visited );
   /** recursive helper for getArrayRepresentationForLambda */
-  static Node getArrayRepresentationForLambdaRec( TNode n, bool reqConst, TypeNode retType );
+  static Node getArrayRepresentationForLambdaRec( TNode n, TypeNode retType );
 public:
  /** Get function type for array type
   *
@@ -109,11 +109,15 @@ public:
   * (lambda x. (ite (= x 1) true (= x 2)))
   */
  static Node getLambdaForArrayRepresentation(TNode a, TNode bvl);
- /** given a lambda expression n, returns an array term. reqConst is true if we
-  * require the return value to be a constant.
-   * This does the opposite direction of the examples described above.
-   */
- static Node getArrayRepresentationForLambda(TNode n, bool reqConst = false);
+ /** 
+  * Given a lambda expression n, returns an array term that corresponds to n.
+  * This does the opposite direction of the examples described above.
+  *
+  * We limit the return values of this method to be a constant. If it is not
+  * possible to construct an array constant that corresponds to n, this method
+  * returns null.
+  */
+ static Node getArrayRepresentationForLambda(TNode n);
 };/* class TheoryBuiltinRewriter */
 
 }/* CVC4::theory::builtin namespace */

--- a/src/theory/builtin/theory_builtin_type_rules.h
+++ b/src/theory/builtin/theory_builtin_type_rules.h
@@ -170,7 +170,7 @@ class LambdaTypeRule {
   {
     Assert(n.getKind() == kind::LAMBDA);
     //get array representation of this function, if possible
-    Node na = TheoryBuiltinRewriter::getArrayRepresentationForLambda( n );
+    Node na = TheoryBuiltinRewriter::getArrayRepresentationForLambda(n);
     if( !na.isNull() ){
       Assert( na.getType().isArray() );
       Trace("lambda-const") << "Array representation for " << n << " is " << na << " " << na.getType() << std::endl;

--- a/src/theory/builtin/theory_builtin_type_rules.h
+++ b/src/theory/builtin/theory_builtin_type_rules.h
@@ -170,7 +170,7 @@ class LambdaTypeRule {
   {
     Assert(n.getKind() == kind::LAMBDA);
     //get array representation of this function, if possible
-    Node na = TheoryBuiltinRewriter::getArrayRepresentationForLambda( n, true );
+    Node na = TheoryBuiltinRewriter::getArrayRepresentationForLambda( n );
     if( !na.isNull() ){
       Assert( na.getType().isArray() );
       Trace("lambda-const") << "Array representation for " << n << " is " << na << " " << na.getType() << std::endl;

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -1547,6 +1547,7 @@ REG1_TESTS = \
 	regress1/sygus/strings-trivial-two-type.sy \
 	regress1/sygus/strings-trivial.sy \
 	regress1/sygus/sygus-dt.sy \
+	regress1/sygus/sygus-lambda-fv.sy \
 	regress1/sygus/sygus-uf-ex.sy \
 	regress1/sygus/t8.sy \
 	regress1/sygus/tl-type-0.sy \

--- a/test/regress/regress1/sygus/sygus-lambda-fv.sy
+++ b/test/regress/regress1/sygus/sygus-lambda-fv.sy
@@ -1,0 +1,21 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+(set-logic ALL)
+
+(synth-fun SC ((y (BitVec 32)) (w (BitVec 32)) ) (BitVec 32)
+  (
+   (Start (BitVec 32) (
+     y
+     w
+     #x00000000
+     (bvadd Start Start)
+     (ite StartBool Start Start)
+   ))
+   (StartBool Bool ((= Start #x10000000) (= Start #x00000000)))
+))
+
+(constraint (= (SC #x00000000 #x00001000) #x00001000))
+(constraint (= (SC #x00001000 #x00001000) #x00001000))
+(constraint (= (SC #x01001000 #x00001000) #x01001000))
+
+(check-synth)


### PR DESCRIPTION
The rewriter for lambda is currently too aggressive, there are cases like:

lambda xy. x = y

that are converted into an array representation that when indexing based on x gives  (store y true false), which is subsequently converted to:

lambda fv_1 fv_2. fv_1 = y

where fv_1 and fv_2 are canonical free variables. Here, y is used as index but was not substituted hence is incorrectly made free. 

To make things simpler, this PR disables any rewriting for lambda unless the array representation of the lambda is a constant, which hardcodes/simplifies a previous argument (reqConst=true). This fixes a sygus issue I ran into yesterday (regression added in this PR).

Some parts of the code were formatted as a result.