### PR TITLE
Solve equalities between Boolean variables in presolve.

### DIFF
--- a/src/theory/booleans/circuit_propagator.cpp
+++ b/src/theory/booleans/circuit_propagator.cpp
@@ -368,7 +368,9 @@ bool CircuitPropagator::propagate() {
     Debug("circuit-prop") << "CircuitPropagator::propagate(): assigned to " << (assignment ? "true" : "false") << std::endl;
 
     // Is this an atom
-    bool atom = Theory::theoryOf(current) != THEORY_BOOL || current.isVar();
+    bool atom = Theory::theoryOf(current) != THEORY_BOOL || current.isVar()
+                || (current.getKind() == kind::EQUAL
+                    && (current[0].isVar() && current[1].isVar()));
 
     // If an atom, add to the list for simplification
     if (atom) {

--- a/src/theory/booleans/theory_bool.cpp
+++ b/src/theory/booleans/theory_bool.cpp
@@ -40,20 +40,20 @@ Theory::PPAssertStatus TheoryBool::ppAssert(TNode in, SubstitutionMap& outSubsti
 
   // Add the substitution from the variable to its value
   if (in.getKind() == kind::NOT) {
-    if (in[0].getKind() == kind::VARIABLE) {
+    if (in[0].isVar())
+    {
       outSubstitutions.addSubstitution(in[0], NodeManager::currentNM()->mkConst<bool>(false));
-    } else {
-      return PP_ASSERT_STATUS_UNSOLVED;
+      return PP_ASSERT_STATUS_SOLVED;
     }
   } else {
-    if (in.getKind() == kind::VARIABLE) {
+    if (in.isVar())
+    {
       outSubstitutions.addSubstitution(in, NodeManager::currentNM()->mkConst<bool>(true));
-    } else {
-      return PP_ASSERT_STATUS_UNSOLVED;
+      return PP_ASSERT_STATUS_SOLVED;
     }
   }
 
-  return PP_ASSERT_STATUS_SOLVED;
+  return Theory::ppAssert(in, outSubstitutions);
 }
 
 /*


### PR DESCRIPTION
This makes it so that decision-level-0-propagated equalities between Boolean variables X = Y are solved so that X -> Y becomes a model substitution.

This is work towards #2305.

This also fixes an issue where TheoryBool was distinguishing between VARIABLE nodes instead of using isVar(), meaning it was treating input variables and skolem variables differently (likely unintentionally).