### PR TITLE
Infrastructure for using active enumerators in sygus modules

### DIFF
--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -169,7 +169,7 @@ bool hasFreeVar(TNode n)
 void getSymbols(TNode n, std::unordered_set<Node, NodeHashFunction>& syms)
 {
   std::unordered_set<TNode, TNodeHashFunction> visited;
-  getSymbols(n, syms);
+  getSymbols(n, syms, visited);
 }
 
 void getSymbols(TNode n,

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -109,10 +109,13 @@ bool Cegis::addEvalLemmas(const std::vector<Node>& candidates,
                           << std::endl;
     // see if any refinement lemma is refuted by evaluation
     std::vector<Node> cre_lems;
-    bool ret = getRefinementEvalLemmas(candidates, candidate_values, cre_lems, doGen);
-    if( ret && !doGen )
+    bool ret =
+        getRefinementEvalLemmas(candidates, candidate_values, cre_lems, doGen);
+    if (ret && !doGen)
     {
-      Trace("cegqi-engine") << "...(actively enumerated) candidate failed refinement lemma evaluation." << std::endl;
+      Trace("cegqi-engine") << "...(actively enumerated) candidate failed "
+                               "refinement lemma evaluation."
+                            << std::endl;
       return true;
     }
     if (!cre_lems.empty())
@@ -231,10 +234,9 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
   }
   // Is every enumerator in enums a passive one? If so, we can do conjecture.
   bool allPassive = true;
-  
 
   // evaluate on refinement lemmas
-  bool addedEvalLemmas = addEvalLemmas(enums, enum_values,allPassive);
+  bool addedEvalLemmas = addEvalLemmas(enums, enum_values, allPassive);
 
   // try to construct candidates
   if (!processConstructCandidates(enums,
@@ -422,7 +424,7 @@ bool Cegis::usingRepairConst() { return true; }
 bool Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
                                     const std::vector<Node>& ms,
                                     std::vector<Node>& lems,
-                               bool doGen)
+                                    bool doGen)
 {
   Trace("sygus-cref-eval") << "Cref eval : conjecture has "
                            << d_refinement_lemma_unit.size() << " unit and "
@@ -459,7 +461,7 @@ bool Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
           << "...after unfolding is : " << lemcsu << std::endl;
       if (lemcsu.isConst() && !lemcsu.getConst<bool>())
       {
-        if( !doGen )
+        if (!doGen)
         {
           // we are not generating the lemmas, instead just return
           return true;
@@ -497,7 +499,7 @@ bool Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
         else
         {
           cre_lem = neg_guard;
-        }      
+        }
         if (std::find(lems.begin(), lems.end(), cre_lem) == lems.end())
         {
           Trace("sygus-cref-eval")

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -315,7 +315,7 @@ void Cegis::addRefinementLemma(Node lem)
   // rewrite with extended rewriter
   slem = d_tds->getExtRewriter()->extendedRewrite(slem);
   // collect all variables in slem
-  //expr::getSymbols(slem,d_refinement_lemma_vars);
+  expr::getSymbols(slem,d_refinement_lemma_vars);
   std::vector<Node> waiting;
   waiting.push_back(lem);
   unsigned wcounter = 0;

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -13,13 +13,13 @@
  **/
 
 #include "theory/quantifiers/sygus/cegis.h"
+#include "expr/node_algorithm.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "printer/printer.h"
 #include "theory/quantifiers/sygus/synth_conjecture.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/theory_engine.h"
-#include "expr/node_algorithm.h"
 
 using namespace std;
 using namespace CVC4::kind;
@@ -111,24 +111,26 @@ bool Cegis::addEvalLemmas(const std::vector<Node>& candidates,
   // "actively generated" (see TermDbSygs::isPassiveEnumerator), since its
   // model values are themselves interpreted as classes of solutions.
   bool doGen = true;
-  for( const Node& v : candidates )
+  for (const Node& v : candidates)
   {
     // if it is relevant to refinement
-    if( d_refinement_lemma_vars.find(v)!=d_refinement_lemma_vars.end() )
+    if (d_refinement_lemma_vars.find(v) != d_refinement_lemma_vars.end())
     {
-      if( !d_tds->isPassiveEnumerator(v) )
+      if (!d_tds->isPassiveEnumerator(v))
       {
         doGen = false;
         break;
       }
     }
-  }  
+  }
   NodeManager* nm = NodeManager::currentNM();
   bool addedEvalLemmas = false;
   if (options::sygusRefEval())
   {
-    Trace("cegqi-engine") << "  *** Do refinement lemma evaluation" << (doGen ? " with conjecture-specific refinement" : "") << "..."
-                          << std::endl;
+    Trace("cegqi-engine") << "  *** Do refinement lemma evaluation"
+                          << (doGen ? " with conjecture-specific refinement"
+                                    : "")
+                          << "..." << std::endl;
     // see if any refinement lemma is refuted by evaluation
     std::vector<Node> cre_lems;
     bool ret =
@@ -314,7 +316,7 @@ void Cegis::addRefinementLemma(Node lem)
   // rewrite with extended rewriter
   slem = d_tds->getExtRewriter()->extendedRewrite(slem);
   // collect all variables in slem
-  expr::getSymbols(slem,d_refinement_lemma_vars);
+  expr::getSymbols(slem, d_refinement_lemma_vars);
   std::vector<Node> waiting;
   waiting.push_back(lem);
   unsigned wcounter = 0;
@@ -442,14 +444,11 @@ void Cegis::registerRefinementLemma(const std::vector<Node>& vars,
 }
 
 bool Cegis::usingRepairConst() { return true; }
-
 bool Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
                                     const std::vector<Node>& ms,
                                     std::vector<Node>& lems,
-                                    bool doGen
-                                   )
+                                    bool doGen)
 {
-  
   Trace("sygus-cref-eval") << "Cref eval : conjecture has "
                            << d_refinement_lemma_unit.size() << " unit and "
                            << d_refinement_lemma_conj.size()
@@ -526,8 +525,8 @@ bool Cegis::getRefinementEvalLemmas(const std::vector<Node>& vs,
         }
         if (std::find(lems.begin(), lems.end(), cre_lem) == lems.end())
         {
-          Trace("sygus-cref-eval")
-              << "...produced lemma : " << cre_lem << std::endl;
+          Trace("sygus-cref-eval") << "...produced lemma : " << cre_lem
+                                   << std::endl;
           lems.push_back(cre_lem);
         }
       }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -116,10 +116,9 @@ bool Cegis::addEvalLemmas(const std::vector<Node>& candidates,
     // if it is relevant to refinement
     if( d_refinement_lemma_vars.find(v)!=d_refinement_lemma_vars.end() )
     {
-      Assert( d_tds->isEnumerator(v) );
       if( !d_tds->isPassiveEnumerator(v) )
       {
-        //doGen = false;
+        doGen = false;
         break;
       }
     }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -119,7 +119,7 @@ bool Cegis::addEvalLemmas(const std::vector<Node>& candidates,
       Assert( d_tds->isEnumerator(v) );
       if( !d_tds->isPassiveEnumerator(v) )
       {
-        doGen = false;
+        //doGen = false;
         break;
       }
     }
@@ -315,7 +315,7 @@ void Cegis::addRefinementLemma(Node lem)
   // rewrite with extended rewriter
   slem = d_tds->getExtRewriter()->extendedRewrite(slem);
   // collect all variables in slem
-  expr::getSymbols(slem,d_refinement_lemma_vars);
+  //expr::getSymbols(slem,d_refinement_lemma_vars);
   std::vector<Node> waiting;
   waiting.push_back(lem);
   unsigned wcounter = 0;

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -154,7 +154,7 @@ class Cegis : public SygusModule
    * for previous refinements (d_refinement_lemmas).
    *
    * Returns true if any such lemma exists. If doGen is false, then the
-   * lemmas are not generated.
+   * lemmas are not generated or added to lems.
    */
   bool getRefinementEvalLemmas(const std::vector<Node>& vs,
                                const std::vector<Node>& ms,

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -104,6 +104,8 @@ class Cegis : public SygusModule
   /** substitution entailed by d_refinement_lemma_unit */
   std::vector<Node> d_rl_eval_hds;
   std::vector<Node> d_rl_vals;
+  /** all variables appearing in refinement lemmas */
+  std::unordered_set<Node, NodeHashFunction> d_refinement_lemma_vars;
   /** adds lem as a refinement lemma */
   void addRefinementLemma(Node lem);
   /** add refinement lemma conjunct
@@ -142,8 +144,7 @@ class Cegis : public SygusModule
    * useful e.g. for boolean connectives
    */
   bool addEvalLemmas(const std::vector<Node>& candidates,
-                     const std::vector<Node>& candidate_values,
-                     bool doGen);
+                     const std::vector<Node>& candidate_values);
   //-----------------------------------end refinement lemmas
 
   /** Get refinement evaluation lemmas

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -150,16 +150,15 @@ class Cegis : public SygusModule
    *
    * Given a candidate solution ms for candidates vs, this function adds lemmas
    * to lems based on evaluating the conjecture, instantiated for ms, on lemmas
-   * for previous refinements (d_refinement_lemmas). 
-   * 
+   * for previous refinements (d_refinement_lemmas).
+   *
    * Returns true if any such lemma exists. If doGen is false, then the
    * lemmas are not generated.
    */
   bool getRefinementEvalLemmas(const std::vector<Node>& vs,
                                const std::vector<Node>& ms,
                                std::vector<Node>& lems,
-                               bool doGen
-                              );
+                               bool doGen);
   /** sampler object for the option cegisSample()
    *
    * This samples points of the type of the inner variables of the synthesis

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -142,18 +142,24 @@ class Cegis : public SygusModule
    * useful e.g. for boolean connectives
    */
   bool addEvalLemmas(const std::vector<Node>& candidates,
-                     const std::vector<Node>& candidate_values);
+                     const std::vector<Node>& candidate_values,
+                     bool doGen);
   //-----------------------------------end refinement lemmas
 
   /** Get refinement evaluation lemmas
    *
    * Given a candidate solution ms for candidates vs, this function adds lemmas
    * to lems based on evaluating the conjecture, instantiated for ms, on lemmas
-   * for previous refinements (d_refinement_lemmas).
+   * for previous refinements (d_refinement_lemmas). 
+   * 
+   * Returns true if any such lemma exists. If doGen is false, then the
+   * lemmas are not generated.
    */
-  void getRefinementEvalLemmas(const std::vector<Node>& vs,
+  bool getRefinementEvalLemmas(const std::vector<Node>& vs,
                                const std::vector<Node>& ms,
-                               std::vector<Node>& lems);
+                               std::vector<Node>& lems,
+                               bool doGen
+                              );
   /** sampler object for the option cegisSample()
    *
    * This samples points of the type of the inner variables of the synthesis

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -101,9 +101,9 @@ void CegisUnif::getTermList(const std::vector<Node>& candidates,
     {
       for (unsigned index = 0; index < 2; index++)
       {
-        std::vector< Node > uenums;
+        std::vector<Node> uenums;
         // get the current unification enumerators
-        d_u_enum_manager.getEnumeratorsForStrategyPt(e, uenums, index);        
+        d_u_enum_manager.getEnumeratorsForStrategyPt(e, uenums, index);
         if (index == 1 && options::sygusUnifCondIndependent())
         {
           Assert(uenums.size() == 1);
@@ -118,7 +118,7 @@ void CegisUnif::getTermList(const std::vector<Node>& candidates,
           }
         }
         // get the model value of each enumerator
-        enums.insert(enums.end(),uenums.begin(),uenums.end());
+        enums.insert(enums.end(), uenums.begin(), uenums.end());
       }
     }
   }
@@ -145,11 +145,11 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
     return false;
   }
   // build model value map
-  std::map< Node, Node > mvMap;
-  for( unsigned i=0, size=enums.size(); i<size; i++ )
+  std::map<Node, Node> mvMap;
+  for (unsigned i = 0, size = enums.size(); i < size; i++)
   {
     mvMap[enums[i]] = enum_values[i];
-  }  
+  }
   // the unification enumerators (return values, conditions) and their model
   // values
   NodeManager* nm = NodeManager::currentNM();
@@ -174,7 +174,7 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
         {
           Assert(unif_enums[index][e].size() == 1);
           Node eu = unif_enums[index][e][0];
-          if( mvMap.find(eu)==mvMap.end() )
+          if (mvMap.find(eu) == mvMap.end())
           {
             Trace("cegis") << "    " << eu << " -> N/A\n";
             unif_enums[index][e].clear();
@@ -184,7 +184,7 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
         // get the model value of each enumerator
         for (const Node& eu : unif_enums[index][e])
         {
-          Assert( mvMap.find(eu)!=mvMap.end() );
+          Assert(mvMap.find(eu) != mvMap.end());
           Node m_eu = mvMap[eu];
           if (Trace.isOn("cegis"))
           {

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -260,13 +260,14 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
       if (options::sygusUnifCondIndependent() && !unif_enums[1][e].empty())
       {
         Node eu = unif_enums[1][e][0];
-        Assert( d_tds->isEnumerator(eu) );
-        if( d_tds->isPassiveEnumerator(eu) )
+        Assert(d_tds->isEnumerator(eu));
+        if (d_tds->isPassiveEnumerator(eu))
         {
           Node g = d_u_enum_manager.getActiveGuardForEnumerator(eu);
-          Node exp_exc = d_tds->getExplain()
-                            ->getExplanationForEquality(eu, unif_values[1][e][0])
-                            .negate();
+          Node exp_exc =
+              d_tds->getExplain()
+                  ->getExplanationForEquality(eu, unif_values[1][e][0])
+                  .negate();
           lems.push_back(nm->mkNode(OR, g.negate(), exp_exc));
         }
       }

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -260,11 +260,15 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
       if (options::sygusUnifCondIndependent() && !unif_enums[1][e].empty())
       {
         Node eu = unif_enums[1][e][0];
-        Node g = d_u_enum_manager.getActiveGuardForEnumerator(eu);
-        Node exp_exc = d_tds->getExplain()
-                           ->getExplanationForEquality(eu, unif_values[1][e][0])
-                           .negate();
-        lems.push_back(nm->mkNode(OR, g.negate(), exp_exc));
+        Assert( d_tds->isEnumerator(eu) );
+        if( d_tds->isPassiveEnumerator(eu) )
+        {
+          Node g = d_u_enum_manager.getActiveGuardForEnumerator(eu);
+          Node exp_exc = d_tds->getExplain()
+                            ->getExplanationForEquality(eu, unif_values[1][e][0])
+                            .negate();
+          lems.push_back(nm->mkNode(OR, g.negate(), exp_exc));
+        }
       }
     }
   }

--- a/src/theory/quantifiers/sygus/cegis_unif.cpp
+++ b/src/theory/quantifiers/sygus/cegis_unif.cpp
@@ -86,6 +86,7 @@ void CegisUnif::getTermList(const std::vector<Node>& candidates,
   // Non-unif candidate are themselves the enumerators
   enums.insert(
       enums.end(), d_non_unif_candidates.begin(), d_non_unif_candidates.end());
+  Valuation& valuation = d_qe->getValuation();
   for (const Node& c : d_unif_candidates)
   {
     // Collect heads of candidates
@@ -94,6 +95,31 @@ void CegisUnif::getTermList(const std::vector<Node>& candidates,
       Trace("cegis-unif-enum-debug")
           << "......cand " << c << " with enum hd " << hd << "\n";
       enums.push_back(hd);
+    }
+    // get unification enumerators
+    for (const Node& e : d_cand_to_strat_pt[c])
+    {
+      for (unsigned index = 0; index < 2; index++)
+      {
+        std::vector< Node > uenums;
+        // get the current unification enumerators
+        d_u_enum_manager.getEnumeratorsForStrategyPt(e, uenums, index);        
+        if (index == 1 && options::sygusUnifCondIndependent())
+        {
+          Assert(uenums.size() == 1);
+          Node eu = uenums[0];
+          Node g = d_u_enum_manager.getActiveGuardForEnumerator(eu);
+          // If active guard for this enumerator is not true, there are no more
+          // values for it, and hence we ignore it
+          Node gstatus = valuation.getSatValue(g);
+          if (gstatus.isNull() || !gstatus.getConst<bool>())
+          {
+            continue;
+          }
+        }
+        // get the model value of each enumerator
+        enums.insert(enums.end(),uenums.begin(),uenums.end());
+      }
     }
   }
 }
@@ -118,10 +144,15 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
     // if we didn't satisfy the specification, there is no way to repair
     return false;
   }
+  // build model value map
+  std::map< Node, Node > mvMap;
+  for( unsigned i=0, size=enums.size(); i<size; i++ )
+  {
+    mvMap[enums[i]] = enum_values[i];
+  }  
   // the unification enumerators (return values, conditions) and their model
   // values
   NodeManager* nm = NodeManager::currentNM();
-  Valuation& valuation = d_qe->getValuation();
   bool addedUnifEnumSymBreakLemma = false;
   Node cost_lit = d_u_enum_manager.getAssertedLiteral();
   std::map<Node, std::vector<Node>> unif_enums[2];
@@ -143,11 +174,7 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
         {
           Assert(unif_enums[index][e].size() == 1);
           Node eu = unif_enums[index][e][0];
-          Node g = d_u_enum_manager.getActiveGuardForEnumerator(eu);
-          // If active guard for this enumerator is not true, there are no more
-          // values for it, and hence we ignore it
-          Node gstatus = valuation.getSatValue(g);
-          if (gstatus.isNull() || !gstatus.getConst<bool>())
+          if( mvMap.find(eu)==mvMap.end() )
           {
             Trace("cegis") << "    " << eu << " -> N/A\n";
             unif_enums[index][e].clear();
@@ -157,7 +184,8 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
         // get the model value of each enumerator
         for (const Node& eu : unif_enums[index][e])
         {
-          Node m_eu = d_parent->getModelValue(eu);
+          Assert( mvMap.find(eu)!=mvMap.end() );
+          Node m_eu = mvMap[eu];
           if (Trace.isOn("cegis"))
           {
             Trace("cegis") << "    " << eu << " -> ";
@@ -165,13 +193,6 @@ bool CegisUnif::processConstructCandidates(const std::vector<Node>& enums,
             Printer::getPrinter(options::outputLanguage())
                 ->toStreamSygus(ss, m_eu);
             Trace("cegis") << ss.str() << std::endl;
-          }
-          if (m_eu.isNull())
-          {
-            // A condition enumerator was excluded by symmetry breaking, fail.
-            // TODO (#2498): either move conditions to getTermList or handle
-            // partial models in this module.
-            return false;
           }
           unif_values[index][e].push_back(m_eu);
         }

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -481,14 +481,17 @@ bool SygusPbe::constructCandidates(const std::vector<Node>& enums,
       Node c = d_enum_to_candidate[e];
       std::vector<Node> enum_lems;
       d_sygus_unif[c].notifyEnumeration(e, v, enum_lems);
-      // the lemmas must be guarded by the active guard of the enumerator
-      Assert(d_enum_to_active_guard.find(e) != d_enum_to_active_guard.end());
-      Node g = d_enum_to_active_guard[e];
-      for (unsigned j = 0, size = enum_lems.size(); j < size; j++)
+      if( !enum_lems.empty() )
       {
-        enum_lems[j] = nm->mkNode(OR, g.negate(), enum_lems[j]);
+        // the lemmas must be guarded by the active guard of the enumerator
+        Assert(d_enum_to_active_guard.find(e) != d_enum_to_active_guard.end());
+        Node g = d_enum_to_active_guard[e];
+        for (unsigned j = 0, size = enum_lems.size(); j < size; j++)
+        {
+          enum_lems[j] = nm->mkNode(OR, g.negate(), enum_lems[j]);
+        }
+        lems.insert(lems.end(), enum_lems.begin(), enum_lems.end());
       }
-      lems.insert(lems.end(), enum_lems.begin(), enum_lems.end());
     }
   }
   for( unsigned i=0; i<candidates.size(); i++ ){

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -481,7 +481,7 @@ bool SygusPbe::constructCandidates(const std::vector<Node>& enums,
       Node c = d_enum_to_candidate[e];
       std::vector<Node> enum_lems;
       d_sygus_unif[c].notifyEnumeration(e, v, enum_lems);
-      if( !enum_lems.empty() )
+      if (!enum_lems.empty())
       {
         // the lemmas must be guarded by the active guard of the enumerator
         Assert(d_enum_to_active_guard.find(e) != d_enum_to_active_guard.end());

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -562,7 +562,9 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
 
   // is it excluded for domain-specific reason?
   std::vector<Node> exp_exc_vec;
-  if (getExplanationForEnumeratorExclude(e, v, base_results, exp_exc_vec))
+  Assert( d_tds->isEnumerator(e) );
+  bool isPassive = d_tds->isPassiveEnumerator(e);
+  if (isPassive && getExplanationForEnumeratorExclude(e, v, base_results, exp_exc_vec))
   {
     Assert(!exp_exc_vec.empty());
     exp_exc = exp_exc_vec.size() == 1
@@ -707,16 +709,20 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
     }
   }
 
-  // exclude this value on subsequent iterations
-  if (exp_exc.isNull())
+  if( isPassive )
   {
-    // if we did not already explain why this should be excluded, use default
-    exp_exc = d_tds->getExplain()->getExplanationForEquality(e, v);
+    // exclude this value on subsequent iterations
+    if (exp_exc.isNull())
+    {
+      Trace("sygus-sui-enum-lemma") << "Use basic exclusion." << std::endl;
+      // if we did not already explain why this should be excluded, use default
+      exp_exc = d_tds->getExplain()->getExplanationForEquality(e, v);
+    }
+    exp_exc = exp_exc.negate();
+    Trace("sygus-sui-enum-lemma")
+        << "SygusUnifIo : enumeration exclude lemma : " << exp_exc << std::endl;
+    lemmas.push_back(exp_exc);
   }
-  exp_exc = exp_exc.negate();
-  Trace("sygus-sui-enum-lemma")
-      << "SygusUnifIo : enumeration exclude lemma : " << exp_exc << std::endl;
-  lemmas.push_back(exp_exc);
 }
 
 bool SygusUnifIo::constructSolution(std::vector<Node>& sols,

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -562,9 +562,10 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
 
   // is it excluded for domain-specific reason?
   std::vector<Node> exp_exc_vec;
-  Assert( d_tds->isEnumerator(e) );
+  Assert(d_tds->isEnumerator(e));
   bool isPassive = d_tds->isPassiveEnumerator(e);
-  if (isPassive && getExplanationForEnumeratorExclude(e, v, base_results, exp_exc_vec))
+  if (isPassive
+      && getExplanationForEnumeratorExclude(e, v, base_results, exp_exc_vec))
   {
     Assert(!exp_exc_vec.empty());
     exp_exc = exp_exc_vec.size() == 1
@@ -709,7 +710,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
     }
   }
 
-  if( isPassive )
+  if (isPassive)
   {
     // exclude this value on subsequent iterations
     if (exp_exc.isNull())

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -633,7 +633,7 @@ bool SynthConjecture::getModelValues(std::vector<Node>& n, std::vector<Node>& v)
 
 Node SynthConjecture::getModelValue(Node n)
 {
-  Assert( d_tds->isEnumerator(n) );
+  Assert(d_tds->isEnumerator(n));
   Trace("cegqi-mv") << "getModelValue for : " << n << std::endl;
   if (n.getAttribute(SygusSymBreakExcAttribute()))
   {
@@ -720,8 +720,7 @@ void SynthConjecture::printAndContinueStream()
     {
       sol = d_cinfo[cprog].d_inst.back();
       // add to explanation of exclusion
-      d_tds->getExplain()->getExplanationForEquality(
-          cprog, sol, exp);
+      d_tds->getExplain()->getExplanationForEquality(cprog, sol, exp);
     }
   }
   Assert(!exp.empty());

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -543,7 +543,7 @@ void SynthConjecture::doRefine(std::vector<Node>& lems)
     if (d_ce_sk_var_mvs.empty())
     {
       std::vector<Node> model_values;
-      for( const Node& v : d_ce_sk_vars )
+      for (const Node& v : d_ce_sk_vars)
       {
         Node mv = getModelValue(v);
         Trace("cegqi-refine") << "  " << v << " -> " << mv << std::endl;
@@ -600,7 +600,8 @@ void SynthConjecture::preregisterConjecture(Node q)
   d_ceg_si->preregisterConjecture(q);
 }
 
-bool SynthConjecture::getEnumeratedValues(std::vector<Node>& n, std::vector<Node>& v)
+bool SynthConjecture::getEnumeratedValues(std::vector<Node>& n,
+                                          std::vector<Node>& v)
 {
   bool ret = true;
   Trace("cegqi-engine") << "  * Value is : ";
@@ -646,11 +647,11 @@ Node SynthConjecture::getEnumeratedValue(Node e)
     // return null.
     return Node::null();
   }
-  if( d_tds->isPassiveEnumerator(e) )
+  if (d_tds->isPassiveEnumerator(e))
   {
     return getModelValue(e);
   }
-  Assert( false );
+  Assert(false);
   // TODO
   return getModelValue(e);
 }

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -652,7 +652,7 @@ Node SynthConjecture::getEnumeratedValue(Node e)
     return getModelValue(e);
   }
   Assert(false);
-  // TODO
+  // management of actively generated enumerators goes here
   return getModelValue(e);
 }
 

--- a/src/theory/quantifiers/sygus/synth_conjecture.h
+++ b/src/theory/quantifiers/sygus/synth_conjecture.h
@@ -138,6 +138,8 @@ class SynthConjecture
  private:
   /** reference to quantifier engine */
   QuantifiersEngine* d_qe;
+  /** term database sygus of d_qe */
+  TermDbSygus* d_tds;
   /** The feasible guard. */
   Node d_feasible_guard;
   /** the decision strategy for the feasible guard */

--- a/src/theory/quantifiers/sygus/synth_conjecture.h
+++ b/src/theory/quantifiers/sygus/synth_conjecture.h
@@ -116,10 +116,14 @@ class SynthConjecture
    * Get model values for terms n, store in vector v. This method returns true
    * if and only if all values added to v are non-null.
    */
-  bool getModelValues(std::vector<Node>& n, std::vector<Node>& v);
+  bool getEnumeratedValues(std::vector<Node>& n, std::vector<Node>& v);
   /**
    * Get model value for term n. If n has a value that was excluded by
    * datatypes sygus symmetry breaking, this method returns null.
+   */
+  Node getEnumeratedValue(Node n);
+  /**
+   * Get model value for term n.
    */
   Node getModelValue(Node n);
 

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -648,7 +648,7 @@ bool TermDbSygus::isVariableAgnosticEnumerator(Node e) const
 
 bool TermDbSygus::isPassiveEnumerator(Node e) const
 {
-  if( isVariableAgnosticEnumerator(e) )
+  if (isVariableAgnosticEnumerator(e))
   {
     return false;
   }

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -646,6 +646,16 @@ bool TermDbSygus::isVariableAgnosticEnumerator(Node e) const
   return false;
 }
 
+bool TermDbSygus::isPassiveEnumerator(Node e) const
+{
+  if( isVariableAgnosticEnumerator(e) )
+  {
+    return false;
+  }
+  // other criteria go here
+  return true;
+}
+
 void TermDbSygus::getEnumerators(std::vector<Node>& mts)
 {
   for (std::map<Node, SynthConjecture*>::iterator itm =

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -102,7 +102,8 @@ class TermDbSygus {
    * are obtained by looking at its model value only. For passively-generated
    * enumerators, it is the responsibility of the user of that enumerator (say
    * a SygusModule) to block the current model value of it before asking for
-   * another value.
+   * another value. By default, the Cegis module uses passively-generated
+   * enumerators.
    *
    * On the other hand, an "actively-generated" enumerator is one for which the
    * terms it enumerates are not necessarily a subset of the model values the

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -103,14 +103,15 @@ class TermDbSygus {
    * enumerators, it is the responsibility of the user of that enumerator (say
    * a SygusModule) to block the current model value of it before asking for
    * another value. By default, the Cegis module uses passively-generated
-   * enumerators.
+   * enumerators and "conjecture-specific refinement" to rule out models
+   * for passively-generated enumerators.
    *
    * On the other hand, an "actively-generated" enumerator is one for which the
    * terms it enumerates are not necessarily a subset of the model values the
    * enumerator takes. Actively-generated enumerators are centrally managed by
    * SynthConjecture. The user of actively-generated enumerators are prohibited
-   * from influencing its model value. For example, "conjecture-specific
-   * refinement" in Cegis is not applied to actively-generated enumerators.
+   * from influencing its model value. For example, conjecture-specific
+   * refinement in Cegis is not applied to actively-generated enumerators.
    */
   bool isPassiveEnumerator(Node e) const;
   /** get all registered enumerators */

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -96,6 +96,11 @@ class TermDbSygus {
   bool usingSymbolicConsForEnumerator(Node e) const;
   /** is this enumerator agnostic to variables? */
   bool isVariableAgnosticEnumerator(Node e) const;
+  /** is this a "passive" enumerator?
+   * 
+   * A passive enumerator is one for which its TODO
+   */
+  bool isPassiveEnumerator(Node e) const;
   /** get all registered enumerators */
   void getEnumerators(std::vector<Node>& mts);
   /** Register symmetry breaking lemma

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -97,7 +97,7 @@ class TermDbSygus {
   /** is this enumerator agnostic to variables? */
   bool isVariableAgnosticEnumerator(Node e) const;
   /** is this a "passive" enumerator?
-   * 
+   *
    * A passive enumerator is one for which its TODO
    */
   bool isPassiveEnumerator(Node e) const;

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -96,9 +96,20 @@ class TermDbSygus {
   bool usingSymbolicConsForEnumerator(Node e) const;
   /** is this enumerator agnostic to variables? */
   bool isVariableAgnosticEnumerator(Node e) const;
-  /** is this a "passive" enumerator?
+  /** is this a "passively-generated" enumerator?
    *
-   * A passive enumerator is one for which its TODO
+   * A "passively-generated" enumerator is one for which the terms it enumerates
+   * are obtained by looking at its model value only. For passively-generated
+   * enumerators, it is the responsibility of the user of that enumerator (say
+   * a SygusModule) to block the current model value of it before asking for
+   * another value.
+   *
+   * On the other hand, an "actively-generated" enumerator is one for which the
+   * terms it enumerates are not necessarily a subset of the model values the
+   * enumerator takes. Actively-generated enumerators are centrally managed by
+   * SynthConjecture. The user of actively-generated enumerators are prohibited
+   * from influencing its model value. For example, "conjecture-specific
+   * refinement" in Cegis is not applied to actively-generated enumerators.
    */
   bool isPassiveEnumerator(Node e) const;
   /** get all registered enumerators */


### PR DESCRIPTION
This introduces a notion of "actively-generated" vs "passively-generated" enumerators, in preparation for variable agnostic enumerators. It updates the logic of sygus modules to account for this kind of enumeration.