### PR TITLE
Make Python a required CVC4 dependency.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1142,19 +1142,10 @@ AM_CONDITIONAL([HAVE_CXXTESTGEN], [test -n "$CXXTESTGEN"])
 
 AC_ARG_VAR(PERL, [PERL interpreter (used when testing)])
 
-AC_ARG_VAR(PYTHON, [PYTHON interpreter (used for building legacy Java library interface)])
-
-if test -z "$PYTHON"; then
-  AC_CHECK_PROGS(PYTHON, python, python, [])
-else
-  AC_CHECK_PROG(PYTHON, "$PYTHON", "$PYTHON", [])
-fi
-
-if test -z "$PYTHON"; then
-  AC_MSG_WARN([python not found, cannot build libcvc4compat_java (the legacy Java interface).])
-  CXXTESTGEN=
-  CXXTEST=
-fi
+# Python is now a required dependency for generating options code
+AM_PATH_PYTHON([2.7],, [
+  AC_MSG_ERROR([Python not found.])
+])
 
 # Checks for libraries.
 

--- a/src/options/Makefile.am
+++ b/src/options/Makefile.am
@@ -149,7 +149,7 @@ $(CPP_TEMPLATE_FILES):;
 $(OPTIONS_GEN_CPP) $(OPTIONS_GEN_H) options_holder.h $(DOCUMENTATION_FILES): options.cpp
 
 options.cpp: mkoptions.py $(CPP_TEMPLATE_FILES) $(OPTIONS_CONFIG_FILES) $(DOCUMENTATION_TEMPLATE_FILES)
-	@srcdir@/mkoptions.py @abs_srcdir@ ../../doc . $(addprefix @abs_srcdir@/, $(OPTIONS_CONFIG_FILES))
+	$(PYTHON) @srcdir@/mkoptions.py @abs_srcdir@ ../../doc . $(addprefix @abs_srcdir@/, $(OPTIONS_CONFIG_FILES))
 
 # This rule is ugly.  It's needed to ensure that automake's dependence
 # includes are available during distclean, even though they come from


### PR DESCRIPTION
Python is now a required dependency for CVC4 (generating the options code). 

This fixes the broken competition and windows nightly builds.