### PR TITLE
Remove outdated references to TLS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,14 +37,8 @@ CVC4 contains MiniSAT code by Niklas Een and Niklas Sorensson.
 The CVC4 parser incorporates some code from ANTLR3, by Jim Idle, Temporal
 Wave LLC.
 
-CVC4 contains the doxygen.m4 autoconf module by Oren Ben-Kiki.
-
-CVC4 contains the pkg.m4 autoconf module by Scott James Remnant.
-
-CVC4 contains the ax_tls.m4 autoconf module by Alan Woodland and Diego Elio
-Petteno`.
-
-CVC4 contains the boost.m4 autoconf module by Benoit Sigoure.
+CVC4 contains various autoconf modules in the config directory. Please refer to
+the individual files for more information on the authors.
 
 CVC4 maintainer versions contain the script autogen.sh by Christopher Sean
 Morrison, and copyright U.S. Army Research Laboratory.

--- a/contrib/depgraph
+++ b/contrib/depgraph
@@ -88,7 +88,6 @@ for path in $paths; do
     if [ -n "$target" -a "$target" != "$package" ]; then continue; fi
     for inc in $incs; do
       case "$inc" in
-        base/tls.h) inc=base/tls.h.in ;;
         expr/expr.h) inc=expr/expr_template.h ;;
         expr/expr_manager.h) inc=expr/expr_manager_template.h ;;
         expr/kind.h) inc=expr/kind_template.h ;;

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -254,10 +254,6 @@ bool Configuration::isBuiltWithReadline() {
   return IS_READLINE_BUILD;
 }
 
-bool Configuration::isBuiltWithTlsSupport() {
-  return USING_TLS;
-}
-
 bool Configuration::isBuiltWithLfsc() {
   return IS_LFSC_BUILD;
 }

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -101,8 +101,6 @@ public:
 
   static bool isBuiltWithReadline();
 
-  static bool isBuiltWithTlsSupport();
-
   static bool isBuiltWithLfsc();
 
   static bool isBuiltWithSymFPU();

--- a/src/base/configuration_private.h
+++ b/src/base/configuration_private.h
@@ -150,12 +150,6 @@ namespace CVC4 {
 #  define IS_GPL_BUILD false
 #endif /* CVC4_GPL_DEPS */
 
-#ifdef TLS
-#  define USING_TLS true
-#else /* TLS */
-#  define USING_TLS false
-#endif /* TLS */
-
 }/* CVC4 namespace */
 
 #endif /* __CVC4__CONFIGURATION_PRIVATE_H */

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -1666,7 +1666,6 @@ void OptionsHandler::showConfiguration(std::string option) {
   print_config_cond("lfsc", Configuration::isBuiltWithLfsc());
   print_config_cond("readline", Configuration::isBuiltWithReadline());
   print_config_cond("symfpu", Configuration::isBuiltWithSymFPU());
-  print_config_cond("tls", Configuration::isBuiltWithTlsSupport());
   
   exit(0);
 }

--- a/src/smt/smt_engine_scope.cpp
+++ b/src/smt/smt_engine_scope.cpp
@@ -21,7 +21,6 @@
 #include "base/configuration_private.h"
 #include "base/cvc4_assert.h"
 #include "base/output.h"
-#include "base/tls.h"
 #include "proof/proof.h"
 #include "smt/smt_engine.h"
 


### PR DESCRIPTION
Commit 546d795470ca7c30fc62fe9b6c7b8e5838e1eed4 removed configure-time
checks for compiler support for thread local storage because C++11
supports it by default. The commit did not quite remove all traces (note
that the `USING_TLS` macro was already broken at the time of that commit
because the configure script was setting `CVC4_TLS` instead of `TLS`).
This commit removes the remaining traces and updates the AUTHORS file to
just refer to the individual *.m4 files for authorship since some of
them have a large number of authors.