### PR TITLE
Remove hasAssertions() method from eager BV solver.

### DIFF
--- a/src/theory/bv/bv_eager_solver.cpp
+++ b/src/theory/bv/bv_eager_solver.cpp
@@ -122,17 +122,6 @@ bool EagerBitblastSolver::checkSat() {
   return d_bitblaster->solve();
 }
 
-bool EagerBitblastSolver::hasAssertions(const std::vector<TNode>& formulas) {
-  Assert(isInitialized());
-  if (formulas.size() != d_assertionSet.size()) return false;
-  for (unsigned i = 0; i < formulas.size(); ++i) {
-    Assert(formulas[i].getKind() == kind::BITVECTOR_EAGER_ATOM);
-    TNode formula = formulas[i][0];
-    if (d_assertionSet.find(formula) == d_assertionSet.end()) return false;
-  }
-  return true;
-}
-
 bool EagerBitblastSolver::collectModelInfo(TheoryModel* m, bool fullModel)
 {
   AlwaysAssert(!d_useAig && d_bitblaster);

--- a/src/theory/bv/bv_eager_solver.h
+++ b/src/theory/bv/bv_eager_solver.h
@@ -42,8 +42,6 @@ class EagerBitblastSolver {
   ~EagerBitblastSolver();
   bool checkSat();
   void assertFormula(TNode formula);
-  // purely for debugging purposes
-  bool hasAssertions(const std::vector<TNode>& formulas);
 
   void turnOffAig();
   bool isInitialized();

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -346,7 +346,6 @@ void TheoryBV::check(Effort e)
       assertions.push_back(fact);
       d_eagerSolver->assertFormula(fact[0]);
     }
-    Assert (d_eagerSolver->hasAssertions(assertions));
 
     bool ok = d_eagerSolver->checkSat();
     if (!ok) {


### PR DESCRIPTION
This method is now obsolete with incremental support (number of assertions usually
differ).