### PR TITLE
Adding less consistency lemmas in bv-ackermann preprocessing pass

### DIFF
--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -46,8 +46,7 @@ void addLemmaForPair(TNode args1,
                      TNode args2,
                      const TNode func,
                      AssertionPipeline* assertionsToPreprocess,
-                     NodeManager* nm,
-                     std::stack<TNode>* stack)
+                     NodeManager* nm)
 {
   Node args_eq;
 
@@ -102,7 +101,7 @@ void storeFunctionAndAddLemmas(TNode func,
         "preprocessing pass for theory BV");
     for (const auto& t : set)
     {
-      addLemmaForPair(t, term, func, assertions, nm, stack);
+      addLemmaForPair(t, term, func, assertions, nm);
     }
     set.insert(term);
     fun_to_skolem.addSubstitution(term, skolem);

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -77,8 +77,6 @@ void addLemmaForPair(TNode args1,
   Node func_eq = nm->mkNode(kind::EQUAL, args1, args2);
   Node lemma = nm->mkNode(kind::IMPLIES, args_eq, func_eq);
   assertionsToPreprocess->push_back(lemma);
-  /* add the constraint to the stack so that
-  * collectFunctionsAndLemmas will process it as well. */
 }
 
 void storeFunctionAndAddLemmas(TNode func,
@@ -108,6 +106,8 @@ void storeFunctionAndAddLemmas(TNode func,
     }
     set.insert(term);
     fun_to_skolem.addSubstitution(term, skolem);
+    /* add the arguments to the stack so that
+     * collectFunctionsAndLemmas will process them as well. */
     for (TNode arg : term)
     {
       stack->push(arg);
@@ -161,8 +161,7 @@ void collectFunctionsAndLemmas(FunctionToArgsMap& fun_to_args,
           AlwaysAssert(
               term.getKind() != kind::STORE,
               "Cannot use eager bitblasting on QF_ABV formula with stores");
-          /* add childrens to the stack, so that they are processed later 
-           * do this only for childred that weren't already processed. */
+          /* add childrens to the stack, so that they are processed later */
           for (const TNode& n : term)
           {
             stack->push(n);

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -109,7 +109,7 @@ void storeFunctionAndAddLemmas(TNode func,
      * set*/
     if (set.size() == 2) 
     {
-      for (const TNode& elem : set)
+      for (TNode elem : set)
       {
         vec->insert(vec->end(), elem.begin(), elem.end());
       }
@@ -167,7 +167,7 @@ void collectFunctionsAndLemmas(FunctionToArgsMap& fun_to_args,
               term.getKind() != kind::STORE,
               "Cannot use eager bitblasting on QF_ABV formula with stores");
           /* add children to the vector, so that they are processed later */
-          for (const TNode& n : term)
+          for (TNode n : term)
           {
             vec->push_back(n);
           }

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -99,7 +99,7 @@ void storeFunctionAndAddLemmas(
         "BVSKOLEM$$",
         tn,
         "is a variable created by the ackermannization "
-        "preprocessing pass for theory BV, in place of: " + term.toString());
+        "preprocessing pass for theory BV");
     for (t: set) {
       addLemmaForPair(t, term, func, assertions, nm, stack);
     }
@@ -160,7 +160,6 @@ PreprocessingPassResult BVAckermann::applyInternal(
   }
   collectFunctionsAndLemmas(d_funcToArgs, d_funcToSkolem, &to_process, assertionsToPreprocess);
   
-  cout << "panda: " << d_funcToSkolem << endl;
   /* replace applications of UF by skolems */
   // FIXME for model building, github issue #1901
   for (unsigned i = 0, size = assertionsToPreprocess->size(); i < size; ++i)

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -175,7 +175,7 @@ void collectFunctionsAndLemmas(FunctionToArgsMap& fun_to_args,
           AlwaysAssert(
               term.getKind() != kind::STORE,
               "Cannot use eager bitblasting on QF_ABV formula with stores");
-          /* add childrens to the stack, so that they are processed later */
+          /* add children to the stack, so that they are processed later */
           for (const TNode& n : term)
           {
             stack->push(n);

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -102,7 +102,7 @@ void storeFunctionAndAddLemmas(
         tn,
         "is a variable created by the ackermannization "
         "preprocessing pass for theory BV");
-    for (t: set) {
+    for (const auto& t: set) {
       addLemmaForPair(t, term, func, assertions, nm, stack);
     }
     set.insert(term);

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -53,8 +53,7 @@ void addLemmaForPair(TNode args1,
 
   if (args1.getKind() == kind::APPLY_UF)
   {
-    AlwaysAssert(args1.getKind() == kind::APPLY_UF
-                 && args1.getOperator() == func);
+    AlwaysAssert(args1.getOperator() == func);
     AlwaysAssert(args2.getKind() == kind::APPLY_UF
                  && args2.getOperator() == func);
     AlwaysAssert(args1.getNumChildren() == args2.getNumChildren());
@@ -99,7 +98,7 @@ void storeFunctionAndAddLemmas(TNode func,
   if (set.find(term) == set.end())
   {
     TypeNode tn = term.getType();
-    Node skolem = NodeManager::currentNM()->mkSkolem(
+    Node skolem = nm->mkSkolem(
         "BVSKOLEM$$",
         tn,
         "is a variable created by the ackermannization "
@@ -114,7 +113,7 @@ void storeFunctionAndAddLemmas(TNode func,
 }
 
 /* We only add top-level applications of functions.
- * For example: when we see "f(g(x))", we do not add g is a function and x as a
+ * For example: when we see "f(g(x))", we do not add g as a function and x as a
  * parameter.
  * Instead, we only include f as a function and g(x) as a parameter.
  * However, if we see g(x) later on as a top-level application, we will add it

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -60,7 +60,7 @@ void storeFunction(
         "BVSKOLEM$$",
         tn,
         "is a variable created by the ackermannization "
-        "preprocessing pass for theory BV for the term " + term.toString());
+        "preprocessing pass for theory BV");
     fun_to_skolem.addSubstitution(term, skolem);
   }
 }
@@ -84,10 +84,10 @@ void collectFunctionSymbols(
   {
     AlwaysAssert(term.getKind() != kind::STORE,
                  "Cannot use eager bitblasting on QF_ABV formula with stores");
-    for (const TNode& n : term)
-    {
-      collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
-    }
+  }
+  for (const TNode& n : term)
+  {
+    collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
   }
   seen.insert(term);
 }

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -60,7 +60,7 @@ void storeFunction(
         "BVSKOLEM$$",
         tn,
         "is a variable created by the ackermannization "
-        "preprocessing pass for theory BV");
+        "preprocessing pass for theory BV for the term " + term.toString());
     fun_to_skolem.addSubstitution(term, skolem);
   }
 }

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -23,12 +23,10 @@
 
 #include "preprocessing/passes/bv_ackermann.h"
 
-#include "expr/node.h"
 #include "options/bv_options.h"
 #include "theory/bv/theory_bv_utils.h"
 
 #include <stack>
-#include <unordered_set>
 
 using namespace CVC4;
 using namespace CVC4::theory;
@@ -52,10 +50,10 @@ void addLemmaForPair(TNode args1,
 
   if (args1.getKind() == kind::APPLY_UF)
   {
-    AlwaysAssert(args1.getOperator() == func);
-    AlwaysAssert(args2.getKind() == kind::APPLY_UF
+    Assert(args1.getOperator() == func);
+    Assert(args2.getKind() == kind::APPLY_UF
                  && args2.getOperator() == func);
-    AlwaysAssert(args1.getNumChildren() == args2.getNumChildren());
+    Assert(args1.getNumChildren() == args2.getNumChildren());
 
     std::vector<Node> eqs(args1.getNumChildren());
 
@@ -67,10 +65,10 @@ void addLemmaForPair(TNode args1,
   }
   else
   {
-    AlwaysAssert(args1.getKind() == kind::SELECT && args1[0] == func);
-    AlwaysAssert(args2.getKind() == kind::SELECT && args2[0] == func);
-    AlwaysAssert(args1.getNumChildren() == 2);
-    AlwaysAssert(args2.getNumChildren() == 2);
+    Assert(args1.getKind() == kind::SELECT && args1[0] == func);
+    Assert(args2.getKind() == kind::SELECT && args2[0] == func);
+    Assert(args1.getNumChildren() == 2);
+    Assert(args2.getNumChildren() == 2);
     args_eq = nm->mkNode(kind::EQUAL, args1[1], args2[1]);
   }
   Node func_eq = nm->mkNode(kind::EQUAL, args1, args2);
@@ -80,7 +78,7 @@ void addLemmaForPair(TNode args1,
 
 void addChildrenToStack(TNode node, std::stack<TNode>* stack)
 {
-  for (TNode arg: node)
+  for (const TNode& arg: node)
   {
     stack->push(arg);
   }
@@ -96,9 +94,9 @@ void storeFunctionAndAddLemmas(TNode func,
 {
   if (fun_to_args.find(func) == fun_to_args.end())
   {
-    fun_to_args.insert(make_pair(func, NodeSet()));
+    fun_to_args.insert(make_pair(func, TNodeSet()));
   }
-  NodeSet& set = fun_to_args[func];
+  TNodeSet& set = fun_to_args[func];
   if (set.find(term) == set.end())
   {
     TypeNode tn = term.getType();
@@ -120,7 +118,7 @@ void storeFunctionAndAddLemmas(TNode func,
      * Therefore, we defer this for term in case it is the first element in the set*/
     if (set.size() == 2) 
     {
-      for (Node elem : set)
+      for (const TNode& elem : set)
       {
         addChildrenToStack(elem, stack);
       }
@@ -147,7 +145,7 @@ void collectFunctionsAndLemmas(FunctionToArgsMap& fun_to_args,
                                std::stack<TNode>* stack,
                                AssertionPipeline* assertions)
 {
-  std::unordered_set<TNode, TNodeHashFunction> seen;       
+  TNodeSet seen;       
   NodeManager* nm = NodeManager::currentNM();
   TNode term;
   while (!stack->empty())

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -84,10 +84,10 @@ void collectFunctionSymbols(
   {
     AlwaysAssert(term.getKind() != kind::STORE,
                  "Cannot use eager bitblasting on QF_ABV formula with stores");
-  }
-  for (const TNode& n : term)
-  {
-    collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
+    for (const TNode& n : term)
+    {
+      collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
+    }
   }
   seen.insert(term);
 }

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -60,7 +60,7 @@ void storeFunction(
         "BVSKOLEM$$",
         tn,
         "is a variable created by the ackermannization "
-        "preprocessing pass for theory BV");
+        "preprocessing pass for theory BV, in place of: " + term.toString());
     fun_to_skolem.addSubstitution(term, skolem);
   }
 }
@@ -84,12 +84,12 @@ void collectFunctionSymbols(
   {
     AlwaysAssert(term.getKind() != kind::STORE,
                  "Cannot use eager bitblasting on QF_ABV formula with stores");
-    for (const TNode& n : term)
-    {
-        collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
-    }
- }
- seen.insert(term);
+  }
+  for (const TNode& n : term)
+  {
+    collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
+  }
+  seen.insert(term);
 }
 
 }  // namespace

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -111,11 +111,11 @@ void storeFunctionAndAddLemmas(TNode func,
     {
       for (const TNode& elem : set)
       {
-        vec->insert(vec.end(), elem.begin(), elem.end())
+        vec->insert(vec->end(), elem.begin(), elem.end());
       }
     } else if (set.size() > 2)
     {
-      vec->insert(vec.end(), term.begin(), term.end())
+      vec->insert(vec->end(), term.begin(), term.end());
     } 
   }
 }
@@ -198,7 +198,7 @@ PreprocessingPassResult BVAckermann::applyInternal(
   std::vector<TNode> to_process;
   for (const Node& a : assertionsToPreprocess->ref())
   {
-    to_process.push(a);
+    to_process.push_back(a);
   }
   collectFunctionsAndLemmas(
       d_funcToArgs, d_funcToSkolem, &to_process, assertionsToPreprocess);

--- a/src/preprocessing/passes/bv_ackermann.cpp
+++ b/src/preprocessing/passes/bv_ackermann.cpp
@@ -84,12 +84,12 @@ void collectFunctionSymbols(
   {
     AlwaysAssert(term.getKind() != kind::STORE,
                  "Cannot use eager bitblasting on QF_ABV formula with stores");
-  }
-  for (const TNode& n : term)
-  {
-    collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
-  }
-  seen.insert(term);
+    for (const TNode& n : term)
+    {
+        collectFunctionSymbols(n, fun_to_args, fun_to_skolem, seen);
+    }
+ }
+ seen.insert(term);
 }
 
 }  // namespace

--- a/src/preprocessing/passes/bv_ackermann.h
+++ b/src/preprocessing/passes/bv_ackermann.h
@@ -26,10 +26,10 @@
 #ifndef __CVC4__PREPROCESSING__PASSES__BV_ACKERMANN_H
 #define __CVC4__PREPROCESSING__PASSES__BV_ACKERMANN_H
 
+#include <unordered_map>
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
 #include "preprocessing/preprocessing_pass_context.h"
-#include <unordered_map>
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_ackermann.h
+++ b/src/preprocessing/passes/bv_ackermann.h
@@ -35,8 +35,9 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
-typedef std::unordered_set<TNode, TNodeHashFunction> TNodeSet;
-typedef std::unordered_map<TNode, TNodeSet, TNodeHashFunction> FunctionToArgsMap;
+using TNodeSet = std::unordered_set<TNode, TNodeHashFunction>;
+using FunctionToArgsMap =
+    std::unordered_map<TNode, TNodeSet, TNodeHashFunction>;
 
 class BVAckermann : public PreprocessingPass
 {

--- a/src/preprocessing/passes/bv_ackermann.h
+++ b/src/preprocessing/passes/bv_ackermann.h
@@ -26,16 +26,17 @@
 #ifndef __CVC4__PREPROCESSING__PASSES__BV_ACKERMANN_H
 #define __CVC4__PREPROCESSING__PASSES__BV_ACKERMANN_H
 
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
 #include "preprocessing/preprocessing_pass_context.h"
-
 #include <unordered_map>
 
 namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
-typedef std::unordered_map<Node, NodeSet, NodeHashFunction> FunctionToArgsMap;
+typedef std::unordered_set<TNode, TNodeHashFunction> TNodeSet;
+typedef std::unordered_map<TNode, TNodeSet, TNodeHashFunction> FunctionToArgsMap;
 
 class BVAckermann : public PreprocessingPass
 {

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -155,6 +155,8 @@ REG0_TESTS = \
 	regress0/bug605.cvc \
 	regress0/bug639.smt2 \
 	regress0/buggy-ite.smt2 \
+	regress0/bv/ackermann1.smt2 \
+	regress0/bv/ackermann2.smt2 \
 	regress0/bv/bool-to-bv.smt2 \
 	regress0/bv/bug260a.smt \
 	regress0/bv/bug260b.smt \

--- a/test/regress/regress0/bv/ackermann1.smt2
+++ b/test/regress/regress0/bv/ackermann1.smt2
@@ -1,0 +1,13 @@
+(set-logic QF_UFBV)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-fun v0 () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun g ((_ BitVec 4)) (_ BitVec 4))
+
+(assert (= (f (f v0)) (g (f v0))))
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/bv/ackermann1.smt2
+++ b/test/regress/regress0/bv/ackermann1.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --bitblast=eager --no-check-models
+; EXPECT: sat
 (set-logic QF_UFBV)
 (set-info :smt-lib-version 2.0)
 (set-info :category "crafted")

--- a/test/regress/regress0/bv/ackermann1.smt2
+++ b/test/regress/regress0/bv/ackermann1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --bitblast=eager --no-check-models
+; COMMAND-LINE: --bitblast=eager --no-check-models --no-check-proofs --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/bv/ackermann2.smt2
+++ b/test/regress/regress0/bv/ackermann2.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --bitblast=eager --no-check-model
+; EXPECT: unsat
 (set-logic QF_UFBV)
 (set-info :smt-lib-version 2.0)
 (set-info :category "crafted")
@@ -9,8 +11,7 @@
 (declare-fun h ((_ BitVec 4)) (_ BitVec 4))
 
 (assert (not (= (f (g (h v0))) (f (g (h v1))))))
-;(assert (= v0 v1))
-(assert (not (= v0 v1)))
+(assert (= v0 v1))
 
 
 (check-sat)

--- a/test/regress/regress0/bv/ackermann2.smt2
+++ b/test/regress/regress0/bv/ackermann2.smt2
@@ -9,6 +9,7 @@
 (declare-fun h ((_ BitVec 4)) (_ BitVec 4))
 
 (assert (not (= (f (g (h v0))) (f (g (h v1))))))
+;(assert (= v0 v1))
 (assert (not (= v0 v1)))
 
 

--- a/test/regress/regress0/bv/ackermann2.smt2
+++ b/test/regress/regress0/bv/ackermann2.smt2
@@ -1,0 +1,16 @@
+(set-logic QF_UFBV)
+(set-info :smt-lib-version 2.0)
+(set-info :category "crafted")
+(set-info :status unsat)
+(declare-fun v0 () (_ BitVec 4))
+(declare-fun v1 () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun g ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun h ((_ BitVec 4)) (_ BitVec 4))
+
+(assert (not (= (f (g (h v0))) (f (g (h v1))))))
+(assert (= v0 v1))
+
+
+(check-sat)
+(exit)

--- a/test/regress/regress0/bv/ackermann2.smt2
+++ b/test/regress/regress0/bv/ackermann2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --bitblast=eager --no-check-model
+; COMMAND-LINE: --bitblast=eager --no-check-models --no-check-proofs --no-check-unsat-cores
 ; EXPECT: unsat
 (set-logic QF_UFBV)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/bv/ackermann2.smt2
+++ b/test/regress/regress0/bv/ackermann2.smt2
@@ -9,7 +9,7 @@
 (declare-fun h ((_ BitVec 4)) (_ BitVec 4))
 
 (assert (not (= (f (g (h v0))) (f (g (h v1))))))
-(assert (= v0 v1))
+(assert (not (= v0 v1)))
 
 
 (check-sat)


### PR DESCRIPTION
The bv-ackermannization preprocessing pass adds consistency lemmas for each occurrence of a function application in the input formula.
However, sometimes not all occurrences are needed.
For example, if the input formula is: `f(f(x))=g(f(x))` then no consistency lemma is needed, because a concrete value for f(x) is not needed for a solution.

This PR changes bv-ackermann, so that it adds consistency lemmas only for function applications that appear at "top-level", that is, not as sub-terms of another function application.
Consistency lemmas are now added while collecting the functions and the arguments. 