### PR TITLE
Plug solver API object into parser.

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2777,5 +2777,23 @@ void Solver::setOption(const std::string& option,
   d_smtEngine->setOption(option, value);
 }
 
+/**
+ * !!! This is only temporarily available until the parser is fully migrated to
+ * the new API. !!!
+ */
+ExprManager* Solver::getExprManager(void) const
+{
+  return d_exprMgr.get();
+}
+
+/**
+ * !!! This is only temporarily available until the parser is fully migrated to
+ * the new API. !!!
+ */
+SmtEngine* Solver::getSmtEngine(void) const
+{
+  return d_smtEngine.get();
+}
+
 }  // namespace api
 }  // namespace CVC4

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2781,19 +2781,13 @@ void Solver::setOption(const std::string& option,
  * !!! This is only temporarily available until the parser is fully migrated to
  * the new API. !!!
  */
-ExprManager* Solver::getExprManager(void) const
-{
-  return d_exprMgr.get();
-}
+ExprManager* Solver::getExprManager(void) const { return d_exprMgr.get(); }
 
 /**
  * !!! This is only temporarily available until the parser is fully migrated to
  * the new API. !!!
  */
-SmtEngine* Solver::getSmtEngine(void) const
-{
-  return d_smtEngine.get();
-}
+SmtEngine* Solver::getSmtEngine(void) const { return d_smtEngine.get(); }
 
 }  // namespace api
 }  // namespace CVC4

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -2349,6 +2349,18 @@ class CVC4_PUBLIC Solver
    */
   void setOption(const std::string& option, const std::string& value) const;
 
+  /**
+   * !!! This is only temporarily available until the parser is fully migrated
+   * to the new API. !!!
+   */
+  ExprManager* getExprManager(void) const;
+
+  /**
+   * !!! This is only temporarily available until the parser is fully migrated
+   * to the new API. !!!
+   */
+  SmtEngine* getSmtEngine(void) const;
+
  private:
   /* Helper to convert a vector of internal types to sorts. */
   std::vector<Type> sortVectorToTypes(const std::vector<Sort>& vector) const;

--- a/src/compat/cvc3_compat.cpp
+++ b/src/compat/cvc3_compat.cpp
@@ -22,6 +22,7 @@
 #include <iterator>
 #include <sstream>
 
+#include "api/cvc4cpp.h"
 #include "base/exception.h"
 #include "base/output.h"
 #include "expr/expr_iomanip.h"
@@ -944,42 +945,55 @@ void ValidityChecker::setUpOptions(CVC4::Options& options, const CLFlags& clflag
   }
 }
 
-ValidityChecker::ValidityChecker() :
-  d_clflags(new CLFlags()),
-  d_options(),
-  d_em(NULL),
-  d_emmc(),
-  d_reverseEmmc(),
-  d_smt(NULL),
-  d_parserContext(NULL),
-  d_exprTypeMapRemove(),
-  d_stackLevel(0),
-  d_constructors(),
-  d_selectors() {
-  d_em = reinterpret_cast<ExprManager*>(new CVC4::ExprManager(d_options));
+ValidityChecker::ValidityChecker()
+    : d_clflags(new CLFlags()),
+      d_options(),
+      d_solver(NULL),
+      d_em(NULL),
+      d_emmc(),
+      d_reverseEmmc(),
+      d_smt(NULL),
+      d_parserContext(NULL),
+      d_exprTypeMapRemove(),
+      d_stackLevel(0),
+      d_constructors(),
+      d_selectors()
+{
+  d_solver = new CVC4::api::Solver(&d_options);
+  d_smt = d_solver->getSmtEngine();
+  d_em = reinterpret_cast<ExprManager*>(d_solver->getExprManager());
   s_validityCheckers[d_em] = this;
-  d_smt = new CVC4::SmtEngine(d_em);
   setUpOptions(d_options, *d_clflags);
-  d_parserContext = CVC4::parser::ParserBuilder(d_em, "<internal>").withInputLanguage(CVC4::language::input::LANG_CVC4).withStringInput("").build();
+  d_parserContext = CVC4::parser::ParserBuilder(d_solver, "<internal>")
+                        .withInputLanguage(CVC4::language::input::LANG_CVC4)
+                        .withStringInput("")
+                        .build();
 }
 
-ValidityChecker::ValidityChecker(const CLFlags& clflags) :
-  d_clflags(new CLFlags(clflags)),
-  d_options(),
-  d_em(NULL),
-  d_emmc(),
-  d_reverseEmmc(),
-  d_smt(NULL),
-  d_parserContext(NULL),
-  d_exprTypeMapRemove(),
-  d_stackLevel(0),
-  d_constructors(),
-  d_selectors() {
-  d_em = reinterpret_cast<ExprManager*>(new CVC4::ExprManager(d_options));
+ValidityChecker::ValidityChecker(const CLFlags& clflags)
+    : d_clflags(new CLFlags(clflags)),
+      d_options(),
+      d_solver(NULL),
+      d_em(NULL),
+      d_emmc(),
+      d_reverseEmmc(),
+      d_smt(NULL),
+      d_parserContext(NULL),
+      d_exprTypeMapRemove(),
+      d_stackLevel(0),
+      d_constructors(),
+      d_selectors()
+{
+  d_solver = new CVC4::api::Solver(&d_options);
+  d_smt = d_solver->getSmtEngine();
+  d_em = reinterpret_cast<ExprManager*>(d_solver->getExprManager());
   s_validityCheckers[d_em] = this;
   d_smt = new CVC4::SmtEngine(d_em);
   setUpOptions(d_options, *d_clflags);
-  d_parserContext = CVC4::parser::ParserBuilder(d_em, "<internal>").withInputLanguage(CVC4::language::input::LANG_CVC4).withStringInput("").build();
+  d_parserContext = CVC4::parser::ParserBuilder(d_solver, "<internal>")
+                        .withInputLanguage(CVC4::language::input::LANG_CVC4)
+                        .withStringInput("")
+                        .build();
 }
 
 ValidityChecker::~ValidityChecker() {
@@ -989,14 +1003,13 @@ ValidityChecker::~ValidityChecker() {
   }
   d_exprTypeMapRemove.clear();
   delete d_parserContext;
-  delete d_smt;
   d_emmc.clear();
   for(set<ValidityChecker*>::iterator i = d_reverseEmmc.begin(); i != d_reverseEmmc.end(); ++i) {
     (*i)->d_emmc.erase(d_em);
   }
   d_reverseEmmc.clear();
   s_validityCheckers.erase(d_em);
-  delete d_em;
+  delete d_solver;
   delete d_clflags;
 }
 
@@ -1609,7 +1622,7 @@ Expr ValidityChecker::exprFromString(const std::string& s, InputLanguage lang) {
     throw Exception("Unsupported language in exprFromString: " + ss.str());
   }
 
-  CVC4::parser::Parser* p = CVC4::parser::ParserBuilder(d_em, "<internal>").withStringInput(s).withInputLanguage(lang).build();
+  CVC4::parser::Parser* p = CVC4::parser::ParserBuilder(d_solver, "<internal>").withStringInput(s).withInputLanguage(lang).build();
   p->useDeclarationsFrom(d_parserContext);
   Expr e = p->nextExpression();
   if( e.isNull() ) {
@@ -2570,7 +2583,7 @@ void ValidityChecker::reset() {
   // reset everything, forget everything
   d_smt->reset();
   delete d_parserContext;
-  d_parserContext = CVC4::parser::ParserBuilder(d_em, "<internal>").withInputLanguage(CVC4::language::input::LANG_CVC4).withStringInput("").build();
+  d_parserContext = CVC4::parser::ParserBuilder(d_solver, "<internal>").withInputLanguage(CVC4::language::input::LANG_CVC4).withStringInput("").build();
   s_typeToExpr.clear();
   s_exprToType.clear();
 }
@@ -2600,7 +2613,7 @@ void ValidityChecker::loadFile(const std::string& fileName,
   langss << lang;
   d_smt->setOption("input-language", CVC4::SExpr(langss.str()));
   d_smt->setOption("interactive-mode", CVC4::SExpr(interactive ? true : false));
-  CVC4::parser::ParserBuilder parserBuilder(d_em, fileName, opts);
+  CVC4::parser::ParserBuilder parserBuilder(d_solver, fileName, opts);
   CVC4::parser::Parser* p = parserBuilder.build();
   p->useDeclarationsFrom(d_parserContext);
   doCommands(p, d_smt, opts);
@@ -2617,7 +2630,7 @@ void ValidityChecker::loadFile(std::istream& is,
   langss << lang;
   d_smt->setOption("input-language", CVC4::SExpr(langss.str()));
   d_smt->setOption("interactive-mode", CVC4::SExpr(interactive ? true : false));
-  CVC4::parser::ParserBuilder parserBuilder(d_em, "[stream]", opts);
+  CVC4::parser::ParserBuilder parserBuilder(d_solver, "[stream]", opts);
   CVC4::parser::Parser* p = parserBuilder.withStreamInput(is).build();
   d_parserContext = p;
   p->useDeclarationsFrom(d_parserContext);

--- a/src/compat/cvc3_compat.cpp
+++ b/src/compat/cvc3_compat.cpp
@@ -1622,7 +1622,10 @@ Expr ValidityChecker::exprFromString(const std::string& s, InputLanguage lang) {
     throw Exception("Unsupported language in exprFromString: " + ss.str());
   }
 
-  CVC4::parser::Parser* p = CVC4::parser::ParserBuilder(d_solver, "<internal>").withStringInput(s).withInputLanguage(lang).build();
+  CVC4::parser::Parser* p = CVC4::parser::ParserBuilder(d_solver, "<internal>")
+                                .withStringInput(s)
+                                .withInputLanguage(lang)
+                                .build();
   p->useDeclarationsFrom(d_parserContext);
   Expr e = p->nextExpression();
   if( e.isNull() ) {
@@ -2583,7 +2586,10 @@ void ValidityChecker::reset() {
   // reset everything, forget everything
   d_smt->reset();
   delete d_parserContext;
-  d_parserContext = CVC4::parser::ParserBuilder(d_solver, "<internal>").withInputLanguage(CVC4::language::input::LANG_CVC4).withStringInput("").build();
+  d_parserContext = CVC4::parser::ParserBuilder(d_solver, "<internal>")
+                        .withInputLanguage(CVC4::language::input::LANG_CVC4)
+                        .withStringInput("")
+                        .build();
   s_typeToExpr.clear();
   s_exprToType.clear();
 }

--- a/src/compat/cvc3_compat.h
+++ b/src/compat/cvc3_compat.h
@@ -232,6 +232,9 @@ class CVC4_PUBLIC Context;
 class CVC4_PUBLIC Proof {};
 class CVC4_PUBLIC Theorem {};
 
+namespace api {
+class CVC4_PUBLIC Solver;
+}
 using CVC4::InputLanguage;
 using CVC4::Integer;
 using CVC4::Rational;
@@ -513,6 +516,7 @@ class CVC4_PUBLIC ValidityChecker {
 
   CLFlags* d_clflags;
   CVC4::Options d_options;
+  CVC4::api::Solver* d_solver;
   CVC3::ExprManager* d_em;
   std::map<CVC4::ExprManager*, CVC4::ExprManagerMapCollection> d_emmc;
   std::set<ValidityChecker*> d_reverseEmmc;

--- a/src/compat/cvc3_compat.h
+++ b/src/compat/cvc3_compat.h
@@ -2,7 +2,7 @@
 /*! \file cvc3_compat.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Morgan Deters, Tim King, Francois Bobot
+ **   Morgan Deters, Tim King, Aina Niemetz
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -49,13 +49,13 @@ void setNoLimitCPU() {
 
 void printStatsIncremental(std::ostream& out, const std::string& prvsStatsString, const std::string& curStatsString);
 
-CommandExecutor::CommandExecutor(api::Solver* solver, Options &options) :
-  d_solver(solver),
-  d_smtEngine(d_solver->getSmtEngine()),
-  d_options(options),
-  d_stats("driver"),
-  d_result(),
-  d_replayStream(NULL)
+CommandExecutor::CommandExecutor(api::Solver* solver, Options& options)
+    : d_solver(solver),
+      d_smtEngine(d_solver->getSmtEngine()),
+      d_options(options),
+      d_stats("driver"),
+      d_result(),
+      d_replayStream(NULL)
 {}
 
 void CommandExecutor::flushStatistics(std::ostream& out) const

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -18,14 +18,15 @@
 #  include <sys/resource.h>
 #endif /* ! __WIN32__ */
 
+#include "api/cvc4cpp.h"
+#include "main/main.h"
+#include "smt/command.h"
+
 #include <cassert>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include "main/main.h"
-#include "smt/command.h"
 
 namespace CVC4 {
 namespace main {
@@ -48,14 +49,28 @@ void setNoLimitCPU() {
 
 void printStatsIncremental(std::ostream& out, const std::string& prvsStatsString, const std::string& curStatsString);
 
-CommandExecutor::CommandExecutor(ExprManager &exprMgr, Options &options) :
-  d_exprMgr(exprMgr),
-  d_smtEngine(new SmtEngine(&exprMgr)),
+CommandExecutor::CommandExecutor(api::Solver* solver, Options &options) :
+  d_solver(solver),
+  d_smtEngine(d_solver->getSmtEngine()),
   d_options(options),
   d_stats("driver"),
   d_result(),
   d_replayStream(NULL)
 {}
+
+void CommandExecutor::flushStatistics(std::ostream& out) const
+{
+  d_solver->getExprManager()->getStatistics().flushInformation(out);
+  d_smtEngine->getStatistics().flushInformation(out);
+  d_stats.flushInformation(out);
+}
+
+void CommandExecutor::safeFlushStatistics(int fd) const
+{
+  d_solver->getExprManager()->safeFlushStatistics(fd);
+  d_smtEngine->safeFlushStatistics(fd);
+  d_stats.safeFlushInformation(fd);
+}
 
 void CommandExecutor::setReplayStream(ExprStream* replayStream) {
   assert(d_replayStream == NULL);
@@ -92,11 +107,11 @@ bool CommandExecutor::doCommand(Command* cmd)
 
 void CommandExecutor::reset()
 {
-  if(d_options.getStatistics()) {
+  if (d_options.getStatistics())
+  {
     flushStatistics(*d_options.getErr());
   }
-  delete d_smtEngine;
-  d_smtEngine = new SmtEngine(&d_exprMgr);
+  d_solver->reset();
 }
 
 bool CommandExecutor::doCommandSingleton(Command* cmd)

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -25,6 +25,11 @@
 #include "util/statistics_registry.h"
 
 namespace CVC4 {
+
+namespace api {
+class Solver;
+}
+
 namespace main {
 
 class CommandExecutor {
@@ -32,7 +37,7 @@ private:
   std::string d_lastStatistics;
 
 protected:
-  ExprManager& d_exprMgr;
+  api::Solver* d_solver;
   SmtEngine* d_smtEngine;
   Options& d_options;
   StatisticsRegistry d_stats;
@@ -40,10 +45,9 @@ protected:
   ExprStream* d_replayStream;
 
 public:
-  CommandExecutor(ExprManager &exprMgr, Options &options);
+  CommandExecutor(api::Solver* solver, Options &options);
 
   virtual ~CommandExecutor() {
-    delete d_smtEngine;
     if(d_replayStream != NULL){
       delete d_replayStream;
     }
@@ -63,20 +67,16 @@ public:
     return d_stats;
   }
 
-  virtual void flushStatistics(std::ostream& out) const {
-    d_exprMgr.getStatistics().flushInformation(out);
-    d_smtEngine->getStatistics().flushInformation(out);
-    d_stats.flushInformation(out);
-  }
+  /**
+   * Flushes statistics to a file descriptor.
+   */
+  virtual void flushStatistics(std::ostream& out) const;
 
   /**
-   * Flushes statistics to a file descriptor. Safe to use in a signal handler.
+   * Flushes statistics to a file descriptor.
+   * Safe to use in a signal handler.
    */
-  void safeFlushStatistics(int fd) const {
-    d_exprMgr.safeFlushStatistics(fd);
-    d_smtEngine->safeFlushStatistics(fd);
-    d_stats.safeFlushInformation(fd);
-  }
+  void safeFlushStatistics(int fd) const;
 
   static void printStatsFilterZeros(std::ostream& out,
                                     const std::string& statsString);

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -37,20 +37,22 @@ private:
   std::string d_lastStatistics;
 
 protected:
-  api::Solver* d_solver;
-  SmtEngine* d_smtEngine;
-  Options& d_options;
-  StatisticsRegistry d_stats;
-  Result d_result;
-  ExprStream* d_replayStream;
+ api::Solver* d_solver;
+ SmtEngine* d_smtEngine;
+ Options& d_options;
+ StatisticsRegistry d_stats;
+ Result d_result;
+ ExprStream* d_replayStream;
 
 public:
-  CommandExecutor(api::Solver* solver, Options &options);
+ CommandExecutor(api::Solver* solver, Options& options);
 
-  virtual ~CommandExecutor() {
-    if(d_replayStream != NULL){
-      delete d_replayStream;
-    }
+ virtual ~CommandExecutor()
+ {
+   if (d_replayStream != NULL)
+   {
+     delete d_replayStream;
+   }
   }
 
   /**

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -2,7 +2,7 @@
 /*! \file command_executor.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Kshitij Bansal, Morgan Deters, Tim King
+ **   Kshitij Bansal, Morgan Deters, Aina Niemetz
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -27,9 +27,9 @@
 #include "cvc4autoconfig.h"
 
 #include "api/cvc4cpp.h"
-#include "base/tls.h"
 #include "base/configuration.h"
 #include "base/output.h"
+#include "base/tls.h"
 #include "expr/expr_iomanip.h"
 #include "expr/expr_manager.h"
 #include "main/command_executor.h"

--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -37,6 +37,7 @@
 #  endif /* HAVE_EXT_STDIO_FILEBUF_H */
 #endif /* HAVE_LIBREADLINE */
 
+#include "api/cvc4cpp.h"
 #include "base/tls.h"
 #include "base/output.h"
 #include "options/language.h"
@@ -88,14 +89,14 @@ static set<string> s_declarations;
 
 #endif /* HAVE_LIBREADLINE */
 
-InteractiveShell::InteractiveShell(ExprManager& exprManager,
+InteractiveShell::InteractiveShell(api::Solver* solver,
                                    const Options& options)
     : d_in(*options.getIn()),
       d_out(*options.getOutConst()),
       d_options(options),
       d_quit(false)
 {
-  ParserBuilder parserBuilder(&exprManager, INPUT_FILENAME, options);
+  ParserBuilder parserBuilder(solver, INPUT_FILENAME, options);
   /* Create parser with bogus input. */
   d_parser = parserBuilder.withStringInput("").build();
   if(d_options.wasSetByUserForceLogicString()) {

--- a/src/main/interactive_shell.cpp
+++ b/src/main/interactive_shell.cpp
@@ -38,8 +38,8 @@
 #endif /* HAVE_LIBREADLINE */
 
 #include "api/cvc4cpp.h"
-#include "base/tls.h"
 #include "base/output.h"
+#include "base/tls.h"
 #include "options/language.h"
 #include "options/options.h"
 #include "parser/input.h"
@@ -89,8 +89,7 @@ static set<string> s_declarations;
 
 #endif /* HAVE_LIBREADLINE */
 
-InteractiveShell::InteractiveShell(api::Solver* solver,
-                                   const Options& options)
+InteractiveShell::InteractiveShell(api::Solver* solver, const Options& options)
     : d_in(*options.getIn()),
       d_out(*options.getOutConst()),
       d_options(options),

--- a/src/main/interactive_shell.h
+++ b/src/main/interactive_shell.h
@@ -25,8 +25,11 @@
 namespace CVC4 {
 
 class Command;
-class ExprManager;
 class Options;
+
+namespace api {
+class Solver;
+}
 
 namespace parser {
   class Parser;
@@ -46,7 +49,7 @@ class CVC4_PUBLIC InteractiveShell {
   static const unsigned s_historyLimit = 500;
 
 public:
-  InteractiveShell(ExprManager& exprManager, const Options& options);
+  InteractiveShell(api::Solver* solver, const Options& options);
 
   /**
    * Close out the interactive session.

--- a/src/main/interactive_shell.h
+++ b/src/main/interactive_shell.h
@@ -2,7 +2,7 @@
 /*! \file interactive_shell.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Morgan Deters, Christopher L. Conway, Tim King
+ **   Morgan Deters, Christopher L. Conway, Aina Niemetz
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/main/interactive_shell.h
+++ b/src/main/interactive_shell.h
@@ -49,25 +49,23 @@ class CVC4_PUBLIC InteractiveShell {
   static const unsigned s_historyLimit = 500;
 
 public:
-  InteractiveShell(api::Solver* solver, const Options& options);
+ InteractiveShell(api::Solver* solver, const Options& options);
 
-  /**
-   * Close out the interactive session.
-   */
-  ~InteractiveShell();
+ /**
+  * Close out the interactive session.
+  */
+ ~InteractiveShell();
 
-  /**
-   * Read a command from the interactive shell. This will read as
-   * many lines as necessary to parse a well-formed command.
-   */
-  Command* readCommand();
+ /**
+  * Read a command from the interactive shell. This will read as
+  * many lines as necessary to parse a well-formed command.
+  */
+ Command* readCommand();
 
-  /**
-   * Return the internal parser being used.
-   */
-  parser::Parser* getParser() {
-    return d_parser;
-  }
+ /**
+  * Return the internal parser being used.
+  */
+ parser::Parser* getParser() { return d_parser; }
 
 };/* class InteractiveShell */
 

--- a/src/parser/cvc/cvc_input.h
+++ b/src/parser/cvc/cvc_input.h
@@ -29,7 +29,6 @@ namespace CVC4 {
 
 class Command;
 class Expr;
-class ExprManager;
 
 namespace parser {
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <unordered_set>
 
+#include "api/cvc4cpp.h"
 #include "base/output.h"
 #include "expr/expr.h"
 #include "expr/expr_iomanip.h"
@@ -42,10 +43,12 @@ using namespace CVC4::kind;
 namespace CVC4 {
 namespace parser {
 
-Parser::Parser(ExprManager* exprManager, Input* input, bool strictMode,
+Parser::Parser(api::Solver* solver,
+               Input* input,
+               bool strictMode,
                bool parseOnly)
-    : d_exprManager(exprManager),
-      d_resourceManager(d_exprManager->getResourceManager()),
+    : d_solver(solver),
+      d_resourceManager(d_solver->getExprManager()->getResourceManager()),
       d_input(input),
       d_symtabAllocated(),
       d_symtab(&d_symtabAllocated),
@@ -58,7 +61,8 @@ Parser::Parser(ExprManager* exprManager, Input* input, bool strictMode,
       d_parseOnly(parseOnly),
       d_canIncludeFile(true),
       d_logicIsForced(false),
-      d_forcedLogic() {
+      d_forcedLogic()
+{
   d_input->setParser(*this);
 }
 
@@ -70,6 +74,11 @@ Parser::~Parser() {
   }
   d_commandQueue.clear();
   delete d_input;
+}
+
+ExprManager* Parser::getExprManager() const
+{
+  return d_solver->getExprManager();
 }
 
 Expr Parser::getSymbol(const std::string& name, SymbolType type) {
@@ -120,12 +129,12 @@ Expr Parser::getExpressionForNameAndType(const std::string& name, Type t) {
   if(isDefinedFunction(expr)) {
     // defined functions/constants are wrapped in an APPLY so that they are
     // expanded into their definition, e.g. during SmtEnginePrivate::expandDefinitions
-    expr = d_exprManager->mkExpr(CVC4::kind::APPLY, expr);
+    expr = getExprManager()->mkExpr(CVC4::kind::APPLY, expr);
   }else{
     Type te = expr.getType();
     if(te.isConstructor() && ConstructorType(te).getArity() == 0) {
       // nullary constructors have APPLY_CONSTRUCTOR kind with no children
-      expr = d_exprManager->mkExpr(CVC4::kind::APPLY_CONSTRUCTOR, expr);
+      expr = getExprManager()->mkExpr(CVC4::kind::APPLY_CONSTRUCTOR, expr);
     }
   }
   return expr;
@@ -210,14 +219,14 @@ Expr Parser::mkVar(const std::string& name, const Type& type, uint32_t flags, bo
     flags |= ExprManager::VAR_FLAG_GLOBAL;
   }
   Debug("parser") << "mkVar(" << name << ", " << type << ")" << std::endl;
-  Expr expr = d_exprManager->mkVar(name, type, flags);
+  Expr expr = getExprManager()->mkVar(name, type, flags);
   defineVar(name, expr, flags & ExprManager::VAR_FLAG_GLOBAL, doOverload);
   return expr;
 }
 
 Expr Parser::mkBoundVar(const std::string& name, const Type& type) {
   Debug("parser") << "mkVar(" << name << ", " << type << ")" << std::endl;
-  Expr expr = d_exprManager->mkBoundVar(name, type);
+  Expr expr = getExprManager()->mkBoundVar(name, type);
   defineVar(name, expr, false);
   return expr;
 }
@@ -228,7 +237,7 @@ Expr Parser::mkFunction(const std::string& name, const Type& type,
     flags |= ExprManager::VAR_FLAG_GLOBAL;
   }
   Debug("parser") << "mkVar(" << name << ", " << type << ")" << std::endl;
-  Expr expr = d_exprManager->mkVar(name, type, flags);
+  Expr expr = getExprManager()->mkVar(name, type, flags);
   defineFunction(name, expr, flags & ExprManager::VAR_FLAG_GLOBAL, doOverload);
   return expr;
 }
@@ -240,7 +249,7 @@ Expr Parser::mkAnonymousFunction(const std::string& prefix, const Type& type,
   }
   stringstream name;
   name << prefix << "_anon_" << ++d_anonymousFunctionCount;
-  return d_exprManager->mkVar(name.str(), type, flags);
+  return getExprManager()->mkVar(name.str(), type, flags);
 }
 
 std::vector<Expr> Parser::mkVars(const std::vector<std::string> names,
@@ -318,7 +327,7 @@ SortType Parser::mkSort(const std::string& name, uint32_t flags) {
     flags |= ExprManager::VAR_FLAG_GLOBAL;
   }
   Debug("parser") << "newSort(" << name << ")" << std::endl;
-  Type type = d_exprManager->mkSort(name, flags);
+  Type type = getExprManager()->mkSort(name, flags);
   defineType(name, type);
   return type;
 }
@@ -327,7 +336,7 @@ SortConstructorType Parser::mkSortConstructor(const std::string& name,
                                               size_t arity) {
   Debug("parser") << "newSortConstructor(" << name << ", " << arity << ")"
                   << std::endl;
-  SortConstructorType type = d_exprManager->mkSortConstructor(name, arity);
+  SortConstructorType type = getExprManager()->mkSortConstructor(name, arity);
   defineType(name, vector<Type>(arity), type);
   return type;
 }
@@ -350,7 +359,7 @@ SortConstructorType Parser::mkUnresolvedTypeConstructor(
   Debug("parser") << "newSortConstructor(P)(" << name << ", " << params.size()
                   << ")" << std::endl;
   SortConstructorType unresolved =
-      d_exprManager->mkSortConstructor(name, params.size());
+      getExprManager()->mkSortConstructor(name, params.size());
   defineType(name, params, unresolved);
   Type t = getSort(name, params);
   d_unresolved.insert(unresolved);
@@ -368,7 +377,7 @@ std::vector<DatatypeType> Parser::mkMutualDatatypeTypes(
     std::vector<Datatype>& datatypes, bool doOverload) {
   try {
     std::vector<DatatypeType> types =
-        d_exprManager->mkMutualDatatypeTypes(datatypes, d_unresolved);
+        getExprManager()->mkMutualDatatypeTypes(datatypes, d_unresolved);
 
     assert(datatypes.size() == types.size());
 
@@ -463,7 +472,7 @@ Type Parser::mkFlatFunctionType(std::vector<Type>& sorts,
       // the introduced variable is internal (not parsable)
       std::stringstream ss;
       ss << "__flatten_var_" << i;
-      Expr v = d_exprManager->mkBoundVar(ss.str(), domainTypes[i]);
+      Expr v = getExprManager()->mkBoundVar(ss.str(), domainTypes[i]);
       flattenVars.push_back(v);
     }
     range = static_cast<FunctionType>(range).getRangeType();
@@ -472,7 +481,7 @@ Type Parser::mkFlatFunctionType(std::vector<Type>& sorts,
   {
     return range;
   }
-  return d_exprManager->mkFunctionType(sorts, range);
+  return getExprManager()->mkFunctionType(sorts, range);
 }
 
 Type Parser::mkFlatFunctionType(std::vector<Type>& sorts, Type range)
@@ -489,14 +498,14 @@ Type Parser::mkFlatFunctionType(std::vector<Type>& sorts, Type range)
     sorts.insert(sorts.end(), domainTypes.begin(), domainTypes.end());
     range = static_cast<FunctionType>(range).getRangeType();
   }
-  return d_exprManager->mkFunctionType(sorts, range);
+  return getExprManager()->mkFunctionType(sorts, range);
 }
 
 Expr Parser::mkHoApply(Expr expr, std::vector<Expr>& args, unsigned startIndex)
 {
   for (unsigned i = startIndex; i < args.size(); i++)
   {
-    expr = d_exprManager->mkExpr(HO_APPLY, expr, args[i]);
+    expr = getExprManager()->mkExpr(HO_APPLY, expr, args[i]);
   }
   return expr;
 }
@@ -569,8 +578,8 @@ void Parser::checkArity(Kind kind, unsigned numArgs)
     return;
   }
 
-  unsigned min = d_exprManager->minArity(kind);
-  unsigned max = d_exprManager->maxArity(kind);
+  unsigned min = getExprManager()->minArity(kind);
+  unsigned max = getExprManager()->maxArity(kind);
 
   if (numArgs < min || numArgs > max) {
     stringstream ss;
@@ -626,7 +635,7 @@ Command* Parser::nextCommand()
       dynamic_cast<QuitCommand*>(cmd) == NULL) {
     // don't count set-option commands as to not get stuck in an infinite
     // loop of resourcing out
-    const Options& options = d_exprManager->getOptions();
+    const Options& options = getExprManager()->getOptions();
     d_resourceManager->spendResource(options.getParseStep());
   }
   return cmd;
@@ -635,7 +644,7 @@ Command* Parser::nextCommand()
 Expr Parser::nextExpression()
 {
   Debug("parser") << "nextExpression()" << std::endl;
-  const Options& options = d_exprManager->getOptions();
+  const Options& options = getExprManager()->getOptions();
   d_resourceManager->spendResource(options.getParseStep());
   Expr result;
   if (!done()) {

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -24,6 +24,7 @@
 #include <list>
 #include <cassert>
 
+#include "api/cvc4cpp.h"
 #include "parser/input.h"
 #include "parser/parser_exception.h"
 #include "expr/expr.h"
@@ -36,11 +37,13 @@ namespace CVC4 {
 
 // Forward declarations
 class BooleanType;
-class ExprManager;
 class Command;
 class FunctionType;
 class Type;
 class ResourceManager;
+namespace api {
+class Solver;
+}
 
 //for sygus gterm two-pass parsing
 class CVC4_PUBLIC SygusGTerm {
@@ -135,8 +138,9 @@ inline std::ostream& operator<<(std::ostream& out, SymbolType type) {
 class CVC4_PUBLIC Parser {
   friend class ParserBuilder;
 private:
-  /** The expression manager */
-  ExprManager *d_exprManager;
+  /** The API Solver object. */
+  api::Solver* d_solver;
+
   /** The resource manager associated with this expr manager */
   ResourceManager *d_resourceManager;
 
@@ -247,23 +251,24 @@ protected:
    * @attention The parser takes "ownership" of the given
    * input and will delete it on destruction.
    *
-   * @param exprManager the expression manager to use when creating expressions
+   * @param the solver API object
    * @param input the parser input
    * @param strictMode whether to incorporate strict(er) compliance checks
    * @param parseOnly whether we are parsing only (and therefore certain checks
    * need not be performed, like those about unimplemented features, @see
    * unimplementedFeature())
    */
-  Parser(ExprManager* exprManager, Input* input, bool strictMode = false, bool parseOnly = false);
+ Parser(api::Solver* solver,
+        Input* input,
+        bool strictMode = false,
+        bool parseOnly = false);
 
 public:
 
   virtual ~Parser();
 
   /** Get the associated <code>ExprManager</code>. */
-  inline ExprManager* getExprManager() const {
-    return d_exprManager;
-  }
+  ExprManager* getExprManager() const;
 
   /** Get the associated input. */
   inline Input* getInput() const {

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -23,9 +23,9 @@
 
 #include "api/cvc4cpp.h"
 #include "expr/expr_manager.h"
+#include "options/options.h"
 #include "parser/input.h"
 #include "parser/parser.h"
-#include "options/options.h"
 #include "smt1/smt1.h"
 #include "smt2/smt2.h"
 #include "tptp/tptp.h"
@@ -134,7 +134,8 @@ ParserBuilder& ParserBuilder::withChecks(bool flag) {
   return *this;
 }
 
-ParserBuilder& ParserBuilder::withSolver(api::Solver* solver) {
+ParserBuilder& ParserBuilder::withSolver(api::Solver* solver)
+{
   d_solver = solver;
   return *this;
 }

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -2,7 +2,7 @@
 /*! \file parser_builder.cpp
  ** \verbatim
  ** Top contributors (to current version):
- **   Christopher L. Conway, Morgan Deters, Tim King
+ **   Christopher L. Conway, Morgan Deters, Aina Niemetz
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/parser/parser_builder.cpp
+++ b/src/parser/parser_builder.cpp
@@ -21,6 +21,7 @@
 
 #include <string>
 
+#include "api/cvc4cpp.h"
 #include "expr/expr_manager.h"
 #include "parser/input.h"
 #include "parser/parser.h"
@@ -32,29 +33,28 @@
 namespace CVC4 {
 namespace parser {
 
-ParserBuilder::ParserBuilder(ExprManager* exprManager,
-                             const std::string& filename) :
-  d_filename(filename),
-  d_exprManager(exprManager) {
-  init(exprManager, filename);
+ParserBuilder::ParserBuilder(api::Solver* solver, const std::string& filename)
+    : d_filename(filename), d_solver(solver)
+{
+  init(solver, filename);
 }
 
-ParserBuilder::ParserBuilder(ExprManager* exprManager,
+ParserBuilder::ParserBuilder(api::Solver* solver,
                              const std::string& filename,
-                             const Options& options) :
-  d_filename(filename),
-  d_exprManager(exprManager) {
-  init(exprManager, filename);
+                             const Options& options)
+    : d_filename(filename), d_solver(solver)
+{
+  init(solver, filename);
   withOptions(options);
 }
 
-void ParserBuilder::init(ExprManager* exprManager,
-                         const std::string& filename) {
+void ParserBuilder::init(api::Solver* solver, const std::string& filename)
+{
   d_inputType = FILE_INPUT;
   d_lang = language::input::LANG_AUTO;
   d_filename = filename;
   d_streamInput = NULL;
-  d_exprManager = exprManager;
+  d_solver = solver;
   d_checksEnabled = true;
   d_strictMode = false;
   d_canIncludeFile = true;
@@ -87,26 +87,27 @@ Parser* ParserBuilder::build()
   assert(input != NULL);
 
   Parser* parser = NULL;
-  switch(d_lang) {
-  case language::input::LANG_SMTLIB_V1:
-    parser = new Smt1(d_exprManager, input, d_strictMode, d_parseOnly);
-    break;
-  case language::input::LANG_SYGUS:
-    parser = new Smt2(d_exprManager, input, d_strictMode, d_parseOnly);
-    break;
-  case language::input::LANG_TPTP:
-    parser = new Tptp(d_exprManager, input, d_strictMode, d_parseOnly);
-    break;
-  default:
-    if (language::isInputLang_smt2(d_lang))
-    {
-      parser = new Smt2(d_exprManager, input, d_strictMode, d_parseOnly);
-    }
-    else
-    {
-      parser = new Parser(d_exprManager, input, d_strictMode, d_parseOnly);
-    }
-    break;
+  switch (d_lang)
+  {
+    case language::input::LANG_SMTLIB_V1:
+      parser = new Smt1(d_solver, input, d_strictMode, d_parseOnly);
+      break;
+    case language::input::LANG_SYGUS:
+      parser = new Smt2(d_solver, input, d_strictMode, d_parseOnly);
+      break;
+    case language::input::LANG_TPTP:
+      parser = new Tptp(d_solver, input, d_strictMode, d_parseOnly);
+      break;
+    default:
+      if (language::isInputLang_smt2(d_lang))
+      {
+        parser = new Smt2(d_solver, input, d_strictMode, d_parseOnly);
+      }
+      else
+      {
+        parser = new Parser(d_solver, input, d_strictMode, d_parseOnly);
+      }
+      break;
   }
 
   if( d_checksEnabled ) {
@@ -133,8 +134,8 @@ ParserBuilder& ParserBuilder::withChecks(bool flag) {
   return *this;
 }
 
-ParserBuilder& ParserBuilder::withExprManager(ExprManager* exprManager) {
-  d_exprManager = exprManager;
+ParserBuilder& ParserBuilder::withSolver(api::Solver* solver) {
+  d_solver = solver;
   return *this;
 }
 

--- a/src/parser/parser_builder.h
+++ b/src/parser/parser_builder.h
@@ -26,8 +26,11 @@
 
 namespace CVC4 {
 
-class ExprManager;
 class Options;
+
+namespace api {
+class Solver;
+}
 
 namespace parser {
 
@@ -61,8 +64,8 @@ class CVC4_PUBLIC ParserBuilder {
   /** The stream input, if any. */
   std::istream* d_streamInput;
 
-  /** The expression manager */
-  ExprManager* d_exprManager;
+  /** The API Solver object. */
+  api::Solver* d_solver;
 
   /** Should semantic checks be enabled during parsing? */
   bool d_checksEnabled;
@@ -86,14 +89,15 @@ class CVC4_PUBLIC ParserBuilder {
   std::string d_forcedLogic;
 
   /** Initialize this parser builder */
-  void init(ExprManager* exprManager, const std::string& filename);
+  void init(api::Solver* solver, const std::string& filename);
 
 public:
 
-  /** Create a parser builder using the given ExprManager and filename. */
-  ParserBuilder(ExprManager* exprManager, const std::string& filename);
+  /** Create a parser builder using the given Solver and filename. */
+  ParserBuilder(api::Solver* solver, const std::string& filename);
 
-  ParserBuilder(ExprManager* exprManager, const std::string& filename,
+  ParserBuilder(api::Solver* solver,
+                const std::string& filename,
                 const Options& options);
 
   /** Build the parser, using the current settings. */
@@ -102,8 +106,8 @@ public:
   /** Should semantic checks be enabled in the parser? (Default: yes) */
   ParserBuilder& withChecks(bool flag = true);
 
-  /** Set the ExprManager to use with the parser. */
-  ParserBuilder& withExprManager(ExprManager* exprManager);
+  /** Set the Solver to use with the parser. */
+  ParserBuilder& withSolver(api::Solver* solver);
 
   /** Set the parser to read a file for its input. (Default) */
   ParserBuilder& withFileInput();

--- a/src/parser/parser_builder.h
+++ b/src/parser/parser_builder.h
@@ -91,8 +91,7 @@ class CVC4_PUBLIC ParserBuilder {
   /** Initialize this parser builder */
   void init(api::Solver* solver, const std::string& filename);
 
-public:
-
+ public:
   /** Create a parser builder using the given Solver and filename. */
   ParserBuilder(api::Solver* solver, const std::string& filename);
 

--- a/src/parser/parser_builder.h
+++ b/src/parser/parser_builder.h
@@ -2,7 +2,7 @@
 /*! \file parser_builder.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Christopher L. Conway, Morgan Deters, Tim King
+ **   Christopher L. Conway, Morgan Deters, Aina Niemetz
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/parser/smt1/smt1.cpp
+++ b/src/parser/smt1/smt1.cpp
@@ -14,6 +14,7 @@
 
 #include "parser/smt1/smt1.h"
 
+#include "api/cvc4cpp.h"
 #include "expr/type.h"
 #include "smt/command.h"
 #include "parser/parser.h"
@@ -70,9 +71,9 @@ Smt1::Logic Smt1::toLogic(const std::string& name) {
   return logicMap[name];
 }
 
-Smt1::Smt1(ExprManager* exprManager, Input* input, bool strictMode,
-           bool parseOnly)
-    : Parser(exprManager, input, strictMode, parseOnly), d_logic(UNSET) {
+Smt1::Smt1(api::Solver* solver, Input* input, bool strictMode, bool parseOnly)
+    : Parser(solver, input, strictMode, parseOnly), d_logic(UNSET)
+{
   // Boolean symbols are always defined
   addOperator(kind::AND);
   addOperator(kind::EQUAL);
@@ -81,7 +82,6 @@ Smt1::Smt1(ExprManager* exprManager, Input* input, bool strictMode,
   addOperator(kind::NOT);
   addOperator(kind::OR);
   addOperator(kind::XOR);
-
 }
 
 void Smt1::addArithmeticOperators() {

--- a/src/parser/smt1/smt1.cpp
+++ b/src/parser/smt1/smt1.cpp
@@ -16,8 +16,8 @@
 
 #include "api/cvc4cpp.h"
 #include "expr/type.h"
-#include "smt/command.h"
 #include "parser/parser.h"
+#include "smt/command.h"
 
 namespace CVC4 {
 namespace parser {

--- a/src/parser/smt1/smt1.h
+++ b/src/parser/smt1/smt1.h
@@ -2,7 +2,7 @@
 /*! \file smt1.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Christopher L. Conway, Morgan Deters, Tim King
+ **   Christopher L. Conway, Morgan Deters, Aina Niemetz
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/parser/smt1/smt1.h
+++ b/src/parser/smt1/smt1.h
@@ -26,6 +26,10 @@ namespace CVC4 {
 
 class SExpr;
 
+namespace api {
+class Solver;
+}
+
 namespace parser {
 
 class Smt1 : public Parser {
@@ -93,7 +97,10 @@ private:
   Logic d_logic;
 
 protected:
-  Smt1(ExprManager* exprManager, Input* input, bool strictMode = false, bool parseOnly = false);
+ Smt1(api::Solver* solver,
+      Input* input,
+      bool strictMode = false,
+      bool parseOnly = false);
 
 public:
   /**

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -15,6 +15,7 @@
  **/
 #include "parser/smt2/smt2.h"
 
+#include "api/cvc4cpp.h"
 #include "expr/type.h"
 #include "options/options.h"
 #include "parser/antlr_input.h"
@@ -34,10 +35,11 @@
 namespace CVC4 {
 namespace parser {
 
-Smt2::Smt2(ExprManager* exprManager, Input* input, bool strictMode, bool parseOnly) :
-  Parser(exprManager,input,strictMode,parseOnly),
-  d_logicSet(false) {
-  if( !strictModeEnabled() ) {
+Smt2::Smt2(api::Solver* solver, Input* input, bool strictMode, bool parseOnly)
+    : Parser(solver, input, strictMode, parseOnly), d_logicSet(false)
+{
+  if (!strictModeEnabled())
+  {
     addTheory(Smt2::THEORY_CORE);
   }
 }

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -38,7 +38,6 @@ namespace api {
 class Solver;
 }
 
-
 namespace parser {
 
 class Smt2 : public Parser {

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -34,6 +34,11 @@ namespace CVC4 {
 
 class SExpr;
 
+namespace api {
+class Solver;
+}
+
+
 namespace parser {
 
 class Smt2 : public Parser {
@@ -69,7 +74,10 @@ private:
   std::map< Expr, bool > d_sygusVarPrimed;
 
 protected:
-  Smt2(ExprManager* exprManager, Input* input, bool strictMode = false, bool parseOnly = false);
+ Smt2(api::Solver* solver,
+      Input* input,
+      bool strictMode = false,
+      bool parseOnly = false);
 
 public:
   /**

--- a/src/parser/tptp/tptp.cpp
+++ b/src/parser/tptp/tptp.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <set>
 
+#include "api/cvc4cpp.h"
 #include "expr/type.h"
 #include "parser/parser.h"
 
@@ -30,11 +31,9 @@
 namespace CVC4 {
 namespace parser {
 
-Tptp::Tptp(ExprManager* exprManager, Input* input, bool strictMode,
-           bool parseOnly)
-    : Parser(exprManager, input, strictMode, parseOnly),
-      d_cnf(false),
-      d_fof(false) {
+Tptp::Tptp(api::Solver* solver, Input* input, bool strictMode, bool parseOnly)
+    : Parser(solver, input, strictMode, parseOnly), d_cnf(false), d_fof(false)
+{
   addTheory(Tptp::THEORY_CORE);
 
   /* Try to find TPTP dir */

--- a/src/parser/tptp/tptp.h
+++ b/src/parser/tptp/tptp.h
@@ -30,6 +30,11 @@
 #include "util/hash.h"
 
 namespace CVC4 {
+
+namespace api {
+class Solver;
+}
+
 namespace parser {
 
 class Tptp : public Parser {
@@ -81,7 +86,9 @@ class Tptp : public Parser {
   bool hasConjecture() const { return d_hasConjecture; }
 
  protected:
-  Tptp(ExprManager* exprManager, Input* input, bool strictMode = false,
+  Tptp(api::Solver* solver,
+       Input* input,
+       bool strictMode = false,
        bool parseOnly = false);
 
  public:

--- a/test/unit/main/interactive_shell_black.h
+++ b/test/unit/main/interactive_shell_black.h
@@ -34,29 +34,30 @@ using namespace std;
 
 class InteractiveShellBlack : public CxxTest::TestSuite {
 private:
-  std::unique_ptr<api::Solver> d_solver;
-  Options d_options;
-  stringstream* d_sin;
-  stringstream* d_sout;
+ std::unique_ptr<api::Solver> d_solver;
+ Options d_options;
+ stringstream* d_sin;
+ stringstream* d_sout;
 
-  /** Read up to maxCommands+1 from the shell and throw an assertion
-      error if it's fewer than minCommands and more than maxCommands.
-      Note that an empty string followed by EOF may be returned as an
-      empty command, and not NULL (subsequent calls to readCommand()
-      should return NULL). E.g., "CHECKSAT;\n" may return two
-      commands: the CHECKSAT, followed by an empty command, followed
-      by NULL. */
-  void countCommands(InteractiveShell& shell, 
-                     int minCommands, 
-                     int maxCommands) {
-    Command* cmd;
-    int n = 0;
-    while( n <= maxCommands && (cmd = shell.readCommand()) != NULL ) {
-      ++n;
-      delete cmd;
-    }
-    TS_ASSERT( n <= maxCommands );
-    TS_ASSERT( n >= minCommands );
+ /**
+  * Read up to maxCommands+1 from the shell and throw an assertion error if
+  * it's fewer than minCommands and more than maxCommands.  Note that an empty
+  * string followed by EOF may be returned as an empty command, and not NULL
+  * (subsequent calls to readCommand() should return NULL). E.g., "CHECKSAT;\n"
+  * may return two commands: the CHECKSAT, followed by an empty command,
+  * followed by NULL.
+  */
+ void countCommands(InteractiveShell& shell, int minCommands, int maxCommands)
+ {
+   Command* cmd;
+   int n = 0;
+   while (n <= maxCommands && (cmd = shell.readCommand()) != NULL)
+   {
+     ++n;
+     delete cmd;
+   }
+   TS_ASSERT(n <= maxCommands);
+   TS_ASSERT(n >= minCommands);
   }
 
  public:

--- a/test/unit/main/interactive_shell_black.h
+++ b/test/unit/main/interactive_shell_black.h
@@ -2,7 +2,7 @@
 /*! \file interactive_shell_black.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Christopher L. Conway, Morgan Deters, Tim King
+ **   Christopher L. Conway, Aina Niemetz, Morgan Deters
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/test/unit/parser/parser_black.h
+++ b/test/unit/parser/parser_black.h
@@ -2,7 +2,7 @@
 /*! \file parser_black.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Christopher L. Conway, Morgan Deters, Tim King
+ **   Christopher L. Conway, Morgan Deters, Aina Niemetz
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/test/unit/parser/parser_black.h
+++ b/test/unit/parser/parser_black.h
@@ -41,7 +41,7 @@ class ParserBlack {
   InputLanguage d_lang;
   std::unique_ptr<api::Solver> d_solver;
 
-protected:
+ protected:
   Options d_options;
 
   /* Set up declaration context for expr inputs */
@@ -55,49 +55,53 @@ protected:
     Type u = parser.mkSort("u");
     Type v = parser.mkSort("v");
     /* f : t->u; g: u->v; h: v->t; */
-    parser.mkVar("f", d_solver->getExprManager()->mkFunctionType(t,u));
-    parser.mkVar("g", d_solver->getExprManager()->mkFunctionType(u,v));
-    parser.mkVar("h", d_solver->getExprManager()->mkFunctionType(v,t));
+    parser.mkVar("f", d_solver->getExprManager()->mkFunctionType(t, u));
+    parser.mkVar("g", d_solver->getExprManager()->mkFunctionType(u, v));
+    parser.mkVar("h", d_solver->getExprManager()->mkFunctionType(v, t));
     /* x:t; y:u; z:v; */
     parser.mkVar("x",t);
     parser.mkVar("y",u);
     parser.mkVar("z",v);
   }
 
-  void tryGoodInput(const string goodInput) {
-      try {
-//        Debug.on("parser");
-//         Debug.on("parser-extra");
-//        cerr << "Testing good input: <<" << goodInput << ">>" << endl;
-//        istringstream stream(goodInputs[i]);
-        Parser *parser =
-          ParserBuilder(d_solver.get(),"test")
-            .withStringInput(goodInput)
-            .withOptions(d_options)
-            .withInputLanguage(d_lang)
-            .build();
-        TS_ASSERT( !parser->done() );
-        Command* cmd;
-        while((cmd = parser->nextCommand()) != NULL) {
-          Debug("parser") << "Parsed command: " << (*cmd) << endl;
-          delete cmd;
-        }
-
-        TS_ASSERT( parser->done() );
-        delete parser;
-//        Debug.off("parser");
-//        Debug.off("parser-extra");
-      } catch (Exception& e) {
-        cout << "\nGood input failed:\n" << goodInput << endl
-             << e << endl;
-//        Debug.off("parser");
-        throw;
+  void tryGoodInput(const string goodInput)
+  {
+    try
+    {
+      //        Debug.on("parser");
+      //         Debug.on("parser-extra");
+      //        cerr << "Testing good input: <<" << goodInput << ">>" << endl;
+      //        istringstream stream(goodInputs[i]);
+      Parser* parser = ParserBuilder(d_solver.get(), "test")
+                           .withStringInput(goodInput)
+                           .withOptions(d_options)
+                           .withInputLanguage(d_lang)
+                           .build();
+      TS_ASSERT(!parser->done());
+      Command* cmd;
+      while ((cmd = parser->nextCommand()) != NULL)
+      {
+        Debug("parser") << "Parsed command: " << (*cmd) << endl;
+        delete cmd;
       }
+
+      TS_ASSERT(parser->done());
+      delete parser;
+      //        Debug.off("parser");
+      //        Debug.off("parser-extra");
+    }
+    catch (Exception& e)
+    {
+      cout << "\nGood input failed:\n" << goodInput << endl << e << endl;
+      //        Debug.off("parser");
+      throw;
+    }
   }
 
-  void tryBadInput(const string badInput, bool strictMode = false) {
-//      cerr << "Testing bad input: '" << badInput << "'\n";
-//      Debug.on("parser");
+  void tryBadInput(const string badInput, bool strictMode = false)
+  {
+    //      cerr << "Testing bad input: '" << badInput << "'\n";
+    //      Debug.on("parser");
 
     Parser* parser = ParserBuilder(d_solver.get(), "test")
                          .withStringInput(badInput)
@@ -108,7 +112,8 @@ protected:
     TS_ASSERT_THROWS(
         {
           Command* cmd;
-          while ((cmd = parser->nextCommand()) != NULL) {
+          while ((cmd = parser->nextCommand()) != NULL)
+          {
             Debug("parser") << "Parsed command: " << (*cmd) << endl;
             delete cmd;
           }
@@ -119,37 +124,40 @@ protected:
     delete parser;
   }
 
-  void tryGoodExpr(const string goodExpr) {
-//    Debug.on("parser");
-//    Debug.on("parser-extra");
-      try {
-//        cerr << "Testing good expr: '" << goodExpr << "'\n";
-        // Debug.on("parser");
-//        istringstream stream(context + goodBooleanExprs[i]);
+  void tryGoodExpr(const string goodExpr)
+  {
+    //    Debug.on("parser");
+    //    Debug.on("parser-extra");
+    try
+    {
+      //        cerr << "Testing good expr: '" << goodExpr << "'\n";
+      // Debug.on("parser");
+      //        istringstream stream(context + goodBooleanExprs[i]);
 
-        Parser *parser =
-          ParserBuilder(d_solver.get(),"test")
-            .withStringInput(goodExpr)
-            .withOptions(d_options)
-            .withInputLanguage(d_lang)
-            .build();
+      Parser* parser = ParserBuilder(d_solver.get(), "test")
+                           .withStringInput(goodExpr)
+                           .withOptions(d_options)
+                           .withInputLanguage(d_lang)
+                           .build();
 
-        TS_ASSERT( !parser->done() );
-        setupContext(*parser);
-        TS_ASSERT( !parser->done() );
-        Expr e = parser->nextExpression();
-        TS_ASSERT( !e.isNull() );
-        e = parser->nextExpression();
-        TS_ASSERT( parser->done() );
-        TS_ASSERT( e.isNull() );
-        delete parser;
-      } catch (Exception& e) {
-        cout << endl
-             << "Good expr failed." << endl
-             << "Input: <<" << goodExpr << ">>" << endl
-             << "Output: <<" << e << ">>" << endl;
-        throw;
-      }
+      TS_ASSERT(!parser->done());
+      setupContext(*parser);
+      TS_ASSERT(!parser->done());
+      Expr e = parser->nextExpression();
+      TS_ASSERT(!e.isNull());
+      e = parser->nextExpression();
+      TS_ASSERT(parser->done());
+      TS_ASSERT(e.isNull());
+      delete parser;
+    }
+    catch (Exception& e)
+    {
+      cout << endl
+           << "Good expr failed." << endl
+           << "Input: <<" << goodExpr << ">>" << endl
+           << "Output: <<" << e << ">>" << endl;
+      throw;
+    }
   }
 
   /* NOTE: The check implemented here may fail if a bad expression
@@ -160,29 +168,28 @@ protected:
    * input was consumed here, so just be careful to avoid valid
    * prefixes in tests.
    */
-  void tryBadExpr(const string badExpr, bool strictMode = false) {
-//    Debug.on("parser");
-//    Debug.on("parser-extra");
-//      cout << "Testing bad expr: '" << badExpr << "'\n";
+  void tryBadExpr(const string badExpr, bool strictMode = false)
+  {
+    //    Debug.on("parser");
+    //    Debug.on("parser-extra");
+    //      cout << "Testing bad expr: '" << badExpr << "'\n";
 
-      Parser *parser =
-        ParserBuilder(d_solver.get(),"test")
-          .withStringInput(badExpr)
-          .withOptions(d_options)
-          .withInputLanguage(d_lang)
-          .withStrictMode(strictMode)
-          .build();
-      setupContext(*parser);
-      TS_ASSERT( !parser->done() );
-      TS_ASSERT_THROWS
-        ( Expr e = parser->nextExpression();
-          cout << endl
-               << "Bad expr succeeded." << endl
-               << "Input: <<" << badExpr << ">>" << endl
-               << "Output: <<" << e << ">>" << endl;,
-          const ParserException& );
-      delete parser;
-//    Debug.off("parser");
+    Parser* parser = ParserBuilder(d_solver.get(), "test")
+                         .withStringInput(badExpr)
+                         .withOptions(d_options)
+                         .withInputLanguage(d_lang)
+                         .withStrictMode(strictMode)
+                         .build();
+    setupContext(*parser);
+    TS_ASSERT(!parser->done());
+    TS_ASSERT_THROWS(Expr e = parser->nextExpression();
+                     cout << endl
+                          << "Bad expr succeeded." << endl
+                          << "Input: <<" << badExpr << ">>" << endl
+                          << "Output: <<" << e << ">>" << endl;
+                     , const ParserException&);
+    delete parser;
+    //    Debug.off("parser");
   }
 
   ParserBlack(InputLanguage lang) :

--- a/test/unit/parser/parser_builder_black.h
+++ b/test/unit/parser/parser_builder_black.h
@@ -2,7 +2,7 @@
 /*! \file parser_builder_black.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Christopher L. Conway, Tim King, Morgan Deters
+ **   Christopher L. Conway, Aina Niemetz, Tim King
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/test/unit/parser/parser_builder_black.h
+++ b/test/unit/parser/parser_builder_black.h
@@ -36,7 +36,6 @@ using namespace CVC4::language::input;
 using namespace std;
 
 class ParserBuilderBlack : public CxxTest::TestSuite {
-
   std::unique_ptr<api::Solver> d_solver;
 
   void checkEmptyInput(ParserBuilder& builder) {
@@ -54,7 +53,7 @@ class ParserBuilderBlack : public CxxTest::TestSuite {
     TS_ASSERT( parser != NULL );
 
     Expr e = parser->nextExpression();
-    TS_ASSERT_EQUALS( e, d_solver->getExprManager()->mkConst(true) );
+    TS_ASSERT_EQUALS(e, d_solver->getExprManager()->mkConst(true));
 
     e = parser->nextExpression();
     TS_ASSERT( e.isNull() );
@@ -70,24 +69,19 @@ class ParserBuilderBlack : public CxxTest::TestSuite {
   }
 
 public:
+ void setUp() { d_solver = std::unique_ptr<api::Solver>(new api::Solver()); }
 
-  void setUp() {
-    d_solver = std::unique_ptr<api::Solver>(new api::Solver());
-  }
+ void tearDown() {}
 
-  void tearDown() {
-  }
+ void testEmptyFileInput()
+ {
+   char *filename = mkTemp();
 
-  void testEmptyFileInput() {
-    char *filename = mkTemp();
+   checkEmptyInput(
+       ParserBuilder(d_solver.get(), filename).withInputLanguage(LANG_CVC4));
 
-    checkEmptyInput(
-      ParserBuilder(d_solver.get(),filename)
-        .withInputLanguage(LANG_CVC4)
-                    );
-
-    remove(filename);
-    free(filename);
+   remove(filename);
+   free(filename);
   }
 
   void testSimpleFileInput() {
@@ -98,46 +92,36 @@ public:
     fs.close();
 
     checkTrueInput(
-      ParserBuilder(d_solver.get(),filename)
-        .withInputLanguage(LANG_CVC4)
-                   );
+        ParserBuilder(d_solver.get(), filename).withInputLanguage(LANG_CVC4));
 
     remove(filename);
     free(filename);
   }
 
   void testEmptyStringInput() {
-    checkEmptyInput(
-      ParserBuilder(d_solver.get(),"foo")
-        .withInputLanguage(LANG_CVC4)
-        .withStringInput("")
-                    );
+    checkEmptyInput(ParserBuilder(d_solver.get(), "foo")
+                        .withInputLanguage(LANG_CVC4)
+                        .withStringInput(""));
   }
 
   void testTrueStringInput() {
-    checkTrueInput(
-      ParserBuilder(d_solver.get(),"foo")
-        .withInputLanguage(LANG_CVC4)
-        .withStringInput("TRUE")
-                   );
+    checkTrueInput(ParserBuilder(d_solver.get(), "foo")
+                       .withInputLanguage(LANG_CVC4)
+                       .withStringInput("TRUE"));
   }
 
   void testEmptyStreamInput() {
     stringstream ss( "", ios_base::in );
-    checkEmptyInput(
-      ParserBuilder(d_solver.get(),"foo")
-        .withInputLanguage(LANG_CVC4)
-        .withStreamInput(ss)
-                    );
+    checkEmptyInput(ParserBuilder(d_solver.get(), "foo")
+                        .withInputLanguage(LANG_CVC4)
+                        .withStreamInput(ss));
   }
 
   void testTrueStreamInput() {
     stringstream ss( "TRUE", ios_base::in );
-    checkTrueInput(
-      ParserBuilder(d_solver.get(),"foo")
-        .withInputLanguage(LANG_CVC4)
-        .withStreamInput(ss)
-                   );
+    checkTrueInput(ParserBuilder(d_solver.get(), "foo")
+                       .withInputLanguage(LANG_CVC4)
+                       .withStreamInput(ss));
   }
 
 


### PR DESCRIPTION
Parser does not yet use API functions, only the solver object.
This is the first step for migrating the parser to use the new API.

Review: commit https://github.com/CVC4/CVC4/commit/62953bf00ddc87b102f160cce83caf0e29689089