### PR TITLE
Using a single condition enumerator in sygus-unif

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -989,7 +989,7 @@ header = "options/quantifiers_options.h"
   long       = "sygus-unif-cond-indpendent-no-repeat-sol"
   type       = "bool"
   default    = "true"
-  help       = "Don't try repeated solutions"
+  help       = "Do not try repeated solutions when using independent synthesis of conditions in unification-based function synthesis"
 
 [[option]]
   name       = "sygusBoolIteReturnConst"

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -741,7 +741,7 @@ header = "options/quantifiers_options.h"
   read_only  = true
   help       = "optimization, skip instances based on possibly irrelevant portions of quantified formulas"
 
-### Rewrite rules options 
+### Rewrite rules options
 
 [[option]]
   name       = "quantRewriteRules"
@@ -761,7 +761,7 @@ header = "options/quantifiers_options.h"
   read_only  = true
   help       = "add one instance of rewrite rule per round"
 
-### Induction options 
+### Induction options
 
 [[option]]
   name       = "quantInduction"
@@ -1180,7 +1180,7 @@ header = "options/quantifiers_options.h"
   type       = "bool"
   default    = "true"
   help       = "Minimize synthesis solutions"
-  
+
 [[option]]
   name       = "sygusEvalOpt"
   category   = "regular"
@@ -1196,7 +1196,7 @@ header = "options/quantifiers_options.h"
   type       = "bool"
   default    = "false"
   help       = "static inference techniques for computing whether arguments of functions-to-synthesize are relevant"
-  
+
 # Internal uses of sygus
 
 [[option]]

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -976,6 +976,22 @@ header = "options/quantifiers_options.h"
   help       = "Unification-based function synthesis"
 
 [[option]]
+  name       = "sygusUnifCondIndependent"
+  category   = "regular"
+  long       = "sygus-unif-cond-independent"
+  type       = "bool"
+  default    = "false"
+  help       = "Synthesize conditions indepedently from return values (may generate bigger solutions)"
+
+[[option]]
+  name       = "sygusUnifCondIndNoRepeatSol"
+  category   = "regular"
+  long       = "sygus-unif-cond-indpendent-no-repeat-sol"
+  type       = "bool"
+  default    = "true"
+  help       = "Don't try repeated solutions"
+
+[[option]]
   name       = "sygusBoolIteReturnConst"
   category   = "regular"
   long       = "sygus-bool-ite-return-const"

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -166,7 +166,17 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
     Trace("cegis") << "  Enumerators :\n";
     for (unsigned i = 0, size = enums.size(); i < size; ++i)
     {
-      Trace("cegis") << "    " << enums[i] << " -> ";
+      bool isUnit = false;
+      for (const Node& hd_unit : d_rl_eval_hds)
+      {
+        if (enums[i] == hd_unit[0])
+        {
+          isUnit = true;
+          break;
+        }
+      }
+      Trace("cegis") << "    " << enums[i]
+                     << (options::sygusUnif() && isUnit ? "*" : "") << " -> ";
       std::stringstream ss;
       Printer::getPrinter(options::outputLanguage())
           ->toStreamSygus(ss, enum_values[i]);

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -388,8 +388,7 @@ void CegisUnifEnumManager::initialize(
       Trace("cegis-unif-enum")
           << "* Registering new enumerator " << ceu << " to strategy point "
           << ci.second.d_pt << "\n";
-      d_tds->registerEnumerator(
-          ceu, ci.second.d_pt, d_parent, true, options::sygusUnifRepairCond());
+      d_tds->registerEnumerator(ceu, ci.second.d_pt, d_parent);
       d_enum_to_active_guard[ceu] = d_tds->getActiveGuardForEnumerator(ceu);
     }
   }
@@ -532,12 +531,7 @@ void CegisUnifEnumManager::incrementNumEnumerators()
         Trace("cegis-unif-enum")
             << "* Registering new enumerator " << e << " to strategy point "
             << ci.second.d_pt << "\n";
-        d_tds->registerEnumerator(e,
-                                  ci.second.d_pt,
-                                  d_parent,
-                                  false,
-                                  index == 0 ? options::sygusUnifRepairRet()
-                                             : options::sygusUnifRepairCond());
+        d_tds->registerEnumerator(e, ci.second.d_pt, d_parent);
       }
     }
     // register the evaluation points at the new value

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -400,7 +400,7 @@ void CegisUnifEnumManager::getEnumeratorsForStrategyPt(Node e,
 
 Node CegisUnifEnumManager::getActiveGuardForEnumerator(Node e)
 {
-  Assert(d_enum_to_active_guard.find(eu) != d_enum_to_active_guard.end());
+  Assert(d_enum_to_active_guard.find(e) != d_enum_to_active_guard.end());
   return d_enum_to_active_guard[e];
 }
 

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -68,8 +68,8 @@ bool CegisUnif::processInitialize(Node n,
       {
         Node cond = d_sygus_unif.getConditionForEvaluationPoint(e);
         Assert(!cond.isNull());
-        Trace("cegis-unif")
-            << "  " << e << " with condition : " << cond << std::endl;
+        Trace("cegis-unif") << "  " << e << " with condition : " << cond
+                            << std::endl;
         pt_to_cond[e] = cond;
       }
     }
@@ -90,8 +90,8 @@ void CegisUnif::getTermList(const std::vector<Node>& candidates,
     // Collect heads of candidates
     for (const Node& hd : d_sygus_unif.getEvalPointHeads(c))
     {
-      Trace("cegis-unif-enum-debug")
-          << "......cand " << c << " with enum hd " << hd << "\n";
+      Trace("cegis-unif-enum-debug") << "......cand " << c << " with enum hd "
+                                     << hd << "\n";
       enums.push_back(hd);
     }
   }
@@ -265,8 +265,8 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
   Assert(options::sygusUnifCondIndependent() || !lemmas.empty());
   for (const Node& lem : lemmas)
   {
-    Trace("cegis-unif-lemma")
-        << "CegisUnif::lemma, separation lemma : " << lem << "\n";
+    Trace("cegis-unif-lemma") << "CegisUnif::lemma, separation lemma : " << lem
+                              << "\n";
     d_qe->getOutputChannel().lemma(lem);
   }
   Trace("cegis-unif") << "..failed to separate heads\n---CegisUnif Engine---\n";
@@ -281,8 +281,8 @@ void CegisUnif::registerRefinementLemma(const std::vector<Node>& vars,
   std::map<Node, std::vector<Node>> eval_pts;
   Node plem = d_sygus_unif.addRefLemma(lem, eval_pts);
   addRefinementLemma(plem);
-  Trace("cegis-unif-lemma")
-      << "CegisUnif::lemma, refinement lemma : " << plem << "\n";
+  Trace("cegis-unif-lemma") << "CegisUnif::lemma, refinement lemma : " << plem
+                            << "\n";
   // Notify the enumeration manager if there are new evaluation points
   for (const std::pair<const Node, std::vector<Node>>& ep : eval_pts)
   {
@@ -339,8 +339,8 @@ void CegisUnifEnumManager::initialize(
     std::map<Node, Node>::const_iterator itcc = e_to_cond.find(e);
     Assert(itcc != e_to_cond.end());
     Node cond = itcc->second;
-    Trace("cegis-unif-enum-debug")
-        << "...its condition strategy point is " << cond << "\n";
+    Trace("cegis-unif-enum-debug") << "...its condition strategy point is "
+                                   << cond << "\n";
     d_ce_info[e].d_ce_type = cond.getType();
     // initialize the symmetry breaking lemma templates
     for (unsigned index = 0; index < 2; index++)
@@ -385,9 +385,9 @@ void CegisUnifEnumManager::initialize(
       }
       // register the enumerator
       ci.second.d_enums[1].push_back(ceu);
-      Trace("cegis-unif-enum")
-          << "* Registering new enumerator " << ceu << " to strategy point "
-          << ci.second.d_pt << "\n";
+      Trace("cegis-unif-enum") << "* Registering new enumerator " << ceu
+                               << " to strategy point " << ci.second.d_pt
+                               << "\n";
       d_tds->registerEnumerator(ceu, ci.second.d_pt, d_parent);
       d_enum_to_active_guard[ceu] = d_tds->getActiveGuardForEnumerator(ceu);
     }
@@ -528,9 +528,9 @@ void CegisUnifEnumManager::incrementNumEnumerators()
         }
         // register the enumerator
         ci.second.d_enums[index].push_back(e);
-        Trace("cegis-unif-enum")
-            << "* Registering new enumerator " << e << " to strategy point "
-            << ci.second.d_pt << "\n";
+        Trace("cegis-unif-enum") << "* Registering new enumerator " << e
+                                 << " to strategy point " << ci.second.d_pt
+                                 << "\n";
         d_tds->registerEnumerator(e, ci.second.d_pt, d_parent);
       }
     }
@@ -627,8 +627,8 @@ void CegisUnifEnumManager::registerEvalPtAtSize(Node e,
     disj.push_back(ei.eqNode(itc->second.d_enums[0][i]));
   }
   Node lem = NodeManager::currentNM()->mkNode(OR, disj);
-  Trace("cegis-unif-enum-lemma")
-      << "CegisUnifEnum::lemma, domain:" << lem << "\n";
+  Trace("cegis-unif-enum-lemma") << "CegisUnifEnum::lemma, domain:" << lem
+                                 << "\n";
   d_qe->getOutputChannel().lemma(lem);
 }
 

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -291,15 +291,6 @@ void CegisUnif::registerRefinementLemma(const std::vector<Node>& vars,
     for (const Node& n : d_cand_to_strat_pt[ep.first])
     {
       d_u_enum_manager.registerEvalPts(ep.second, n);
-      // Notify unif if a substitution is entailed for evaluation point
-      for (const Node& hd_unit : d_rl_eval_hds)
-      {
-        if (std::find(ep.second.begin(), ep.second.end(), hd_unit[0])
-            != ep.second.end())
-        {
-          d_sygus_unif.setEntailed(n, hd_unit[0]);
-        }
-      }
     }
   }
   // Make the refinement lemma and add it to lems. This lemma is guarded by the

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -142,15 +142,14 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
         {
           Assert(unif_enums[index][e].size() == 1);
           Node eu = unif_enums[index][e][0];
-          Assert(d_u_enum_manager.d_enum_to_active_guard.find(eu)
-                 != d_u_enum_manager.d_enum_to_active_guard.end());
-          Node g = d_u_enum_manager.d_enum_to_active_guard[eu];
-          // Get whether the active guard for this enumerator is true, otherwise
-          // there are no more values for it, and hence we ignore it
+          Node g = d_u_enum_manager.getActiveGuardForEnumerator(eu);
+          // If active guard for this enumerator is not true, there are no more
+          // values for it, and hence we ignore it
           Node gstatus = valuation.getSatValue(g);
           if (gstatus.isNull() || !gstatus.getConst<bool>())
           {
             Trace("cegis") << "    " << eu << " -> N/A\n";
+            unif_enums[index][e].clear();
             continue;
           }
         }
@@ -232,9 +231,7 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
       if (options::sygusUnifCondIndependent() && !unif_enums[1][e].empty())
       {
         Node eu = unif_enums[1][e][0];
-        Assert(d_u_enum_manager.d_enum_to_active_guard.find(eu)
-               != d_u_enum_manager.d_enum_to_active_guard.end());
-        Node g = d_u_enum_manager.d_enum_to_active_guard[eu];
+        Node g = d_u_enum_manager.getActiveGuardForEnumerator(eu);
         Node exp_exc = d_tds->getExplain()
                            ->getExplanationForEquality(eu, unif_values[1][e][0])
                            .negate();
@@ -415,6 +412,12 @@ void CegisUnifEnumManager::getEnumeratorsForStrategyPt(Node e,
               itc->second.d_enums[index].begin(),
               itc->second.d_enums[index].begin() + num_enums);
   }
+}
+
+Node CegisUnifEnumManager::getActiveGuardForEnumerator(Node e)
+{
+  Assert(d_enum_to_active_guard.find(eu) != d_enum_to_active_guard.end());
+  return d_enum_to_active_guard[e];
 }
 
 void CegisUnifEnumManager::registerEvalPts(const std::vector<Node>& eis, Node e)

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -68,8 +68,8 @@ bool CegisUnif::processInitialize(Node n,
       {
         Node cond = d_sygus_unif.getConditionForEvaluationPoint(e);
         Assert(!cond.isNull());
-        Trace("cegis-unif") << "  " << e << " with condition : " << cond
-                            << std::endl;
+        Trace("cegis-unif")
+            << "  " << e << " with condition : " << cond << std::endl;
         pt_to_cond[e] = cond;
       }
     }
@@ -90,8 +90,8 @@ void CegisUnif::getTermList(const std::vector<Node>& candidates,
     // Collect heads of candidates
     for (const Node& hd : d_sygus_unif.getEvalPointHeads(c))
     {
-      Trace("cegis-unif-enum-debug") << "......cand " << c << " with enum hd "
-                                     << hd << "\n";
+      Trace("cegis-unif-enum-debug")
+          << "......cand " << c << " with enum hd " << hd << "\n";
       enums.push_back(hd);
     }
   }
@@ -336,8 +336,8 @@ void CegisUnifEnumManager::initialize(
     std::map<Node, Node>::const_iterator itcc = e_to_cond.find(e);
     Assert(itcc != e_to_cond.end());
     Node cond = itcc->second;
-    Trace("cegis-unif-enum-debug") << "...its condition strategy point is "
-                                   << cond << "\n";
+    Trace("cegis-unif-enum-debug")
+        << "...its condition strategy point is " << cond << "\n";
     d_ce_info[e].d_ce_type = cond.getType();
     // initialize the symmetry breaking lemma templates
     for (unsigned index = 0; index < 2; index++)
@@ -621,8 +621,8 @@ void CegisUnifEnumManager::registerEvalPtAtSize(Node e,
     disj.push_back(ei.eqNode(itc->second.d_enums[0][i]));
   }
   Node lem = NodeManager::currentNM()->mkNode(OR, disj);
-  Trace("cegis-unif-enum-lemma") << "CegisUnifEnum::lemma, domain:" << lem
-                                 << "\n";
+  Trace("cegis-unif-enum-lemma")
+      << "CegisUnifEnum::lemma, domain:" << lem << "\n";
   d_qe->getOutputChannel().lemma(lem);
 }
 

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -68,8 +68,8 @@ bool CegisUnif::processInitialize(Node n,
       {
         Node cond = d_sygus_unif.getConditionForEvaluationPoint(e);
         Assert(!cond.isNull());
-        Trace("cegis-unif") << "  " << e << " with condition : " << cond
-                            << std::endl;
+        Trace("cegis-unif")
+            << "  " << e << " with condition : " << cond << std::endl;
         pt_to_cond[e] = cond;
       }
     }
@@ -90,8 +90,8 @@ void CegisUnif::getTermList(const std::vector<Node>& candidates,
     // Collect heads of candidates
     for (const Node& hd : d_sygus_unif.getEvalPointHeads(c))
     {
-      Trace("cegis-unif-enum-debug") << "......cand " << c << " with enum hd "
-                                     << hd << "\n";
+      Trace("cegis-unif-enum-debug")
+          << "......cand " << c << " with enum hd " << hd << "\n";
       enums.push_back(hd);
     }
   }
@@ -112,12 +112,15 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
   }
   if (!satisfiedRl)
   {
+    Trace("cegis-unif")
+        << "..added refinement lemmas\n---CegisUnif Engine---\n";
     // if we didn't satisfy the specification, there is no way to repair
     return false;
   }
   // the unification enumerators (return values, conditions) and their model
   // values
   NodeManager* nm = NodeManager::currentNM();
+  Valuation& valuation = d_qe->getValuation();
   bool addedUnifEnumSymBreakLemma = false;
   Node cost_lit = d_u_enum_manager.getCurrentLiteral();
   std::map<Node, std::vector<Node>> unif_enums[2];
@@ -135,6 +138,22 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
         // get the current unification enumerators
         d_u_enum_manager.getEnumeratorsForStrategyPt(
             e, unif_enums[index][e], index);
+        if (index == 1 && options::sygusUnifCondIndependent())
+        {
+          Assert(unif_enums[index][e].size() == 1);
+          Node eu = unif_enums[index][e][0];
+          Assert(d_u_enum_manager.d_enum_to_active_guard.find(eu)
+                 != d_u_enum_manager.d_enum_to_active_guard.end());
+          Node g = d_u_enum_manager.d_enum_to_active_guard[eu];
+          // Get whether the active guard for this enumerator is true, otherwise
+          // there are no more values for it, and hence we ignore it
+          Node gstatus = valuation.getSatValue(g);
+          if (gstatus.isNull() || !gstatus.getConst<bool>())
+          {
+            Trace("cegis") << "    " << eu << " -> N/A\n";
+            continue;
+          }
+        }
         // get the model value of each enumerator
         for (const Node& eu : unif_enums[index][e])
         {
@@ -149,9 +168,9 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
           }
           unif_values[index][e].push_back(m_eu);
         }
+        // inter-enumerator symmetry breaking for return values
         if (index == 0)
         {
-          // inter-enumerator symmetry breaking
           // given a pool of unification enumerators eu_1, ..., eu_n,
           // CegisUnifEnumManager insists that size(eu_1) <= ... <= size(eu_n).
           // We additionally insist that M(eu_i) < M(eu_{i+1}) when
@@ -198,6 +217,8 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
   }
   if (addedUnifEnumSymBreakLemma)
   {
+    Trace("cegis-unif") << "..added unif enum symmetry breaking "
+                           "lemma\n---CegisUnif Engine---\n";
     return false;
   }
   // set the conditions
@@ -207,6 +228,18 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
     {
       d_sygus_unif.setConditions(
           e, cost_lit, unif_enums[1][e], unif_values[1][e]);
+      // if condition enumerator had value, exclude this value
+      if (options::sygusUnifCondIndependent() && !unif_enums[1][e].empty())
+      {
+        Node eu = unif_enums[1][e][0];
+        Assert(d_u_enum_manager.d_enum_to_active_guard.find(eu)
+               != d_u_enum_manager.d_enum_to_active_guard.end());
+        Node g = d_u_enum_manager.d_enum_to_active_guard[eu];
+        Node exp_exc = d_tds->getExplain()
+                           ->getExplanationForEquality(eu, unif_values[1][e][0])
+                           .negate();
+        lems.push_back(nm->mkNode(OR, g.negate(), exp_exc));
+      }
     }
   }
   // build solutions (for unif candidates a divide-and-conquer approach is used)
@@ -228,13 +261,15 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
     return true;
   }
 
-  Assert(!lemmas.empty());
+  // TODO tie this to the lemma for getting a new condition value
+  Assert(options::sygusUnifCondIndependent() || !lemmas.empty());
   for (const Node& lem : lemmas)
   {
-    Trace("cegis-unif") << "CegisUnif::lemma, separation lemma : " << lem
-                        << "\n";
+    Trace("cegis-unif-lemma")
+        << "CegisUnif::lemma, separation lemma : " << lem << "\n";
     d_qe->getOutputChannel().lemma(lem);
   }
+  Trace("cegis-unif") << "..failed to separate heads\n---CegisUnif Engine---\n";
   return false;
 }
 
@@ -246,15 +281,25 @@ void CegisUnif::registerRefinementLemma(const std::vector<Node>& vars,
   std::map<Node, std::vector<Node>> eval_pts;
   Node plem = d_sygus_unif.addRefLemma(lem, eval_pts);
   addRefinementLemma(plem);
-  Trace("cegis-unif-lemma") << "* Refinement lemma:\n" << plem << "\n";
+  Trace("cegis-unif-lemma")
+      << "CegisUnif::lemma, refinement lemma : " << plem << "\n";
   // Notify the enumeration manager if there are new evaluation points
   for (const std::pair<const Node, std::vector<Node>>& ep : eval_pts)
   {
     Assert(d_cand_to_strat_pt.find(ep.first) != d_cand_to_strat_pt.end());
-    // Notify each startegy point of the respective candidate
+    // Notify each strategy point of the respective candidate
     for (const Node& n : d_cand_to_strat_pt[ep.first])
     {
       d_u_enum_manager.registerEvalPts(ep.second, n);
+      // Notify unif if a substitution is entailed for evaluation point
+      for (const Node& hd_unit : d_rl_eval_hds)
+      {
+        if (std::find(ep.second.begin(), ep.second.end(), hd_unit[0])
+            != ep.second.end())
+        {
+          d_sygus_unif.setEntailed(n, hd_unit[0]);
+        }
+      }
     }
   }
   // Make the refinement lemma and add it to lems. This lemma is guarded by the
@@ -303,8 +348,8 @@ void CegisUnifEnumManager::initialize(
     std::map<Node, Node>::const_iterator itcc = e_to_cond.find(e);
     Assert(itcc != e_to_cond.end());
     Node cond = itcc->second;
-    Trace("cegis-unif-enum-debug") << "...its condition strategy point is "
-                                   << cond << "\n";
+    Trace("cegis-unif-enum-debug")
+        << "...its condition strategy point is " << cond << "\n";
     d_ce_info[e].d_ce_type = cond.getType();
     // initialize the symmetry breaking lemma templates
     for (unsigned index = 0; index < 2; index++)
@@ -329,6 +374,34 @@ void CegisUnifEnumManager::initialize(
   }
   // initialize the current literal
   incrementNumEnumerators();
+  // create single condition enumerator for each decision tree strategy
+  if (options::sygusUnifCondIndependent())
+  {
+    // allocate a condition enumerator for each candidate
+    for (std::pair<const Node, StrategyPtInfo>& ci : d_ce_info)
+    {
+      Node ceu = nm->mkSkolem("cu", ci.second.d_ce_type);
+      // instantiate template for removing redundant operators
+      if (!ci.second.d_sbt_lemma_tmpl[1].first.isNull())
+      {
+        Node templ = ci.second.d_sbt_lemma_tmpl[1].first;
+        TNode templ_var = ci.second.d_sbt_lemma_tmpl[1].second;
+        Node sym_break_red_ops = templ.substitute(templ_var, ceu);
+        Trace("cegis-unif-enum-lemma")
+            << "CegisUnifEnum::lemma, remove redundant ops of " << ceu << " : "
+            << sym_break_red_ops << "\n";
+        d_qe->getOutputChannel().lemma(sym_break_red_ops);
+      }
+      // register the enumerator
+      ci.second.d_enums[1].push_back(ceu);
+      Trace("cegis-unif-enum")
+          << "* Registering new enumerator " << ceu << " to strategy point "
+          << ci.second.d_pt << "\n";
+      d_tds->registerEnumerator(
+          ceu, ci.second.d_pt, d_parent, true, options::sygusUnifRepairCond());
+      d_enum_to_active_guard[ceu] = d_tds->getActiveGuardForEnumerator(ceu);
+    }
+  }
 }
 
 void CegisUnifEnumManager::getEnumeratorsForStrategyPt(Node e,
@@ -340,8 +413,8 @@ void CegisUnifEnumManager::getEnumeratorsForStrategyPt(Node e,
   Assert(num_enums > 0);
   if (index == 1)
   {
-    // we always use (cost-1) conditions
-    num_enums = num_enums - 1;
+    // we always use (cost-1) conditions, or 1 if in the indepedent case
+    num_enums = !options::sygusUnifCondIndependent() ? num_enums - 1 : 1;
   }
   if (num_enums > 0)
   {
@@ -427,7 +500,7 @@ void CegisUnifEnumManager::incrementNumEnumerators()
       TypeNode ct = c.getType();
       Node eu = nm->mkSkolem("eu", ct);
       Node ceu;
-      if (!ci.second.d_enums[0].empty())
+      if (!options::sygusUnifCondIndependent() && !ci.second.d_enums[0].empty())
       {
         // make a new conditional enumerator as well, starting the
         // second type around
@@ -465,14 +538,15 @@ void CegisUnifEnumManager::incrementNumEnumerators()
         }
         // register the enumerator
         ci.second.d_enums[index].push_back(e);
-        Trace("cegis-unif-enum") << "* Registering new enumerator " << e
-                                 << " to strategy point " << ci.second.d_pt
-                                 << "\n";
-        d_tds->registerEnumerator(e, ci.second.d_pt, d_parent);
-        // TODO symmetry breaking for making
-        //   e distinct from ei : (ci.second.d_enums[index] \ {e})
-        // if its respective type has had at least
-        // ci.second.d_enums[index].size() distinct values enumerated
+        Trace("cegis-unif-enum")
+            << "* Registering new enumerator " << e << " to strategy point "
+            << ci.second.d_pt << "\n";
+        d_tds->registerEnumerator(e,
+                                  ci.second.d_pt,
+                                  d_parent,
+                                  false,
+                                  index == 0 ? options::sygusUnifRepairRet()
+                                             : options::sygusUnifRepairCond());
       }
     }
     // register the evaluation points at the new value
@@ -568,8 +642,8 @@ void CegisUnifEnumManager::registerEvalPtAtSize(Node e,
     disj.push_back(ei.eqNode(itc->second.d_enums[0][i]));
   }
   Node lem = NodeManager::currentNM()->mkNode(OR, disj);
-  Trace("cegis-unif-enum-lemma") << "CegisUnifEnum::lemma, domain:" << lem
-                                 << "\n";
+  Trace("cegis-unif-enum-lemma")
+      << "CegisUnifEnum::lemma, domain:" << lem << "\n";
   d_qe->getOutputChannel().lemma(lem);
 }
 

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -262,8 +262,8 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
   Assert(options::sygusUnifCondIndependent() || !lemmas.empty());
   for (const Node& lem : lemmas)
   {
-    Trace("cegis-unif-lemma") << "CegisUnif::lemma, separation lemma : " << lem
-                              << "\n";
+    Trace("cegis-unif-lemma")
+        << "CegisUnif::lemma, separation lemma : " << lem << "\n";
     d_qe->getOutputChannel().lemma(lem);
   }
   Trace("cegis-unif") << "..failed to separate heads\n---CegisUnif Engine---\n";
@@ -278,8 +278,8 @@ void CegisUnif::registerRefinementLemma(const std::vector<Node>& vars,
   std::map<Node, std::vector<Node>> eval_pts;
   Node plem = d_sygus_unif.addRefLemma(lem, eval_pts);
   addRefinementLemma(plem);
-  Trace("cegis-unif-lemma") << "CegisUnif::lemma, refinement lemma : " << plem
-                            << "\n";
+  Trace("cegis-unif-lemma")
+      << "CegisUnif::lemma, refinement lemma : " << plem << "\n";
   // Notify the enumeration manager if there are new evaluation points
   for (const std::pair<const Node, std::vector<Node>>& ep : eval_pts)
   {
@@ -382,9 +382,9 @@ void CegisUnifEnumManager::initialize(
       }
       // register the enumerator
       ci.second.d_enums[1].push_back(ceu);
-      Trace("cegis-unif-enum") << "* Registering new enumerator " << ceu
-                               << " to strategy point " << ci.second.d_pt
-                               << "\n";
+      Trace("cegis-unif-enum")
+          << "* Registering new enumerator " << ceu << " to strategy point "
+          << ci.second.d_pt << "\n";
       d_tds->registerEnumerator(ceu, ci.second.d_pt, d_parent);
       d_enum_to_active_guard[ceu] = d_tds->getActiveGuardForEnumerator(ceu);
     }

--- a/src/theory/quantifiers/sygus/cegis_unif.h
+++ b/src/theory/quantifiers/sygus/cegis_unif.h
@@ -93,6 +93,9 @@ class CegisUnifEnumManager
    * is not asserted negatively in the current SAT context.
    */
   Node getCurrentLiteral() const;
+  /** map from condition enumerators to active guards (in case they are
+   * enumerated indepedently of the return values) */
+  std::map<Node, Node> d_enum_to_active_guard;
 
  private:
   /** reference to quantifier engine */

--- a/src/theory/quantifiers/sygus/cegis_unif.h
+++ b/src/theory/quantifiers/sygus/cegis_unif.h
@@ -76,6 +76,8 @@ class CegisUnifEnumManager
    * registerEvalPtAtValue on the output channel of d_qe.
    */
   void registerEvalPts(const std::vector<Node>& eis, Node e);
+  /** Retrieves active guard for enumerator */
+  Node getActiveGuardForEnumerator(Node e);
   /** get next decision request
    *
    * This function has the same contract as Theory::getNextDecisionRequest.
@@ -93,9 +95,6 @@ class CegisUnifEnumManager
    * is not asserted negatively in the current SAT context.
    */
   Node getCurrentLiteral() const;
-  /** map from condition enumerators to active guards (in case they are
-   * enumerated indepedently of the return values) */
-  std::map<Node, Node> d_enum_to_active_guard;
 
  private:
   /** reference to quantifier engine */
@@ -108,6 +107,9 @@ class CegisUnifEnumManager
   bool d_initialized;
   /** null node */
   Node d_null;
+  /** map from condition enumerators to active guards (in case they are
+   * enumerated indepedently of the return values) */
+  std::map<Node, Node> d_enum_to_active_guard;
   /** information per initialized type */
   class StrategyPtInfo
   {

--- a/src/theory/quantifiers/sygus/cegis_unif.h
+++ b/src/theory/quantifiers/sygus/cegis_unif.h
@@ -170,6 +170,15 @@ class CegisUnifEnumManager
    * current SAT context.
    */
   context::CDO<unsigned> d_curr_guq_val;
+  /** Registers an enumerator and adds symmetry breaking lemmas
+   *
+   * The symmetry breaking lemmas are generated according to the stored
+   * information from the enumerator's respective strategy point and whether it
+   * is a condition or return value enumerator. For the latter we add symmetry
+   * breaking lemmas that force enumerators to consider values in an increasing
+   * order of size.
+   */
+  void setUpEnumerator(Node e, StrategyPtInfo& si, unsigned index);
   /** increment the number of enumerators */
   void incrementNumEnumerators();
   /** get literal G_uq_n */

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -576,8 +576,8 @@ Node SygusUnifRl::DecisionTreeInfo::buildSolAllCond(Node cons,
       continue;
     }
     Assert(hd_mv.find(er) != hd_mv.end())
-    // merged into separation class with same model value, no conflict
-    if (hd_mv[e] == hd_mv[er])
+        // merged into separation class with same model value, no conflict
+        if (hd_mv[e] == hd_mv[er])
     {
       continue;
     }
@@ -599,7 +599,7 @@ Node SygusUnifRl::DecisionTreeInfo::buildSolAllCond(Node cons,
 }
 
 Node SygusUnifRl::DecisionTreeInfo::buildSolMinCond(Node cons,
-                                             std::vector<Node>& lemmas)
+                                                    std::vector<Node>& lemmas)
 {
   NodeManager* nm = NodeManager::currentNM();
   // model values for evaluation heads

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -511,7 +511,7 @@ void SygusUnifRl::DecisionTreeInfo::setConditions(
   d_enums.insert(d_enums.end(), enums.begin(), enums.end());
   d_conds.insert(d_conds.end(), conds.begin(), conds.end());
   // add to condition pool
-  if (options::sygusUnifCondIndependent() || options::sygusUnifCondPool())
+  if (options::sygusUnifCondIndependent())
   {
     if (Trace.isOn("sygus-unif-cond-pool"))
     {

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -270,9 +270,9 @@ Node SygusUnifRl::addRefLemma(Node lemma,
         for (const Node& stratpt : d_cenum_to_stratpt[cenum])
         {
           Assert(d_stratpt_to_dt.find(stratpt) != d_stratpt_to_dt.end());
-          Trace("sygus-unif-rl-dt")
-              << "Register point with head " << cp.second[j]
-              << " to strategy point " << stratpt << "\n";
+          Trace("sygus-unif-rl-dt") << "Register point with head "
+                                    << cp.second[j] << " to strategy point "
+                                    << stratpt << "\n";
           // Register new point from new head
           d_stratpt_to_dt[stratpt].d_hds.push_back(cp.second[j]);
         }
@@ -589,8 +589,8 @@ Node SygusUnifRl::DecisionTreeInfo::buildSol(Node cons,
         continue;
       }
       // conflict. Explanation?
-      Trace("sygus-unif-sol")
-          << "  ...can't separate " << e << " from " << er << std::endl;
+      Trace("sygus-unif-sol") << "  ...can't separate " << e << " from " << er
+                              << std::endl;
       return Node::null();
     }
     Trace("sygus-unif-sol") << "...ready to build solution from DT\n";

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.cpp
@@ -575,9 +575,9 @@ Node SygusUnifRl::DecisionTreeInfo::buildSolAllCond(Node cons,
       // new separation class, no conflict
       continue;
     }
-    Assert(hd_mv.find(er) != hd_mv.end())
-        // merged into separation class with same model value, no conflict
-        if (hd_mv[e] == hd_mv[er])
+    Assert(hd_mv.find(er) != hd_mv.end());
+    // merged into separation class with same model value, no conflict
+    if (hd_mv[e] == hd_mv[er])
     {
       continue;
     }

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.h
@@ -205,16 +205,27 @@ class SygusUnifRl : public SygusUnif
                     unsigned strategy_index);
     /** returns index of strategy information of strategy node for this DT */
     unsigned getStrategyIndex() const;
-    /** builds solution stored in DT, if any, using the given constructor
+    /** builds solution, if possible, using the given constructor
      *
-     * The DT contains a solution when no class contains two heads of evaluation
-     * points with different model values, i.e. when all points that must be
-     * separated indeed are separated by the current set of conditions.
-     *
-     * This method either returns a solution (if all points are separated).
-     * It it fails, it adds a conflict lemma to lemmas.
+     * A solution is possible when all different valued heads can be separated,
+     * i.e. the current set of conditions separates them in a decision tree
      */
     Node buildSol(Node cons, std::vector<Node>& lemmas);
+    /** bulids a solution by considering all condition values ever enumerated */
+    Node buildSolAllCond(Node cons, std::vector<Node>& lemmas);
+    /** builds a solution by incrementally adding points and conditions to DT
+     *
+     * Differently from the above method, here a condition is only added to the
+     * DT when it's necessary for resolving a separation conflict (i.e. heads
+     * with different values in the same leaf of the DT). Only one value per
+     * condition enumerated is considered.
+     *
+     * If a solution cannot be built, then there are more conflicts to be
+     * resolved than condition enumerators. A conflict lemma is added to lemmas
+     * that forces a new assigment in which the conflict is removed (heads are
+     * made equal) or a new condition is enumerated to try to separate them.
+     */
+    Node buildSolMinCond(Node cons, std::vector<Node>& lemmas);
     /** reference to parent unif util */
     SygusUnifRl* d_unif;
     /** enumerator template (if no templates, nodes in pair are Node::null()) */

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.h
@@ -235,7 +235,7 @@ class SygusUnifRl : public SygusUnif
     /** gathered evaluation point heads */
     std::vector<Node> d_hds;
     /** all enumerated model values for conditions */
-    std::set<Node> d_cond_mvs;
+    std::unordered_set<Node, NodeHashFunction> d_cond_mvs;
     /** get condition enumerator */
     Node getConditionEnumerator() const { return d_cond_enum; }
     /** set conditions */
@@ -244,8 +244,9 @@ class SygusUnifRl : public SygusUnif
                        const std::vector<Node>& conds);
 
    private:
-    /** built solutions */
-    std::set<Node> d_sols;
+    /** Accumulates solutions built when considering all enumerated condition
+     * values (which may generate repeated solutions) */
+    std::unordered_set<Node, NodeHashFunction> d_sols;
     /**
      * Conditional enumerator variables corresponding to the condition values in
      * d_conds. These are used for generating separation lemmas during

--- a/src/theory/quantifiers/sygus/sygus_unif_rl.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_rl.h
@@ -223,6 +223,8 @@ class SygusUnifRl : public SygusUnif
     std::vector<Node> d_conds;
     /** gathered evaluation point heads */
     std::vector<Node> d_hds;
+    /** all enumerated model values for conditions */
+    std::set<Node> d_cond_mvs;
     /** get condition enumerator */
     Node getConditionEnumerator() const { return d_cond_enum; }
     /** set conditions */
@@ -231,6 +233,8 @@ class SygusUnifRl : public SygusUnif
                        const std::vector<Node>& conds);
 
    private:
+    /** built solutions */
+    std::set<Node> d_sols;
     /**
      * Conditional enumerator variables corresponding to the condition values in
      * d_conds. These are used for generating separation lemmas during
@@ -278,6 +282,8 @@ class SygusUnifRl : public SygusUnif
 
       /** the lazy trie for building the separation classes */
       LazyTrieMulti d_trie;
+      /** extracts solution from decision tree built */
+      Node extractSol(Node cons, std::map<Node, Node>& hd_mv);
 
      private:
       /** reference to parent unif util */


### PR DESCRIPTION
This commit allows the use of unification techniques in which the search space for conditions in explored independently of the search space for return values (i.e. there is a single condition enumerator for which we always ask new values, similar to the PBE case).

In comparison with asking the ground solver to come up with a minimal number of condition values to resolve all my separation conflicts:

- *main advantage*: can quickly enumerate relevant condition values for solving the problem
- *main disadvantage*: there are many "spurious" values (as in not useful for actual solutions) that get in the way of "good" values when we build solutions from the lazy trie.

A follow-up PR will introduce an information-gain heuristic for building solutions, which ultimately greatly outperforms the other flavor of sygus-unif.

There is also small improvements for trace messages.