### PR TITLE
Do beta-reduction in expandDefinitions

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2823,17 +2823,19 @@ Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, Node
       {
         // Always do beta-reduction here. The reason is that there may be
         // operators such as INTS_MODULUS in the body of the lambda that would
-        // otherwise be introduced by beta-reduction via the rewriter. Hence,
-        // we expand here to ensure they are expanded during this call.
+        // otherwise be introduced by beta-reduction via the rewriter, but are
+        // not expanded here since the traversal in this function does not
+        // traverse the operators of nodes. Hence, we beta-reducte here to
+        // ensure operators in the body of the lambda are expanded during this
+        // call.
         if (n.getOperator().getKind() == kind::LAMBDA)
         {
           doExpand = true;
         }
         else if (options::macrosQuant() || options::sygusInference())
         {
-          // The above options that assign substitutions to APPLY_UF, thus we
-          // expand if we have inferred an operator corresponds to a defined
-          // function.
+          // The above options assign substitutions to APPLY_UF, thus we check
+          // here and expand if this operator corresponds to a defined function.
           doExpand = d_smt.isDefinedFunction(n.getOperator().toExpr());
         }
       }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2814,13 +2814,27 @@ Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, Node
       }
 
       // otherwise expand it
-      bool doExpand = k == kind::APPLY;
-      if( !doExpand ){
-        // options that assign substitutions to APPLY_UF
-        if (options::macrosQuant() || options::sygusInference())
+      bool doExpand = false;
+      if( k==kind::APPLY )
+      {
+        doExpand = true;
+      }
+      else if( k==kind::APPLY_UF )
+      {
+        // Always do beta-reduction here. The reason is that there may be
+        // operators such as INTS_MODULUS in the body of the lambda that would
+        // otherwise be introduced by beta-reduction via the rewriter. Hence,
+        // we expand here to ensure they are expanded during this call.
+        if( n.getOperator().getKind()==kind::LAMBDA )
         {
-          //expand if we have inferred an operator corresponds to a defined function
-          doExpand = k==kind::APPLY_UF && d_smt.isDefinedFunction( n.getOperator().toExpr() );
+          doExpand = true;
+        }
+        else if (options::macrosQuant() || options::sygusInference())
+        {
+          // The above options that assign substitutions to APPLY_UF, thus we
+          // expand if we have inferred an operator corresponds to a defined
+          // function.
+          doExpand = d_smt.isDefinedFunction( n.getOperator().toExpr() );
         }
       }
       if (doExpand) {

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2815,17 +2815,17 @@ Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, Node
 
       // otherwise expand it
       bool doExpand = false;
-      if( k==kind::APPLY )
+      if (k == kind::APPLY)
       {
         doExpand = true;
       }
-      else if( k==kind::APPLY_UF )
+      else if (k == kind::APPLY_UF)
       {
         // Always do beta-reduction here. The reason is that there may be
         // operators such as INTS_MODULUS in the body of the lambda that would
         // otherwise be introduced by beta-reduction via the rewriter. Hence,
         // we expand here to ensure they are expanded during this call.
-        if( n.getOperator().getKind()==kind::LAMBDA )
+        if (n.getOperator().getKind() == kind::LAMBDA)
         {
           doExpand = true;
         }
@@ -2834,7 +2834,7 @@ Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, Node
           // The above options that assign substitutions to APPLY_UF, thus we
           // expand if we have inferred an operator corresponds to a defined
           // function.
-          doExpand = d_smt.isDefinedFunction( n.getOperator().toExpr() );
+          doExpand = d_smt.isDefinedFunction(n.getOperator().toExpr());
         }
       }
       if (doExpand) {

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2825,8 +2825,8 @@ Node SmtEnginePrivate::expandDefinitions(TNode n, unordered_map<Node, Node, Node
         // operators such as INTS_MODULUS in the body of the lambda that would
         // otherwise be introduced by beta-reduction via the rewriter, but are
         // not expanded here since the traversal in this function does not
-        // traverse the operators of nodes. Hence, we beta-reducte here to
-        // ensure operators in the body of the lambda are expanded during this
+        // traverse the operators of nodes. Hence, we beta-reduce here to
+        // ensure terms in the body of the lambda are expanded during this
         // call.
         if (n.getOperator().getKind() == kind::LAMBDA)
         {


### PR DESCRIPTION
The PR #2266 uncovered a bug in SmtEngine for higher-order queries. In particular, --check-synth-sol (checking synthesis solutions) may give higher-order queries to CVC4 that involve beta-reducable applications of lambdas that contain operators that should be expanded during expandDefinitions.

This PR corrects this issue.

Consider the term:
`(APPLY_UF (lambda (x) (INT_MODULUS x 10)) t)`

Notice that this term's operator is `(lambda (x) (INT_MODULUS x 10))`.

We expect that INT_MODULUS is eliminated during the expand definitions pass and replaced by an appropriate term involving INT_MODULUS_TOTAL. However, expandDefinitions does not traverse into operators of nodes, hence that term remains unchanged currently, leading to an assertion failure when the rewriter beta-reduces the above expression to `(INT_MODULUS t 10)`.

This PR ensures that we apply beta-reduction during expandDefinitions, hence all terms that should be expanded are exposed in the expandDefinitions call.

This fixes the nightlies.