### PR TITLE
Addressing 'Invalid iterator comparison' warnings from coverity.

### DIFF
--- a/src/theory/quantifiers/conjecture_generator.cpp
+++ b/src/theory/quantifiers/conjecture_generator.cpp
@@ -14,6 +14,9 @@
  **/
 
 #include "theory/quantifiers/conjecture_generator.h"
+
+#include <utility>
+
 #include "options/quantifiers_options.h"
 #include "theory/quantifiers/first_order_model.h"
 #include "theory/quantifiers/skolemize.h"
@@ -882,9 +885,12 @@ unsigned ConjectureGenerator::flushWaitingConjectures( unsigned& addedLemmas, in
               d_conj_count++;
             }else{
               std::vector< Node > bvs;
-              for( std::map< TypeNode, unsigned >::iterator it = d_pattern_var_id[lhs].begin(); it != d_pattern_var_id[lhs].end(); ++it ){
-                for( unsigned i=0; i<=it->second; i++ ){
-                  bvs.push_back( getFreeVar( it->first, i ) );
+              for (const std::pair<TypeNode, unsigned>& lhs_pattern :
+                   d_pattern_var_id[lhs])
+              {
+                for (unsigned i = 0; i <= lhs_pattern.second; i++)
+                {
+                  bvs.push_back(getFreeVar(lhs_pattern.first, i));
                 }
               }
               Node rsg;

--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -16,6 +16,7 @@
 
 #include "theory/quantifiers/fmf/bounded_integers.h"
 
+#include "base/map_util.h"
 #include "expr/node_algorithm.h"
 #include "options/quantifiers_options.h"
 #include "theory/arith/arith_msum.h"
@@ -459,7 +460,7 @@ void BoundedIntegers::checkOwnership(Node f)
           success = true;
           //set Attributes on literals
           for( unsigned b=0; b<2; b++ ){
-            if (bound_lit_map[b].find(v) != bound_lit_map[b].end())
+            if (ContainsKey(bound_lit_map[b], v))
             {
               // WARNING_CANDIDATE:
               // This assertion may fail. We intentionally do not enable this in

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -14,6 +14,7 @@
  **/
 #include "theory/quantifiers/sygus/ce_guided_single_inv.h"
 
+#include "base/map_util.h"
 #include "expr/node_algorithm.h"
 #include "options/quantifiers_options.h"
 #include "theory/arith/arith_msum.h"
@@ -1036,13 +1037,14 @@ int TransitionInference::incrementTrace( DetTrace& dt, Node loc, bool fwd ) {
     }
   }
   if( fwd ){
-    std::map< Node, std::map< Node, Node > >::iterator it = d_com[0].d_const_eq.find( loc );
-    if( it!=d_com[0].d_const_eq.end() ){
+    if (std::map<Node, Node>* const_eq_loc =
+            FindOrNull(d_com[0].d_const_eq, loc))
+    {
       std::vector< Node > next;
       for( unsigned i=0; i<d_prime_vars.size(); i++ ){
         Node pv = d_prime_vars[i];
-        Assert( it->second.find( pv )!=it->second.end() );
-        Node pvs = it->second[pv];
+        Assert(ContainsKey(*const_eq_loc, pv));
+        Node pvs = (*const_eq_loc)[pv];
         Assert( d_vars.size()==dt.d_curr.size() );
         Node pvsr = Rewriter::rewrite( pvs.substitute( d_vars.begin(), d_vars.end(), dt.d_curr.begin(), dt.d_curr.end() ) );
         next.push_back( pvsr );

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -646,7 +646,8 @@ void TheorySep::check(Effort e) {
             if( assert_active[fact] ){
               Assert( atom.getKind()==kind::SEP_LABEL );
               TNode s_lbl = atom[1];
-              if( d_label_map[s_atom].find( s_lbl )!=d_label_map[s_atom].end() ){
+              if (ContainsKey(d_label_map[s_atom], s_lbl))
+              {
                 Trace("sep-process-debug") << "Active lbl : " << s_lbl << std::endl;
                 active_lbl[s_lbl] = true;
               }

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include "theory/sets/theory_sets_private.h"
 
+#include "base/map_util.h"
 #include "expr/emptyset.h"
 #include "expr/node_algorithm.h"
 #include "options/sets_options.h"
@@ -611,10 +612,13 @@ void TheorySetsPrivate::fullEffortCheck(){
           }else{
             Node r1 = d_equalityEngine.getRepresentative( n[0] );
             Node r2 = d_equalityEngine.getRepresentative( n[1] );
-            if( d_bop_index[n.getKind()][r1].find( r2 )==d_bop_index[n.getKind()][r1].end() ){
+            if (!ContainsKey(d_bop_index[n.getKind()][r1], r2))
+            {
               d_bop_index[n.getKind()][r1][r2] = n;
               d_op_list[n.getKind()].push_back( n );
-            }else{
+            }
+            else
+            {
               d_congruent[n] = d_bop_index[n.getKind()][r1][r2];
             }
           }


### PR DESCRIPTION
The main cause seems to be having map operator[] on both sides of comparisons.