### PR TITLE
Cmake: Fix ctest call for example/translator.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -68,7 +68,9 @@ endmacro()
 set(EXAMPLES_LINK_LIBS cvc4 cvc4parser)
 cvc4_add_example(simple_vc_cxx "" "${EXAMPLES_LINK_LIBS}" "")
 cvc4_add_example(simple_vc_quant_cxx "" "${EXAMPLES_LINK_LIBS}" "")
-cvc4_add_example(translator "" "${EXAMPLES_LINK_LIBS}" "")
+cvc4_add_example(translator "" "${EXAMPLES_LINK_LIBS}" ""
+    # argument to binary (for testing)
+    ${CMAKE_CURRENT_SOURCE_DIR}/translator-example-input.smt2)
 
 if(BUILD_BINDINGS_JAVA)
   find_package(Java REQUIRED)

--- a/examples/sets-translate/sets-translate-example-input.smt2
+++ b/examples/sets-translate/sets-translate-example-input.smt2
@@ -1,5 +1,3 @@
-; COMMAND-LINE: --finite-model-find
-; EXPECT: sat
 (set-logic ALL)
 (declare-sort Atom 0)
 

--- a/examples/translator-example-input.smt2
+++ b/examples/translator-example-input.smt2
@@ -1,0 +1,22 @@
+; COMMAND-LINE: --finite-model-find
+; EXPECT: sat
+(set-logic ALL)
+(declare-sort Atom 0)
+
+(declare-fun k (Atom Atom) (Set Atom))
+
+(declare-fun t0 () Atom)
+(declare-fun t1 () Atom)
+(declare-fun t2 () Atom)
+(declare-fun v () Atom)
+(declare-fun b2 () Atom)
+
+(assert (forall ((b Atom)) (or 
+(member v (k t0 b))
+(member v (k t1 b))
+) ))
+
+(assert (not (member v (k t2 b2))))
+
+(check-sat)
+

--- a/examples/translator-example-input.smt2
+++ b/examples/translator-example-input.smt2
@@ -1,5 +1,3 @@
-; COMMAND-LINE: --finite-model-find
-; EXPECT: sat
 (set-logic ALL)
 (declare-sort Atom 0)
 


### PR DESCRIPTION
example/translator expects an input file to translate but none was provided in the ctest call.
This caused the ctest call to hang and wait for input on stdin in some configurations (in
particular in the nightlies).