### PR TITLE
cmake: Exclude examples for coverage target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,7 @@ if(ENABLE_COVERAGE)
   add_definitions(-DCVC4_COVERAGE)
   setup_target_for_coverage_lcov(
     NAME coverage
-    EXECUTABLE ctest -j${CTEST_NTHREADS} $(ARGS)
+    EXECUTABLE ctest -j${CTEST_NTHREADS} -LE "example" $(ARGS)
     DEPENDENCIES cvc4-bin)
 endif()
 


### PR DESCRIPTION
We should not rely on examples to increase the code coverage.