### PR TITLE
Make output for flushInformation and safeFlushInformation consistent.

### DIFF
--- a/src/util/statistics.cpp
+++ b/src/util/statistics.cpp
@@ -112,6 +112,7 @@ void StatisticsBase::flushInformation(std::ostream &out) const {
       out << d_prefix << s_regDelim;
     }
     s->flushStat(out);
+    out << std::endl;
   }
 #endif /* CVC4_STATISTICS_ON */
 }

--- a/src/util/statistics_registry.h
+++ b/src/util/statistics_registry.h
@@ -562,7 +562,7 @@ public:
 
   void flushInformation(std::ostream& out) const override
   {
-    out << d_data << std::endl;
+    out << d_data;
   }
 
   void safeFlushInformation(int fd) const override


### PR DESCRIPTION
There was still a minor issue with printing statistics. Now `flushInformation` and `safeFlushInformation` produce the same number of newlines.