### PR TITLE
Remove throw specifiers in FP type checker

### DIFF
--- a/src/theory/fp/theory_fp_type_rules.h
+++ b/src/theory/fp/theory_fp_type_rules.h
@@ -618,10 +618,9 @@ class FloatingPointToRealTotalTypeRule {
 class FloatingPointComponentBit
 {
  public:
-  inline static TypeNode computeType(
-      NodeManager* nodeManager,
-      TNode n,
-      bool check) throw(TypeCheckingExceptionPrivate, AssertionException)
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
   {
     TRACE("FloatingPointComponentBit");
 
@@ -653,10 +652,9 @@ class FloatingPointComponentBit
 class FloatingPointComponentExponent
 {
  public:
-  inline static TypeNode computeType(
-      NodeManager* nodeManager,
-      TNode n,
-      bool check) throw(TypeCheckingExceptionPrivate, AssertionException)
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
   {
     TRACE("FloatingPointComponentExponent");
 
@@ -701,10 +699,9 @@ class FloatingPointComponentExponent
 class FloatingPointComponentSignificand
 {
  public:
-  inline static TypeNode computeType(
-      NodeManager* nodeManager,
-      TNode n,
-      bool check) throw(TypeCheckingExceptionPrivate, AssertionException)
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
   {
     TRACE("FloatingPointComponentSignificand");
 
@@ -745,10 +742,9 @@ class FloatingPointComponentSignificand
 class RoundingModeBitBlast
 {
  public:
-  inline static TypeNode computeType(
-      NodeManager* nodeManager,
-      TNode n,
-      bool check) throw(TypeCheckingExceptionPrivate, AssertionException)
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
   {
     TRACE("RoundingModeBitBlast");
 


### PR DESCRIPTION
We've decided not to use throw specifiers anymore since they've been
deprecated in C++11. This should also fix Coverity issues 1473023,
1473020, 1469507, 1469505, 1469500, and 1469498.