### PR TITLE
Fix export of bound variables

### DIFF
--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -197,7 +197,7 @@ public:
           // temporarily set the node manager to NULL; this gets around
           // a check that mkVar isn't called internally
 
-          if(n.getKind() == kind::BOUND_VAR_LIST || n.getKind() == kind::BOUND_VARIABLE) {
+          if(n.getKind() == kind::BOUND_VARIABLE) {
             NodeManagerScope nullScope(NULL);
             to_e = to->mkBoundVar(name, type);// FIXME thread safety
           } else if(n.getKind() == kind::VARIABLE) {
@@ -217,10 +217,18 @@ public:
 
           Debug("export") << "+ exported var `" << from_e << "'[" << from_e.getId() << "] with name `" << name << "' and type `" << from_e.getType() << "' to `" << to_e << "'[" << to_e.getId() << "] with type `" << type << "'" << std::endl;
         } else {
-          // temporarily set the node manager to NULL; this gets around
-          // a check that mkVar isn't called internally
-          NodeManagerScope nullScope(NULL);
-          to_e = to->mkVar(type);// FIXME thread safety
+          if (n.getKind() == kind::BOUND_VARIABLE)
+          {
+            NodeManagerScope nullScope(NULL);
+            to_e = to->mkBoundVar(type);  // FIXME thread safety
+          }
+          else
+          {
+            // temporarily set the node manager to NULL; this gets around
+            // a check that mkVar isn't called internally
+            NodeManagerScope nullScope(NULL);
+            to_e = to->mkVar(type);  // FIXME thread safety
+          }
           Debug("export") << "+ exported unnamed var `" << from_e << "' with type `" << from_e.getType() << "' to `" << to_e << "' with type `" << type << "'" << std::endl;
         }
         uint64_t to_int = (uint64_t)(to_e.getNode().d_nv);

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -194,7 +194,11 @@ public:
         Type type = from->exportType(from_e.getType(), to, vmap);
         if(Node::fromExpr(from_e).getAttribute(VarNameAttr(), name)) {
           if(n.getKind() == kind::BOUND_VARIABLE) {
-            to_e = to->mkBoundVar(name, type);// FIXME thread safety
+            // bound vars are only available at the Node level (not the Expr level)
+            TypeNode typeNode = TypeNode::fromType(type);
+            NodeManager* to_nm = NodeManager::fromExprManager(to);
+            Node n = to_nm->mkBoundVar(name, typeNode);// FIXME thread safety
+            to_e = n.toExpr();
           } else if(n.getKind() == kind::VARIABLE) {
             bool isGlobal;
             Node::fromExpr(from_e).getAttribute(GlobalVarAttr(), isGlobal);
@@ -213,6 +217,7 @@ public:
         } else {
           if (n.getKind() == kind::BOUND_VARIABLE)
           {
+            // bound vars are only available at the Node level (not the Expr level)
             TypeNode typeNode = TypeNode::fromType(type);
             NodeManager* to_nm = NodeManager::fromExprManager(to);
             Node n = to_nm->mkBoundVar(typeNode);  // FIXME thread safety

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -180,7 +180,6 @@ public:
     } else if(n.getMetaKind() == metakind::NULLARY_OPERATOR ){
       Expr from_e(from, new Node(n));
       Type type = from->exportType(from_e.getType(), to, vmap);
-      NodeManagerScope nullScope(NULL);
       return to->mkNullaryOperator(type, n.getKind()); // FIXME thread safety
     } else if(n.getMetaKind() == metakind::VARIABLE) {
       Expr from_e(from, new Node(n));
@@ -194,16 +193,11 @@ public:
         std::string name;
         Type type = from->exportType(from_e.getType(), to, vmap);
         if(Node::fromExpr(from_e).getAttribute(VarNameAttr(), name)) {
-          // temporarily set the node manager to NULL; this gets around
-          // a check that mkVar isn't called internally
-
           if(n.getKind() == kind::BOUND_VARIABLE) {
-            NodeManagerScope nullScope(NULL);
             to_e = to->mkBoundVar(name, type);// FIXME thread safety
           } else if(n.getKind() == kind::VARIABLE) {
             bool isGlobal;
             Node::fromExpr(from_e).getAttribute(GlobalVarAttr(), isGlobal);
-            NodeManagerScope nullScope(NULL);
             to_e = to->mkVar(name, type, isGlobal ? ExprManager::VAR_FLAG_GLOBAL : flags);// FIXME thread safety
           } else if(n.getKind() == kind::SKOLEM) {
             // skolems are only available at the Node level (not the Expr level)
@@ -219,14 +213,13 @@ public:
         } else {
           if (n.getKind() == kind::BOUND_VARIABLE)
           {
-            NodeManagerScope nullScope(NULL);
-            to_e = to->mkBoundVar(type);  // FIXME thread safety
+            TypeNode typeNode = TypeNode::fromType(type);
+            NodeManager* to_nm = NodeManager::fromExprManager(to);
+            Node n = to_nm->mkBoundVar(typeNode);  // FIXME thread safety
+            to_e = n.toExpr();
           }
           else
           {
-            // temporarily set the node manager to NULL; this gets around
-            // a check that mkVar isn't called internally
-            NodeManagerScope nullScope(NULL);
             to_e = to->mkVar(type);  // FIXME thread safety
           }
           Debug("export") << "+ exported unnamed var `" << from_e << "' with type `" << from_e.getType() << "' to `" << to_e << "' with type `" << type << "'" << std::endl;

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -193,11 +193,13 @@ public:
         std::string name;
         Type type = from->exportType(from_e.getType(), to, vmap);
         if(Node::fromExpr(from_e).getAttribute(VarNameAttr(), name)) {
-          if(n.getKind() == kind::BOUND_VARIABLE) {
-            // bound vars are only available at the Node level (not the Expr level)
+          if (n.getKind() == kind::BOUND_VARIABLE)
+          {
+            // bound vars are only available at the Node level (not the Expr
+            // level)
             TypeNode typeNode = TypeNode::fromType(type);
             NodeManager* to_nm = NodeManager::fromExprManager(to);
-            Node n = to_nm->mkBoundVar(name, typeNode);// FIXME thread safety
+            Node n = to_nm->mkBoundVar(name, typeNode);  // FIXME thread safety
             to_e = n.toExpr();
           } else if(n.getKind() == kind::VARIABLE) {
             bool isGlobal;
@@ -217,7 +219,8 @@ public:
         } else {
           if (n.getKind() == kind::BOUND_VARIABLE)
           {
-            // bound vars are only available at the Node level (not the Expr level)
+            // bound vars are only available at the Node level (not the Expr
+            // level)
             TypeNode typeNode = TypeNode::fromType(type);
             NodeManager* to_nm = NodeManager::fromExprManager(to);
             Node n = to_nm->mkBoundVar(typeNode);  // FIXME thread safety


### PR DESCRIPTION
When exporting quantified formulas from one expression manager to the other, three things were breaking:
- bound variables without a name attribute were erroneously converted into variables
- lists of bound variables were erroneously converted into bound variables
- bound variables were not being created at the node manager level in the new expression manager

This commit fixes these issues. It also removes unnecessary temporary settings of the current node manager to `NULL` due to checks that no longer are made (for creating variables internally).