### PR TITLE
 Fix simple reg exp consume rewrite

### DIFF
--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -983,11 +983,18 @@ Node TheoryStringsRewriter::rewriteMembership(TNode node) {
         return scn;
       }else{
         if( (children.size() + mchildren.size())!=prevSize ){
+          // Given a membership (str.++ x1 ... xn) in (re.++ r1 ... rm),
+          // above, we strip components to construct an equivalent membership:
+          // (str.++ xi .. xj) in (re.++ rk ... rl).
           Node xn = mkConcat(kind::STRING_CONCAT, mchildren);
           Node emptyStr = nm->mkConst(String(""));
           if( children.empty() ){
+            // If we stripped all components on the right, then the left is
+            // equal to the empty string.
+            // e.g. (str.++ "a" x) in (re.++ (str.to.re "a")) ---> (= x "")
             retNode = xn.eqNode(emptyStr);
           }else{
+            // otherwise, construct the updated regular expression
             retNode = nm->mkNode(
                 STRING_IN_REGEXP, xn, mkConcat(REGEXP_CONCAT, children));
           }

--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -983,12 +983,15 @@ Node TheoryStringsRewriter::rewriteMembership(TNode node) {
         return scn;
       }else{
         if( (children.size() + mchildren.size())!=prevSize ){
+          Node xn = mkConcat( kind::STRING_CONCAT, mchildren );
+          Node emptyStr = nm->mkConst( String("") );
           if( children.empty() ){
-            retNode = NodeManager::currentNM()->mkConst( mchildren.empty() );
+            retNode = xn.eqNode(emptyStr);
           }else{
-            retNode = NodeManager::currentNM()->mkNode( kind::STRING_IN_REGEXP, mkConcat( kind::STRING_CONCAT, mchildren ), mkConcat( kind::REGEXP_CONCAT, children ) );
+            retNode = nm->mkNode( STRING_IN_REGEXP, xn, mkConcat( REGEXP_CONCAT, children ) );
           }
           Trace("regexp-ext-rewrite") << "Regexp : rewrite : " << node << " -> " << retNode << std::endl;
+          return returnRewrite(node,retNode,"re-simple-consume");
         }
       }
     }

--- a/src/theory/strings/theory_strings_rewriter.cpp
+++ b/src/theory/strings/theory_strings_rewriter.cpp
@@ -983,15 +983,16 @@ Node TheoryStringsRewriter::rewriteMembership(TNode node) {
         return scn;
       }else{
         if( (children.size() + mchildren.size())!=prevSize ){
-          Node xn = mkConcat( kind::STRING_CONCAT, mchildren );
-          Node emptyStr = nm->mkConst( String("") );
+          Node xn = mkConcat(kind::STRING_CONCAT, mchildren);
+          Node emptyStr = nm->mkConst(String(""));
           if( children.empty() ){
             retNode = xn.eqNode(emptyStr);
           }else{
-            retNode = nm->mkNode( STRING_IN_REGEXP, xn, mkConcat( REGEXP_CONCAT, children ) );
+            retNode = nm->mkNode(
+                STRING_IN_REGEXP, xn, mkConcat(REGEXP_CONCAT, children));
           }
           Trace("regexp-ext-rewrite") << "Regexp : rewrite : " << node << " -> " << retNode << std::endl;
-          return returnRewrite(node,retNode,"re-simple-consume");
+          return returnRewrite(node, retNode, "re-simple-consume");
         }
       }
     }

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -1472,6 +1472,7 @@ REG1_TESTS = \
 	regress1/strings/norn-nel-bug-052116.smt2 \
 	regress1/strings/norn-simp-rew-sat.smt2 \
 	regress1/strings/pierre150331.smt2 \
+	regress1/strings/re-unsound-080718.smt2 \
 	regress1/strings/regexp001.smt2 \
 	regress1/strings/regexp002.smt2 \
 	regress1/strings/regexp003.smt2 \

--- a/test/regress/regress1/strings/re-unsound-080718.smt2
+++ b/test/regress/regress1/strings/re-unsound-080718.smt2
@@ -1,7 +1,7 @@
+; COMMAND-LINE: --strings-print-ascii --strings-exp
+; EXPECT: sat
 (set-info :smt-lib-version 2.5)
 (set-logic ALL)
-(set-option :strings-exp true)
-(set-option :strings-print-ascii true)
 (set-info :status sat)
 (declare-fun x () String)
 (assert
@@ -17,4 +17,3 @@
 )
 )
 (check-sat)
-(get-model)

--- a/test/regress/regress1/strings/re-unsound-080718.smt2
+++ b/test/regress/regress1/strings/re-unsound-080718.smt2
@@ -1,6 +1,7 @@
 (set-info :smt-lib-version 2.5)
 (set-logic ALL)
 (set-option :strings-exp true)
+(set-option :strings-print-ascii true)
 (set-info :status sat)
 (declare-fun x () String)
 (assert

--- a/test/regress/regress1/strings/re-unsound-080718.smt2
+++ b/test/regress/regress1/strings/re-unsound-080718.smt2
@@ -1,0 +1,19 @@
+(set-info :smt-lib-version 2.5)
+(set-logic ALL)
+(set-option :strings-exp true)
+(set-info :status sat)
+(declare-fun x () String)
+(assert
+(and 
+(not (= 
+  (str.in.re x (re.++ (str.to.re "B") (re.* (str.to.re "B")))) 
+  (str.in.re x (re.++ (str.to.re "B") (str.to.re (str.++ "B" "B"))))
+)) 
+(not (= 
+  (str.in.re x (re.++ (re.union (re.++ (str.to.re "A") re.allchar ) re.allchar ) (str.to.re "B"))) 
+  (str.in.re x (re.++ (str.to.re "A") (str.to.re "B")))
+))
+)
+)
+(check-sat)
+(get-model)


### PR DESCRIPTION
This PR fixes an unsound rewrite introduced in https://github.com/CVC4/CVC4/commit/b0feac10d73770819839624dd943eedb14bd4c86.

When we stripped away all components on the RHS of a membership of the form:
`(str.++ x1...xn) in (re.++ r1...rm)`
we incorrectly rewrote the membership to false. However, if the resulting LHS contains only variables, then the membership should rewrite to LHS equals "".

Here is an instance of an incorrect rewrite:
`Regexp : rewrite : (str.in.re (str.++ "B" c_spt_10 "B") (re.++ (re.union (re.++ (str.to.re "A") re.allchar ) re.allchar ) (str.to.re "B"))) -> false`
In the corrected code, we rewrite:
`Regexp : rewrite : (str.in.re (str.++ "B" c_spt_10 "B") (re.++ (re.union (re.++ (str.to.re "A") re.allchar ) re.allchar ) (str.to.re "B"))) -> (= c_spt_10 "")`

This issue was found by the branch https://github.com/ajreynol/CVC4/tree/sygusQueryGen after 2358 seconds using --sygus-query-gen.