### PR TITLE
Eagerly ensure literal on active guards for sygus enumerators

### DIFF
--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -42,7 +42,7 @@ SynthEngine::~SynthEngine() { delete d_conj; }
 
 bool SynthEngine::needsCheck(Theory::Effort e)
 {
-  return !d_quantEngine->getTheoryEngine()->needCheck() && e >= Theory::EFFORT_LAST_CALL;
+  return e >= Theory::EFFORT_LAST_CALL;
 }
 
 QuantifiersModule::QEffort SynthEngine::needsModel(Theory::Effort e)

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -42,7 +42,7 @@ SynthEngine::~SynthEngine() { delete d_conj; }
 
 bool SynthEngine::needsCheck(Theory::Effort e)
 {
-  return e >= Theory::EFFORT_LAST_CALL;
+  return !d_quantEngine->getTheoryEngine()->needCheck() && e >= Theory::EFFORT_LAST_CALL;
 }
 
 QuantifiersModule::QEffort SynthEngine::needsModel(Theory::Effort e)

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -484,7 +484,7 @@ void TermDbSygus::registerEnumerator(Node e,
     // make the guard
     Node ag = nm->mkSkolem("eG", nm->booleanType());
     // must ensure it is a literal immediately here
-    ag = d_quantEngine->getValuation().ensureLiteral( ag );
+    ag = d_quantEngine->getValuation().ensureLiteral(ag);
     d_enum_to_active_guard[e] = ag;
   }
 

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -482,7 +482,10 @@ void TermDbSygus::registerEnumerator(Node e,
   NodeManager* nm = NodeManager::currentNM();
   if( mkActiveGuard ){
     // make the guard
-    d_enum_to_active_guard[e] = nm->mkSkolem("eG", nm->booleanType());
+    Node ag = nm->mkSkolem("eG", nm->booleanType());
+    // must ensure it is a literal immediately here
+    ag = d_quantEngine->getValuation().ensureLiteral( ag );
+    d_enum_to_active_guard[e] = ag;
   }
 
   Trace("sygus-db") << "  registering symmetry breaking clauses..."


### PR DESCRIPTION
This fixes a bug where two recent PRs were incompatible (#2511 and #2499).