### PR TITLE
Skip invalid objects in ContextObj::destroy()

### DIFF
--- a/src/context/context.cpp
+++ b/src/context/context.cpp
@@ -209,6 +209,7 @@ ContextObj* ContextObj::restoreAndContinue()
 
     Debug("context") << "NULL restore object! " << this << std::endl;
     pContextObjNext = d_pContextObjNext;
+    d_pScope = nullptr;
 
     // Nothing else to do
   } else {
@@ -237,11 +238,6 @@ ContextObj* ContextObj::restoreAndContinue()
 
 void ContextObj::destroy()
 {
-  /* Context can be big and complicated, so we only want to process this output
-   * if we're really going to use it. (Same goes below.) */
-  Debug("context") << "before destroy " << this << " (level " << getLevel()
-                   << "):" << std::endl << *getContext() << std::endl;
-
   // Under rare circumstances, we could be trying to destroy an object that is
   // invalid. In that case, the prev()/next() pointers are stale and must not
   // be used. Since invalid objects have no old versions to restore and remove
@@ -251,13 +247,18 @@ void ContextObj::destroy()
   // when calling the ContextObj constructor) and kept on the stack, we pop
   // down to level 0 (the object keeps level 1 because it does not exist below
   // that level), and at the end of the function the object is destroyed.
-  if (getLevel() > getContext()->getLevel())
+  if (d_pScope == nullptr)
   {
     Assert(d_pContextObjRestore == NULL);
     Debug("context") << "skipping destroy because object already invalid"
                      << std::endl;
     return;
   }
+
+  /* Context can be big and complicated, so we only want to process this output
+   * if we're really going to use it. (Same goes below.) */
+  Debug("context") << "before destroy " << this << " (level " << getLevel()
+                   << "):" << std::endl << *getContext() << std::endl;
 
   for(;;) {
     // If valgrind reports invalid writes on the next few lines,

--- a/test/unit/context/context_black.h
+++ b/test/unit/context/context_black.h
@@ -215,6 +215,13 @@ private:
     // ContextObj allocated primordially "in the top scope" (first arg
     // to ctor is "true"), doesn't get updated if you immediately call
     // makeCurrent().
+    //
+    // Note that this unit test is quite tricky because we are destroying `x`
+    // at level 0 even though it was created and associated with level 1, which
+    // is not something that we normally want to be doing. Usually, you'd want
+    // to allocate `x` in context memory where it gets cleaned up automatically
+    // when we pop below level 1 instead of it being destroyed when the
+    // variable's scope ends.
 
     MyContextNotifyObj n(d_context, true);
 


### PR DESCRIPTION
Background
==========

Context-dependent objects store their older version in the pointer
`d_pContextObjRestore`. Additionally, each object is part of a
doubly-linked list of objects in the same scope (i.e. the same level).
When a scope is popped, all objects in the linked list look up their
previous version and insert themselves into the linked list at the level
of the previous version. If an object does not have an older version,
the `d_pContextObjRestore` pointer is `null` and restoring the older
version does not do anything.

When we destroy an object (which should be called from the destructor of
a context-dependent object), remove the object from all scopes by
repeatedly removing it from the current scope, restoring the older
version, removing it from the older scope and so on.

A side note: The doubly-linked lists used are somewhat unusual: Instead
of holding a pointer to the previous object, the context-dependent
objects store a pointer to the next pointer of the previous object.

Problem
=======

The mechanisms described above may be problematic under rare
circumstances. Specifically, this came up because Clang 6.0's ASAN
detected a stack-user-after-scope issue in the
`testTopScopeContextObj()` unit test in context_black.h. Note that Clang
5.0's ASAN was not able to detect this issue. In this unit test the
following happened:

1. We push our context.
2. We create two context-dependent objects: `x` at level 1 (by setting
`allocatedInCMM` to true when calling the `ContextObj` constructor) and
`y` at level 0. At this point, scope 0 has `y` in its linked list and
scope 1 has `x` in its linked list.
3. We call `makeCurrent()` on both objects. This does nothing for `x`
because it already is at level 1. For `y` it creates a backup of the
current information and inserts `y` into the scope 1. Scope 0 now has a
backup of `y` in its linked list and scope 1 has both `x` and `y` in its
linked list. Note that `x`'s `prev()` now points to `y`'s `next()`.
4. We do an additional push, another call to `makeCurrent` on both
objects, and a first `pop()`. After those operations, we have the same
state as after 3.
5. We pop our context again, which restores the original `y` in scope 0.
We now only have scope 0 with `y` in it. As described above, `x` is
untouched because there is no older version to restore.
6. We are at the end of the function and because `y` was created after
`x`, it is destroyed first (standard destruction order of stack objects
in C++). When destroying `x`, `x`'s `prev()` still points to `y`'s
`next()`, so we are doing an invalid write and ASAN complains.

Solution
========

The solution that this commit implements is fairly simple. We can detect
that `x`'s `prev()`/`next()` pointers are stale by checking whether the
objects level is greater than the context's level. If it is, we know
that this object is invalid and that we do not have any old versions to
remove. Note that this situation should be very rare because objects
with `allocatedInCMM` should usually be allocated in context memory,
where they get cleaned up automatically when the context is popped below
the level that they are associated with.

@timothy-king I am adding you to this PR since you may be interested in it.