### PR TITLE
Replace boost::integer_traits with std::numeric_limits.

### DIFF
--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -29,7 +29,6 @@
 #include "base/modal_exception.h"
 #include "base/output.h"
 #include "lib/strtok_r.h"
-#include "gmp.h"
 #include "options/arith_heuristic_pivot_rule.h"
 #include "options/arith_propagation_mode.h"
 #include "options/arith_unate_lemma_mode.h"

--- a/src/util/dense_map.h
+++ b/src/util/dense_map.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <boost/integer_traits.hpp>
+#include <limits>
 #include <vector>
 
 #include "base/cvc4_assert.h"
@@ -48,7 +48,8 @@ private:
 
   typedef Index Position;
   typedef std::vector<Position> PositionMap;
-  static const Position POSITION_SENTINEL = boost::integer_traits<Position>::const_max;
+  static const Position POSITION_SENTINEL =
+      std::numeric_limits<Position>::max();
 
   //Each Key in the set is mapped to its position in d_list.
   //Each Key not in the set is mapped to KEY_SENTINEL


### PR DESCRIPTION
Further, remove redundant gmp.h include in options_handler.cpp.