### PR TITLE
Improvements to rewrite rules from inputs

### DIFF
--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -63,6 +63,55 @@ bool hasSubterm(TNode n, TNode t, bool strict)
   return false;
 }
 
+bool hasSubtermMulti(TNode n, TNode t)
+{
+  std::unordered_map<TNode, bool, TNodeHashFunction> visited;
+  std::unordered_map< TNode, bool, TNodeHashFunction > contains;
+  std::unordered_map<TNode, bool, TNodeHashFunction>::iterator it;
+  std::vector<TNode> visit;
+  TNode cur;
+  visit.push_back(n);
+  do {
+    cur = visit.back();
+    visit.pop_back();
+    it = visited.find(cur);
+
+    if (it == visited.end()) {
+      if( cur==t )
+      {
+        visited[cur] = true;
+        contains[cur] = true;
+      }
+      else
+      {
+        visited[cur] = false;
+        visit.push_back(cur);
+        for( const Node& cc : cur ){
+          visit.push_back(cc);
+        }
+      }
+    }else if( !it->second ){
+      bool doesContain = false;
+      for (const Node& cn : cur) {
+        it = contains.find(cn);
+        Assert(it != visited.end());
+        if( it->second )
+        {
+          if( doesContain )
+          {
+            // two children have t, return true
+            return true;
+          }
+          doesContain = true;
+        }
+      }
+      contains[cur] = doesContain;
+      visited[cur] = true;
+    }
+  } while (!visit.empty());
+  return false;
+}
+
 struct HasBoundVarTag
 {
 };

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -66,18 +66,20 @@ bool hasSubterm(TNode n, TNode t, bool strict)
 bool hasSubtermMulti(TNode n, TNode t)
 {
   std::unordered_map<TNode, bool, TNodeHashFunction> visited;
-  std::unordered_map< TNode, bool, TNodeHashFunction > contains;
+  std::unordered_map<TNode, bool, TNodeHashFunction> contains;
   std::unordered_map<TNode, bool, TNodeHashFunction>::iterator it;
   std::vector<TNode> visit;
   TNode cur;
   visit.push_back(n);
-  do {
+  do
+  {
     cur = visit.back();
     visit.pop_back();
     it = visited.find(cur);
 
-    if (it == visited.end()) {
-      if( cur==t )
+    if (it == visited.end())
+    {
+      if (cur == t)
       {
         visited[cur] = true;
         contains[cur] = true;
@@ -86,18 +88,22 @@ bool hasSubtermMulti(TNode n, TNode t)
       {
         visited[cur] = false;
         visit.push_back(cur);
-        for( const Node& cc : cur ){
+        for (const Node& cc : cur)
+        {
           visit.push_back(cc);
         }
       }
-    }else if( !it->second ){
+    }
+    else if (!it->second)
+    {
       bool doesContain = false;
-      for (const Node& cn : cur) {
+      for (const Node& cn : cur)
+      {
         it = contains.find(cn);
         Assert(it != visited.end());
-        if( it->second )
+        if (it->second)
         {
-          if( doesContain )
+          if (doesContain)
           {
             // two children have t, return true
             return true;

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -39,6 +39,11 @@ namespace expr {
 bool hasSubterm(TNode n, TNode t, bool strict = false);
 
 /**
+ * Check if the node n has >1 occurrences of a subterm t.
+ */
+bool hasSubtermMulti(TNode n, TNode t);
+
+/**
  * Returns true iff the node n contains a bound variable, that is a node of
  * kind BOUND_VARIABLE. This bound variable may or may not be free.
  * @param n The node under investigation

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1260,6 +1260,14 @@ header = "options/quantifiers_options.h"
   help       = "filter candidate rewrites based on congruence"
 
 [[option]]
+  name       = "sygusRewSynthFilterNonLinear"
+  category   = "regular"
+  long       = "sygus-rr-synth-filter-nl"
+  type       = "bool"
+  default    = "false"
+  help       = "filter non-linear candidate rewrites"
+
+[[option]]
   name       = "sygusRewVerify"
   category   = "regular"
   long       = "sygus-rr-verify"

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -126,6 +126,9 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
             // add the standard constants for this type
             theory::quantifiers::CegGrammarConstructor::mkSygusConstantsForType(
                 tn, consts[tn]);
+            // We prepend them so that they come first in the grammar
+            // construction. The motivation is we'd prefer seeing e.g. "true"
+            // instead of (= x x) as a canonical term.
             terms.insert(terms.begin(), consts[tn].begin(), consts[tn].end());
           }
           terms.push_back(cur);

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -60,7 +60,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
   // does the input contain a Boolean variable?
   bool hasBoolVar = false;
   // the types of subterms of our input
-  std::map<TypeNode, bool > typesFound;
+  std::map<TypeNode, bool> typesFound;
   // standard constants for each type (e.g. true, false for Bool)
   std::map<TypeNode, std::vector<Node> > consts;
 
@@ -114,7 +114,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
           if (cur.isVar())
           {
             vars.push_back(cur);
-            if( tn.isBoolean() )
+            if (tn.isBoolean())
             {
               hasBoolVar = true;
             }
@@ -135,7 +135,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
     } while (!visit.empty());
   }
   Trace("srs-input") << "...finished." << std::endl;
-  
+
   Trace("srs-input") << "Make synth variables for types..." << std::endl;
   // We will generate a fixed number of variables per type. These are the
   // variables that appear as free variables in the rewrites we generate.
@@ -146,7 +146,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
   std::vector<TypeNode> allVarTypes;
   std::vector<Node> allVars;
   unsigned varCounter = 0;
-  for( std::pair<const TypeNode, bool > tfp : typesFound )
+  for (std::pair<const TypeNode, bool> tfp : typesFound)
   {
     TypeNode tn = tfp.first;
     // If we are not interested in purely propositional rewrites, we only
@@ -157,7 +157,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
     unsigned useNVars =
         (options::sygusRewSynthInputUseBool() || !tn.isBoolean())
             ? nvars
-            : ( hasBoolVar ? 1 : 0 );
+            : (hasBoolVar ? 1 : 0);
     for (unsigned i = 0; i < useNVars; i++)
     {
       // We must have a good name for these variables, these are
@@ -180,7 +180,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
     }
   }
   Trace("srs-input") << "...finished." << std::endl;
-  
+
   Trace("srs-input") << "Convert subterms to free variable form..."
                      << std::endl;
   // Replace all free variables with bound variables. This ensures that
@@ -270,7 +270,8 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
     // we add variable constructors if we are not Boolean, we are interested
     // in purely propositional rewrites (via the option), or this term is
     // a Boolean variable.
-    if( !ctt.isBoolean() || options::sygusRewSynthInputUseBool() || ct.getKind()==BOUND_VARIABLE )
+    if (!ctt.isBoolean() || options::sygusRewSynthInputUseBool()
+        || ct.getKind() == BOUND_VARIABLE)
     {
       for (const Node& v : tvars[ctt])
       {
@@ -361,7 +362,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
         datatypes[i].addSygusConstructor(op.toExpr(), ssc.str(), argList);
       }
     }
-    Assert( datatypes[i].getNumConstructors()>0 );
+    Assert(datatypes[i].getNumConstructors() > 0);
     datatypes[i].setSygus(ctt.toType(), sygusVarListE, false, false);
   }
   Trace("srs-input") << "...finished." << std::endl;

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -57,16 +57,10 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
   std::vector<Node> terms;
   // all variables (free constants) appearing in the input
   std::vector<Node> vars;
-
-  // We will generate a fixed number of variables per type. These are the
-  // variables that appear as free variables in the rewrites we generate.
-  unsigned nvars = options::sygusRewSynthInputNVars();
-  // must have at least one variable per type
-  nvars = nvars < 1 ? 1 : nvars;
-  std::map<TypeNode, std::vector<Node> > tvars;
-  std::vector<TypeNode> allVarTypes;
-  std::vector<Node> allVars;
-  unsigned varCounter = 0;
+  // does the input contain a Boolean variable?
+  bool hasBoolVar = false;
+  // the types of subterms of our input
+  std::map<TypeNode, bool > typesFound;
   // standard constants for each type (e.g. true, false for Bool)
   std::map<TypeNode, std::vector<Node> > consts;
 
@@ -116,41 +110,20 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
         {
           Trace("srs-input-debug") << "...children are valid" << std::endl;
           Trace("srs-input-debug") << "Add term " << cur << std::endl;
+          TypeNode tn = cur.getType();
           if (cur.isVar())
           {
             vars.push_back(cur);
+            if( tn.isBoolean() )
+            {
+              hasBoolVar = true;
+            }
           }
           // register type information
-          TypeNode tn = cur.getType();
-          if (tvars.find(tn) == tvars.end())
+          if (typesFound.find(tn) == typesFound.end())
           {
-            // Only make one Boolean variable unless option is set. This ensures
-            // we do not compute purely Boolean rewrites by default.
-            unsigned useNVars =
-                (options::sygusRewSynthInputUseBool() || !tn.isBoolean())
-                    ? nvars
-                    : 1;
-            for (unsigned i = 0; i < useNVars; i++)
-            {
-              // We must have a good name for these variables, these are
-              // the ones output in rewrite rules. We choose
-              // a,b,c,...,y,z,x1,x2,...
-              std::stringstream ssv;
-              if (varCounter < 26)
-              {
-                ssv << String::convertUnsignedIntToChar(varCounter + 32);
-              }
-              else
-              {
-                ssv << "x" << (varCounter - 26);
-              }
-              varCounter++;
-              Node v = nm->mkBoundVar(ssv.str(), tn);
-              tvars[tn].push_back(v);
-              allVars.push_back(v);
-              allVarTypes.push_back(tn);
-            }
-            // also add the standard constants for this type
+            typesFound[tn] = true;
+            // add the standard constants for this type
             theory::quantifiers::CegGrammarConstructor::mkSygusConstantsForType(
                 tn, consts[tn]);
             visit.insert(visit.end(), consts[tn].begin(), consts[tn].end());
@@ -162,7 +135,52 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
     } while (!visit.empty());
   }
   Trace("srs-input") << "...finished." << std::endl;
-
+  
+  Trace("srs-input") << "Make synth variables for types..." << std::endl;
+  // We will generate a fixed number of variables per type. These are the
+  // variables that appear as free variables in the rewrites we generate.
+  unsigned nvars = options::sygusRewSynthInputNVars();
+  // must have at least one variable per type
+  nvars = nvars < 1 ? 1 : nvars;
+  std::map<TypeNode, std::vector<Node> > tvars;
+  std::vector<TypeNode> allVarTypes;
+  std::vector<Node> allVars;
+  unsigned varCounter = 0;
+  for( std::pair<const TypeNode, bool > tfp : typesFound )
+  {
+    TypeNode tn = tfp.first;
+    // If we are not interested in purely propositional rewrites, we only
+    // need to make one Boolean variable if the input has a Boolean variable.
+    // This ensures that no type in our grammar has zero constructors. If
+    // our input does not contain a Boolean variable, we need not allocate any
+    // Boolean variables here.
+    unsigned useNVars =
+        (options::sygusRewSynthInputUseBool() || !tn.isBoolean())
+            ? nvars
+            : ( hasBoolVar ? 1 : 0 );
+    for (unsigned i = 0; i < useNVars; i++)
+    {
+      // We must have a good name for these variables, these are
+      // the ones output in rewrite rules. We choose
+      // a,b,c,...,y,z,x1,x2,...
+      std::stringstream ssv;
+      if (varCounter < 26)
+      {
+        ssv << String::convertUnsignedIntToChar(varCounter + 32);
+      }
+      else
+      {
+        ssv << "x" << (varCounter - 26);
+      }
+      varCounter++;
+      Node v = nm->mkBoundVar(ssv.str(), tn);
+      tvars[tn].push_back(v);
+      allVars.push_back(v);
+      allVarTypes.push_back(tn);
+    }
+  }
+  Trace("srs-input") << "...finished." << std::endl;
+  
   Trace("srs-input") << "Convert subterms to free variable form..."
                      << std::endl;
   // Replace all free variables with bound variables. This ensures that
@@ -249,11 +267,17 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
     TypeNode ctt = ct.getType();
     Assert(tvars.find(ctt) != tvars.end());
     std::vector<Type> argList;
-    for (const Node& v : tvars[ctt])
+    // we add variable constructors if we are not Boolean, we are interested
+    // in purely propositional rewrites (via the option), or this term is
+    // a Boolean variable.
+    if( !ctt.isBoolean() || options::sygusRewSynthInputUseBool() || ct.getKind()==BOUND_VARIABLE )
     {
-      std::stringstream ssc;
-      ssc << "C_" << i << "_" << v;
-      datatypes[i].addSygusConstructor(v.toExpr(), ssc.str(), argList);
+      for (const Node& v : tvars[ctt])
+      {
+        std::stringstream ssc;
+        ssc << "C_" << i << "_" << v;
+        datatypes[i].addSygusConstructor(v.toExpr(), ssc.str(), argList);
+      }
     }
     // add the constructor for the operator if it is not a variable
     if (ct.getKind() != BOUND_VARIABLE)
@@ -337,6 +361,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
         datatypes[i].addSygusConstructor(op.toExpr(), ssc.str(), argList);
       }
     }
+    Assert( datatypes[i].getNumConstructors()>0 );
     datatypes[i].setSygus(ctt.toType(), sygusVarListE, false, false);
   }
   Trace("srs-input") << "...finished." << std::endl;

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -126,7 +126,7 @@ PreprocessingPassResult SynthRewRulesPass::applyInternal(
             // add the standard constants for this type
             theory::quantifiers::CegGrammarConstructor::mkSygusConstantsForType(
                 tn, consts[tn]);
-            visit.insert(visit.end(), consts[tn].begin(), consts[tn].end());
+            terms.insert(terms.begin(), consts[tn].begin(), consts[tn].end());
           }
           terms.push_back(cur);
         }

--- a/src/theory/quantifiers/candidate_rewrite_filter.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_filter.cpp
@@ -242,12 +242,12 @@ bool CandidateRewriteFilter::filterPair(Node n, Node eq_n)
   // whether we will keep this pair
   bool keep = true;
 
-  // ----- check ordering redundancy
-  if (options::sygusRewSynthFilterOrder())
+  // ----- check redundancy based on variables
+  if (options::sygusRewSynthFilterOrder() || options::sygusRewSynthFilterNonLinear())
   {
-    bool nor = d_ss->isOrdered(bn);
-    bool eqor = d_ss->isOrdered(beq_n);
-    Trace("cr-filter-debug") << "Ordered? : " << nor << " " << eqor
+    bool nor = d_ss->checkVariables(bn, options::sygusRewSynthFilterOrder(), options::sygusRewSynthFilterNonLinear() );
+    bool eqor = d_ss->checkVariables(beq_n, options::sygusRewSynthFilterOrder(), options::sygusRewSynthFilterNonLinear() );
+    Trace("cr-filter-debug") << "Variables ok? : " << nor << " " << eqor
                              << std::endl;
     if (eqor || nor)
     {

--- a/src/theory/quantifiers/candidate_rewrite_filter.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_filter.cpp
@@ -243,12 +243,17 @@ bool CandidateRewriteFilter::filterPair(Node n, Node eq_n)
   bool keep = true;
 
   // ----- check redundancy based on variables
-  if (options::sygusRewSynthFilterOrder() || options::sygusRewSynthFilterNonLinear())
+  if (options::sygusRewSynthFilterOrder()
+      || options::sygusRewSynthFilterNonLinear())
   {
-    bool nor = d_ss->checkVariables(bn, options::sygusRewSynthFilterOrder(), options::sygusRewSynthFilterNonLinear() );
-    bool eqor = d_ss->checkVariables(beq_n, options::sygusRewSynthFilterOrder(), options::sygusRewSynthFilterNonLinear() );
-    Trace("cr-filter-debug") << "Variables ok? : " << nor << " " << eqor
-                             << std::endl;
+    bool nor = d_ss->checkVariables(bn,
+                                    options::sygusRewSynthFilterOrder(),
+                                    options::sygusRewSynthFilterNonLinear());
+    bool eqor = d_ss->checkVariables(beq_n,
+                                     options::sygusRewSynthFilterOrder(),
+                                     options::sygusRewSynthFilterNonLinear());
+    Trace("cr-filter-debug")
+        << "Variables ok? : " << nor << " " << eqor << std::endl;
     if (eqor || nor)
     {
       // if only one is ordered, then we require that the ordered one's

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -14,6 +14,7 @@
 
 #include "theory/quantifiers/sygus_sampler.h"
 
+#include "expr/node_algorithm.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
 #include "printer/printer.h"
@@ -21,7 +22,6 @@
 #include "util/bitvector.h"
 #include "util/random.h"
 #include "util/sampler.h"
-#include "expr/node_algorithm.h"
 
 namespace CVC4 {
 namespace theory {
@@ -342,15 +342,9 @@ void SygusSampler::computeFreeVariables(Node n, std::vector<Node>& fvs)
   } while (!visit.empty());
 }
 
-bool SygusSampler::isOrdered(Node n)
-{
-  return checkVariables(n, true, false );
-}
+bool SygusSampler::isOrdered(Node n) { return checkVariables(n, true, false); }
 
-bool SygusSampler::isLinear(Node n)
-{
-  return checkVariables(n, false, true);
-}
+bool SygusSampler::isLinear(Node n) { return checkVariables(n, false, true); }
 
 bool SygusSampler::checkVariables(Node n, bool checkOrder, bool checkLinear)
 {
@@ -374,7 +368,7 @@ bool SygusSampler::checkVariables(Node n, bool checkOrder, bool checkLinear)
         std::map<Node, unsigned>::iterator itv = d_var_index.find(cur);
         if (itv != d_var_index.end())
         {
-          if( checkOrder )
+          if (checkOrder)
           {
             unsigned tnid = d_type_ids[cur];
             // if this variable is out of order
@@ -384,9 +378,9 @@ bool SygusSampler::checkVariables(Node n, bool checkOrder, bool checkLinear)
             }
             fvs[tnid].push_back(cur);
           }
-          if( checkLinear )
+          if (checkLinear)
           {
-            if( expr::hasSubtermMulti(n,cur) )
+            if (expr::hasSubtermMulti(n, cur))
             {
               return false;
             }

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -21,6 +21,7 @@
 #include "util/bitvector.h"
 #include "util/random.h"
 #include "util/sampler.h"
+#include "expr/node_algorithm.h"
 
 namespace CVC4 {
 namespace theory {
@@ -343,6 +344,16 @@ void SygusSampler::computeFreeVariables(Node n, std::vector<Node>& fvs)
 
 bool SygusSampler::isOrdered(Node n)
 {
+  return checkVariables(n, true, false );
+}
+
+bool SygusSampler::isLinear(Node n)
+{
+  return checkVariables(n, false, true);
+}
+
+bool SygusSampler::checkVariables(Node n, bool checkOrder, bool checkLinear)
+{
   // compute free variables in n for each type
   std::map<unsigned, std::vector<Node> > fvs;
 
@@ -363,13 +374,23 @@ bool SygusSampler::isOrdered(Node n)
         std::map<Node, unsigned>::iterator itv = d_var_index.find(cur);
         if (itv != d_var_index.end())
         {
-          unsigned tnid = d_type_ids[cur];
-          // if this variable is out of order
-          if (itv->second != fvs[tnid].size())
+          if( checkOrder )
           {
-            return false;
+            unsigned tnid = d_type_ids[cur];
+            // if this variable is out of order
+            if (itv->second != fvs[tnid].size())
+            {
+              return false;
+            }
+            fvs[tnid].push_back(cur);
           }
-          fvs[tnid].push_back(cur);
+          if( checkLinear )
+          {
+            if( expr::hasSubtermMulti(n,cur) )
+            {
+              return false;
+            }
+          }
         }
       }
       for (unsigned j = 0, nchildren = cur.getNumChildren(); j < nchildren; j++)

--- a/src/theory/quantifiers/sygus_sampler.h
+++ b/src/theory/quantifiers/sygus_sampler.h
@@ -144,15 +144,15 @@ class SygusSampler : public LazyTrieEvaluator
    * y and y+x are not.
    */
   bool isOrdered(Node n);
-  /** is linear 
-   * 
+  /** is linear
+   *
    * This returns whether n contains at most one occurrence of each free
    * variable. For example, x, x+y are linear, but x+x, (x-y)+y, (x+0)+(x+0) are
    * non-linear.
    */
   bool isLinear(Node n);
   /** check variables
-   * 
+   *
    * This returns false if !isOrdered(n) and checkOrder is true or !isLinear(n)
    * if checkLinear is true, or false otherwise.
    */

--- a/src/theory/quantifiers/sygus_sampler.h
+++ b/src/theory/quantifiers/sygus_sampler.h
@@ -144,6 +144,19 @@ class SygusSampler : public LazyTrieEvaluator
    * y and y+x are not.
    */
   bool isOrdered(Node n);
+  /** is linear 
+   * 
+   * This returns whether n contains at most one occurrence of each free
+   * variable. For example, x, x+y are linear, but x+x, (x-y)+y, (x+0)+(x+0) are
+   * non-linear.
+   */
+  bool isLinear(Node n);
+  /** check variables
+   * 
+   * This returns false if !isOrdered(n) and checkOrder is true or !isLinear(n)
+   * if checkLinear is true, or false otherwise.
+   */
+  bool checkVariables(Node n, bool checkOrder, bool checkLinear);
   /** contains free variables
    *
    * Returns true if the free variables of b are a subset of those in a, where


### PR DESCRIPTION
This includes:
- Not including Boolean variables in rewrites if the input does not have any.
- An option to filter "non-linear" rewrites --sygus-rr-synth-filter-nl. When this option is enabled, we only print rewrites where at least one side of the rewrite has a term with no repeated variables. @4tXJ7f , you may be interested in this.
- Better ordering so that constants (e.g. true) are preferred to others.

