### PR TITLE
Do not use static initialization in CxxTest runner

### DIFF
--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -150,7 +150,7 @@ $(UNIT_TESTS:%=@am__quote@./@DEPDIR@/%.Plo@am__quote@): %.Plo:
 
 $(UNIT_TESTS:%=@abs_builddir@/%.cpp): @abs_builddir@/%.cpp: %.h
 	$(AM_V_at)$(MKDIR_P) `dirname "$@"`
-	$(AM_V_GEN)$(CXXTESTGEN) --have-eh --have-std --error-printer -o "$@" "$<"
+	$(AM_V_GEN)$(CXXTESTGEN) --no-static-init --have-eh --have-std --error-printer -o "$@" "$<"
 
 $(WHITE_TESTS:%=%.lo): %_white.lo: @abs_builddir@/%_white.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LTCXXCOMPILE) $(AM_CXXFLAGS_WHITE) -MT $@ -MD -MP -MF $(DEPDIR)/$(@:%.lo=%).Tpo -c -o $@ $<

--- a/test/unit/parser/parser_black.h
+++ b/test/unit/parser/parser_black.h
@@ -194,6 +194,8 @@ class ParserBlack
     d_lang(lang) {
   }
 
+  virtual ~ParserBlack() {}
+
   void setUp()
   {
     d_options.set(options::parseOnly, true);


### PR DESCRIPTION
The static initialization in the CxxTest runner was causing problems
when having `std::unique_ptr`s in test classes. When the ExprManager's
deconstructor is called, we count on certain static objects to be around
(e.g.
https://github.com/CVC4/CVC4/blob/0a02fd2b69c0c0f454fc33d8028b24f4fcf431de/src/expr/attribute_internals.h#L508).
If the ExprManager is (indirectly) owned by a `std::unique_ptr` in a
static class, however, there are no such guarantees as the destruction
order of static objects is not defined. This commit adds a flag for
CxxTest to not use static initialization in the test runner, which
solves the issue.  Additionally, the commit fixes a warning about a
missing virtual deconstructor in ParserBlack that came up after using
the new flags.

This fixes an issue reported in the nightly builds.