### PR TITLE
Make flat form inferences optional in strings

### DIFF
--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -208,3 +208,12 @@ header = "options/strings_options.h"
   default    = "false"
   read_only  = true
   help       = "do length propagation based on constant splits"
+
+[[option]]
+  name       = "stringFlatForms"
+  category   = "regular"
+  long       = "strings-ff"
+  type       = "bool"
+  default    = "true"
+  read_only  = true
+  help       = "do flat form inferences"

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -4915,7 +4915,10 @@ void TheoryStrings::initializeStrategy()
     addStrategyStep(CHECK_CONST_EQC);
     addStrategyStep(CHECK_EXTF_EVAL, 0);
     addStrategyStep(CHECK_CYCLES);
-    addStrategyStep(CHECK_FLAT_FORMS);
+    if( options::stringFlatForms() )
+    {
+      addStrategyStep(CHECK_FLAT_FORMS);
+    }
     addStrategyStep(CHECK_EXTF_REDUCTION, 1);
     if (options::stringEager())
     {

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -4915,7 +4915,7 @@ void TheoryStrings::initializeStrategy()
     addStrategyStep(CHECK_CONST_EQC);
     addStrategyStep(CHECK_EXTF_EVAL, 0);
     addStrategyStep(CHECK_CYCLES);
-    if( options::stringFlatForms() )
+    if (options::stringFlatForms())
     {
       addStrategyStep(CHECK_FLAT_FORMS);
     }


### PR DESCRIPTION
Flat form inferences aren't strictly necessary and some benchmark sets we improve for "sat" without them.