### PR TITLE
cmake: Add build target build-tests to build all test dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,9 @@ if(ENABLE_COVERAGE)
     NAME coverage
     EXECUTABLE
       ctest -j${CTEST_NTHREADS} -LE "example"
-        --output-on-failure $(ARGS) || exit 0)
+        --output-on-failure $(ARGS) || exit 0
+    DEPENDS
+      build-tests)
 endif()
 
 if(ENABLE_DEBUG_CONTEXT_MM)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,8 @@
 # > regression tests of levels 0 and 1
 # > system tests
 
+add_custom_target(build-tests)
+
 # Note: Do not add custom targets for running tests (regress, systemtests,
 # units) as dependencies to other run targets. This will result in executing
 # tests multiple times. For example, if check would depend on regress it would
@@ -12,7 +14,9 @@
 # Dependencies of check are added in the corresponding subdirectories.
 add_custom_target(check
   COMMAND
-    ctest --output-on-failure -LE "regress[2-4]" -j${CTEST_NTHREADS} $(ARGS))
+    ctest --output-on-failure -LE "regress[2-4]" -j${CTEST_NTHREADS} $(ARGS)
+  DEPENDS
+    build-tests)
 
 #-----------------------------------------------------------------------------#
 # Add subdirectories

--- a/test/java/CMakeLists.txt
+++ b/test/java/CMakeLists.txt
@@ -18,7 +18,7 @@ add_jar(build-javatests
   OUTPUT_NAME javatests
 )
 add_dependencies(build-javatests cvc4jar)
-add_dependencies(check build-javatests)
+add_dependencies(build-tests build-javatests)
 
 # Add java tests to ctest
 set(classpath "${CMAKE_CURRENT_BINARY_DIR}/javatests.jar")

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2079,10 +2079,7 @@ get_target_property(path_to_cvc4 cvc4-bin RUNTIME_OUTPUT_DIRECTORY)
 set(run_regress_script ${CMAKE_CURRENT_LIST_DIR}/run_regression.py)
 
 add_custom_target(build-regress DEPENDS cvc4-bin)
-add_dependencies(check build-regress)
-if(ENABLE_COVERAGE)
-  add_dependencies(coverage build-regress)
-endif()
+add_dependencies(build-tests build-regress)
 
 add_custom_target(regress
   COMMAND

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -8,10 +8,7 @@ include_directories(${CMAKE_BINARY_DIR}/src)
 # > system tests
 
 add_custom_target(build-systemtests)
-add_dependencies(check build-systemtests)
-if(ENABLE_COVERAGE)
-  add_dependencies(coverage build-systemtests)
-endif()
+add_dependencies(build-tests build-systemtests)
 
 add_custom_target(systemtests
   COMMAND ctest --output-on-failure -L "system" -j${CTEST_NTHREADS} $(ARGS)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -14,10 +14,7 @@ include_directories(${CMAKE_BINARY_DIR}/src)
 # > unit tests
 
 add_custom_target(build-units)
-add_dependencies(check build-units)
-if(ENABLE_COVERAGE)
-  add_dependencies(coverage build-units)
-endif()
+add_dependencies(build-tests build-units)
 
 add_custom_target(units
   COMMAND ctest --output-on-failure -L "unit" -j${CTEST_NTHREADS} $(ARGS)


### PR DESCRIPTION
This adds target `build-tests` to build all test dependencies at once `make build-tests && ctest ...`. Targets `make check` and `make coverage` now depend on `build-tests`.