### PR TITLE
cmake: Only do Java tests when unit testing on

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,10 +20,10 @@ add_custom_target(check
 add_subdirectory(regress)
 add_subdirectory(system EXCLUDE_FROM_ALL)
 
-if(BUILD_BINDINGS_JAVA)
-  add_subdirectory(java)
-endif()
-
 if(ENABLE_UNIT_TESTING)
   add_subdirectory(unit EXCLUDE_FROM_ALL)
+
+  if(BUILD_BINDINGS_JAVA)
+    add_subdirectory(java)
+  endif()
 endif()


### PR DESCRIPTION
Right now, we are adding the Java tests even when we are not building
unit tests. This commit changes the build system to only add the Java
tests when unit tests are enabled. There are two reasons for this
change:

- building a production version of CVC4 should not require JUnit
- it seems more intuitive (to me at least) to disable JUnit tests when
  unit tests are disabled

This change also simplifies building the Java bindings in our homebrew
formula.