### PR TITLE
 Fix arithmetic division by zero in sygus repair constant module

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -576,7 +576,9 @@ bool SygusRepairConst::getFitToLogicExcludeVar(LogicInfo& logic,
     {
       visited.insert(cur);
       Kind ck = cur.getKind();
-      if (restrictLA && (ck == NONLINEAR_MULT || ck == DIVISION))
+      bool isArithDivKind = ( ck == DIVISION_TOTAL || ck == INTS_DIVISION_TOTAL || ck == INTS_MODULUS_TOTAL );
+      Assert( ck != DIVISION && ck != INTS_DIVISION && ck != INTS_MODULUS );
+      if (restrictLA && (ck == NONLINEAR_MULT || isArithDivKind))
       {
         for (unsigned j = 0, size = cur.getNumChildren(); j < size; j++)
         {
@@ -584,7 +586,7 @@ bool SygusRepairConst::getFitToLogicExcludeVar(LogicInfo& logic,
           std::map<Node, Node>::iterator itf = d_fo_to_sk.find(ccur);
           if (itf != d_fo_to_sk.end())
           {
-            if (ck == NONLINEAR_MULT || (ck == DIVISION && j == 1))
+            if (ck == NONLINEAR_MULT || (isArithDivKind && j == 1))
             {
               exvar = itf->second;
               return true;

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -576,8 +576,9 @@ bool SygusRepairConst::getFitToLogicExcludeVar(LogicInfo& logic,
     {
       visited.insert(cur);
       Kind ck = cur.getKind();
-      bool isArithDivKind = ( ck == DIVISION_TOTAL || ck == INTS_DIVISION_TOTAL || ck == INTS_MODULUS_TOTAL );
-      Assert( ck != DIVISION && ck != INTS_DIVISION && ck != INTS_MODULUS );
+      bool isArithDivKind = (ck == DIVISION_TOTAL || ck == INTS_DIVISION_TOTAL
+                             || ck == INTS_MODULUS_TOTAL);
+      Assert(ck != DIVISION && ck != INTS_DIVISION && ck != INTS_MODULUS);
       if (restrictLA && (ck == NONLINEAR_MULT || isArithDivKind))
       {
         for (unsigned j = 0, size = cur.getNumChildren(); j < size; j++)


### PR DESCRIPTION
This adds a part of the intended bug fix in #2323 that was missed.

This fixes the nightlies.