### PR TITLE
 Disable extended rewriter when applicable with var agnostic enumeration

### DIFF
--- a/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
+++ b/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
@@ -509,8 +509,11 @@ Node EnumStreamSubstitution::getNext()
       domain_sub.begin(), domain_sub.end(), range_sub.begin(), range_sub.end());
   // the new combination value should be fresh, modulo rewriting, by
   // construction (unless it's equiv to a constant, e.g. true / false)
-  Node builtin_comb_value = d_tds->getExtRewriter()->extendedRewrite(
-      d_tds->sygusToBuiltin(comb_value, comb_value.getType()));
+  Node builtin_comb_value = d_tds->sygusToBuiltin(comb_value, comb_value.getType());
+  if (options::sygusSymBreakDynamic())
+  {
+    builtin_comb_value = d_tds->getExtRewriter()->extendedRewrite(builtin_comb_value);
+  }
   if (Trace.isOn("synth-stream-concrete"))
   {
     std::stringstream ss;

--- a/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
+++ b/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
@@ -187,7 +187,7 @@ Node EnumStreamPermutation::getNext()
     bultin_perm_value = d_tds->sygusToBuiltin(perm_value, perm_value.getType());
     Trace("synth-stream-concrete-debug")
         << " ......perm builtin is " << bultin_perm_value;
-    if( options::options::sygusSymBreakDynamic() )
+    if (options::options::sygusSymBreakDynamic())
     {
       bultin_perm_value =
           d_tds->getExtRewriter()->extendedRewrite(bultin_perm_value);

--- a/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
+++ b/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
@@ -187,8 +187,11 @@ Node EnumStreamPermutation::getNext()
     bultin_perm_value = d_tds->sygusToBuiltin(perm_value, perm_value.getType());
     Trace("synth-stream-concrete-debug")
         << " ......perm builtin is " << bultin_perm_value;
-    bultin_perm_value =
-        d_tds->getExtRewriter()->extendedRewrite(bultin_perm_value);
+    if( options::options::sygusSymBreakDynamic() )
+    {
+      bultin_perm_value =
+          d_tds->getExtRewriter()->extendedRewrite(bultin_perm_value);
+    }
     Trace("synth-stream-concrete-debug")
         << " and rewrites to " << bultin_perm_value << "\n";
     // if permuted value is equivalent modulo rewriting to a previous one, look

--- a/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
+++ b/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
@@ -191,9 +191,10 @@ Node EnumStreamPermutation::getNext()
     {
       bultin_perm_value =
           d_tds->getExtRewriter()->extendedRewrite(bultin_perm_value);
-    }
     Trace("synth-stream-concrete-debug")
-        << " and rewrites to " << bultin_perm_value << "\n";
+        << " and rewrites to " << bultin_perm_value;
+    }
+    Trace("synth-stream-concrete-debug") << "\n";
     // if permuted value is equivalent modulo rewriting to a previous one, look
     // for another
   } while (!d_perm_values.insert(bultin_perm_value).second);

--- a/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
+++ b/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
@@ -191,8 +191,8 @@ Node EnumStreamPermutation::getNext()
     {
       bultin_perm_value =
           d_tds->getExtRewriter()->extendedRewrite(bultin_perm_value);
-    Trace("synth-stream-concrete-debug")
-        << " and rewrites to " << bultin_perm_value;
+      Trace("synth-stream-concrete-debug")
+          << " and rewrites to " << bultin_perm_value;
     }
     Trace("synth-stream-concrete-debug") << "\n";
     // if permuted value is equivalent modulo rewriting to a previous one, look

--- a/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
+++ b/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
@@ -16,6 +16,7 @@
 #include "theory/quantifiers/sygus/enum_stream_substitution.h"
 
 #include "options/base_options.h"
+#include "options/datatypes_options.h"
 #include "options/quantifiers_options.h"
 #include "printer/printer.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
@@ -187,7 +188,7 @@ Node EnumStreamPermutation::getNext()
     bultin_perm_value = d_tds->sygusToBuiltin(perm_value, perm_value.getType());
     Trace("synth-stream-concrete-debug")
         << " ......perm builtin is " << bultin_perm_value;
-    if (options::options::sygusSymBreakDynamic())
+    if (options::sygusSymBreakDynamic())
     {
       bultin_perm_value =
           d_tds->getExtRewriter()->extendedRewrite(bultin_perm_value);

--- a/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
+++ b/src/theory/quantifiers/sygus/enum_stream_substitution.cpp
@@ -509,10 +509,12 @@ Node EnumStreamSubstitution::getNext()
       domain_sub.begin(), domain_sub.end(), range_sub.begin(), range_sub.end());
   // the new combination value should be fresh, modulo rewriting, by
   // construction (unless it's equiv to a constant, e.g. true / false)
-  Node builtin_comb_value = d_tds->sygusToBuiltin(comb_value, comb_value.getType());
+  Node builtin_comb_value =
+      d_tds->sygusToBuiltin(comb_value, comb_value.getType());
   if (options::sygusSymBreakDynamic())
   {
-    builtin_comb_value = d_tds->getExtRewriter()->extendedRewrite(builtin_comb_value);
+    builtin_comb_value =
+        d_tds->getExtRewriter()->extendedRewrite(builtin_comb_value);
   }
   if (Trace.isOn("synth-stream-concrete"))
   {


### PR DESCRIPTION
This makes `--sygus-var-agnostic` and `--no-sygus-sym-break-dynamic` (which disables rewriter-based symmetry breaking) work together.