### PR TITLE
Remove Subversion build info

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,7 +34,6 @@ libcvc4_la_LDFLAGS = \
 nodist_EXTRA_libcvc4_la_SOURCES = dummy.cpp
 libcvc4_la_SOURCES = \
 	git_versioninfo.cpp \
-	svn_versioninfo.cpp \
 	api/cvc4cpp.h \
 	api/cvc4cppkind.h \
 	api/cvc4cpp.cpp \
@@ -638,9 +637,6 @@ BUILT_SOURCES = \
 	$(top_builddir)/src/.subdirs
 
 CLEANFILES = \
-	svn_versioninfo.cpp \
-	svninfo.tmp \
-	svninfo \
 	git_versioninfo.cpp \
 	gitinfo.tmp \
 	gitinfo \
@@ -686,34 +682,6 @@ EXTRA_DIST = \
 	theory/theory_traits_template.h \
 	theory/type_enumerator_template.cpp \
 	theory/uf/kinds
-
-svn_versioninfo.cpp: svninfo
-	$(AM_V_GEN)( \
-	  if test -s svninfo; then \
-	    issvn=true; \
-	    branch=`grep '^URL: ' svninfo | sed 's,.*/cvc4/,,'`; \
-	    rev=`grep '^Revision: ' svninfo | awk '{print$$2}'`; \
-	    mods=`grep '^Modifications: ' svninfo | awk '{print$$2} END { if(!NR) print "false" }'`; \
-	  else \
-	    issvn=false; \
-	    branch=unknown; \
-	    rev=0; \
-	    mods=false; \
-	  fi; \
-	  echo "#include \"base/configuration.h\""; \
-	  echo "const bool ::CVC4::Configuration::IS_SUBVERSION_BUILD = $$issvn;"; \
-	  echo "const char* const ::CVC4::Configuration::SUBVERSION_BRANCH_NAME = \"$$branch\";"; \
-	  echo "const unsigned ::CVC4::Configuration::SUBVERSION_REVISION = $$rev;"; \
-	  echo "const bool ::CVC4::Configuration::SUBVERSION_HAS_MODIFICATIONS = $$mods;"; \
-	) >"$@"
-# This .tmp business is to keep from having to re-compile options.cpp
-# (and then re-link the libraries) if nothing has changed.
-svninfo: svninfo.tmp
-	$(AM_V_GEN)if diff -q svninfo.tmp svninfo &>/dev/null; then rm -f svninfo.tmp; else mv svninfo.tmp svninfo; fi
-# .PHONY ensures the .tmp version is always rebuilt (to check for any changes)
-.PHONY: svninfo.tmp
-svninfo.tmp:
-	$(AM_V_GEN)(cd "$(top_srcdir)" && svn info && echo "Modifications: `test -z \"\`svn status -q\`\" && echo false || echo true`") >"$@" 2>/dev/null || true
 
 git_versioninfo.cpp: gitinfo
 	$(AM_V_GEN)( \

--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -215,8 +215,6 @@ std::string Configuration::about() {
   ss << "This is CVC4 version " << CVC4_RELEASE_STRING;
   if (Configuration::isGitBuild()) {
     ss << " [" << Configuration::getGitId() << "]";
-  } else if (CVC4::Configuration::isSubversionBuild()) {
-    ss << " [" << Configuration::getSubversionId() << "]";
   }
   ss << "\ncompiled with " << Configuration::getCompiler()
      << "\non " << Configuration::getCompiledDateTime() << "\n\n";
@@ -359,33 +357,6 @@ std::string Configuration::getGitId() {
   stringstream ss;
   ss << "git " << branchName << " " << string(getGitCommit()).substr(0, 8)
      << ( ::CVC4::Configuration::hasGitModifications() ? " (with modifications)" : "" );
-  return ss.str();
-}
-
-bool Configuration::isSubversionBuild() {
-  return IS_SUBVERSION_BUILD;
-}
-
-const char* Configuration::getSubversionBranchName() {
-  return SUBVERSION_BRANCH_NAME;
-}
-
-unsigned Configuration::getSubversionRevision() {
-  return SUBVERSION_REVISION;
-}
-
-bool Configuration::hasSubversionModifications() {
-  return SUBVERSION_HAS_MODIFICATIONS;
-}
-
-std::string Configuration::getSubversionId() {
-  if(! isSubversionBuild()) {
-    return "";
-  }
-
-  stringstream ss;
-  ss << "subversion " << getSubversionBranchName() << " r" << getSubversionRevision()
-     << ( ::CVC4::Configuration::hasSubversionModifications() ? " (with modifications)" : "" );
   return ss.str();
 }
 

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -34,10 +34,6 @@ private:
   Configuration();
 
   // these constants are filled in by the build system
-  static const bool IS_SUBVERSION_BUILD;
-  static const char* const SUBVERSION_BRANCH_NAME;
-  static const unsigned SUBVERSION_REVISION;
-  static const bool SUBVERSION_HAS_MODIFICATIONS;
   static const bool IS_GIT_BUILD;
   static const char* const GIT_BRANCH_NAME;
   static const char* const GIT_COMMIT;
@@ -126,12 +122,6 @@ public:
   static const char* getGitCommit();
   static bool hasGitModifications();
   static std::string getGitId();
-
-  static bool isSubversionBuild();
-  static const char* getSubversionBranchName();
-  static unsigned getSubversionRevision();
-  static bool hasSubversionModifications();
-  static std::string getSubversionId();
 
   static std::string getCompiler();
   static std::string getCompiledDateTime();

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -288,8 +288,6 @@ int runCvc4(int argc, char* argv[], Options& opts) {
                   << " " << Configuration::getVersionString();
         if(Configuration::isGitBuild()) {
           Message() << " [" << Configuration::getGitId() << "]";
-        } else if(Configuration::isSubversionBuild()) {
-          Message() << " [" << Configuration::getSubversionId() << "]";
         }
         Message() << (Configuration::isDebugBuild() ? " DEBUG" : "")
                   << " assertions:"

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -1620,15 +1620,6 @@ void OptionsHandler::showConfiguration(std::string option) {
        << (Configuration::hasGitModifications() ? " (with modifications)" : "")
        << "]";
     print_config("scm", ss.str());
-  } else if(Configuration::isSubversionBuild()) {
-    std::stringstream ss;
-    ss << "svn ["
-       << Configuration::getSubversionBranchName() << " r"
-       << Configuration::getSubversionRevision()
-       << (Configuration::hasSubversionModifications()
-           ? " (with modifications)" : "")
-       << "]";
-    print_config("scm", ss.str());
   } else {
     print_config_cond("scm", false);
   }


### PR DESCRIPTION
The CVC4 project is not using SVN anymore, so printing SVN info is not
needed. This commit removes the code for detecting and printing SVN
build info.