### PR TITLE
Make sort inference a preprocessing pass

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -85,6 +85,8 @@ libcvc4_la_SOURCES = \
 	preprocessing/passes/rewrite.h \
 	preprocessing/passes/sep_skolem_emp.cpp \
 	preprocessing/passes/sep_skolem_emp.h \
+	preprocessing/passes/sort_infer.cpp \
+	preprocessing/passes/sort_infer.h \
 	preprocessing/passes/static_learning.cpp \
 	preprocessing/passes/static_learning.h \
 	preprocessing/passes/symmetry_breaker.cpp \

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -61,7 +61,7 @@ PreprocessingPassResult SortInferencePass::applyInternal(
     // indicate correspondence between the functions
     // TODO (#2308): move this to a better place
     SmtEngine* smt = smt::currentSmtEngine();
-    for( const std::pair< const Node, Node >& mrf : model_replace_f )
+    for (const std::pair<const Node, Node>& mrf : model_replace_f)
     {
       smt->setPrintFuncInModel(mrf.first.toExpr(), false);
       smt->setPrintFuncInModel(mrf.second.toExpr(), true);

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -58,7 +58,8 @@ PreprocessingPassResult SortInferencePass::applyInternal(
     {
       Node nar = theory::Rewriter::rewrite(na);
       Trace("sort-infer-preprocess")
-          << "*** Preprocess SortInferencePass : new constraint " << nar << endl;
+          << "*** Preprocess SortInferencePass : new constraint " << nar
+          << endl;
       assertionsToPreprocess->push_back(nar);
     }
     // indicate correspondence between the functions

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -16,6 +16,7 @@
 
 #include "options/smt_options.h"
 #include "options/uf_options.h"
+#include "theory/rewriter.h"
 
 using namespace std;
 
@@ -43,7 +44,7 @@ PreprocessingPassResult SortInferencePass::applyInternal(
       Node next = d_si->simplify(prev, model_replace_f, visited);
       if (next != prev)
       {
-        next = Rewriter::rewrite(next);
+        next = theory::Rewriter::rewrite(next);
         assertionsToPreprocess->replace(i, next);
         Trace("sort-infer-preprocess")
             << "*** Preprocess SortInferencePass " << prev << endl;

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -41,8 +41,8 @@ PreprocessingPassResult SortInferencePass::applyInternal(
       if (next != prev)
       {
         assertionsToPreprocess->replace(i, next);
-        Trace("sort_infer-preprocess") << "*** Preprocess SortInferencePass " << prev << endl;
-        Trace("sort_infer-preprocess") << "   ...got " << (*assertionsToPreprocess)[i]
+        Trace("sort-infer-preprocess") << "*** Preprocess SortInferencePass " << prev << endl;
+        Trace("sort-infer-preprocess") << "   ...got " << (*assertionsToPreprocess)[i]
                                 << endl;
       }
     }
@@ -50,7 +50,7 @@ PreprocessingPassResult SortInferencePass::applyInternal(
     d_si->getNewAssertions(newAsserts);
     for( const Node& na : newAsserts )
     {
-      Trace("sort_infer-preprocess") << "*** Preprocess SortInferencePass : new constraint " << na << endl;
+      Trace("sort-infer-preprocess") << "*** Preprocess SortInferencePass : new constraint " << na << endl;
       assertionsToPreprocess->push_back(na);
     }
   }

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -43,6 +43,7 @@ PreprocessingPassResult SortInferencePass::applyInternal(
       Node next = d_si->simplify(prev, model_replace_f, visited);
       if (next != prev)
       {
+        next = Rewriter::rewrite(next);
         assertionsToPreprocess->replace(i, next);
         Trace("sort-infer-preprocess")
             << "*** Preprocess SortInferencePass " << prev << endl;

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -14,8 +14,8 @@
 
 #include "preprocessing/passes/sort_infer.h"
 
-#include "options/uf_options.h"
 #include "options/smt_options.h"
+#include "options/uf_options.h"
 
 using namespace std;
 
@@ -23,42 +23,46 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
-
-SortInferencePass::SortInferencePass(PreprocessingPassContext* preprocContext, SortInference * si)
-    : PreprocessingPass(preprocContext, "sort-inference"), d_si(si){}
+SortInferencePass::SortInferencePass(PreprocessingPassContext* preprocContext,
+                                     SortInference* si)
+    : PreprocessingPass(preprocContext, "sort-inference"), d_si(si)
+{
+}
 
 PreprocessingPassResult SortInferencePass::applyInternal(
     AssertionPipeline* assertionsToPreprocess)
 {
-  if( options::sortInference() )
+  if (options::sortInference())
   {
-    d_si->initialize( assertionsToPreprocess->ref() );
-    std::map< Node, std::map< TypeNode, Node > > visited;
-    for (unsigned i = 0, size = assertionsToPreprocess->size(); i<size; i++)
+    d_si->initialize(assertionsToPreprocess->ref());
+    std::map<Node, std::map<TypeNode, Node> > visited;
+    for (unsigned i = 0, size = assertionsToPreprocess->size(); i < size; i++)
     {
       Node prev = (*assertionsToPreprocess)[i];
       Node next = d_si->simplify(prev, visited);
       if (next != prev)
       {
         assertionsToPreprocess->replace(i, next);
-        Trace("sort-infer-preprocess") << "*** Preprocess SortInferencePass " << prev << endl;
-        Trace("sort-infer-preprocess") << "   ...got " << (*assertionsToPreprocess)[i]
-                                << endl;
+        Trace("sort-infer-preprocess")
+            << "*** Preprocess SortInferencePass " << prev << endl;
+        Trace("sort-infer-preprocess")
+            << "   ...got " << (*assertionsToPreprocess)[i] << endl;
       }
     }
-    std::vector< Node > newAsserts;
+    std::vector<Node> newAsserts;
     d_si->getNewAssertions(newAsserts);
-    for( const Node& na : newAsserts )
+    for (const Node& na : newAsserts)
     {
-      Trace("sort-infer-preprocess") << "*** Preprocess SortInferencePass : new constraint " << na << endl;
+      Trace("sort-infer-preprocess")
+          << "*** Preprocess SortInferencePass : new constraint " << na << endl;
       assertionsToPreprocess->push_back(na);
     }
   }
   // only need to compute monotonicity on the resulting formula if we are
   // using this option
-  if( options::ufssFairnessMonotone() )
+  if (options::ufssFairnessMonotone())
   {
-    d_si->computeMonotonicity(assertionsToPreprocess->ref() );
+    d_si->computeMonotonicity(assertionsToPreprocess->ref());
   }
   return PreprocessingPassResult::NO_CONFLICT;
 }

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -61,12 +61,10 @@ PreprocessingPassResult SortInferencePass::applyInternal(
     // indicate correspondence between the functions
     // TODO (#2308): move this to a better place
     SmtEngine* smt = smt::currentSmtEngine();
-    for (std::map<Node, Node>::iterator it = model_replace_f.begin();
-         it != model_replace_f.end();
-         ++it)
+    for( const std::pair< const Node, Node >& mrf : model_replace_f )
     {
-      smt->setPrintFuncInModel(it->first.toExpr(), false);
-      smt->setPrintFuncInModel(it->second.toExpr(), true);
+      smt->setPrintFuncInModel(mrf.first.toExpr(), false);
+      smt->setPrintFuncInModel(mrf.second.toExpr(), true);
     }
   }
   // only need to compute monotonicity on the resulting formula if we are

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -35,7 +35,7 @@ PreprocessingPassResult SortInferencePass::applyInternal(
   if (options::sortInference())
   {
     d_si->initialize(assertionsToPreprocess->ref());
-    std::map< Node, Node > model_replace_f;
+    std::map<Node, Node> model_replace_f;
     std::map<Node, std::map<TypeNode, Node> > visited;
     for (unsigned i = 0, size = assertionsToPreprocess->size(); i < size; i++)
     {
@@ -60,11 +60,13 @@ PreprocessingPassResult SortInferencePass::applyInternal(
     }
     // indicate correspondence between the functions
     // TODO (#2308): move this to a better place
-    SmtEngine * smt = smt::currentSmtEngine();
-    for( std::map< Node, Node >::iterator it = model_replace_f.begin();
-     it != model_replace_f.end(); ++it ){
-      smt->setPrintFuncInModel( it->first.toExpr(), false );
-      smt->setPrintFuncInModel( it->second.toExpr(), true );
+    SmtEngine* smt = smt::currentSmtEngine();
+    for (std::map<Node, Node>::iterator it = model_replace_f.begin();
+         it != model_replace_f.end();
+         ++it)
+    {
+      smt->setPrintFuncInModel(it->first.toExpr(), false);
+      smt->setPrintFuncInModel(it->second.toExpr(), true);
     }
   }
   // only need to compute monotonicity on the resulting formula if we are

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -1,0 +1,68 @@
+/*********************                                                        */
+/*! \file sort_infer.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Symmetry breaker module
+ **/
+
+#include "preprocessing/passes/sort_infer.h"
+
+#include "options/uf_options.h"
+#include "options/smt_options.h"
+
+using namespace std;
+
+namespace CVC4 {
+namespace preprocessing {
+namespace passes {
+
+
+SortInferencePass::SortInferencePass(PreprocessingPassContext* preprocContext, SortInference * si)
+    : PreprocessingPass(preprocContext, "sort-inference"), d_si(si){}
+
+PreprocessingPassResult SortInferencePass::applyInternal(
+    AssertionPipeline* assertionsToPreprocess)
+{
+  if( options::sortInference() )
+  {
+    d_si->initialize( assertionsToPreprocess->ref() );
+    std::map< Node, std::map< TypeNode, Node > > visited;
+    for (unsigned i = 0, size = assertionsToPreprocess->size(); i<size; i++)
+    {
+      Node prev = (*assertionsToPreprocess)[i];
+      Node next = d_si->simplify(prev, visited);
+      if (next != prev)
+      {
+        assertionsToPreprocess->replace(i, next);
+        Trace("sort_infer-preprocess") << "*** Preprocess SortInferencePass " << prev << endl;
+        Trace("sort_infer-preprocess") << "   ...got " << (*assertionsToPreprocess)[i]
+                                << endl;
+      }
+    }
+    std::vector< Node > newAsserts;
+    d_si->getNewAssertions(newAsserts);
+    for( const Node& na : newAsserts )
+    {
+      Trace("sort_infer-preprocess") << "*** Preprocess SortInferencePass : new constraint " << na << endl;
+      assertionsToPreprocess->push_back(na);
+    }
+  }
+  // only need to compute monotonicity on the resulting formula if we are
+  // using this option
+  if( options::ufssFairnessMonotone() )
+  {
+    d_si->computeMonotonicity(assertionsToPreprocess->ref() );
+  }
+  return PreprocessingPassResult::NO_CONFLICT;
+}
+
+}  // namespace passes
+}  // namespace preprocessing
+}  // namespace CVC4

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -56,9 +56,10 @@ PreprocessingPassResult SortInferencePass::applyInternal(
     d_si->getNewAssertions(newAsserts);
     for (const Node& na : newAsserts)
     {
+      Node nar = theory::Rewriter::rewrite(na);
       Trace("sort-infer-preprocess")
-          << "*** Preprocess SortInferencePass : new constraint " << na << endl;
-      assertionsToPreprocess->push_back(na);
+          << "*** Preprocess SortInferencePass : new constraint " << nar << endl;
+      assertionsToPreprocess->push_back(nar);
     }
     // indicate correspondence between the functions
     // TODO (#2308): move this to a better place

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -9,7 +9,7 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief Symmetry breaker module
+ ** \brief Sort inference preprocessing pass
  **/
 
 #include "preprocessing/passes/sort_infer.h"

--- a/src/preprocessing/passes/sort_infer.h
+++ b/src/preprocessing/passes/sort_infer.h
@@ -1,0 +1,53 @@
+/*********************                                                        */
+/*! \file pass.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief SortInferencePass
+ **/
+
+#ifndef __CVC4__PREPROCESSING__PASSES__SORT_INFERENCE_PASS_H_
+#define __CVC4__PREPROCESSING__PASSES__SORT_INFERENCE_PASS_H_
+
+#include <map>
+#include <string>
+#include <vector>
+#include "expr/node.h"
+
+#include "preprocessing/preprocessing_pass.h"
+#include "preprocessing/preprocessing_pass_context.h"
+#include "theory/sort_inference.h"
+
+namespace CVC4 {
+namespace preprocessing {
+namespace passes {
+
+
+/** SortInferencePass
+ * 
+ * This preprocessing pass runs sort inference techniques on the input formula
+ */
+class SortInferencePass : public PreprocessingPass
+{
+ public:
+  SortInferencePass(PreprocessingPassContext* preprocContext, SortInference * si);
+
+ protected:
+  PreprocessingPassResult applyInternal(
+      AssertionPipeline* assertionsToPreprocess) override;
+ private:
+  /** pointer to the sort inference module */
+  SortInference * d_si;
+};
+
+}  // namespace passes
+}  // namespace preprocessing
+}  // namespace CVC4
+
+#endif /* __CVC4__PREPROCESSING__PASSES__SORT_INFERENCE_PASS_H_ */

--- a/src/preprocessing/passes/sort_infer.h
+++ b/src/preprocessing/passes/sort_infer.h
@@ -1,5 +1,5 @@
 /*********************                                                        */
-/*! \file pass.h
+/*! \file sort_infer.h
  ** \verbatim
  ** Top contributors (to current version):
  **   Andrew Reynolds
@@ -9,7 +9,7 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief SortInferencePass
+ ** \brief Sort inference preprocessing pass
  **/
 
 #ifndef __CVC4__PREPROCESSING__PASSES__SORT_INFERENCE_PASS_H_
@@ -30,7 +30,8 @@ namespace passes {
 
 /** SortInferencePass
  *
- * This preprocessing pass runs sort inference techniques on the input formula
+ * This preprocessing pass runs sort inference techniques on the input formula.
+ * For details on these techniques, see theory/sort_inference.h.
  */
 class SortInferencePass : public PreprocessingPass
 {
@@ -43,7 +44,10 @@ class SortInferencePass : public PreprocessingPass
       AssertionPipeline* assertionsToPreprocess) override;
 
  private:
-  /** pointer to the sort inference module */
+  /** 
+   * Pointer to the sort inference module. This should be the sort inference
+   * belonging to the theory engine of the current SMT engine.
+   */
   SortInference* d_si;
 };
 

--- a/src/preprocessing/passes/sort_infer.h
+++ b/src/preprocessing/passes/sort_infer.h
@@ -28,22 +28,23 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
-
 /** SortInferencePass
- * 
+ *
  * This preprocessing pass runs sort inference techniques on the input formula
  */
 class SortInferencePass : public PreprocessingPass
 {
  public:
-  SortInferencePass(PreprocessingPassContext* preprocContext, SortInference * si);
+  SortInferencePass(PreprocessingPassContext* preprocContext,
+                    SortInference* si);
 
  protected:
   PreprocessingPassResult applyInternal(
       AssertionPipeline* assertionsToPreprocess) override;
+
  private:
   /** pointer to the sort inference module */
-  SortInference * d_si;
+  SortInference* d_si;
 };
 
 }  // namespace passes

--- a/src/preprocessing/passes/sort_infer.h
+++ b/src/preprocessing/passes/sort_infer.h
@@ -44,7 +44,7 @@ class SortInferencePass : public PreprocessingPass
       AssertionPipeline* assertionsToPreprocess) override;
 
  private:
-  /** 
+  /**
    * Pointer to the sort inference module. This should be the sort inference
    * belonging to the theory engine of the current SMT engine.
    */

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2737,7 +2737,8 @@ void SmtEnginePrivate::finishInit()
   std::unique_ptr<Rewrite> rewrite(
       new Rewrite(d_preprocessingPassContext.get()));
   std::unique_ptr<SortInferencePass> sortInfer(
-      new SortInferencePass(d_preprocessingPassContext.get(),d_smt.d_theoryEngine->getSortInference()));
+      new SortInferencePass(d_preprocessingPassContext.get(),
+                            d_smt.d_theoryEngine->getSortInference()));
   std::unique_ptr<StaticLearning> staticLearning(
       new StaticLearning(d_preprocessingPassContext.get()));
   std::unique_ptr<SymBreakerPass> sbProc(
@@ -2746,7 +2747,7 @@ void SmtEnginePrivate::finishInit()
       new SynthRewRulesPass(d_preprocessingPassContext.get()));
   std::unique_ptr<SepSkolemEmp> sepSkolemEmp(
       new SepSkolemEmp(d_preprocessingPassContext.get()));
-   d_preprocessingPassRegistry.registerPass("apply-substs",
+  d_preprocessingPassRegistry.registerPass("apply-substs",
                                            std::move(applySubsts));
   d_preprocessingPassRegistry.registerPass("bool-to-bv", std::move(boolToBv));
   d_preprocessingPassRegistry.registerPass("bv-abstraction",
@@ -4337,10 +4338,10 @@ void SmtEnginePrivate::processAssertions() {
   }
 
   if( options::sortInference() || options::ufssFairnessMonotone() ){
-    d_preprocessingPassRegistry.getPass("sort-inference")
-        ->apply(&d_assertions);
+    d_preprocessingPassRegistry.getPass("sort-inference")->apply(&d_assertions);
     // FIXME
-    //for( std::map< Node, Node >::iterator it = si->d_model_replace_f.begin(); it != si->d_model_replace_f.end(); ++it ){
+    // for( std::map< Node, Node >::iterator it = si->d_model_replace_f.begin();
+    // it != si->d_model_replace_f.end(); ++it ){
     //  d_smt.setPrintFuncInModel( it->first.toExpr(), false );
     //  d_smt.setPrintFuncInModel( it->second.toExpr(), true );
     //}

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -80,6 +80,7 @@
 #include "preprocessing/passes/real_to_int.h"
 #include "preprocessing/passes/rewrite.h"
 #include "preprocessing/passes/sep_skolem_emp.h"
+#include "preprocessing/passes/sort_infer.h"
 #include "preprocessing/passes/static_learning.h"
 #include "preprocessing/passes/symmetry_breaker.h"
 #include "preprocessing/passes/symmetry_detect.h"
@@ -2735,13 +2736,15 @@ void SmtEnginePrivate::finishInit()
       new RealToInt(d_preprocessingPassContext.get()));
   std::unique_ptr<Rewrite> rewrite(
       new Rewrite(d_preprocessingPassContext.get()));
+  std::unique_ptr<SortInferencePass> sortInfer(
+      new SortInferencePass(d_preprocessingPassContext.get(),d_smt.d_theoryEngine->getSortInference()));
   std::unique_ptr<StaticLearning> staticLearning(
       new StaticLearning(d_preprocessingPassContext.get()));
   std::unique_ptr<SymBreakerPass> sbProc(
       new SymBreakerPass(d_preprocessingPassContext.get()));
   std::unique_ptr<SynthRewRulesPass> srrProc(
       new SynthRewRulesPass(d_preprocessingPassContext.get()));
- std::unique_ptr<SepSkolemEmp> sepSkolemEmp(
+  std::unique_ptr<SepSkolemEmp> sepSkolemEmp(
       new SepSkolemEmp(d_preprocessingPassContext.get()));
    d_preprocessingPassRegistry.registerPass("apply-substs",
                                            std::move(applySubsts));
@@ -2761,6 +2764,8 @@ void SmtEnginePrivate::finishInit()
   d_preprocessingPassRegistry.registerPass("rewrite", std::move(rewrite));
   d_preprocessingPassRegistry.registerPass("sep-skolem-emp",
                                            std::move(sepSkolemEmp));
+  d_preprocessingPassRegistry.registerPass("sort-inference",
+                                           std::move(sortInfer));
   d_preprocessingPassRegistry.registerPass("static-learning", 
                                            std::move(staticLearning));
   d_preprocessingPassRegistry.registerPass("sym-break", std::move(sbProc));
@@ -4332,13 +4337,13 @@ void SmtEnginePrivate::processAssertions() {
   }
 
   if( options::sortInference() || options::ufssFairnessMonotone() ){
-    //sort inference technique
-    SortInference * si = d_smt.d_theoryEngine->getSortInference();
-    si->simplify( d_assertions.ref(), options::sortInference(), options::ufssFairnessMonotone() );
-    for( std::map< Node, Node >::iterator it = si->d_model_replace_f.begin(); it != si->d_model_replace_f.end(); ++it ){
-      d_smt.setPrintFuncInModel( it->first.toExpr(), false );
-      d_smt.setPrintFuncInModel( it->second.toExpr(), true );
-    }
+    d_preprocessingPassRegistry.getPass("sort-inference")
+        ->apply(&d_assertions);
+    // FIXME
+    //for( std::map< Node, Node >::iterator it = si->d_model_replace_f.begin(); it != si->d_model_replace_f.end(); ++it ){
+    //  d_smt.setPrintFuncInModel( it->first.toExpr(), false );
+    //  d_smt.setPrintFuncInModel( it->second.toExpr(), true );
+    //}
   }
 
   if( options::pbRewrites() ){

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4339,12 +4339,6 @@ void SmtEnginePrivate::processAssertions() {
 
   if( options::sortInference() || options::ufssFairnessMonotone() ){
     d_preprocessingPassRegistry.getPass("sort-inference")->apply(&d_assertions);
-    // FIXME
-    // for( std::map< Node, Node >::iterator it = si->d_model_replace_f.begin();
-    // it != si->d_model_replace_f.end(); ++it ){
-    //  d_smt.setPrintFuncInModel( it->first.toExpr(), false );
-    //  d_smt.setPrintFuncInModel( it->second.toExpr(), true );
-    //}
   }
 
   if( options::pbRewrites() ){

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -544,8 +544,11 @@ TypeNode SortInference::getOrCreateTypeForId( int t, TypeNode pref ){
     return d_type_types[rt];
   }else{
     TypeNode retType;
-    //see if we can assign pref
-    if( !pref.isNull() && d_id_for_types.find( pref )==d_id_for_types.end() ){
+    // See if we can assign pref. This is an optimization for reusing an
+    // uninterpreted sort as the first subsort, so that fewer symbols needed
+    // to be rewritten in the sort-inferred signature. Notice we only assign
+    // pref here if it is an uninterpreted sort.
+    if( !pref.isNull() && d_id_for_types.find( pref )==d_id_for_types.end() && pref.isSort() ){
       retType = pref;
     }else{
       //must create new type

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -198,7 +198,8 @@ void SortInference::initialize(const std::vector<Node>& assertions)
 }
 
 Node SortInference::simplify(Node n,
-                             std::map< Node, Node >& model_replace_f, std::map<Node, std::map<TypeNode, Node> >& visited)
+                             std::map<Node, Node>& model_replace_f,
+                             std::map<Node, std::map<TypeNode, Node> >& visited)
 {
   Trace("sort-inference-debug") << "Simplify " << n << std::endl;
   std::map<Node, Node> var_bound;
@@ -603,7 +604,13 @@ Node SortInference::getNewSymbol( Node old, TypeNode tn ){
   }
 }
 
-Node SortInference::simplifyNode( Node n, std::map< Node, Node >& var_bound, TypeNode tnn, std::map< Node, Node >& model_replace_f, std::map< Node, std::map< TypeNode, Node > >& visited ){
+Node SortInference::simplifyNode(
+    Node n,
+    std::map<Node, Node>& var_bound,
+    TypeNode tnn,
+    std::map<Node, Node>& model_replace_f,
+    std::map<Node, std::map<TypeNode, Node> >& visited)
+{
   std::map< TypeNode, Node >::iterator itv = visited[n].find( tnn );
   if( itv!=visited[n].end() ){
     return itv->second;
@@ -651,7 +658,11 @@ Node SortInference::simplifyNode( Node n, std::map< Node, Node >& var_bound, Typ
           tnnc = getOrCreateTypeForId( d_equality_types[n], n[0].getType() );
           Assert( !tnnc.isNull() );
         }
-        Node nc = simplifyNode( n[i], var_bound, tnnc, model_replace_f, use_new_visited ? new_visited : visited );
+        Node nc = simplifyNode(n[i],
+                               var_bound,
+                               tnnc,
+                               model_replace_f,
+                               use_new_visited ? new_visited : visited);
         Trace("sort-inference-debug2") << "Simplify " << i << " " << n[i] << " returned " << nc << std::endl;
         children.push_back( nc );
         childChanged = childChanged || nc!=n[i];

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -114,53 +114,63 @@ void SortInference::reset() {
   d_const_map.clear();
 }
 
-
-void SortInference::initialize( const std::vector< Node >& assertions )
+void SortInference::initialize(const std::vector<Node>& assertions)
 {
   Trace("sort-inference-proc") << "Calculating sort inference..." << std::endl;
-  //process all assertions
-  std::map< Node, int > visited;
-  for( unsigned i=0; i<assertions.size(); i++ ){
+  // process all assertions
+  std::map<Node, int> visited;
+  for (unsigned i = 0; i < assertions.size(); i++)
+  {
     Trace("sort-inference-debug") << "Process " << assertions[i] << std::endl;
-    std::map< Node, Node > var_bound;
-    process( assertions[i], var_bound, visited );
+    std::map<Node, Node> var_bound;
+    process(assertions[i], var_bound, visited);
   }
   Trace("sort-inference-proc") << "...done" << std::endl;
-  for( std::map< Node, int >::iterator it = d_op_return_types.begin(); it != d_op_return_types.end(); ++it ){
+  for (std::map<Node, int>::iterator it = d_op_return_types.begin();
+       it != d_op_return_types.end();
+       ++it)
+  {
     Trace("sort-inference") << it->first << " : ";
     TypeNode retTn = it->first.getType();
-    if( !d_op_arg_types[ it->first ].empty() ){
+    if (!d_op_arg_types[it->first].empty())
+    {
       Trace("sort-inference") << "( ";
-      for( size_t i=0; i<d_op_arg_types[ it->first ].size(); i++ ){
-        recordSubsort( retTn[i], d_op_arg_types[ it->first ][i] );
-        printSort( "sort-inference", d_op_arg_types[ it->first ][i] );
+      for (size_t i = 0; i < d_op_arg_types[it->first].size(); i++)
+      {
+        recordSubsort(retTn[i], d_op_arg_types[it->first][i]);
+        printSort("sort-inference", d_op_arg_types[it->first][i]);
         Trace("sort-inference") << " ";
       }
       Trace("sort-inference") << ") -> ";
-      retTn = retTn[(int)retTn.getNumChildren()-1];
+      retTn = retTn[(int)retTn.getNumChildren() - 1];
     }
-    recordSubsort( retTn, it->second );
-    printSort( "sort-inference", it->second );
+    recordSubsort(retTn, it->second);
+    printSort("sort-inference", it->second);
     Trace("sort-inference") << std::endl;
   }
-  for( std::map< Node, std::map< Node, int > >::iterator it = d_var_types.begin(); it != d_var_types.end(); ++it ){
-    Trace("sort-inference") << "Quantified formula : " << it->first << " : " << std::endl;
-    for( unsigned i=0; i<it->first[0].getNumChildren(); i++ ){
-      recordSubsort( it->first[0][i].getType(), it->second[it->first[0][i]] );
-      printSort( "sort-inference", it->second[it->first[0][i]] );
+  for (std::map<Node, std::map<Node, int> >::iterator it = d_var_types.begin();
+       it != d_var_types.end();
+       ++it)
+  {
+    Trace("sort-inference")
+        << "Quantified formula : " << it->first << " : " << std::endl;
+    for (unsigned i = 0; i < it->first[0].getNumChildren(); i++)
+    {
+      recordSubsort(it->first[0][i].getType(), it->second[it->first[0][i]]);
+      printSort("sort-inference", it->second[it->first[0][i]]);
       Trace("sort-inference") << std::endl;
     }
     Trace("sort-inference") << std::endl;
   }
 
   // determine monotonicity of sorts
-  Trace("sort-inference-proc") << "Calculating monotonicty for subsorts..."
-                                << std::endl;
+  Trace("sort-inference-proc")
+      << "Calculating monotonicty for subsorts..." << std::endl;
   std::map<Node, std::map<int, bool> > visitedm;
   for (const Node& a : assertions)
   {
-    Trace("sort-inference-debug") << "Process monotonicity for " << a
-                                  << std::endl;
+    Trace("sort-inference-debug")
+        << "Process monotonicity for " << a << std::endl;
     std::map<Node, Node> var_bound;
     processMonotonic(a, true, true, var_bound, visitedm);
   }
@@ -176,7 +186,7 @@ void SortInference::initialize( const std::vector< Node >& assertions )
       Trace("sort-inference") << " is interpreted." << std::endl;
     }
     else if (d_non_monotonic_sorts.find(d_sub_sorts[i])
-              == d_non_monotonic_sorts.end())
+             == d_non_monotonic_sorts.end())
     {
       Trace("sort-inference") << " is monotonic." << std::endl;
     }
@@ -187,7 +197,8 @@ void SortInference::initialize( const std::vector< Node >& assertions )
   }
 }
 
-Node SortInference::simplify( Node n, std::map< Node, std::map< TypeNode, Node > >& visited )
+Node SortInference::simplify(Node n,
+                             std::map<Node, std::map<TypeNode, Node> >& visited)
 {
   Trace("sort-inference-debug") << "Simplify " << n << std::endl;
   std::map<Node, Node> var_bound;
@@ -197,19 +208,19 @@ Node SortInference::simplify( Node n, std::map< Node, std::map< TypeNode, Node >
   return ret;
 }
 
-void SortInference::getNewAssertions( std::vector< Node >& new_asserts )
+void SortInference::getNewAssertions(std::vector<Node>& new_asserts)
 {
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   // now, ensure constants are distinct
   for (std::map<TypeNode, std::map<Node, Node> >::iterator it =
-            d_const_map.begin();
-        it != d_const_map.end();
-        ++it)
+           d_const_map.begin();
+       it != d_const_map.end();
+       ++it)
   {
     std::vector<Node> consts;
     for (std::map<Node, Node>::iterator it2 = it->second.begin();
-          it2 != it->second.end();
-          ++it2)
+         it2 != it->second.end();
+         ++it2)
     {
       Assert(it2->first.isConst());
       consts.push_back(it2->second);
@@ -228,9 +239,9 @@ void SortInference::getNewAssertions( std::vector< Node >& new_asserts )
   // enforce constraints based on monotonicity
   Trace("sort-inference-proc") << "Enforce monotonicity..." << std::endl;
   for (std::map<TypeNode, std::vector<int> >::iterator it =
-            d_type_sub_sorts.begin();
-        it != d_type_sub_sorts.end();
-        ++it)
+           d_type_sub_sorts.begin();
+       it != d_type_sub_sorts.end();
+       ++it)
   {
     int nmonSort = -1;
     unsigned nsorts = it->second.size();
@@ -266,7 +277,9 @@ void SortInference::getNewAssertions( std::vector< Node >& new_asserts )
       }
       if (Trace.isOn("sort-inference-rewrite"))
       {
-        Trace("sort-inference-rewrite") << "Add the following injections for " << it->first << " to ensure consistency wrt non-monotonic sorts : " << std::endl;
+        Trace("sort-inference-rewrite")
+            << "Add the following injections for " << it->first
+            << " to ensure consistency wrt non-monotonic sorts : " << std::endl;
         for (const Node& i : injections)
         {
           Trace("sort-inference-rewrite") << "   " << i << std::endl;
@@ -274,25 +287,24 @@ void SortInference::getNewAssertions( std::vector< Node >& new_asserts )
       }
       new_asserts.insert(
           new_asserts.end(), injections.begin(), injections.end());
-
     }
   }
   Trace("sort-inference-proc") << "...done" << std::endl;
   // no sub-sort information is stored
   reset();
-  Trace("sort-inference-debug")
-      << "Finished sort inference" << std::endl;
+  Trace("sort-inference-debug") << "Finished sort inference" << std::endl;
 }
 
-void SortInference::computeMonotonicity( const std::vector< Node >& assertions )
+void SortInference::computeMonotonicity(const std::vector<Node>& assertions)
 {
   std::map<Node, std::map<int, bool> > visitedmt;
-  Trace("sort-inference-proc") << "Calculating monotonicty for types..." << std::endl;
+  Trace("sort-inference-proc")
+      << "Calculating monotonicty for types..." << std::endl;
   for (const Node& a : assertions)
   {
-    Trace("sort-inference-debug") << "Process type monotonicity for " << a
-                                  << std::endl;
-    std::map< Node, Node > var_bound;
+    Trace("sort-inference-debug")
+        << "Process type monotonicity for " << a << std::endl;
+    std::map<Node, Node> var_bound;
     processMonotonic(a, true, true, var_bound, visitedmt, true);
   }
   Trace("sort-inference-proc") << "...done" << std::endl;
@@ -343,8 +355,8 @@ int SortInference::getIdForType( TypeNode tn ){
   std::map< TypeNode, int >::iterator it = d_id_for_types.find( tn );
   if( it==d_id_for_types.end() ){
     int sc = d_sortCount;
-    d_type_types[ d_sortCount ] = tn;
-    d_id_for_types[ tn ] = d_sortCount;
+    d_type_types[d_sortCount] = tn;
+    d_id_for_types[tn] = d_sortCount;
     d_sortCount++;
     return sc;
   }else{
@@ -366,7 +378,7 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
       }else{
         for( size_t i=0; i<n[0].getNumChildren(); i++ ){
           //apply sort inference to quantified variables
-          d_var_types[n][ n[0][i] ] = d_sortCount;
+          d_var_types[n][n[0][i]] = d_sortCount;
           d_sortCount++;
 
           //type of the quantified variable must be the same
@@ -427,10 +439,10 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
           d_op_return_types[op] = d_sortCount;
           d_sortCount++;
         }
-        //d_type_eq_class[d_sortCount].push_back( op );
-        //assign arbitrary sort for argument types
+        // d_type_eq_class[d_sortCount].push_back( op );
+        // assign arbitrary sort for argument types
         for( size_t i=0; i<n.getNumChildren(); i++ ){
-          d_op_arg_types[op].push_back( d_sortCount );
+          d_op_arg_types[op].push_back(d_sortCount);
           d_sortCount++;
         }
       }
@@ -462,7 +474,7 @@ int SortInference::process( Node n, std::map< Node, Node >& var_bound, std::map<
           //assign arbitrary sort
           d_op_return_types[n] = d_sortCount;
           d_sortCount++;
-          //d_type_eq_class[d_sortCount].push_back( n );
+          // d_type_eq_class[d_sortCount].push_back( n );
         }
         retType = d_op_return_types[n];
       }else if( n.isConst() ){

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -126,29 +126,26 @@ void SortInference::initialize(const std::vector<Node>& assertions)
     process(a, var_bound, visited);
   }
   Trace("sort-inference-proc") << "...done" << std::endl;
-  for (std::map<Node, int>::iterator it = d_op_return_types.begin();
-       it != d_op_return_types.end();
-       ++it)
-    for (const std::pair<const Node, int>& rt : d_op_return_types)
+  for (const std::pair<const Node, int>& rt : d_op_return_types)
+  {
+    Trace("sort-inference") << rt.first << " : ";
+    TypeNode retTn = rt.first.getType();
+    if (!d_op_arg_types[rt.first].empty())
     {
-      Trace("sort-inference") << rt.first << " : ";
-      TypeNode retTn = rt.first.getType();
-      if (!d_op_arg_types[rt.first].empty())
+      Trace("sort-inference") << "( ";
+      for (size_t i = 0; i < d_op_arg_types[rt.first].size(); i++)
       {
-        Trace("sort-inference") << "( ";
-        for (size_t i = 0; i < d_op_arg_types[rt.first].size(); i++)
-        {
-          recordSubsort(retTn[i], d_op_arg_types[rt.first][i]);
-          printSort("sort-inference", d_op_arg_types[rt.first][i]);
-          Trace("sort-inference") << " ";
-        }
-        Trace("sort-inference") << ") -> ";
-        retTn = retTn[(int)retTn.getNumChildren() - 1];
+        recordSubsort(retTn[i], d_op_arg_types[rt.first][i]);
+        printSort("sort-inference", d_op_arg_types[rt.first][i]);
+        Trace("sort-inference") << " ";
       }
-      recordSubsort(retTn, rt.second);
-      printSort("sort-inference", rt.second);
-      Trace("sort-inference") << std::endl;
+      Trace("sort-inference") << ") -> ";
+      retTn = retTn[(int)retTn.getNumChildren() - 1];
     }
+    recordSubsort(retTn, rt.second);
+    printSort("sort-inference", rt.second);
+    Trace("sort-inference") << std::endl;
+  }
   for (std::pair<const Node, std::map<Node, int> >& vt : d_var_types)
   {
     Trace("sort-inference")

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -119,8 +119,7 @@ void SortInference::initialize(const std::vector<Node>& assertions)
   Trace("sort-inference-proc") << "Calculating sort inference..." << std::endl;
   // process all assertions
   std::map<Node, int> visited;
-  for (unsigned i = 0; i < assertions.size(); i++)
-  for( const Node& a : assertions )
+  for (const Node& a : assertions)
   {
     Trace("sort-inference-debug") << "Process " << a << std::endl;
     std::map<Node, Node> var_bound;
@@ -130,31 +129,31 @@ void SortInference::initialize(const std::vector<Node>& assertions)
   for (std::map<Node, int>::iterator it = d_op_return_types.begin();
        it != d_op_return_types.end();
        ++it)
-  for( const std::pair< const Node, int >& rt : d_op_return_types )
-  {
-    Trace("sort-inference") << rt.first << " : ";
-    TypeNode retTn = rt.first.getType();
-    if (!d_op_arg_types[rt.first].empty())
+    for (const std::pair<const Node, int>& rt : d_op_return_types)
     {
-      Trace("sort-inference") << "( ";
-      for (size_t i = 0; i < d_op_arg_types[rt.first].size(); i++)
+      Trace("sort-inference") << rt.first << " : ";
+      TypeNode retTn = rt.first.getType();
+      if (!d_op_arg_types[rt.first].empty())
       {
-        recordSubsort(retTn[i], d_op_arg_types[rt.first][i]);
-        printSort("sort-inference", d_op_arg_types[rt.first][i]);
-        Trace("sort-inference") << " ";
+        Trace("sort-inference") << "( ";
+        for (size_t i = 0; i < d_op_arg_types[rt.first].size(); i++)
+        {
+          recordSubsort(retTn[i], d_op_arg_types[rt.first][i]);
+          printSort("sort-inference", d_op_arg_types[rt.first][i]);
+          Trace("sort-inference") << " ";
+        }
+        Trace("sort-inference") << ") -> ";
+        retTn = retTn[(int)retTn.getNumChildren() - 1];
       }
-      Trace("sort-inference") << ") -> ";
-      retTn = retTn[(int)retTn.getNumChildren() - 1];
+      recordSubsort(retTn, rt.second);
+      printSort("sort-inference", rt.second);
+      Trace("sort-inference") << std::endl;
     }
-    recordSubsort(retTn, rt.second);
-    printSort("sort-inference", rt.second);
-    Trace("sort-inference") << std::endl;
-  }
-  for( std::pair< const Node, std::map< Node, int > >& vt : d_var_types )
+  for (std::pair<const Node, std::map<Node, int> >& vt : d_var_types)
   {
     Trace("sort-inference")
         << "Quantified formula : " << vt.first << " : " << std::endl;
-    for( const Node& v : vt.first[0] )
+    for (const Node& v : vt.first[0])
     {
       recordSubsort(v.getType(), vt.second[v]);
       printSort("sort-inference", vt.second[v]);
@@ -213,10 +212,10 @@ void SortInference::getNewAssertions(std::vector<Node>& new_asserts)
 {
   NodeManager* nm = NodeManager::currentNM();
   // now, ensure constants are distinct
-  for( const std::pair< const TypeNode, std::map< Node, Node > >& cm : d_const_map )
+  for (const std::pair<const TypeNode, std::map<Node, Node> >& cm : d_const_map)
   {
     std::vector<Node> consts;
-    for( const std::pair< const Node, Node >& c : cm.second )
+    for (const std::pair<const Node, Node>& c : cm.second)
     {
       Assert(c.first.isConst());
       consts.push_back(c.second);
@@ -235,7 +234,8 @@ void SortInference::getNewAssertions(std::vector<Node>& new_asserts)
   // enforce constraints based on monotonicity
   Trace("sort-inference-proc") << "Enforce monotonicity..." << std::endl;
 
-  for( const std::pair<const TypeNode, std::vector<int> >& tss : d_type_sub_sorts )
+  for (const std::pair<const TypeNode, std::vector<int> >& tss :
+       d_type_sub_sorts)
   {
     int nmonSort = -1;
     unsigned nsorts = tss.second.size();

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -548,7 +548,9 @@ TypeNode SortInference::getOrCreateTypeForId( int t, TypeNode pref ){
     // uninterpreted sort as the first subsort, so that fewer symbols needed
     // to be rewritten in the sort-inferred signature. Notice we only assign
     // pref here if it is an uninterpreted sort.
-    if( !pref.isNull() && d_id_for_types.find( pref )==d_id_for_types.end() && pref.isSort() ){
+    if (!pref.isNull() && d_id_for_types.find(pref) == d_id_for_types.end()
+        && pref.isSort())
+    {
       retType = pref;
     }else{
       //must create new type

--- a/src/theory/sort_inference.h
+++ b/src/theory/sort_inference.h
@@ -93,7 +93,7 @@ private:
   TypeNode getTypeForId( int t );
   Node getNewSymbol( Node old, TypeNode tn );
   //simplify
-  Node simplifyNode( Node n, std::map< Node, Node >& var_bound, TypeNode tnn, std::map< Node, std::map< TypeNode, Node > >& visited );
+  Node simplifyNode( Node n, std::map< Node, Node >& var_bound, TypeNode tnn, std::map< Node, Node >& model_replace_f, std::map< Node, std::map< TypeNode, Node > >& visited );
   //make injection
   Node mkInjection( TypeNode tn1, TypeNode tn2 );
   //reset
@@ -111,12 +111,15 @@ private:
   /** simplify
    *
    * This returns the simplified form of formula n, based on the information
-   * computed during initialization. The argument visited is a cache of the
-   * internal results of simplifying previous nodes with this class.
+   * computed during initialization. The argument model_replace_f stores the
+   * mapping between functions and their analog in the sort-inferred signature.
+   * The argument visited is a cache of the internal results of simplifying
+   * previous nodes with this class.
    *
    * Must call initialize() before this function.
    */
-  Node simplify(Node n, std::map<Node, std::map<TypeNode, Node> >& visited);
+  Node simplify(Node n, 
+  std::map< Node, Node >& model_replace_f, std::map< Node, std::map<TypeNode, Node> >& visited);
   /** get new constraints
    *
    * This adds constraints to new_asserts that ensure the following.
@@ -147,10 +150,6 @@ public:
   bool isWellSorted( Node n );
   //get constraints for being well-typed according to computed sub-types
   void getSortConstraints( Node n, SortInference::UnionFind& uf );
-public:
-  //list of all functions and the uninterpreted symbols they were replaced with
-  std::map< Node, Node > d_model_replace_f;
-
 private:
   // store monotonicity for original sorts as well
  std::map<TypeNode, bool> d_non_monotonic_sorts_orig;

--- a/src/theory/sort_inference.h
+++ b/src/theory/sort_inference.h
@@ -60,6 +60,7 @@ public:
     bool areEqual( int t1, int t2 ) { return getRepresentative( t1 )==getRepresentative( t2 ); }
     bool isValid();
   };
+
  private:
   /** the id count for all subsorts we have allocated */
   int d_sortCount;
@@ -78,8 +79,8 @@ public:
   void printSort( const char* c, int t );
   //process
   int process( Node n, std::map< Node, Node >& var_bound, std::map< Node, int >& visited );
- // for monotonicity inference
-private:
+  // for monotonicity inference
+ private:
   void processMonotonic( Node n, bool pol, bool hasPol, std::map< Node, Node >& var_bound, std::map< Node, std::map< int, bool > >& visited, bool typeMode = false );
 
 //for rewriting
@@ -93,7 +94,11 @@ private:
   TypeNode getTypeForId( int t );
   Node getNewSymbol( Node old, TypeNode tn );
   //simplify
-  Node simplifyNode( Node n, std::map< Node, Node >& var_bound, TypeNode tnn, std::map< Node, Node >& model_replace_f, std::map< Node, std::map< TypeNode, Node > >& visited );
+  Node simplifyNode(Node n,
+                    std::map<Node, Node>& var_bound,
+                    TypeNode tnn,
+                    std::map<Node, Node>& model_replace_f,
+                    std::map<Node, std::map<TypeNode, Node> >& visited);
   //make injection
   Node mkInjection( TypeNode tn1, TypeNode tn2 );
   //reset
@@ -118,8 +123,9 @@ private:
    *
    * Must call initialize() before this function.
    */
-  Node simplify(Node n, 
-  std::map< Node, Node >& model_replace_f, std::map< Node, std::map<TypeNode, Node> >& visited);
+  Node simplify(Node n,
+                std::map<Node, Node>& model_replace_f,
+                std::map<Node, std::map<TypeNode, Node> >& visited);
   /** get new constraints
    *
    * This adds constraints to new_asserts that ensure the following.

--- a/src/theory/sort_inference.h
+++ b/src/theory/sort_inference.h
@@ -33,7 +33,7 @@ namespace CVC4 {
  * replaced by others g', possibly of different types. For details, see e.g.:
  *   "Sort it out with Monotonicity" Claessen 2011
  *   "Non-Cyclic Sorts for First-Order Satisfiability" Korovin 2013.
- */ 
+ */
 class SortInference {
 private:
   //all subsorts
@@ -60,7 +60,7 @@ public:
     bool areEqual( int t1, int t2 ) { return getRepresentative( t1 )==getRepresentative( t2 ); }
     bool isValid();
   };
-private:
+ private:
   /** the id count for all subsorts we have allocated */
   int d_sortCount;
   UnionFind d_type_union_find;
@@ -78,7 +78,7 @@ private:
   void printSort( const char* c, int t );
   //process
   int process( Node n, std::map< Node, Node >& var_bound, std::map< Node, int >& visited );
-//for monotonicity inference
+ // for monotonicity inference
 private:
   void processMonotonic( Node n, bool pol, bool hasPol, std::map< Node, Node >& var_bound, std::map< Node, std::map< int, bool > >& visited, bool typeMode = false );
 
@@ -103,12 +103,12 @@ private:
   SortInference() : d_sortCount(1) {}
   ~SortInference(){}
 
-  /** initialize 
+  /** initialize
    *
    * This initializes this class. The input formula is indicated by assertions.
    */
-  void initialize( const std::vector< Node >& assertions );
-  /** simplify 
+  void initialize(const std::vector<Node>& assertions);
+  /** simplify
    *
    * This returns the simplified form of formula n, based on the information
    * computed during initialization. The argument visited is a cache of the
@@ -116,8 +116,8 @@ private:
    *
    * Must call initialize() before this function.
    */
-  Node simplify( Node n, std::map< Node, std::map< TypeNode, Node > >& visited );
-  /** get new constraints 
+  Node simplify(Node n, std::map<Node, std::map<TypeNode, Node> >& visited);
+  /** get new constraints
    *
    * This adds constraints to new_asserts that ensure the following.
    * Let F be the conjunction of assertions from the input. Let F' be the
@@ -125,16 +125,16 @@ private:
    * conjunction of formulas adding to new_asserts. Then, F and F' ^ C are
    * equisatisfiable.
    */
-  void getNewAssertions( std::vector< Node >& new_asserts );
-  /** compute monotonicity 
+  void getNewAssertions(std::vector<Node>& new_asserts);
+  /** compute monotonicity
    *
    * This computes whether sorts are monotonic (see e.g. Claessen 2011). If
    * this function is called, then calls to isMonotonic() can subsequently be
    * used to query whether sorts are monotonic.
    */
-  void computeMonotonicity( const std::vector< Node >& assertions );
+  void computeMonotonicity(const std::vector<Node>& assertions);
   /** return true if tn was inferred to be monotonic */
-  bool isMonotonic( TypeNode tn );  
+  bool isMonotonic(TypeNode tn);
   //get sort id for term n
   int getSortId( Node n );
   //get sort id for variable of quantified formula f
@@ -153,7 +153,7 @@ public:
 
 private:
   // store monotonicity for original sorts as well
-  std::map< TypeNode, bool > d_non_monotonic_sorts_orig;
+ std::map<TypeNode, bool> d_non_monotonic_sorts_orig;
 };
 
 }

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -433,6 +433,7 @@ REG0_TESTS = \
 	regress0/fmf/quant_real_univ.cvc \
 	regress0/fmf/sat-logic.smt2 \
 	regress0/fmf/sc_bad_model_1221.smt2 \
+	regress0/fmf/sort-inf-int.smt2 \
 	regress0/fmf/syn002-si-real-int.smt2 \
 	regress0/fmf/tail_rec.smt2 \
 	regress0/fp/simple.smt2 \

--- a/test/regress/regress0/fmf/sort-inf-int.smt2
+++ b/test/regress/regress0/fmf/sort-inf-int.smt2
@@ -1,0 +1,13 @@
+; COMMAND-LINE: --finite-model-find --sort-inference --no-check-models
+; EXPECT: sat
+(set-logic UFLIRA)
+(set-info :status sat)
+(declare-fun f (Int) Int)
+(declare-fun g (Int) Int)
+(declare-fun h (Int) Int)
+(assert (forall ((x Int)) (or (= (f x) (h x)) (= (f x) (g x)))))
+(assert (not (= (f 3) (h 3))))
+(assert (not (= (f 5) (g 5))))
+(assert (= (f 4) (g 8)))
+
+(check-sat)

--- a/test/regress/regress1/fmf/ALG008-1.smt2
+++ b/test/regress/regress1/fmf/ALG008-1.smt2
@@ -1,4 +1,5 @@
 ; COMMAND-LINE: --finite-model-find
+; COMMAND-LINE: --finite-model-find --sort-inference --no-check-models
 ; EXPECT: sat
 ;%--------------------------------------------------------------------------
 ;% File     : ALG008-1 : TPTP v5.4.0. Released v2.2.0.


### PR DESCRIPTION
This changes the interface of the SortInference module to be multiple steps, which can then be used by the preprocessing architecture.