### PR TITLE
Remove clock_gettime() replacement for macOS.

### DIFF
--- a/src/lib/clock_gettime.c
+++ b/src/lib/clock_gettime.c
@@ -9,11 +9,9 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief Replacement for clock_gettime() for systems without it (like
- ** Mac OS X)
+ ** \brief Replacement for clock_gettime() for systems without it (Windows)
  **
- ** Replacement for clock_gettime() for systems without it (like Mac
- ** OS X).
+ ** Replacement for clock_gettime() for systems without it (Windows).
  **/
 
 // #warning "TODO(taking): Make lib/clock_gettime.h cvc4_private.h again."
@@ -26,43 +24,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#ifdef __APPLE__
-
-#include <stdio.h>
-#include <errno.h>
-#include <mach/mach_time.h>
-
-static double s_clockconv = 0.0;
-
-long clock_gettime(clockid_t which_clock, struct timespec* tp) {
-  if( s_clockconv == 0.0 ) {
-    mach_timebase_info_data_t tb;
-    kern_return_t err = mach_timebase_info(&tb);
-    if(err == 0) {
-      s_clockconv = ((double) tb.numer) / tb.denom;
-    } else {
-      return -EINVAL;
-    }
-  }
-
-  switch(which_clock) {
-  case CLOCK_REALTIME:
-  case CLOCK_REALTIME_HR:
-  case CLOCK_MONOTONIC:
-  case CLOCK_MONOTONIC_HR: {
-      uint64_t t = mach_absolute_time() * s_clockconv;
-      tp->tv_sec = t / 1000000000ul;
-      tp->tv_nsec = t % 1000000000ul;
-    }
-    break;
-  default:
-    return -EINVAL;
-  }
-
-  return 0;
-}
-
-#else /* not defined __APPLE__ */
 #ifdef __WIN32__
 
 #include <time.h>
@@ -80,7 +41,6 @@ long clock_gettime(clockid_t which_clock, struct timespec* tp) {
 }
 
 #endif /* closing #ifdef __WIN32__ */
-#endif /* closing #else for #ifdef __APPLE__ / __WIN32__ */
 
 #ifdef __cplusplus
 }/* extern "C" */

--- a/src/lib/clock_gettime.h
+++ b/src/lib/clock_gettime.h
@@ -9,9 +9,9 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief Replacement for clock_gettime() for systems without it (like Mac OS X)
+ ** \brief Replacement for clock_gettime() for systems without it (Windows)
  **
- ** Replacement for clock_gettime() for systems without it (like Mac OS X).
+ ** Replacement for clock_gettime() for systems without it (Windows).
  **/
 
 #include "cvc4_private_library.h"


### PR DESCRIPTION
Not needed anymore since macOS 10.12 introduced clock_gettime().