### PR TITLE
Optimize regular expression elimination

### DIFF
--- a/src/theory/strings/regexp_elim.cpp
+++ b/src/theory/strings/regexp_elim.cpp
@@ -105,7 +105,7 @@ Node RegExpElimination::eliminateConcat(Node atom)
     // searching.
     Node prev_end = d_zero;
     // the symbolic index we start searching, for each child in sep_children.
-    std::vector< Node > prev_ends;
+    std::vector<Node> prev_ends;
     unsigned gap_minsize_end = gap_minsize.back();
     bool gap_exact_end = gap_exact.back();
     std::vector<Node> non_greedy_find_vars;
@@ -196,7 +196,9 @@ Node RegExpElimination::eliminateConcat(Node atom)
         // above says that the "B" we find at end-2 can be found >=1 after
         // the "A".
         conj.pop_back();
-        Node fit = nm->mkNode( gap_exact[sep_children.size() - 1] ? EQUAL : LEQ, prev_ends.back(), loc );
+        Node fit = nm->mkNode(gap_exact[sep_children.size() - 1] ? EQUAL : LEQ,
+                              prev_ends.back(),
+                              loc);
 
         conj.push_back(scc);
         conj.push_back(fit);

--- a/src/theory/strings/regexp_elim.cpp
+++ b/src/theory/strings/regexp_elim.cpp
@@ -188,7 +188,7 @@ Node RegExpElimination::eliminateConcat(Node atom)
         if( !gap_exact[sep_children.size() - 1] )
         {
           // With respect to the above example, this is an optimization. For
-          // that example, we produce:
+          // that example, we instead produce:
           //     x in (re.++ "A" _ (re.* _) "B" _) --->
           //       substr( x, 0, 1 ) = "A" ^          // find "A"
           //       substr( x, len(x)-2, 1 ) = "B" ^   // "B" is at end - 2
@@ -196,8 +196,9 @@ Node RegExpElimination::eliminateConcat(Node atom)
           // The intuition is that above, there are two constraints that insist
           // that "B" is found, whereas we only need one. The last constraint
           // above says that the "B" we find at end-2 can be found >=1 after
-          // the "A". Notice we only need two constraints if both the last
-          // gap and second-to-last gaps are exact.
+          // the "A". Notice we only need two constraints that talk about the
+          // location of finding "B" if both the last gap and second-to-last
+          // gaps are exact.
           conj.pop_back();
           fit = nm->mkNode( LEQ, prev_ends.back(), loc );
         }

--- a/src/theory/strings/regexp_elim.cpp
+++ b/src/theory/strings/regexp_elim.cpp
@@ -184,28 +184,20 @@ Node RegExpElimination::eliminateConcat(Node atom)
         // would have been the case than "ABB" would be a model for x, where
         // the second constraint refers to the third position, and the third
         // constraint refers to the second position.
-        Node fit;
-        if( !gap_exact[sep_children.size() - 1] )
-        {
-          // With respect to the above example, this is an optimization. For
-          // that example, we instead produce:
-          //     x in (re.++ "A" _ (re.* _) "B" _) --->
-          //       substr( x, 0, 1 ) = "A" ^          // find "A"
-          //       substr( x, len(x)-2, 1 ) = "B" ^   // "B" is at end - 2
-          //       2 <= len( x ) - 2
-          // The intuition is that above, there are two constraints that insist
-          // that "B" is found, whereas we only need one. The last constraint
-          // above says that the "B" we find at end-2 can be found >=1 after
-          // the "A". Notice we only need two constraints that talk about the
-          // location of finding "B" if both the last gap and second-to-last
-          // gaps are exact.
-          conj.pop_back();
-          fit = nm->mkNode( LEQ, prev_ends.back(), loc );
-        }
-        else
-        {
-          fit = nm->mkNode( EQUAL, nm->mkNode(MINUS, prev_end, lenSc), loc );
-        }
+        //
+        // With respect to the above example, the following is an optimization.
+        // For that example, we instead produce:
+        //     x in (re.++ "A" _ (re.* _) "B" _) --->
+        //       substr( x, 0, 1 ) = "A" ^          // find "A"
+        //       substr( x, len(x)-2, 1 ) = "B" ^   // "B" is at end - 2
+        //       2 <= len( x ) - 2
+        // The intuition is that above, there are two constraints that insist
+        // that "B" is found, whereas we only need one. The last constraint
+        // above says that the "B" we find at end-2 can be found >=1 after
+        // the "A".
+        conj.pop_back();
+        Node fit = nm->mkNode( gap_exact[sep_children.size() - 1] ? EQUAL : LEQ, prev_ends.back(), loc );
+
         conj.push_back(scc);
         conj.push_back(fit);
       }

--- a/src/theory/strings/regexp_elim.cpp
+++ b/src/theory/strings/regexp_elim.cpp
@@ -187,9 +187,8 @@ Node RegExpElimination::eliminateConcat(Node atom)
         Node fit;
         if( !gap_exact[sep_children.size() - 1] )
         {
-          // with respect to the above example, this is an optimization
-          // that simplifies the constraints above. For that example, we 
-          // produce:
+          // With respect to the above example, this is an optimization. For
+          // that example, we produce:
           //     x in (re.++ "A" _ (re.* _) "B" _) --->
           //       substr( x, 0, 1 ) = "A" ^          // find "A"
           //       substr( x, len(x)-2, 1 ) = "B" ^   // "B" is at end - 2
@@ -197,7 +196,8 @@ Node RegExpElimination::eliminateConcat(Node atom)
           // The intuition is that above, there are two constraints that insist
           // that "B" is found, whereas we only need one. The last constraint
           // above says that the "B" we find at end-2 can be found >=1 after
-          // the "A".
+          // the "A". Notice we only need two constraints if both the last
+          // gap and second-to-last gaps are exact.
           conj.pop_back();
           fit = nm->mkNode( LEQ, prev_ends.back(), loc );
         }

--- a/src/theory/strings/regexp_elim.cpp
+++ b/src/theory/strings/regexp_elim.cpp
@@ -104,18 +104,20 @@ Node RegExpElimination::eliminateConcat(Node atom)
     // prev_end stores the current (symbolic) index in x that we are
     // searching.
     Node prev_end = d_zero;
+    std::vector< Node > prev_ends;
     unsigned gap_minsize_end = gap_minsize.back();
     bool gap_exact_end = gap_exact.back();
     std::vector<Node> non_greedy_find_vars;
     for (unsigned i = 0, size = sep_children.size(); i < size; i++)
     {
-      Node sc = sep_children[i];
       if (gap_minsize[i] > 0)
       {
         // the gap to this child is at least gap_minsize[i]
         prev_end =
             nm->mkNode(PLUS, prev_end, nm->mkConst(Rational(gap_minsize[i])));
       }
+      prev_ends.push_back(prev_end);
+      Node sc = sep_children[i];
       Node lensc = nm->mkNode(STRING_LENGTH, sc);
       if (gap_exact[i])
       {
@@ -169,7 +171,6 @@ Node RegExpElimination::eliminateConcat(Node atom)
         Node lenSc = nm->mkNode(STRING_LENGTH, sc);
         Node loc = nm->mkNode(MINUS, lenx, nm->mkNode(PLUS, lenSc, cEnd));
         Node scc = sc.eqNode(nm->mkNode(STRING_SUBSTR, x, loc, lenSc));
-        conj.push_back(scc);
         // We also must ensure that we fit. This constraint is necessary in
         // addition to the constraint above. Take this example:
         //     x in (re.++ "A" _ (re.* _) "B" _) --->
@@ -182,9 +183,28 @@ Node RegExpElimination::eliminateConcat(Node atom)
         // would have been the case than "ABB" would be a model for x, where
         // the second constraint refers to the third position, and the third
         // constraint refers to the second position.
-        Node fit = nm->mkNode(gap_exact[sep_children.size() - 1] ? EQUAL : LEQ,
-                              nm->mkNode(MINUS, prev_end, lenSc),
-                              loc);
+        Node fit;
+        if( !gap_exact[sep_children.size() - 1] )
+        {
+          // with respect to the above example, this is an optimization
+          // that simplifies the constraints above. For that example, we 
+          // produce:
+          //     x in (re.++ "A" _ (re.* _) "B" _) --->
+          //       substr( x, 0, 1 ) = "A" ^          // find "A"
+          //       substr( x, len(x)-2, 1 ) = "B" ^   // "B" is at end - 2
+          //       2 <= len( x ) - 2
+          // The intuition is that above, there are two constraints that insist
+          // that "B" is found, whereas we only need one. The last constraint
+          // above says that the "B" we find at end-2 can be found >=1 after
+          // "A".
+          conj.pop_back();
+          fit = nm->mkNode( LEQ, prev_ends.back(), loc );
+        }
+        else
+        {
+          fit = nm->mkNode( EQUAL, nm->mkNode(MINUS, prev_end, lenSc), loc );
+        }
+        conj.push_back(scc);
         conj.push_back(fit);
       }
       else if (gap_minsize_end > 0)

--- a/src/theory/strings/regexp_elim.cpp
+++ b/src/theory/strings/regexp_elim.cpp
@@ -104,6 +104,7 @@ Node RegExpElimination::eliminateConcat(Node atom)
     // prev_end stores the current (symbolic) index in x that we are
     // searching.
     Node prev_end = d_zero;
+    // the symbolic index we start searching, for each child in sep_children.
     std::vector< Node > prev_ends;
     unsigned gap_minsize_end = gap_minsize.back();
     bool gap_exact_end = gap_exact.back();
@@ -196,7 +197,7 @@ Node RegExpElimination::eliminateConcat(Node atom)
           // The intuition is that above, there are two constraints that insist
           // that "B" is found, whereas we only need one. The last constraint
           // above says that the "B" we find at end-2 can be found >=1 after
-          // "A".
+          // the "A".
           conj.pop_back();
           fit = nm->mkNode( LEQ, prev_ends.back(), loc );
         }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1710,6 +1710,7 @@ set(regress_2_tests
   regress2/strings/cmu-disagree-0707-dd.smt2
   regress2/strings/cmu-prereg-fmf.smt2
   regress2/strings/cmu-repl-len-nterm.smt2
+  regress2/strings/non_termination_regular_expression6.smt2
   regress2/strings/norn-dis-0707-3.smt2
   regress2/strings/repl-repl.smt2
   regress2/sygus/MPwL_d1s3.sy

--- a/test/regress/Makefile.tests
+++ b/test/regress/Makefile.tests
@@ -1703,6 +1703,7 @@ REG2_TESTS = \
 	regress2/strings/cmu-disagree-0707-dd.smt2 \
 	regress2/strings/cmu-prereg-fmf.smt2 \
 	regress2/strings/cmu-repl-len-nterm.smt2 \
+	regress2/strings/non_termination_regular_expression6.smt2 \
 	regress2/strings/norn-dis-0707-3.smt2 \
 	regress2/strings/repl-repl.smt2 \
 	regress2/sygus/MPwL_d1s3.sy \

--- a/test/regress/regress2/strings/non_termination_regular_expression6.smt2
+++ b/test/regress/regress2/strings/non_termination_regular_expression6.smt2
@@ -1,0 +1,61 @@
+; COMMAND-LINE: --strings-exp --re-elim
+; EXPECT: unsat
+(set-logic ALL)
+(set-info :status unsat)
+(declare-const actionName String)
+(declare-const actionNamespace String)
+(declare-const resource_account String)
+(declare-const resource_partition String)
+(declare-const resource_prefix String)
+(declare-const resource_region String)
+(declare-const resource_resource String)
+(declare-const resource_service String)
+
+; Action: p0.0
+(declare-const p0.0.action Bool)
+(assert (= p0.0.action (and (= "sqs" actionNamespace) (= "sendmessage" actionName))))
+
+; Resource: p0.0
+(declare-const p0.0.resource Bool)
+(assert (= p0.0.resource (and (= resource_prefix "arn") (= resource_partition "aws") (= resource_service "sqs") (= resource_region "us-east-1") (= resource_account "111144448888") (str.in.re resource_resource (re.++ (str.to.re "ab") (re.* re.allchar) (str.to.re "b") (re.* re.allchar) (str.to.re "b") (re.* re.allchar) (str.to.re "b"))))))
+
+; Statement: p0.0
+(declare-const p0.0.statement.allows Bool)
+(assert (= p0.0.statement.allows (and p0.0.action p0.0.resource)))
+
+; Policy: 0
+(declare-const p0.denies Bool)
+(assert (not p0.denies))
+(declare-const p0.allows Bool)
+(assert (= p0.allows (and (not p0.denies) p0.0.statement.allows)))
+(declare-const p0.neutral Bool)
+(assert (= p0.neutral (and (not p0.allows) (not p0.denies))))
+
+; Action: p1.0
+(declare-const p1.0.action Bool)
+(assert (= p1.0.action (and (= "sqs" actionNamespace) (= "sendmessage" actionName))))
+
+; Resource: p1.0
+(declare-const p1.0.resource Bool)
+(assert (= p1.0.resource (and (= resource_prefix "arn") (= resource_partition "aws") (= resource_service "sqs") (= resource_region "us-east-1") (= resource_account "111144448888") (str.in.re resource_resource (re.++ (str.to.re "a") (re.* re.allchar) (str.to.re "b") (re.* re.allchar) (str.to.re "b") (re.* re.allchar) (str.to.re "b"))))))
+
+; Statement: p1.0
+(declare-const p1.0.statement.allows Bool)
+(assert (= p1.0.statement.allows (and p1.0.action p1.0.resource)))
+
+; Policy: 1
+(declare-const p1.denies Bool)
+(assert (not p1.denies))
+(declare-const p1.allows Bool)
+(assert (= p1.allows (and (not p1.denies) p1.0.statement.allows)))
+(declare-const p1.neutral Bool)
+(assert (= p1.neutral (and (not p1.allows) (not p1.denies))))
+
+; Resource service invariant
+(assert (not (str.contains resource_service ":")))
+(assert (= resource_prefix "arn"))
+
+; Goals
+(assert p0.allows)
+(assert (or p1.denies p1.neutral))
+(check-sat)


### PR DESCRIPTION
This simplifies the case when the last gap is exact but the second-to-last gap is not exact in the "concat with gaps" membership fragment.