### PR TITLE
Consolidating the Node::substitute() functions into one implementation.

### DIFF
--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -254,7 +254,7 @@ class NodeTemplate {
    * return values and the NodeBuilders on the stack [potentially
    * transitively].)
    */
-  Node substitute_internal(
+  Node substituteInternal(
       std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const;
 
  public:
@@ -1351,11 +1351,11 @@ NodeTemplate<ref_count>::substitute(TNode node, TNode replacement) const {
   }
   std::unordered_map<TNode, TNode, TNodeHashFunction> cache{
       {node, replacement}};
-  return substitute_internal(cache);
+  return substituteInternal(cache);
 }
 
 template <bool ref_count>
-Node NodeTemplate<ref_count>::substitute_internal(
+Node NodeTemplate<ref_count>::substituteInternal(
     std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const
 {
   if (TNode* in_cache = FindOrNull(cache, *this))
@@ -1375,7 +1375,7 @@ Node NodeTemplate<ref_count>::substitute_internal(
     }
     else
     {
-      nb << getOperator().substitute_internal(cache);
+      nb << getOperator().substituteInternal(cache);
     }
   }
   for (const_iterator i = begin(), iend = end(); i != iend; ++i)
@@ -1386,11 +1386,13 @@ Node NodeTemplate<ref_count>::substitute_internal(
     }
     else
     {
-      nb << (*i).substitute_internal(cache);
+      nb << (*i).substituteInternal(cache);
     }
   }
   Node n = nb;
-  AlwaysAssert(cache.insert(std::make_pair(*this, n)).second);
+  CVC4_UNUSED const bool inserted =
+      cache.insert(std::make_pair(*this, n)).second;
+  Assert(inserted);
   return n;
 }
 
@@ -1409,7 +1411,7 @@ NodeTemplate<ref_count>::substitute(Iterator1 nodesBegin,
     cache.insert(std::make_pair(*nodesBegin, *replacementsBegin));
   }
   Assert(nodesBegin == nodesEnd && replacementsBegin == replacementsEnd);
-  return substitute_internal(cache);
+  return substituteInternal(cache);
 }
 
 template <bool ref_count>
@@ -1424,7 +1426,7 @@ NodeTemplate<ref_count>::substitute(Iterator substitutionsBegin,
     cache.insert(std::make_pair((*substitutionsBegin).first,
                                 (*substitutionsBegin).second));
   }
-  return substitute_internal(cache);
+  return substituteInternal(cache);
 }
 
 template <bool ref_count>

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -36,12 +36,13 @@
 #include "base/configuration.h"
 #include "base/cvc4_assert.h"
 #include "base/exception.h"
+#include "base/map_util.h"
 #include "base/output.h"
-#include "expr/type.h"
-#include "expr/kind.h"
-#include "expr/metakind.h"
 #include "expr/expr.h"
 #include "expr/expr_iomanip.h"
+#include "expr/kind.h"
+#include "expr/metakind.h"
+#include "expr/type.h"
 #include "options/language.h"
 #include "options/set_language.h"
 #include "util/hash.h"
@@ -237,32 +238,26 @@ class NodeTemplate {
     }
   }
 
-public:
-
+  // TODO Deprecate making this public.
+ public:
   /**
    * Cache-aware, recursive version of substitute() used by the public
-   * member function with a similar signature.
+   * member functions that substitutes any descendent reachable from this
+   * to a result node using the [descendent -> value] values in cache.
+   *
+   * Populates cache with any additional substitutions.
+   *
+   * May not produce a consistent result for all descendents if subnodes.
+   *
+   * Using TNodes here is potentially unsafe.
+   * Internal usage in Node is safe as node ref counts are kept >0 via the
+   * return values and the NodeBuilders on the stack [potentially
+   * transitively].)
    */
-  Node substitute(TNode node, TNode replacement,
-                  std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const;
+  Node substitute_internal(
+      std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const;
 
-  /**
-   * Cache-aware, recursive version of substitute() used by the public
-   * member function with a similar signature.
-   */
-  template <class Iterator1, class Iterator2>
-  Node substitute(Iterator1 nodesBegin, Iterator1 nodesEnd,
-                  Iterator2 replacementsBegin, Iterator2 replacementsEnd,
-                  std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const;
-
-  /**
-   * Cache-aware, recursive version of substitute() used by the public
-   * member function with a similar signature.
-   */
-  template <class Iterator>
-  Node substitute(Iterator substitutionsBegin, Iterator substitutionsEnd,
-                  std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const;
-
+ public:
   /** Default constructor, makes a null expression. */
   NodeTemplate() : d_nv(&expr::NodeValue::null()) { }
 
@@ -1354,51 +1349,48 @@ NodeTemplate<ref_count>::substitute(TNode node, TNode replacement) const {
   if (node == *this) {
     return replacement;
   }
-  std::unordered_map<TNode, TNode, TNodeHashFunction> cache;
-  return substitute(node, replacement, cache);
+  std::unordered_map<TNode, TNode, TNodeHashFunction> cache{
+      {node, replacement}};
+  return substitute_internal(cache);
 }
 
 template <bool ref_count>
-Node
-NodeTemplate<ref_count>::substitute(TNode node, TNode replacement,
-                                    std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const {
-  Assert(node != *this);
-
+Node NodeTemplate<ref_count>::substitute_internal(
+    std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const
+{
+  if (TNode* in_cache = FindOrNull(cache, *this))
+  {
+    return *in_cache;
+  }
+  // TODO(taking): can getNumChildren() == 0 and getMetaKind() == PARAMETERIZED?
   if (getNumChildren() == 0) {
     return *this;
   }
-
-  // in cache?
-  typename std::unordered_map<TNode, TNode, TNodeHashFunction>::const_iterator i = cache.find(*this);
-  if(i != cache.end()) {
-    return (*i).second;
-  }
-
-  // otherwise compute
   NodeBuilder<> nb(getKind());
   if(getMetaKind() == kind::metakind::PARAMETERIZED) {
     // push the operator
-    if(getOperator() == node) {
-      nb << replacement;
-    } else {
-      nb << getOperator().substitute(node, replacement, cache);
+    if (TNode* replacement = FindOrNull(cache, getOperator()))
+    {
+      nb << *replacement;
+    }
+    else
+    {
+      nb << getOperator().substitute_internal(cache);
     }
   }
-  for(const_iterator i = begin(),
-        iend = end();
-      i != iend;
-      ++i) {
-    if(*i == node) {
-      nb << replacement;
-    } else {
-      nb << (*i).substitute(node, replacement, cache);
+  for (const_iterator i = begin(), iend = end(); i != iend; ++i)
+  {
+    if (TNode* replacement = FindOrNull(cache, *i))
+    {
+      nb << *replacement;
+    }
+    else
+    {
+      nb << (*i).substitute_internal(cache);
     }
   }
-
-  // put in cache
   Node n = nb;
-  Assert(node != n);
-  cache[*this] = n;
+  AlwaysAssert(cache.insert(std::make_pair(*this, n)).second);
   return n;
 }
 
@@ -1410,57 +1402,14 @@ NodeTemplate<ref_count>::substitute(Iterator1 nodesBegin,
                                     Iterator2 replacementsBegin,
                                     Iterator2 replacementsEnd) const {
   std::unordered_map<TNode, TNode, TNodeHashFunction> cache;
-  return substitute(nodesBegin, nodesEnd,
-                    replacementsBegin, replacementsEnd, cache);
-}
-
-template <bool ref_count>
-template <class Iterator1, class Iterator2>
-Node
-NodeTemplate<ref_count>::substitute(Iterator1 nodesBegin,
-                                    Iterator1 nodesEnd,
-                                    Iterator2 replacementsBegin,
-                                    Iterator2 replacementsEnd,
-                                    std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const {
-  // in cache?
-  typename std::unordered_map<TNode, TNode, TNodeHashFunction>::const_iterator i = cache.find(*this);
-  if(i != cache.end()) {
-    return (*i).second;
+  for (; nodesBegin != nodesEnd && replacementsBegin != replacementsEnd;
+       ++nodesBegin, ++replacementsBegin)
+  {
+    // Keep the first key on a collision.
+    cache.insert(std::make_pair(*nodesBegin, *replacementsBegin));
   }
-
-  // otherwise compute
-  Assert( std::distance(nodesBegin, nodesEnd) == std::distance(replacementsBegin, replacementsEnd),
-          "Substitution iterator ranges must be equal size" );
-  Iterator1 j = find(nodesBegin, nodesEnd, TNode(*this));
-  if(j != nodesEnd) {
-    Iterator2 b = replacementsBegin;
-    std::advance(b, std::distance(nodesBegin, j));
-    Node n = *b;
-    cache[*this] = n;
-    return n;
-  } else if(getNumChildren() == 0) {
-    cache[*this] = *this;
-    return *this;
-  } else {
-    NodeBuilder<> nb(getKind());
-    if(getMetaKind() == kind::metakind::PARAMETERIZED) {
-      // push the operator
-      nb << getOperator().substitute(nodesBegin, nodesEnd,
-                                     replacementsBegin, replacementsEnd,
-                                     cache);
-    }
-    for(const_iterator i = begin(),
-          iend = end();
-        i != iend;
-        ++i) {
-      nb << (*i).substitute(nodesBegin, nodesEnd,
-                            replacementsBegin, replacementsEnd,
-                            cache);
-    }
-    Node n = nb;
-    cache[*this] = n;
-    return n;
-  }
+  Assert(nodesBegin == nodesEnd && replacementsBegin == replacementsEnd);
+  return substitute_internal(cache);
 }
 
 template <bool ref_count>
@@ -1469,47 +1418,13 @@ inline Node
 NodeTemplate<ref_count>::substitute(Iterator substitutionsBegin,
                                     Iterator substitutionsEnd) const {
   std::unordered_map<TNode, TNode, TNodeHashFunction> cache;
-  return substitute(substitutionsBegin, substitutionsEnd, cache);
-}
-
-template <bool ref_count>
-template <class Iterator>
-Node
-NodeTemplate<ref_count>::substitute(Iterator substitutionsBegin,
-                                    Iterator substitutionsEnd,
-                                    std::unordered_map<TNode, TNode, TNodeHashFunction>& cache) const {
-  // in cache?
-  typename std::unordered_map<TNode, TNode, TNodeHashFunction>::const_iterator i = cache.find(*this);
-  if(i != cache.end()) {
-    return (*i).second;
+  for (; substitutionsBegin != substitutionsEnd; ++substitutionsBegin)
+  {
+    // Keep the first key on a collision.
+    cache.insert(std::make_pair((*substitutionsBegin).first,
+                                (*substitutionsBegin).second));
   }
-
-  // otherwise compute
-  Iterator j = find_if(substitutionsBegin, substitutionsEnd,
-                       bind2nd(first_equal_to<typename Iterator::value_type::first_type, typename Iterator::value_type::second_type>(), *this));
-  if(j != substitutionsEnd) {
-    Node n = (*j).second;
-    cache[*this] = n;
-    return n;
-  } else if(getNumChildren() == 0) {
-    cache[*this] = *this;
-    return *this;
-  } else {
-    NodeBuilder<> nb(getKind());
-    if(getMetaKind() == kind::metakind::PARAMETERIZED) {
-      // push the operator
-      nb << getOperator().substitute(substitutionsBegin, substitutionsEnd, cache);
-    }
-    for(const_iterator i = begin(),
-          iend = end();
-        i != iend;
-        ++i) {
-      nb << (*i).substitute(substitutionsBegin, substitutionsEnd, cache);
-    }
-    Node n = nb;
-    cache[*this] = n;
-    return n;
-  }
+  return substitute_internal(cache);
 }
 
 template <bool ref_count>

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -332,7 +332,7 @@ void SygusSymBreakNew::assertTesterInternal( int tindex, TNode n, Node exp, std:
     Node rlv = getRelevancyCondition(n);
     for (const Node& slem : sb_lemmas)
     {
-      Node sslem = slem.substitute_internal(cache);
+      Node sslem = slem.substituteInternal(cache);
       if (!rlv.isNull())
       {
         sslem = nm->mkNode(OR, rlv, sslem);
@@ -1044,7 +1044,7 @@ void SygusSymBreakNew::addSymBreakLemmasFor( TypeNode tn, Node t, unsigned d, No
       if( (int)it->first<=max_sz ){
         for (const Node& lem : it->second)
         {
-          Node slem = lem.substitute_internal(cache);
+          Node slem = lem.substituteInternal(cache);
           // add the relevancy condition for t
           if (!rlv.isNull())
           {
@@ -1214,7 +1214,7 @@ void SygusSymBreakNew::incrementCurrentSearchSize( Node m, std::vector< Node >& 
                     {x, t}};
                 for (const Node& lem : it->second)
                 {
-                  Node slem = lem.substitute_internal(cache);
+                  Node slem = lem.substituteInternal(cache);
                   slem = nm->mkNode(OR, rlv, slem);
                   lemmas.push_back(slem);
                 }

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -328,11 +328,11 @@ void SygusSymBreakNew::assertTesterInternal( int tindex, TNode n, Node exp, std:
     }
 
     // add the above symmetry breaking predicates to lemmas
-    std::unordered_map<TNode, TNode, TNodeHashFunction> cache;
+    std::unordered_map<TNode, TNode, TNodeHashFunction> cache{{x, n}};
     Node rlv = getRelevancyCondition(n);
     for (const Node& slem : sb_lemmas)
     {
-      Node sslem = slem.substitute(x, n, cache);
+      Node sslem = slem.substitute_internal(cache);
       if (!rlv.isNull())
       {
         sslem = nm->mkNode(OR, rlv, sslem);
@@ -1039,12 +1039,12 @@ void SygusSymBreakNew::addSymBreakLemmasFor( TypeNode tn, Node t, unsigned d, No
     Trace("sygus-sb-debug2")
         << "add lemmas up to size " << max_sz << ", which is (search_size) "
         << csz << " - (depth) " << d << std::endl;
-    std::unordered_map<TNode, TNode, TNodeHashFunction> cache;
+    std::unordered_map<TNode, TNode, TNodeHashFunction> cache{{x, t}};
     for( std::map< unsigned, std::vector< Node > >::iterator it = its->second.begin(); it != its->second.end(); ++it ){
       if( (int)it->first<=max_sz ){
         for (const Node& lem : it->second)
         {
-          Node slem = lem.substitute(x, t, cache);
+          Node slem = lem.substitute_internal(cache);
           // add the relevancy condition for t
           if (!rlv.isNull())
           {
@@ -1210,10 +1210,11 @@ void SygusSymBreakNew::incrementCurrentSearchSize( Node m, std::vector< Node >& 
                          && !it->second.empty())
               {
                 Node rlv = getRelevancyCondition(t);
-                std::unordered_map<TNode, TNode, TNodeHashFunction> cache;
+                std::unordered_map<TNode, TNode, TNodeHashFunction> cache{
+                    {x, t}};
                 for (const Node& lem : it->second)
                 {
-                  Node slem = lem.substitute(x, t, cache);
+                  Node slem = lem.substitute_internal(cache);
                   slem = nm->mkNode(OR, rlv, slem);
                   lemmas.push_back(slem);
                 }

--- a/src/theory/quantifiers/sygus/sygus_invariance.cpp
+++ b/src/theory/quantifiers/sygus/sygus_invariance.cpp
@@ -58,7 +58,7 @@ bool EvalSygusInvarianceTest::invariant(TermDbSygus* tds, Node nvn, Node x)
   std::unordered_map<TNode, TNode, TNodeHashFunction> cache{{d_var, tnvn}};
   for (const Node& c : d_terms)
   {
-    Node conj_subs = c.substitute_internal(cache);
+    Node conj_subs = c.substituteInternal(cache);
     Node conj_subs_unfold = doEvaluateWithUnfolding(tds, conj_subs);
     Trace("sygus-cref-eval2-debug")
         << "  ...check unfolding : " << conj_subs_unfold << std::endl;

--- a/src/theory/quantifiers/sygus/sygus_invariance.cpp
+++ b/src/theory/quantifiers/sygus/sygus_invariance.cpp
@@ -55,10 +55,10 @@ Node EvalSygusInvarianceTest::doEvaluateWithUnfolding(TermDbSygus* tds, Node n)
 bool EvalSygusInvarianceTest::invariant(TermDbSygus* tds, Node nvn, Node x)
 {
   TNode tnvn = nvn;
-  std::unordered_map<TNode, TNode, TNodeHashFunction> cache;
+  std::unordered_map<TNode, TNode, TNodeHashFunction> cache{{d_var, tnvn}};
   for (const Node& c : d_terms)
   {
-    Node conj_subs = c.substitute(d_var, tnvn, cache);
+    Node conj_subs = c.substitute_internal(cache);
     Node conj_subs_unfold = doEvaluateWithUnfolding(tds, conj_subs);
     Trace("sygus-cref-eval2-debug")
         << "  ...check unfolding : " << conj_subs_unfold << std::endl;


### PR DESCRIPTION
This PR consolidates the implementations of Node::substitute() down to one workhorse based around std::unordered_map.

I have gone with the approach of:
* keeping old behaviors and contracts (orders are kept when relevant, keep using TNode even if dangerous, keep substitute_internal public as their are existing users)
* using c++11 features and map_util.h to simplify the code.

I will need help with doing a before/after performance comparison.

A follow-up PR will move the Node::substitute() implementations into its own class. These do not need to be on Node/TNode.