### PR TITLE
Add RegLan to smt2/sygus parsers

### DIFF
--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -287,6 +287,7 @@ void Smt2::addTheory(Theory theory) {
 
   case THEORY_STRINGS:
     defineType("String", getExprManager()->stringType());
+    defineType("RegLan", getExprManager()->regExpType());
     defineType("Int", getExprManager()->integerType());
     addStringOperators();
     break;

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -1542,6 +1542,7 @@ REG1_TESTS = \
 	regress1/sygus/process-10-vars.sy \
 	regress1/sygus/qe.sy \
 	regress1/sygus/real-grammar.sy \
+	regress1/sygus/simple-regexp.sy \
 	regress1/sygus/stopwatch-bt.sy \
 	regress1/sygus/strings-concat-3-args.sy \
 	regress1/sygus/strings-double-rec.sy \

--- a/test/regress/regress1/sygus/simple-regexp.sy
+++ b/test/regress/regress1/sygus/simple-regexp.sy
@@ -1,0 +1,37 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+(set-logic SLIA)
+(synth-fun P ((x String)) Bool (
+(Start Bool (
+  (str.in.re StartStr StartRL)
+  ))
+(StartStr String (
+  x
+  (str.++ StartStr StartStr)
+  ))
+(StartStrC String (
+  "A" "B" ""
+  (str.++ StartStrC StartStrC)))
+(StartRL RegLan (
+(re.++ StartRLi StartRLi)
+(re.inter StartRL StartRL)
+(re.union StartRL StartRL)
+(re.* StartRLi)
+))
+(StartRLi RegLan (
+(str.to.re StartStrC)
+(re.inter StartRLi StartRLi)
+(re.union StartRLi StartRLi)
+(re.++ StartRLi StartRLi)
+(re.* StartRLi)
+))
+))
+
+(constraint (P "AAAAA"))
+(constraint (P "AAA"))
+(constraint (P "AA"))
+(constraint (not (P "AB")))
+(constraint (not (P "B")))
+
+; (str.in.re x (re.* (str.to.re "A"))) is a solution
+(check-synth)


### PR DESCRIPTION
We can now handle sygus grammars involving regular expressions, and our theory solver is robust to reject regular expression variables. This PR adds RegLan to the smt2/sygus parser. It adds a simple sygus problem involving regular expressions.