### PR TITLE
New C++ API: Introduce new macro and exception for API checks.

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -17,6 +17,7 @@
 #include "api/cvc4cpp.h"
 
 #include "base/cvc4_assert.h"
+#include "base/cvc4_check.h"
 #include "expr/expr.h"
 #include "expr/expr_manager.h"
 #include "expr/kind.h"
@@ -33,6 +34,34 @@
 
 namespace CVC4 {
 namespace api {
+
+namespace {
+/* -------------------------------------------------------------------------- */
+/* API guard helpers                                                          */
+/* -------------------------------------------------------------------------- */
+
+class CVC4_PUBLIC CVC4ApiException : public Exception
+{
+ public:
+  CVC4ApiException(std::stringstream& stream) { d_msg = stream.str(); }
+};
+
+/**
+ * Macro to check for API misuse.
+ * 'msg' can be variadic of the form 'msg_1 << msg_2 << ... << msg_n'
+ */
+#define CVC4_API_CHECK(cond, msg)    \
+  do                                 \
+  {                                  \
+    if (!(CVC4_PREDICT_FALSE(cond))) \
+    {                                \
+      std::stringstream ss;          \
+      ss << msg;                     \
+      throw CVC4ApiException(ss);    \
+    }                                \
+  } while (0)
+
+}  // namespace
 
 /* -------------------------------------------------------------------------- */
 /* Result                                                                     */
@@ -1813,57 +1842,51 @@ Term Solver::mkConst(RoundingMode rm) const
 
 Term Solver::mkConst(Kind kind, Sort arg) const
 {
-  PrettyCheckArgument(kind == EMPTYSET,
-                      kind,
-                      "Invalid kind '%s', expected EMPTY_SET",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == EMPTYSET,
+                 "Invalid kind '" << kindToString(kind).c_str()
+                                  << "', expected EMPTY_SET");
   return d_exprMgr->mkConst(CVC4::EmptySet(*arg.d_type));
 }
 
 Term Solver::mkConst(Kind kind, Sort arg1, int32_t arg2) const
 {
-  PrettyCheckArgument(kind == UNINTERPRETED_CONSTANT,
-                      kind,
-                      "Invalid kind '%s', expected UNINTERPRETED_CONSTANT",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == UNINTERPRETED_CONSTANT,
+                 "Invalid kind '%s', expected UNINTERPRETED_CONSTANT"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::UninterpretedConstant(*arg1.d_type, arg2));
 }
 
 Term Solver::mkConst(Kind kind, bool arg) const
 {
-  PrettyCheckArgument(kind == CONST_BOOLEAN,
-                      kind,
-                      "Invalid kind '%s', expected CONST_BOOLEAN",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_BOOLEAN,
+                 "Invalid kind '%s', expected CONST_BOOLEAN"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst<bool>(arg);
 }
 
 Term Solver::mkConst(Kind kind, const char* arg) const
 {
-  PrettyCheckArgument(kind == CONST_STRING,
-                      kind,
-                      "Invalid kind '%s', expected CONST_STRING",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(
+      kind == CONST_STRING,
+      "Invalid kind '%s', expected CONST_STRING" << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::String(arg));
 }
 
 Term Solver::mkConst(Kind kind, const std::string& arg) const
 {
-  PrettyCheckArgument(kind == CONST_STRING,
-                      kind,
-                      "Invalid kind '%s', expected CONST_STRING",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(
+      kind == CONST_STRING,
+      "Invalid kind '%s', expected CONST_STRING" << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::String(arg));
 }
 
 Term Solver::mkConst(Kind kind, const char* arg1, uint32_t arg2) const
 {
-  PrettyCheckArgument(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
-                          || kind == CONST_BITVECTOR,
-                      kind,
-                      "Invalid kind '%s', expected ABSTRACT_VALUE or "
-                      "CONST_RATIONAL or CONST_BITVECTOR",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
+                     || kind == CONST_BITVECTOR,
+                 "Invalid kind '%s', expected ABSTRACT_VALUE or "
+                 "CONST_RATIONAL or CONST_BITVECTOR"
+                     << kindToString(kind).c_str());
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg1, arg2)));
@@ -1877,12 +1900,11 @@ Term Solver::mkConst(Kind kind, const char* arg1, uint32_t arg2) const
 
 Term Solver::mkConst(Kind kind, const std::string& arg1, uint32_t arg2) const
 {
-  PrettyCheckArgument(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
-                          || kind == CONST_BITVECTOR,
-                      kind,
-                      "Invalid kind '%s', expected ABSTRACT_VALUE or "
-                      "CONST_RATIONAL or CONST_BITVECTOR",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
+                     || kind == CONST_BITVECTOR,
+                 "Invalid kind '%s', expected ABSTRACT_VALUE or "
+                 "CONST_RATIONAL or CONST_BITVECTOR"
+                     << kindToString(kind).c_str());
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg1, arg2)));
@@ -1896,12 +1918,11 @@ Term Solver::mkConst(Kind kind, const std::string& arg1, uint32_t arg2) const
 
 Term Solver::mkConst(Kind kind, uint32_t arg) const
 {
-  PrettyCheckArgument(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
-                          || kind == CONST_BITVECTOR,
-                      kind,
-                      "Invalid kind '%s', expected ABSTRACT_VALUE or "
-                      "CONST_RATIONAL or CONST_BITVECTOR",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
+                     || kind == CONST_BITVECTOR,
+                 "Invalid kind '%s', expected ABSTRACT_VALUE or "
+                 "CONST_RATIONAL or CONST_BITVECTOR"
+                     << kindToString(kind).c_str());
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1915,11 +1936,9 @@ Term Solver::mkConst(Kind kind, uint32_t arg) const
 
 Term Solver::mkConst(Kind kind, int32_t arg) const
 {
-  PrettyCheckArgument(
-      kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
-      kind,
-      "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL",
-      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
+                 "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
+                     << kindToString(kind).c_str());
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1929,11 +1948,9 @@ Term Solver::mkConst(Kind kind, int32_t arg) const
 
 Term Solver::mkConst(Kind kind, int64_t arg) const
 {
-  PrettyCheckArgument(
-      kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
-      kind,
-      "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL",
-      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
+                 "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
+                     << kindToString(kind).c_str());
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1943,11 +1960,9 @@ Term Solver::mkConst(Kind kind, int64_t arg) const
 
 Term Solver::mkConst(Kind kind, uint64_t arg) const
 {
-  PrettyCheckArgument(
-      kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
-      kind,
-      "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL",
-      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
+                 "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
+                     << kindToString(kind).c_str());
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1957,56 +1972,50 @@ Term Solver::mkConst(Kind kind, uint64_t arg) const
 
 Term Solver::mkConst(Kind kind, uint32_t arg1, uint32_t arg2) const
 {
-  PrettyCheckArgument(kind == CONST_RATIONAL,
-                      kind,
-                      "Invalid kind '%s', expected CONST_RATIONAL",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL,
+                 "Invalid kind '%s', expected CONST_RATIONAL"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, int32_t arg1, int32_t arg2) const
 {
-  PrettyCheckArgument(kind == CONST_RATIONAL,
-                      kind,
-                      "Invalid kind '%s', expected CONST_RATIONAL",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL,
+                 "Invalid kind '%s', expected CONST_RATIONAL"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, int64_t arg1, int64_t arg2) const
 {
-  PrettyCheckArgument(kind == CONST_RATIONAL,
-                      kind,
-                      "Invalid kind '%s', expected CONST_RATIONAL",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL,
+                 "Invalid kind '%s', expected CONST_RATIONAL"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, uint64_t arg1, uint64_t arg2) const
 {
-  PrettyCheckArgument(kind == CONST_RATIONAL,
-                      kind,
-                      "Invalid kind '%s', expected CONST_RATIONAL",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL,
+                 "Invalid kind '%s', expected CONST_RATIONAL"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, uint32_t arg1, uint64_t arg2) const
 {
-  PrettyCheckArgument(kind == CONST_BITVECTOR,
-                      kind,
-                      "Invalid kind '%s', expected CONST_BITVECTOR",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_BITVECTOR,
+                 "Invalid kind '%s', expected CONST_BITVECTOR"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::BitVector(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, uint32_t arg1, uint32_t arg2, Term arg3) const
 {
   // CHECK: arg 3 is bit-vector constant
-  PrettyCheckArgument(kind == CONST_FLOATINGPOINT,
-                      kind,
-                      "Invalid kind '%s', expected CONST_FLOATINGPOINT",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_FLOATINGPOINT,
+                 "Invalid kind '%s', expected CONST_FLOATINGPOINT"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(
       CVC4::FloatingPoint(arg1, arg2, arg3.d_expr->getConst<BitVector>()));
 }
@@ -2043,11 +2052,10 @@ Term Solver::mkBoundVar(Sort sort) const
 
 Term Solver::mkTerm(Kind kind) const
 {
-  PrettyCheckArgument(
+  CVC4_API_CHECK(
       kind == PI || kind == REGEXP_EMPTY || kind == REGEXP_SIGMA,
-      kind,
-      "Invalid kind '%s', expected PI or REGEXP_EMPTY or REGEXP_SIGMA",
-      kindToString(kind).c_str());
+      "Invalid kind '%s', expected PI or REGEXP_EMPTY or REGEXP_SIGMA"
+          << kindToString(kind).c_str());
   if (kind == REGEXP_EMPTY || kind == REGEXP_SIGMA)
   {
     CVC4::Kind k = extToIntKind(kind);
@@ -2060,10 +2068,8 @@ Term Solver::mkTerm(Kind kind) const
 
 Term Solver::mkTerm(Kind kind, Sort sort) const
 {
-  PrettyCheckArgument(kind == SEP_NIL || kind == UNIVERSE_SET,
-                      kind,
-                      "Invalid kind '%s'",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == SEP_NIL || kind == UNIVERSE_SET,
+                 "Invalid kind '%s'" << kindToString(kind).c_str());
   return d_exprMgr->mkNullaryOperator(*sort.d_type, extToIntKind(kind));
 }
 
@@ -2083,10 +2089,8 @@ Term Solver::mkTerm(Kind kind, Term child) const
   // n < minArity(kind) || n > maxArity(kind)
   // else "Exprs with kind %s must have at least %u children and "
   //      "at most %u children (the one under construction has %u)"
-  PrettyCheckArgument(isDefinedKind(kind),
-                      kind,
-                      "Invalid kind '%s'",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind),
+                 "Invalid kind '%s'" << kindToString(kind).c_str());
   CVC4::Kind k = extToIntKind(kind);
   Assert(isDefinedIntKind(k));
   return d_exprMgr->mkExpr(k, *child.d_expr);
@@ -2094,10 +2098,8 @@ Term Solver::mkTerm(Kind kind, Term child) const
 
 Term Solver::mkTerm(Kind kind, Term child1, Term child2) const
 {
-  PrettyCheckArgument(isDefinedKind(kind),
-                      kind,
-                      "Invalid kind '%s'",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind),
+                 "Invalid kind '%s'" << kindToString(kind).c_str());
   // CHECK:
   // NodeManager::fromExprManager(d_exprMgr)
   // == NodeManager::fromExprManager(child1.getExprManager())
@@ -2139,10 +2141,8 @@ Term Solver::mkTerm(Kind kind, Term child1, Term child2, Term child3) const
   // n < minArity(kind) || n > maxArity(kind)
   // else "Exprs with kind %s must have at least %u children and "
   //      "at most %u children (the one under construction has %u)"
-  PrettyCheckArgument(isDefinedKind(kind),
-                      kind,
-                      "Invalid kind '%s'",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind),
+                 "Invalid kind '%s'" << kindToString(kind).c_str());
   std::vector<Expr> echildren{*child1.d_expr, *child2.d_expr, *child3.d_expr};
   CVC4::Kind k = extToIntKind(kind);
   Assert(isDefinedIntKind(k));
@@ -2167,10 +2167,8 @@ Term Solver::mkTerm(Kind kind, const std::vector<Term>& children) const
   // 1 : 0); n < minArity(kind) || n > maxArity(kind) else "Exprs with kind %s
   // must have at least %u children and "
   //      "at most %u children (the one under construction has %u)"
-  PrettyCheckArgument(isDefinedKind(kind),
-                      kind,
-                      "Invalid kind '%s'",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind),
+                 "Invalid kind '%s'" << kindToString(kind).c_str());
   std::vector<Expr> echildren = termVectorToExprs(children);
   CVC4::Kind k = extToIntKind(kind);
   Assert(isDefinedIntKind(k));
@@ -2296,28 +2294,24 @@ std::vector<Expr> Solver::termVectorToExprs(
 
 OpTerm Solver::mkOpTerm(Kind kind, Kind k)
 {
-  PrettyCheckArgument(kind == CHAIN_OP,
-                      kind,
-                      "Invalid kind '%s', expected CHAIN_OP",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(
+      kind == CHAIN_OP,
+      "Invalid kind '%s', expected CHAIN_OP" << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::Chain(extToIntKind(k)));
 }
 
 OpTerm Solver::mkOpTerm(Kind kind, const std::string& arg)
 {
-  PrettyCheckArgument(kind == RECORD_UPDATE_OP,
-                      kind,
-                      "Invalid kind '%s', expected RECORD_UPDATE_OP",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == RECORD_UPDATE_OP,
+                 "Invalid kind '%s', expected RECORD_UPDATE_OP"
+                     << kindToString(kind).c_str());
   return d_exprMgr->mkConst(CVC4::RecordUpdate(arg));
 }
 
 OpTerm Solver::mkOpTerm(Kind kind, uint32_t arg)
 {
-  PrettyCheckArgument(isDefinedKind(kind),
-                      kind,
-                      "Invalid kind '%s'",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind),
+                 "Invalid kind '%s'" << kindToString(kind).c_str());
   OpTerm res;
   switch (kind)
   {
@@ -2364,10 +2358,8 @@ OpTerm Solver::mkOpTerm(Kind kind, uint32_t arg)
 
 OpTerm Solver::mkOpTerm(Kind kind, uint32_t arg1, uint32_t arg2)
 {
-  PrettyCheckArgument(isDefinedKind(kind),
-                      kind,
-                      "Invalid kind '%s'",
-                      kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind),
+                 "Invalid kind '%s'" << kindToString(kind).c_str());
   OpTerm res;
   switch (kind)
   {

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -46,21 +46,33 @@ class CVC4_PUBLIC CVC4ApiException : public Exception
   CVC4ApiException(std::stringstream& stream) { d_msg = stream.str(); }
 };
 
-/**
- * Macro to check for API misuse.
- * 'msg' can be variadic of the form 'msg_1 << msg_2 << ... << msg_n'
- */
-#define CVC4_API_CHECK(cond, msg)    \
-  do                                 \
-  {                                  \
-    if (!(CVC4_PREDICT_FALSE(cond))) \
-    {                                \
-      std::stringstream ss;          \
-      ss << msg;                     \
-      throw CVC4ApiException(ss);    \
-    }                                \
-  } while (0)
+class CVC4ApiExceptionStream
+{
+ public:
+  CVC4ApiExceptionStream() {}
+  /* Note: This needs to be explicitly set to 'noexcept(false)' since it is
+   * a destructor that throws an exception and in C++11 all destructors
+   * default to noexcept(true) (else this triggers a call to std::terminate). */
+  CVC4_NO_RETURN ~CVC4ApiExceptionStream() noexcept(false)
+  {
+    throw CVC4ApiException(d_stream);
+  }
 
+  std::ostream& ostream() { return d_stream; }
+
+  CVC4ApiExceptionStream& operator<<(const std::string& msg)
+  {
+    d_stream << msg;
+    return *this;
+  }
+
+ private:
+  std::stringstream d_stream;
+};
+
+#define CVC4_API_CHECK(cond) \
+  CVC4_PREDICT_FALSE(cond)   \
+  ? (void)0 : OstreamVoider() & CVC4ApiExceptionStream().ostream()
 }  // namespace
 
 /* -------------------------------------------------------------------------- */
@@ -1842,51 +1854,51 @@ Term Solver::mkConst(RoundingMode rm) const
 
 Term Solver::mkConst(Kind kind, Sort arg) const
 {
-  CVC4_API_CHECK(kind == EMPTYSET,
-                 "Invalid kind '" << kindToString(kind).c_str()
-                                  << "', expected EMPTY_SET");
+  CVC4_API_CHECK(kind == EMPTYSET)
+      << "Invalid kind '" << kindToString(kind).c_str()
+      << "', expected EMPTY_SET";
   return d_exprMgr->mkConst(CVC4::EmptySet(*arg.d_type));
 }
 
 Term Solver::mkConst(Kind kind, Sort arg1, int32_t arg2) const
 {
-  CVC4_API_CHECK(kind == UNINTERPRETED_CONSTANT,
-                 "Invalid kind '%s', expected UNINTERPRETED_CONSTANT"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == UNINTERPRETED_CONSTANT)
+      << "Invalid kind '%s', expected UNINTERPRETED_CONSTANT"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::UninterpretedConstant(*arg1.d_type, arg2));
 }
 
 Term Solver::mkConst(Kind kind, bool arg) const
 {
-  CVC4_API_CHECK(kind == CONST_BOOLEAN,
-                 "Invalid kind '%s', expected CONST_BOOLEAN"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_BOOLEAN)
+      << "Invalid kind '%s', expected CONST_BOOLEAN"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst<bool>(arg);
 }
 
 Term Solver::mkConst(Kind kind, const char* arg) const
 {
-  CVC4_API_CHECK(
-      kind == CONST_STRING,
-      "Invalid kind '%s', expected CONST_STRING" << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_STRING)
+      << "Invalid kind '%s', expected CONST_STRING"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::String(arg));
 }
 
 Term Solver::mkConst(Kind kind, const std::string& arg) const
 {
-  CVC4_API_CHECK(
-      kind == CONST_STRING,
-      "Invalid kind '%s', expected CONST_STRING" << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_STRING)
+      << "Invalid kind '%s', expected CONST_STRING"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::String(arg));
 }
 
 Term Solver::mkConst(Kind kind, const char* arg1, uint32_t arg2) const
 {
   CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
-                     || kind == CONST_BITVECTOR,
-                 "Invalid kind '%s', expected ABSTRACT_VALUE or "
-                 "CONST_RATIONAL or CONST_BITVECTOR"
-                     << kindToString(kind).c_str());
+                 || kind == CONST_BITVECTOR)
+      << "Invalid kind '%s', expected ABSTRACT_VALUE or "
+         "CONST_RATIONAL or CONST_BITVECTOR"
+      << kindToString(kind).c_str();
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg1, arg2)));
@@ -1901,10 +1913,10 @@ Term Solver::mkConst(Kind kind, const char* arg1, uint32_t arg2) const
 Term Solver::mkConst(Kind kind, const std::string& arg1, uint32_t arg2) const
 {
   CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
-                     || kind == CONST_BITVECTOR,
-                 "Invalid kind '%s', expected ABSTRACT_VALUE or "
-                 "CONST_RATIONAL or CONST_BITVECTOR"
-                     << kindToString(kind).c_str());
+                 || kind == CONST_BITVECTOR)
+      << "Invalid kind '%s', expected ABSTRACT_VALUE or "
+         "CONST_RATIONAL or CONST_BITVECTOR"
+      << kindToString(kind).c_str();
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg1, arg2)));
@@ -1919,10 +1931,10 @@ Term Solver::mkConst(Kind kind, const std::string& arg1, uint32_t arg2) const
 Term Solver::mkConst(Kind kind, uint32_t arg) const
 {
   CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL
-                     || kind == CONST_BITVECTOR,
-                 "Invalid kind '%s', expected ABSTRACT_VALUE or "
-                 "CONST_RATIONAL or CONST_BITVECTOR"
-                     << kindToString(kind).c_str());
+                 || kind == CONST_BITVECTOR)
+      << "Invalid kind '%s', expected ABSTRACT_VALUE or "
+         "CONST_RATIONAL or CONST_BITVECTOR"
+      << kindToString(kind).c_str();
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1936,9 +1948,9 @@ Term Solver::mkConst(Kind kind, uint32_t arg) const
 
 Term Solver::mkConst(Kind kind, int32_t arg) const
 {
-  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
-                 "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL)
+      << "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
+      << kindToString(kind).c_str();
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1948,9 +1960,9 @@ Term Solver::mkConst(Kind kind, int32_t arg) const
 
 Term Solver::mkConst(Kind kind, int64_t arg) const
 {
-  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
-                 "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL)
+      << "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
+      << kindToString(kind).c_str();
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1960,9 +1972,9 @@ Term Solver::mkConst(Kind kind, int64_t arg) const
 
 Term Solver::mkConst(Kind kind, uint64_t arg) const
 {
-  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL,
-                 "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == ABSTRACT_VALUE || kind == CONST_RATIONAL)
+      << "Invalid kind '%s', expected ABSTRACT_VALUE or CONST_RATIONAL"
+      << kindToString(kind).c_str();
   if (kind == ABSTRACT_VALUE)
   {
     return d_exprMgr->mkConst(CVC4::AbstractValue(Integer(arg)));
@@ -1972,50 +1984,50 @@ Term Solver::mkConst(Kind kind, uint64_t arg) const
 
 Term Solver::mkConst(Kind kind, uint32_t arg1, uint32_t arg2) const
 {
-  CVC4_API_CHECK(kind == CONST_RATIONAL,
-                 "Invalid kind '%s', expected CONST_RATIONAL"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL)
+      << "Invalid kind '%s', expected CONST_RATIONAL"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, int32_t arg1, int32_t arg2) const
 {
-  CVC4_API_CHECK(kind == CONST_RATIONAL,
-                 "Invalid kind '%s', expected CONST_RATIONAL"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL)
+      << "Invalid kind '%s', expected CONST_RATIONAL"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, int64_t arg1, int64_t arg2) const
 {
-  CVC4_API_CHECK(kind == CONST_RATIONAL,
-                 "Invalid kind '%s', expected CONST_RATIONAL"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL)
+      << "Invalid kind '%s', expected CONST_RATIONAL"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, uint64_t arg1, uint64_t arg2) const
 {
-  CVC4_API_CHECK(kind == CONST_RATIONAL,
-                 "Invalid kind '%s', expected CONST_RATIONAL"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_RATIONAL)
+      << "Invalid kind '%s', expected CONST_RATIONAL"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::Rational(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, uint32_t arg1, uint64_t arg2) const
 {
-  CVC4_API_CHECK(kind == CONST_BITVECTOR,
-                 "Invalid kind '%s', expected CONST_BITVECTOR"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_BITVECTOR)
+      << "Invalid kind '%s', expected CONST_BITVECTOR"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::BitVector(arg1, arg2));
 }
 
 Term Solver::mkConst(Kind kind, uint32_t arg1, uint32_t arg2, Term arg3) const
 {
   // CHECK: arg 3 is bit-vector constant
-  CVC4_API_CHECK(kind == CONST_FLOATINGPOINT,
-                 "Invalid kind '%s', expected CONST_FLOATINGPOINT"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CONST_FLOATINGPOINT)
+      << "Invalid kind '%s', expected CONST_FLOATINGPOINT"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(
       CVC4::FloatingPoint(arg1, arg2, arg3.d_expr->getConst<BitVector>()));
 }
@@ -2052,10 +2064,9 @@ Term Solver::mkBoundVar(Sort sort) const
 
 Term Solver::mkTerm(Kind kind) const
 {
-  CVC4_API_CHECK(
-      kind == PI || kind == REGEXP_EMPTY || kind == REGEXP_SIGMA,
-      "Invalid kind '%s', expected PI or REGEXP_EMPTY or REGEXP_SIGMA"
-          << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == PI || kind == REGEXP_EMPTY || kind == REGEXP_SIGMA)
+      << "Invalid kind '%s', expected PI or REGEXP_EMPTY or REGEXP_SIGMA"
+      << kindToString(kind).c_str();
   if (kind == REGEXP_EMPTY || kind == REGEXP_SIGMA)
   {
     CVC4::Kind k = extToIntKind(kind);
@@ -2068,8 +2079,8 @@ Term Solver::mkTerm(Kind kind) const
 
 Term Solver::mkTerm(Kind kind, Sort sort) const
 {
-  CVC4_API_CHECK(kind == SEP_NIL || kind == UNIVERSE_SET,
-                 "Invalid kind '%s'" << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == SEP_NIL || kind == UNIVERSE_SET)
+      << "Invalid kind '%s'" << kindToString(kind).c_str();
   return d_exprMgr->mkNullaryOperator(*sort.d_type, extToIntKind(kind));
 }
 
@@ -2089,8 +2100,8 @@ Term Solver::mkTerm(Kind kind, Term child) const
   // n < minArity(kind) || n > maxArity(kind)
   // else "Exprs with kind %s must have at least %u children and "
   //      "at most %u children (the one under construction has %u)"
-  CVC4_API_CHECK(isDefinedKind(kind),
-                 "Invalid kind '%s'" << kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind))
+      << "Invalid kind '%s'" << kindToString(kind).c_str();
   CVC4::Kind k = extToIntKind(kind);
   Assert(isDefinedIntKind(k));
   return d_exprMgr->mkExpr(k, *child.d_expr);
@@ -2098,8 +2109,8 @@ Term Solver::mkTerm(Kind kind, Term child) const
 
 Term Solver::mkTerm(Kind kind, Term child1, Term child2) const
 {
-  CVC4_API_CHECK(isDefinedKind(kind),
-                 "Invalid kind '%s'" << kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind))
+      << "Invalid kind '%s'" << kindToString(kind).c_str();
   // CHECK:
   // NodeManager::fromExprManager(d_exprMgr)
   // == NodeManager::fromExprManager(child1.getExprManager())
@@ -2141,8 +2152,8 @@ Term Solver::mkTerm(Kind kind, Term child1, Term child2, Term child3) const
   // n < minArity(kind) || n > maxArity(kind)
   // else "Exprs with kind %s must have at least %u children and "
   //      "at most %u children (the one under construction has %u)"
-  CVC4_API_CHECK(isDefinedKind(kind),
-                 "Invalid kind '%s'" << kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind))
+      << "Invalid kind '%s'" << kindToString(kind).c_str();
   std::vector<Expr> echildren{*child1.d_expr, *child2.d_expr, *child3.d_expr};
   CVC4::Kind k = extToIntKind(kind);
   Assert(isDefinedIntKind(k));
@@ -2167,8 +2178,8 @@ Term Solver::mkTerm(Kind kind, const std::vector<Term>& children) const
   // 1 : 0); n < minArity(kind) || n > maxArity(kind) else "Exprs with kind %s
   // must have at least %u children and "
   //      "at most %u children (the one under construction has %u)"
-  CVC4_API_CHECK(isDefinedKind(kind),
-                 "Invalid kind '%s'" << kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind))
+      << "Invalid kind '%s'" << kindToString(kind).c_str();
   std::vector<Expr> echildren = termVectorToExprs(children);
   CVC4::Kind k = extToIntKind(kind);
   Assert(isDefinedIntKind(k));
@@ -2294,24 +2305,23 @@ std::vector<Expr> Solver::termVectorToExprs(
 
 OpTerm Solver::mkOpTerm(Kind kind, Kind k)
 {
-  CVC4_API_CHECK(
-      kind == CHAIN_OP,
-      "Invalid kind '%s', expected CHAIN_OP" << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == CHAIN_OP)
+      << "Invalid kind '%s', expected CHAIN_OP" << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::Chain(extToIntKind(k)));
 }
 
 OpTerm Solver::mkOpTerm(Kind kind, const std::string& arg)
 {
-  CVC4_API_CHECK(kind == RECORD_UPDATE_OP,
-                 "Invalid kind '%s', expected RECORD_UPDATE_OP"
-                     << kindToString(kind).c_str());
+  CVC4_API_CHECK(kind == RECORD_UPDATE_OP)
+      << "Invalid kind '%s', expected RECORD_UPDATE_OP"
+      << kindToString(kind).c_str();
   return d_exprMgr->mkConst(CVC4::RecordUpdate(arg));
 }
 
 OpTerm Solver::mkOpTerm(Kind kind, uint32_t arg)
 {
-  CVC4_API_CHECK(isDefinedKind(kind),
-                 "Invalid kind '%s'" << kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind))
+      << "Invalid kind '%s'" << kindToString(kind).c_str();
   OpTerm res;
   switch (kind)
   {
@@ -2358,8 +2368,8 @@ OpTerm Solver::mkOpTerm(Kind kind, uint32_t arg)
 
 OpTerm Solver::mkOpTerm(Kind kind, uint32_t arg1, uint32_t arg2)
 {
-  CVC4_API_CHECK(isDefinedKind(kind),
-                 "Invalid kind '%s'" << kindToString(kind).c_str());
+  CVC4_API_CHECK(isDefinedKind(kind))
+      << "Invalid kind '%s'" << kindToString(kind).c_str();
   OpTerm res;
   switch (kind)
   {


### PR DESCRIPTION
This introduces a new macro `CVC4_API_CHECK` for guards against API misuse.

Note that the destructor of stream `CVC4ApiExceptionStream` has to be explicitly set to `noexcept(false)`. This is due to the fact that in C++11, destructors default to noexcept(true), which triggers a call to std::terminate() if the destructor throws an exception.