### PR TITLE
Allow (_ to_fp ...) in strict parsing mode

### DIFF
--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -188,6 +188,7 @@ void Smt2::addFloatingPointOperators() {
   addOperator(kind::FLOATINGPOINT_ISPOS, "fp.isPositive");
   addOperator(kind::FLOATINGPOINT_TO_REAL, "fp.to_real");
 
+  Parser::addOperator(kind::FLOATINGPOINT_TO_FP_GENERIC);
   Parser::addOperator(kind::FLOATINGPOINT_TO_FP_IEEE_BITVECTOR);
   Parser::addOperator(kind::FLOATINGPOINT_TO_FP_FLOATINGPOINT);
   Parser::addOperator(kind::FLOATINGPOINT_TO_FP_REAL);

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -520,6 +520,7 @@ set(regress_0_tests
   regress0/parser/shadow_fun_symbol_nirat.smt2
   regress0/parser/strings20.smt2
   regress0/parser/strings25.smt2
+  regress0/parser/to_fp.smt2
   regress0/precedence/and-not.cvc
   regress0/precedence/and-xor.cvc
   regress0/precedence/bool-cmp.cvc

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -528,6 +528,7 @@ REG0_TESTS = \
 	regress0/parser/shadow_fun_symbol_nirat.smt2 \
 	regress0/parser/strings20.smt2 \
 	regress0/parser/strings25.smt2 \
+	regress0/parser/to_fp.smt2 \
 	regress0/precedence/and-not.cvc \
 	regress0/precedence/and-xor.cvc \
 	regress0/precedence/bool-cmp.cvc \

--- a/test/regress/regress0/parser/to_fp.smt2
+++ b/test/regress/regress0/parser/to_fp.smt2
@@ -1,0 +1,10 @@
+; REQUIRES: symfpu
+; COMMAND-LINE: --strict-parsing
+; EXPECT: sat
+(set-logic QF_FP)
+(declare-fun |c::main::main::3::div@1!0&0#1| () (_ FloatingPoint 8 24))
+(assert (not (fp.eq ((_ to_fp 11 53)
+                     roundNearestTiesToEven
+                     |c::main::main::3::div@1!0&0#1|)
+              (fp #b0 #b00000000000 #x0000000000000))))
+(check-sat)


### PR DESCRIPTION
When parsing with `--strict-parsing`, we are checking whether the
operators that we encounter have been explicitly added to the
`d_logicOperators` set in the `Parser` class. We did not add the
indexed operator `(_ to_fp ...)` (which is represented by the kind
`FLOATINGPOINT_TO_FP_GENERIC`). This commit adds the operator.