### PR TITLE
Improvements and tests for the API around separation logic

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5280,13 +5280,13 @@ std::pair<Expr, Expr> SmtEngine::getSepHeapAndNilExpr(void)
     return std::make_pair(heap, nil);
   }
   InternalError(
-      "SmtEngine::getHeapExpr(): failed to obtain heap/nil expressions from "
+      "SmtEngine::getSepHeapExpr(): failed to obtain heap/nil expressions from "
       "theory model.");
 }
 
-Expr SmtEngine::getHeapExpr() { return getSepHeapAndNilExpr().first; }
+Expr SmtEngine::getSepHeapExpr() { return getSepHeapAndNilExpr().first; }
 
-Expr SmtEngine::getNilExpr() { return getSepHeapAndNilExpr().second; }
+Expr SmtEngine::getSepNilExpr() { return getSepHeapAndNilExpr().second; }
 
 void SmtEngine::checkUnsatCore() {
   Assert(options::unsatCores(), "cannot check unsat core if unsat cores are turned off");

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5273,8 +5273,8 @@ std::pair<Expr, Expr> SmtEngine::getSepLogExprs(void)
     return std::make_pair(heap, nil);
   }
   InternalError(
-      "SmtEngine::getHeapExpr(): failed to obtain heap expression from theory "
-      "model.");
+      "SmtEngine::getHeapExpr(): failed to obtain heap/nil expressions from "
+      "theory model.");
 }
 
 Expr SmtEngine::getHeapExpr() { return getSepLogExprs().first; }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5262,7 +5262,7 @@ Model* SmtEngine::getModel() {
   return m;
 }
 
-std::pair<Expr, Expr> SmtEngine::getSepLogExprs(void)
+std::pair<Expr, Expr> SmtEngine::getSeparationLogicHeapAndNilExprs(void)
 {
   if (!d_logic.isTheoryEnabled(THEORY_SEP))
   {
@@ -5284,9 +5284,15 @@ std::pair<Expr, Expr> SmtEngine::getSepLogExprs(void)
       "theory model.");
 }
 
-Expr SmtEngine::getHeapExpr() { return getSepLogExprs().first; }
+Expr SmtEngine::getHeapExpr()
+{
+  return getSeparationLogicHeapAndNilExprs().first;
+}
 
-Expr SmtEngine::getNilExpr() { return getSepLogExprs().second; }
+Expr SmtEngine::getNilExpr()
+{
+  return getSeparationLogicHeapAndNilExprs().second;
+}
 
 void SmtEngine::checkUnsatCore() {
   Assert(options::unsatCores(), "cannot check unsat core if unsat cores are turned off");

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5264,6 +5264,13 @@ Model* SmtEngine::getModel() {
 
 std::pair<Expr, Expr> SmtEngine::getSepLogExprs(void)
 {
+  if (!d_logic.isTheoryEnabled(THEORY_SEP))
+  {
+    const char* msg =
+        "Cannot obtain separation logic expressions if not using the "
+        "separation logic theory.";
+    throw RecoverableModalException(msg);
+  }
   NodeManagerScope nms(d_nodeManager);
   Expr heap;
   Expr nil;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5262,35 +5262,24 @@ Model* SmtEngine::getModel() {
   return m;
 }
 
-Expr SmtEngine::getHeapExpr()
+std::pair<Expr, Expr> SmtEngine::getSepLogExprs(void)
 {
   NodeManagerScope nms(d_nodeManager);
   Expr heap;
-  Expr nil;  // we don't actually use this
+  Expr nil;
   Model* m = getModel();
   if (m->getHeapModel(heap, nil))
   {
-    return heap;
+    return std::make_pair(heap, nil);
   }
   InternalError(
       "SmtEngine::getHeapExpr(): failed to obtain heap expression from theory "
       "model.");
 }
 
-Expr SmtEngine::getNilExpr()
-{
-  NodeManagerScope nms(d_nodeManager);
-  Expr heap;  // we don't actually use this
-  Expr nil;
-  Model* m = getModel();
-  if (m->getHeapModel(heap, nil))
-  {
-    return nil;
-  }
-  InternalError(
-      "SmtEngine::getNilExpr(): failed to obtain nil expression from theory "
-      "model.");
-}
+Expr SmtEngine::getHeapExpr() { return getSepLogExprs().first; }
+
+Expr SmtEngine::getNilExpr() { return getSepLogExprs().second; }
 
 void SmtEngine::checkUnsatCore() {
   Assert(options::unsatCores(), "cannot check unsat core if unsat cores are turned off");

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5262,7 +5262,7 @@ Model* SmtEngine::getModel() {
   return m;
 }
 
-std::pair<Expr, Expr> SmtEngine::getSeparationLogicHeapAndNilExprs(void)
+std::pair<Expr, Expr> SmtEngine::getSepHeapAndNilExpr(void)
 {
   if (!d_logic.isTheoryEnabled(THEORY_SEP))
   {
@@ -5284,15 +5284,9 @@ std::pair<Expr, Expr> SmtEngine::getSeparationLogicHeapAndNilExprs(void)
       "theory model.");
 }
 
-Expr SmtEngine::getHeapExpr()
-{
-  return getSeparationLogicHeapAndNilExprs().first;
-}
+Expr SmtEngine::getHeapExpr() { return getSepHeapAndNilExpr().first; }
 
-Expr SmtEngine::getNilExpr()
-{
-  return getSeparationLogicHeapAndNilExprs().second;
-}
+Expr SmtEngine::getNilExpr() { return getSepHeapAndNilExpr().second; }
 
 void SmtEngine::checkUnsatCore() {
   Assert(options::unsatCores(), "cannot check unsat core if unsat cores are turned off");

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5280,8 +5280,8 @@ std::pair<Expr, Expr> SmtEngine::getSepHeapAndNilExpr(void)
     return std::make_pair(heap, nil);
   }
   InternalError(
-      "SmtEngine::getSepHeapExpr(): failed to obtain heap/nil expressions from "
-      "theory model.");
+      "SmtEngine::getSepHeapAndNilExpr(): failed to obtain heap/nil "
+      "expressions from theory model.");
 }
 
 Expr SmtEngine::getSepHeapExpr() { return getSepHeapAndNilExpr().first; }

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -430,9 +430,11 @@ class CVC4_PUBLIC SmtEngine {
                               Expr func);
 
   /**
-   * Helper method to obtain both the heap and nil from the solver
+   * Helper method to obtain both the heap and nil from the solver. Returns a
+   * std::pair where the first element is the heap expression and the second
+   * element is the nil expression.
    */
-  std::pair<Expr, Expr> getSepLogExprs(void);
+  std::pair<Expr, Expr> getSeparationLogicHeapAndNilExprs();
 
  public:
 
@@ -494,12 +496,12 @@ class CVC4_PUBLIC SmtEngine {
   /**
    * When using separation logic, obtain the expression for the heap.
    */
-  Expr getHeapExpr(void);
+  Expr getHeapExpr();
 
   /**
    * When using separation logic, obtain the expression for nil.
    */
-  Expr getNilExpr(void);
+  Expr getNilExpr();
 
   /**
    * Get an aspect of the current SMT execution environment.

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -496,12 +496,12 @@ class CVC4_PUBLIC SmtEngine {
   /**
    * When using separation logic, obtain the expression for the heap.
    */
-  Expr getHeapExpr();
+  Expr getSepHeapExpr();
 
   /**
    * When using separation logic, obtain the expression for nil.
    */
-  Expr getNilExpr();
+  Expr getSepNilExpr();
 
   /**
    * Get an aspect of the current SMT execution environment.

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -429,6 +429,11 @@ class CVC4_PUBLIC SmtEngine {
                               const std::vector<Expr>& formals,
                               Expr func);
 
+  /**
+   * Helper method to obtain both the heap and nil from the solver
+   */
+  std::pair<Expr, Expr> getSepLogExprs(void);
+
  public:
 
   /**
@@ -489,12 +494,12 @@ class CVC4_PUBLIC SmtEngine {
   /**
    * When using separation logic, obtain the expression for the heap.
    */
-  Expr getHeapExpr();
+  Expr getHeapExpr(void);
 
   /**
    * When using separation logic, obtain the expression for nil.
    */
-  Expr getNilExpr();
+  Expr getNilExpr(void);
 
   /**
    * Get an aspect of the current SMT execution environment.

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -434,7 +434,7 @@ class CVC4_PUBLIC SmtEngine {
    * std::pair where the first element is the heap expression and the second
    * element is the nil expression.
    */
-  std::pair<Expr, Expr> getSeparationLogicHeapAndNilExprs();
+  std::pair<Expr, Expr> getSepHeapAndNilExpr();
 
  public:
 

--- a/test/system/Makefile.am
+++ b/test/system/Makefile.am
@@ -6,7 +6,8 @@ CPLUSPLUS_TESTS = \
 	reset_assertions \
 	two_smt_engines \
 	smt2_compliance \
-	statistics
+	statistics \
+	sep_log_api
 
 if CVC4_BUILD_LIBCOMPAT
 #CPLUSPLUS_TESTS += \

--- a/test/system/sep_log_api.cpp
+++ b/test/system/sep_log_api.cpp
@@ -62,7 +62,6 @@ int validate_exception(void)
 
   /* check */
   Result r(smt.checkSat());
-  ;
 
   /* If this is UNSAT, we have an issue; so bail-out */
   if (!r.isSat())
@@ -102,7 +101,6 @@ int validate_exception(void)
   try
   {
     Expr nil_expr(smt.getNilExpr());
-    ;
   }
   catch (CVC4::RecoverableModalException &e)
   {
@@ -120,6 +118,7 @@ int validate_exception(void)
     return -1;
   }
 
+  /* All tests pass! */
   return 0;
 }
 

--- a/test/system/sep_log_api.cpp
+++ b/test/system/sep_log_api.cpp
@@ -84,7 +84,7 @@ int validate_exception(void)
   /* test the heap expression */
   try
   {
-    Expr heap_expr(smt.getHeapExpr());
+    Expr heap_expr(smt.getSepHeapExpr());
   }
   catch (const CVC4::RecoverableModalException& e)
   {
@@ -100,7 +100,7 @@ int validate_exception(void)
   /* test the nil expression */
   try
   {
-    Expr nil_expr(smt.getNilExpr());
+    Expr nil_expr(smt.getSepNilExpr());
   }
   catch (const CVC4::RecoverableModalException& e)
   {
@@ -190,8 +190,8 @@ int validate_getters(void)
   }
 
   /* Obtain our separation logic terms from the solver */
-  Expr heap_expr(smt.getHeapExpr());
-  Expr nil_expr(smt.getNilExpr());
+  Expr heap_expr(smt.getSepHeapExpr());
+  Expr nil_expr(smt.getSepNilExpr());
 
   /* If the heap is not a separating conjunction, bail-out */
   if (heap_expr.getKind() != kind::SEP_STAR)

--- a/test/system/sep_log_api.cpp
+++ b/test/system/sep_log_api.cpp
@@ -23,6 +23,10 @@
 using namespace CVC4;
 using namespace std;
 
+/**
+ * Function to demonstrate the use of, and validate the capability, of
+ * obtaining the heap/nil expressions when using separation logic.
+ */
 int validate_getters(void)
 {
   ExprManager em;
@@ -188,8 +192,9 @@ int validate_getters(void)
   return 0;
 }
 
-int main()
+int main(void)
 {
-  int check1 = validate_getters();
-  return check1;
+  /* check the getters */
+  int check_getters = validate_getters();
+  return check_getters;
 }

--- a/test/system/sep_log_api.cpp
+++ b/test/system/sep_log_api.cpp
@@ -48,20 +48,21 @@ int validate_exception(void)
   smt.setOption("incremental", SExpr("false"));
 
   /* Our integer type */
-  Type integer = em.integerType();
+  Type integer(em.integerType());
 
   /* Our SMT constants */
-  Expr x = em.mkVar("x", integer);
-  Expr y = em.mkVar("y", integer);
+  Expr x(em.mkVar("x", integer));
+  Expr y(em.mkVar("y", integer));
 
   /* y > x */
-  Expr y_gt_x = em.mkExpr(kind::GT, y, x);
+  Expr y_gt_x(em.mkExpr(kind::GT, y, x));
 
   /* assert it */
   smt.assertFormula(y_gt_x);
 
   /* check */
-  Result r = smt.checkSat();
+  Result r(smt.checkSat());
+  ;
 
   /* If this is UNSAT, we have an issue; so bail-out */
   if (!r.isSat())
@@ -73,8 +74,8 @@ int validate_exception(void)
    * We now try to obtain our separation logic expressions from the solver --
    * we want to validate that we get our expected exceptions.
    */
-  int caught_on_heap = false;
-  int caught_on_nil = false;
+  bool caught_on_heap(false);
+  bool caught_on_nil(false);
 
   /* The exception message we expect to obtain */
   std::string expected(
@@ -84,7 +85,7 @@ int validate_exception(void)
   /* test the heap expression */
   try
   {
-    Expr heap_expr = smt.getHeapExpr();
+    Expr heap_expr(smt.getHeapExpr());
   }
   catch (CVC4::RecoverableModalException &e)
   {
@@ -100,7 +101,8 @@ int validate_exception(void)
   /* test the nil expression */
   try
   {
-    Expr nil_expr = smt.getNilExpr();
+    Expr nil_expr(smt.getNilExpr());
+    ;
   }
   catch (CVC4::RecoverableModalException &e)
   {
@@ -137,38 +139,38 @@ int validate_getters(void)
   smt.setOption("incremental", SExpr("false"));
 
   /* Our integer type */
-  Type integer = em.integerType();
+  Type integer(em.integerType());
 
   /* A "random" constant */
-  Rational val_for_random_constant = Rational(0xDEADBEEF);
-  Expr random_constant = em.mkConst(val_for_random_constant);
+  Rational val_for_random_constant(Rational(0xDEADBEEF));
+  Expr random_constant(em.mkConst(val_for_random_constant));
 
   /* Another random constant */
-  Rational val_for_expr_nil_val = Rational(0xFBADBEEF);
-  Expr expr_nil_val = em.mkConst(val_for_expr_nil_val);
+  Rational val_for_expr_nil_val(Rational(0xFBADBEEF));
+  Expr expr_nil_val(em.mkConst(val_for_expr_nil_val));
 
   /* Our nil term */
-  Expr nil = em.mkNullaryOperator(integer, kind::SEP_NIL);
+  Expr nil(em.mkNullaryOperator(integer, kind::SEP_NIL));
 
   /* Our SMT constants */
-  Expr x = em.mkVar("x", integer);
-  Expr y = em.mkVar("y", integer);
-  Expr p1 = em.mkVar("p1", integer);
-  Expr p2 = em.mkVar("p2", integer);
+  Expr x(em.mkVar("x", integer));
+  Expr y(em.mkVar("y", integer));
+  Expr p1(em.mkVar("p1", integer));
+  Expr p2(em.mkVar("p2", integer));
 
   /* Constraints on x and y */
-  Expr x_equal_const = em.mkExpr(kind::EQUAL, x, random_constant);
-  Expr y_gt_x = em.mkExpr(kind::GT, y, x);
+  Expr x_equal_const(em.mkExpr(kind::EQUAL, x, random_constant));
+  Expr y_gt_x(em.mkExpr(kind::GT, y, x));
 
   /* Points-to expressions */
-  Expr p1_to_x = em.mkExpr(kind::SEP_PTO, p1, x);
-  Expr p2_to_y = em.mkExpr(kind::SEP_PTO, p2, y);
+  Expr p1_to_x(em.mkExpr(kind::SEP_PTO, p1, x));
+  Expr p2_to_y(em.mkExpr(kind::SEP_PTO, p2, y));
 
   /* Heap -- the points-to have to be "starred"! */
-  Expr heap = em.mkExpr(kind::SEP_STAR, p1_to_x, p2_to_y);
+  Expr heap(em.mkExpr(kind::SEP_STAR, p1_to_x, p2_to_y));
 
   /* Constain "nil" to be something random */
-  Expr fix_nil = em.mkExpr(kind::EQUAL, nil, expr_nil_val);
+  Expr fix_nil(em.mkExpr(kind::EQUAL, nil, expr_nil_val));
 
   /* Add it all to the solver! */
   smt.assertFormula(x_equal_const);
@@ -180,7 +182,7 @@ int validate_getters(void)
    * Incremental is disabled due to using separation logic, so don't query
    * twice!
    */
-  Result r = smt.checkSat();
+  Result r(smt.checkSat());
 
   /* If this is UNSAT, we have an issue; so bail-out */
   if (!r.isSat())
@@ -189,8 +191,8 @@ int validate_getters(void)
   }
 
   /* Obtain our separation logic terms from the solver */
-  Expr heap_expr = smt.getHeapExpr();
-  Expr nil_expr = smt.getNilExpr();
+  Expr heap_expr(smt.getHeapExpr());
+  Expr nil_expr(smt.getNilExpr());
 
   /* If the heap is not a separating conjunction, bail-out */
   if (heap_expr.getKind() != kind::SEP_STAR)
@@ -205,12 +207,12 @@ int validate_getters(void)
   }
 
   /* Obtain the values for our "pointers" */
-  Rational val_for_p1 = smt.getValue(p1).getConst<CVC4::Rational>();
-  Rational val_for_p2 = smt.getValue(p2).getConst<CVC4::Rational>();
+  Rational val_for_p1(smt.getValue(p1).getConst<CVC4::Rational>());
+  Rational val_for_p2(smt.getValue(p2).getConst<CVC4::Rational>());
 
   /* We need to make sure we find both pointers in the heap */
-  bool checked_p1 = false;
-  bool checked_p2 = false;
+  bool checked_p1(false);
+  bool checked_p2(false);
 
   /* Walk all the children */
   for (Expr child : heap_expr.getChildren())
@@ -222,10 +224,10 @@ int validate_getters(void)
     }
 
     /* Find both sides of the PTO operator */
-    Rational addr =
-        smt.getValue(child.getChildren().at(0)).getConst<CVC4::Rational>();
-    Rational value =
-        smt.getValue(child.getChildren().at(1)).getConst<CVC4::Rational>();
+    Rational addr(
+        smt.getValue(child.getChildren().at(0)).getConst<CVC4::Rational>());
+    Rational value(
+        smt.getValue(child.getChildren().at(1)).getConst<CVC4::Rational>());
 
     /* If the current address is the value for p1 */
     if (addr == val_for_p1)
@@ -293,7 +295,7 @@ int validate_getters(void)
 int main(void)
 {
   /* check that we get an exception when we should */
-  int check_exception = validate_exception();
+  int check_exception(validate_exception());
 
   if (check_exception)
   {
@@ -301,7 +303,7 @@ int main(void)
   }
 
   /* check the getters */
-  int check_getters = validate_getters();
+  int check_getters(validate_getters());
 
   if (check_getters)
   {

--- a/test/system/sep_log_api.cpp
+++ b/test/system/sep_log_api.cpp
@@ -86,7 +86,7 @@ int validate_exception(void)
   {
     Expr heap_expr(smt.getHeapExpr());
   }
-  catch (CVC4::RecoverableModalException &e)
+  catch (const CVC4::RecoverableModalException& e)
   {
     caught_on_heap = true;
 
@@ -102,7 +102,7 @@ int validate_exception(void)
   {
     Expr nil_expr(smt.getNilExpr());
   }
-  catch (CVC4::RecoverableModalException &e)
+  catch (const CVC4::RecoverableModalException& e)
   {
     caught_on_nil = true;
 

--- a/test/system/sep_log_api.cpp
+++ b/test/system/sep_log_api.cpp
@@ -1,0 +1,195 @@
+/******************************************************************************/
+/*! \file sep_log_api.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew V. Jones
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS or file
+ ** THANKS (in the top-level source directory) and their institutional
+ ** affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief A simple example for using the separation logic API with
+ ** Importantly, it checks that we can obtain the heap from the solver.
+ *****************************************************************************/
+
+#include <iostream>
+#include <sstream>
+
+#include "expr/expr.h"
+#include "smt/smt_engine.h"
+
+using namespace CVC4;
+using namespace std;
+
+int validate_getters(void)
+{
+  ExprManager em;
+  Options opts;
+  SmtEngine smt(&em);
+
+  /* Setup some options for CVC4 */
+  smt.setLogic("QF_ALL_SUPPORTED");
+  smt.setOption("produce-models", SExpr("true"));
+  smt.setOption("incremental", SExpr("false"));
+
+  /* Our integer type */
+  Type integer = em.integerType();
+
+  /* A "random" constant */
+  Rational val_for_random_constant = Rational(0xDEADBEEF);
+  Expr random_constant = em.mkConst(val_for_random_constant);
+
+  /* Another random constant */
+  Rational val_for_expr_nil_val = Rational(0xFBADBEEF);
+  Expr expr_nil_val = em.mkConst(val_for_expr_nil_val);
+
+  /* Our nil term */
+  Expr nil = em.mkNullaryOperator(integer, kind::SEP_NIL);
+
+  /* Our SMT constants */
+  Expr x = em.mkVar("x", integer);
+  Expr y = em.mkVar("y", integer);
+  Expr p1 = em.mkVar("p1", integer);
+  Expr p2 = em.mkVar("p2", integer);
+
+  /* Constraints on x and y */
+  Expr x_equal_const = em.mkExpr(kind::EQUAL, x, random_constant);
+  Expr y_gt_x = em.mkExpr(kind::GT, y, x);
+
+  /* Points-to expressions */
+  Expr p1_to_x = em.mkExpr(kind::SEP_PTO, p1, x);
+  Expr p2_to_y = em.mkExpr(kind::SEP_PTO, p2, y);
+
+  /* Heap -- the points-to have to be "starred"! */
+  Expr heap = em.mkExpr(kind::SEP_STAR, p1_to_x, p2_to_y);
+
+  /* Constain "nil" to be something random */
+  Expr fix_nil = em.mkExpr(kind::EQUAL, nil, expr_nil_val);
+
+  /* Add it all to the solver! */
+  smt.assertFormula(x_equal_const);
+  smt.assertFormula(y_gt_x);
+  smt.assertFormula(heap);
+  smt.assertFormula(fix_nil);
+
+  /*
+   * Incremental is disabled due to using separation logic, so don't query
+   * twice!
+   */
+  Result r = smt.checkSat();
+
+  /* If this is UNSAT, we have an issue; so bail-out */
+  if (!r.isSat())
+  {
+    return -1;
+  }
+
+  /* Obtain our separation logic terms from the solver */
+  Expr heap_expr = smt.getHeapExpr();
+  Expr nil_expr = smt.getNilExpr();
+
+  /* If the heap is not a separating conjunction, bail-out */
+  if (heap_expr.getKind() != kind::SEP_STAR)
+  {
+    return -1;
+  }
+
+  /* If nil is not a direct equality, bail-out */
+  if (nil_expr.getKind() != kind::EQUAL)
+  {
+    return -1;
+  }
+
+  /* Obtain the values for our "pointers" */
+  Rational val_for_p1 = smt.getValue(p1).getConst<CVC4::Rational>();
+  Rational val_for_p2 = smt.getValue(p2).getConst<CVC4::Rational>();
+
+  /* We need to make sure we find both pointers in the heap */
+  bool checked_p1 = false;
+  bool checked_p2 = false;
+
+  /* Walk all the children */
+  for (Expr child : heap_expr.getChildren())
+  {
+    /* If we don't have a PTO operator, bail-out */
+    if (child.getKind() != kind::SEP_PTO)
+    {
+      return -1;
+    }
+
+    /* Find both sides of the PTO operator */
+    Rational addr =
+        smt.getValue(child.getChildren().at(0)).getConst<CVC4::Rational>();
+    Rational value =
+        smt.getValue(child.getChildren().at(1)).getConst<CVC4::Rational>();
+
+    /* If the current address is the value for p1 */
+    if (addr == val_for_p1)
+    {
+      checked_p1 = true;
+
+      /* If it doesn't match the random constant, we have a problem */
+      if (value != val_for_random_constant)
+      {
+        return -1;
+      }
+      continue;
+    }
+
+    /* If the current address is the value for p2 */
+    if (addr == val_for_p2)
+    {
+      checked_p2 = true;
+
+      /*
+       * Our earlier constraint was that what p2 points to must be *greater*
+       * than the random constant -- if we get a value that is LTE, then
+       * something has gone wrong!
+       */
+      if (value <= val_for_random_constant)
+      {
+        return -1;
+      }
+      continue;
+    }
+
+    /*
+     * We should only have two addresses in heap, so if we haven't hit the
+     * "continue" for p1 or p2, then bail-out
+     */
+    return -1;
+  }
+
+  /*
+   * If we complete the loop and we haven't validated both p1 and p2, then we
+   * have a problem
+   */
+  if (!checked_p1 || !checked_p2)
+  {
+    return -1;
+  }
+
+  /* We now get our value for what nil is */
+  Rational value_for_nil =
+      smt.getValue(nil_expr.getChildren().at(1)).getConst<CVC4::Rational>();
+
+  /*
+   * The value for nil from the solver should be the value we originally tied
+   * nil to
+   */
+  if (value_for_nil != val_for_expr_nil_val)
+  {
+    return -1;
+  }
+
+  /* All tests pass! */
+  return 0;
+}
+
+int main()
+{
+  int check1 = validate_getters();
+  return check1;
+}


### PR DESCRIPTION
As part of #2194, @4tXJ7f asked if it was possible to make some tweaks around the separation logic "API". This PR actions those changes.

Four main modifications:

- Introduces a system that validating that, when not using `THEORY_SEP`, that it is not possible to obtain the separation logic heap/nil (`validate_exception()`)
- Introduces a system test demonstrating how to use the separation logic theory, and then how to use the "getters" to obtain and interrogate the heap/nil expressions (`validate_getters()`)
- Refactors the original getters to avoid duplicate code
- Add a check as part of the getters to ensure that `THEORY_SEP` is in use