### PR TITLE
Fix wrong evaluation of STRING_STOI

### DIFF
--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -434,11 +434,11 @@ EvalResult Evaluator::evalInternal(TNode n,
           const String& s = results[currNode[0]].d_str;
           if (s.isNumber())
           {
-            results[currNode] = EvalResult(Rational(-1));
+            results[currNode] = EvalResult(Rational(s.toNumber()));
           }
           else
           {
-            results[currNode] = EvalResult(Rational(s.toNumber()));
+            results[currNode] = EvalResult(Rational(-1));
           }
           break;
         }


### PR DESCRIPTION
Due to a flipped condition, the evaluation was returning -1 for numbers
and trying to convert a string into a number if it was not a number.
This commit fixes the issue.