### PR TITLE
Fix candidate rewrite rule filtering

### DIFF
--- a/src/theory/quantifiers/candidate_rewrite_database.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_database.cpp
@@ -64,7 +64,7 @@ void CandidateRewriteDatabase::initializeSygus(const std::vector<Node>& vars,
   d_qe = qe;
   d_tds = d_qe->getTermDatabaseSygus();
   d_ext_rewrite = nullptr;
-  d_crewrite_filter.initialize(ss, d_tds, false);
+  d_crewrite_filter.initialize(ss, d_tds, d_using_sygus);
   ExprMiner::initialize(vars, ss);
 }
 


### PR DESCRIPTION
Currently we are not filtering rewrite rules effectively due to an incorrect option set on our filter.