### PR TITLE
Add HAVE_CLOCK_GETTIME guard to clock_gettime.c

### DIFF
--- a/src/lib/clock_gettime.c
+++ b/src/lib/clock_gettime.c
@@ -20,6 +20,8 @@
 
 #include "lib/clock_gettime.h"
 
+#ifndef HAVE_CLOCK_GETTIME
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -83,3 +85,5 @@ long clock_gettime(clockid_t which_clock, struct timespec* tp) {
 #ifdef __cplusplus
 }/* extern "C" */
 #endif /* __cplusplus */
+
+#endif /* HAVE_CLOCK_GETTIME */


### PR DESCRIPTION
If `HAVE_CLOCK_GETTIME` is defined `<time.h>` will be included in `clock_gettime.h` but in `clock_gettime.c` the function `clock_gettime(...)` will be defined if ` __APPLE__` or` __WIN32__` is defined, which is not guarded by `#ifndef HAVE_CLOCK_GETTIME`.