### PR TITLE
Remove assertion related to sygus enumerators

### DIFF
--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -639,7 +639,6 @@ bool SynthConjecture::getEnumeratedValues(std::vector<Node>& n,
 
 Node SynthConjecture::getEnumeratedValue(Node e)
 {
-  Assert(d_tds->isEnumerator(e));
   if (e.getAttribute(SygusSymBreakExcAttribute()))
   {
     // if the current model value of e was excluded by symmetry breaking, then


### PR DESCRIPTION
Fixes regress1.

This was caused by combining #2547 and #2541.