### PR TITLE
Improve reduction for int.to.str

### DIFF
--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -201,16 +201,17 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     std::vector< TypeNode > argTypes;
     argTypes.push_back(nm->integerType());
     Node ufP = nm->mkSkolem("ufP",
-              nm->mkFunctionType(
-                argTypes, nm->integerType()),
-              "uf type conv P");
+                            nm->mkFunctionType(argTypes, nm->integerType()),
+                            "uf type conv P");
     Node ufM = nm->mkSkolem("ufM",
-              nm->mkFunctionType(
-                argTypes, nm->integerType()),
-              "uf type conv M");
-    Node itosPre = nm->mkSkolem("itos_pre",nm->mkFunctionType(argTypes,nm->stringType()));
-    Node itosDigit = nm->mkSkolem("itos_digit",nm->mkFunctionType(argTypes,nm->stringType()));
-    Node itosPost = nm->mkSkolem("itos_post",nm->mkFunctionType(argTypes,nm->stringType()));
+                            nm->mkFunctionType(argTypes, nm->integerType()),
+                            "uf type conv M");
+    Node itosPre = nm->mkSkolem("itos_pre",
+                                nm->mkFunctionType(argTypes, nm->stringType()));
+    Node itosDigit = nm->mkSkolem(
+        "itos_digit", nm->mkFunctionType(argTypes, nm->stringType()));
+    Node itosPost = nm->mkSkolem(
+        "itos_post", nm->mkFunctionType(argTypes, nm->stringType()));
 
     lem = num.eqNode(NodeManager::currentNM()->mkNode(kind::APPLY_UF, ufP, d_zero));
     new_nodes.push_back( lem );
@@ -233,14 +234,15 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     Node cc3 = NodeManager::currentNM()->mkNode(kind::GEQ, ufMx, d_zero);
     Node cc4 = NodeManager::currentNM()->mkNode(kind::GEQ, nine, ufMx);
 
-    Node b21 = nm->mkNode(APPLY_UF,itosPre,b1);
-    Node b2d = nm->mkNode(APPLY_UF,itosDigit,b1);
-    Node b22 = nm->mkNode(APPLY_UF,itosPost,b1);
+    Node b21 = nm->mkNode(APPLY_UF, itosPre, b1);
+    Node b2d = nm->mkNode(APPLY_UF, itosDigit, b1);
+    Node b22 = nm->mkNode(APPLY_UF, itosPost, b1);
 
     Node c21 = NodeManager::currentNM()->mkNode(kind::STRING_LENGTH, b21).eqNode(
           NodeManager::currentNM()->mkNode(kind::MINUS, lenp, NodeManager::currentNM()->mkNode(kind::PLUS, b1, one) ));
-    Node c22 = pret.eqNode( nm->mkNode(STRING_CONCAT, b21, b2d, b22) );
-    Node c2d = nm->mkNode( STRING_CODE, b2d ).eqNode( nm->mkNode( PLUS, ufMx, nm->mkConst(Rational(48))));
+    Node c22 = pret.eqNode(nm->mkNode(STRING_CONCAT, b21, b2d, b22));
+    Node c2d = nm->mkNode(STRING_CODE, b2d)
+                   .eqNode(nm->mkNode(PLUS, ufMx, nm->mkConst(Rational(48))));
     Node cc5 = nm->mkNode(AND, c21, c22, c2d);
     std::vector< Node > svec;
     svec.push_back(cc1);svec.push_back(cc2);

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -174,7 +174,9 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
 
     // Thus, indexof( x, y, n ) = skk.
     retNode = skk;
-  } else if( t.getKind() == STRING_ITOS ) {
+  }
+  else if (t.getKind() == STRING_ITOS)
+  {
     // processing term:  int.to.str( n )
     Node n = t[0];
     Node itost = d_sc->mkSkolemCached(t, SkolemCache::SK_PURIFY, "itost");
@@ -182,54 +184,56 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
 
     Node nonneg = nm->mkNode(GEQ, t[0], d_zero);
 
-    Node lem = nm->mkNode(EQUAL, nonneg.negate(),
-      itost.eqNode(d_empty_str)
-      );
+    Node lem = nm->mkNode(EQUAL, nonneg.negate(), itost.eqNode(d_empty_str));
     new_nodes.push_back(lem);
 
     std::vector< TypeNode > argTypes;
     argTypes.push_back(nm->integerType());
-    Node u = nm->mkSkolem("U",
-                            nm->mkFunctionType(argTypes, nm->integerType()));
-    Node us = nm->mkSkolem("Us",
-                            nm->mkFunctionType(argTypes, nm->stringType()));
-    Node ud = nm->mkSkolem("Ud",
-                            nm->mkFunctionType(argTypes, nm->stringType()));
+    Node u = nm->mkSkolem("U", nm->mkFunctionType(argTypes, nm->integerType()));
+    Node us =
+        nm->mkSkolem("Us", nm->mkFunctionType(argTypes, nm->stringType()));
+    Node ud =
+        nm->mkSkolem("Ud", nm->mkFunctionType(argTypes, nm->stringType()));
 
     lem = n.eqNode(nm->mkNode(APPLY_UF, u, leni));
     new_nodes.push_back( lem );
-    
+
     lem = d_zero.eqNode(nm->mkNode(APPLY_UF, u, d_zero));
-    new_nodes.push_back( lem );
-    
+    new_nodes.push_back(lem);
+
     lem = d_empty_str.eqNode(nm->mkNode(APPLY_UF, us, leni));
-    new_nodes.push_back( lem );
-    
+    new_nodes.push_back(lem);
+
     lem = itost.eqNode(nm->mkNode(APPLY_UF, us, d_zero));
-    new_nodes.push_back( lem );
-    
+    new_nodes.push_back(lem);
+
     Node x = nm->mkBoundVar(nm->integerType());
     Node xbv = nm->mkNode(BOUND_VAR_LIST, x);
-    Node g = nm->mkNode( AND, nm->mkNode( GEQ, x, d_zero ),nm->mkNode( LT, x, leni ) );
-    Node udx = nm->mkNode(APPLY_UF, ud, x );
+    Node g =
+        nm->mkNode(AND, nm->mkNode(GEQ, x, d_zero), nm->mkNode(LT, x, leni));
+    Node udx = nm->mkNode(APPLY_UF, ud, x);
     Node ux = nm->mkNode(APPLY_UF, u, x);
-    Node ux1 = nm->mkNode(APPLY_UF, u, nm->mkNode(PLUS,x,d_one));
-    Node c = nm->mkNode( MINUS, nm->mkNode( STRING_CODE, udx ), nm->mkConst(Rational(48)));
+    Node ux1 = nm->mkNode(APPLY_UF, u, nm->mkNode(PLUS, x, d_one));
+    Node c = nm->mkNode(
+        MINUS, nm->mkNode(STRING_CODE, udx), nm->mkConst(Rational(48)));
     Node usx = nm->mkNode(APPLY_UF, us, x);
-    Node usx1 = nm->mkNode(APPLY_UF, us, nm->mkNode(PLUS,x,d_one));
-    
+    Node usx1 = nm->mkNode(APPLY_UF, us, nm->mkNode(PLUS, x, d_one));
+
     Node ten = nm->mkConst(Rational(10));
-    Node eqs = usx.eqNode( nm->mkNode( STRING_CONCAT, udx, usx1 ) );
-    Node eq = ux1.eqNode( nm->mkNode( PLUS, c, nm->mkNode( MULT, ten, ux ) ) );
-    Node cb = nm->mkNode( AND, nm->mkNode( GEQ, c, nm->mkNode( ITE, x.eqNode(d_zero), d_one, d_zero ) ), nm->mkNode( LT, c, ten));
-    
-    lem = nm->mkNode( OR, g.negate(), nm->mkNode( AND, eqs, eq, cb ) );
-    lem = nm->mkNode( FORALL, xbv, lem );
-    new_nodes.push_back( lem );
-    
+    Node eqs = usx.eqNode(nm->mkNode(STRING_CONCAT, udx, usx1));
+    Node eq = ux1.eqNode(nm->mkNode(PLUS, c, nm->mkNode(MULT, ten, ux)));
+    Node cb = nm->mkNode(
+        AND,
+        nm->mkNode(GEQ, c, nm->mkNode(ITE, x.eqNode(d_zero), d_one, d_zero)),
+        nm->mkNode(LT, c, ten));
+
+    lem = nm->mkNode(OR, g.negate(), nm->mkNode(AND, eqs, eq, cb));
+    lem = nm->mkNode(FORALL, xbv, lem);
+    new_nodes.push_back(lem);
+
     // assert:
     //   (n>=0) <=> (itost != "") ^
-    //   n = U( len( itost ) ) ^ U( 0 ) = 0 ^ 
+    //   n = U( len( itost ) ) ^ U( 0 ) = 0 ^
     //   "" = Us( len( itost ) ) ^ itost = Us( 0 ) ^
     //   forall x. (x>=0 ^ x < str.len(itost)) =>
     //     Us( x ) = Ud( x ) ++ Us( x+1 ) ^

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -249,9 +249,9 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     // In the above encoding, we use Us/Ud to introduce a chain of strings
     // that allow us to refer to each character substring of itost. Notice this
     // is more efficient than using str.substr( itost, x, 1 ).
-    // The function U is an accumulator, where U( x ) is the value of
+    // The function U is an accumulator, where U( x ) for x>0 is the value of
     // str.to.int( str.substr( int.to.str( n ), 0, x ) ). For example, for
-    // n=345, we have that U(0), U(1), U(2), U(3) = 0, 3, 34, 345.
+    // n=345, we have that U(1), U(2), U(3) = 3, 34, 345.
     // Above, we use str.code to map characters to their integer value, where
     // note that str.code( "0" ) = 48. Further notice that ite( x=0, 49, 48 )
     // enforces that int.to.str( n ) has no leading zeroes.

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -209,6 +209,7 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
                 argTypes, nm->integerType()),
               "uf type conv M");
     Node itosPre = nm->mkSkolem("itos_pre",nm->mkFunctionType(argTypes,nm->stringType()));
+    Node itosDigit = nm->mkSkolem("itos_digit",nm->mkFunctionType(argTypes,nm->stringType()));
     Node itosPost = nm->mkSkolem("itos_post",nm->mkFunctionType(argTypes,nm->stringType()));
 
     lem = num.eqNode(NodeManager::currentNM()->mkNode(kind::APPLY_UF, ufP, d_zero));
@@ -233,32 +234,14 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     Node cc4 = NodeManager::currentNM()->mkNode(kind::GEQ, nine, ufMx);
 
     Node b21 = nm->mkNode(APPLY_UF,itosPre,b1);
+    Node b2d = nm->mkNode(APPLY_UF,itosDigit,b1);
     Node b22 = nm->mkNode(APPLY_UF,itosPost,b1);
 
     Node c21 = NodeManager::currentNM()->mkNode(kind::STRING_LENGTH, b21).eqNode(
           NodeManager::currentNM()->mkNode(kind::MINUS, lenp, NodeManager::currentNM()->mkNode(kind::PLUS, b1, one) ));
-    Node ch =
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(0))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("0")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(1))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("1")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(2))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("2")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(3))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("3")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(4))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("4")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(5))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("5")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(6))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("6")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(7))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("7")),
-      NodeManager::currentNM()->mkNode(kind::ITE, ufMx.eqNode(NodeManager::currentNM()->mkConst(::CVC4::Rational(8))),
-      NodeManager::currentNM()->mkConst(::CVC4::String("8")),
-      NodeManager::currentNM()->mkConst(::CVC4::String("9")))))))))));
-    Node c22 = pret.eqNode( NodeManager::currentNM()->mkNode(kind::STRING_CONCAT, b21, ch, b22) );
-    Node cc5 = NodeManager::currentNM()->mkNode(kind::AND, c21, c22);
+    Node c22 = pret.eqNode( nm->mkNode(STRING_CONCAT, b21, b2d, b22) );
+    Node c2d = nm->mkNode( STRING_CODE, b2d ).eqNode( nm->mkNode( PLUS, ufMx, nm->mkConst(Rational(48))));
+    Node cc5 = nm->mkNode(AND, c21, c22, c2d);
     std::vector< Node > svec;
     svec.push_back(cc1);svec.push_back(cc2);
     svec.push_back(cc21);

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -210,8 +210,9 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     Node udx = nm->mkNode(APPLY_UF, ud, x);
     Node ux = nm->mkNode(APPLY_UF, u, x);
     Node ux1 = nm->mkNode(APPLY_UF, u, nm->mkNode(PLUS, x, d_one));
+    Node c0 = nm->mkNode(STRING_CODE, nm->mkConst(String("0")));
     Node c = nm->mkNode(
-        MINUS, nm->mkNode(STRING_CODE, udx), nm->mkConst(Rational(48)));
+        MINUS, nm->mkNode(STRING_CODE, udx), c0);
     Node usx = nm->mkNode(APPLY_UF, us, x);
     Node usx1 = nm->mkNode(APPLY_UF, us, nm->mkNode(PLUS, x, d_one));
 

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -182,7 +182,7 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     Node itost = d_sc->mkSkolemCached(t, SkolemCache::SK_PURIFY, "itost");
     Node leni = nm->mkNode(STRING_LENGTH, itost);
 
-    std::vector< Node > conc;
+    std::vector<Node> conc;
     std::vector< TypeNode > argTypes;
     argTypes.push_back(nm->integerType());
     Node u = nm->mkSkolem("U", nm->mkFunctionType(argTypes, nm->integerType()));
@@ -192,7 +192,7 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
         nm->mkSkolem("Ud", nm->mkFunctionType(argTypes, nm->stringType()));
 
     Node lem = n.eqNode(nm->mkNode(APPLY_UF, u, leni));
-    conc.push_back( lem );
+    conc.push_back(lem);
 
     lem = d_zero.eqNode(nm->mkNode(APPLY_UF, u, d_zero));
     conc.push_back(lem);
@@ -228,8 +228,9 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     conc.push_back(lem);
 
     Node nonneg = nm->mkNode(GEQ, n, d_zero);
-    
-    lem = nm->mkNode( ITE, nonneg, nm->mkNode( AND, conc ), itost.eqNode(d_empty_str));
+
+    lem = nm->mkNode(
+        ITE, nonneg, nm->mkNode(AND, conc), itost.eqNode(d_empty_str));
     new_nodes.push_back(lem);
     // assert:
     // IF n>=0

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -248,8 +248,9 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     // The function U is an accumulator, where U( x ) is the value of
     // str.to.int( str.substr( int.to.str( n ), 0, x ) ). For example, for
     // n=345, we have that U(0), U(1), U(2), U(3) = 0, 3, 34, 345.
-    // Notice that ite( x=0, 49, 48 ) enforces that int.to.str( n ) has no
-    // leading zeroes.
+    // Above, we use str.code to map characters to their integer value, where
+    // note that str.code( "0" ) = 48. Further notice that ite( x=0, 49, 48 )
+    // enforces that int.to.str( n ) has no leading zeroes.
     retNode = itost;
   } else if( t.getKind() == kind::STRING_STOI ) {
     Node str = t[0];

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -199,15 +199,17 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     Node ten = NodeManager::currentNM()->mkConst( ::CVC4::Rational(10) );
 
     std::vector< TypeNode > argTypes;
-    argTypes.push_back(NodeManager::currentNM()->integerType());
-    Node ufP = NodeManager::currentNM()->mkSkolem("ufP",
-              NodeManager::currentNM()->mkFunctionType(
-                argTypes, NodeManager::currentNM()->integerType()),
+    argTypes.push_back(nm->integerType());
+    Node ufP = nm->mkSkolem("ufP",
+              nm->mkFunctionType(
+                argTypes, nm->integerType()),
               "uf type conv P");
-    Node ufM = NodeManager::currentNM()->mkSkolem("ufM",
-              NodeManager::currentNM()->mkFunctionType(
-                argTypes, NodeManager::currentNM()->integerType()),
+    Node ufM = nm->mkSkolem("ufM",
+              nm->mkFunctionType(
+                argTypes, nm->integerType()),
               "uf type conv M");
+    Node itosPre = nm->mkSkolem("itos_pre",nm->mkFunctionType(argTypes,nm->stringType()));
+    Node itosPost = nm->mkSkolem("itos_post",nm->mkFunctionType(argTypes,nm->stringType()));
 
     lem = num.eqNode(NodeManager::currentNM()->mkNode(kind::APPLY_UF, ufP, d_zero));
     new_nodes.push_back( lem );
@@ -230,9 +232,8 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     Node cc3 = NodeManager::currentNM()->mkNode(kind::GEQ, ufMx, d_zero);
     Node cc4 = NodeManager::currentNM()->mkNode(kind::GEQ, nine, ufMx);
 
-    Node b21 = NodeManager::currentNM()->mkBoundVar(NodeManager::currentNM()->stringType());
-    Node b22 = NodeManager::currentNM()->mkBoundVar(NodeManager::currentNM()->stringType());
-    Node b2v = NodeManager::currentNM()->mkNode(kind::BOUND_VAR_LIST, b21, b22);
+    Node b21 = nm->mkNode(APPLY_UF,itosPre,b1);
+    Node b22 = nm->mkNode(APPLY_UF,itosPost,b1);
 
     Node c21 = NodeManager::currentNM()->mkNode(kind::STRING_LENGTH, b21).eqNode(
           NodeManager::currentNM()->mkNode(kind::MINUS, lenp, NodeManager::currentNM()->mkNode(kind::PLUS, b1, one) ));
@@ -257,7 +258,7 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
       NodeManager::currentNM()->mkConst(::CVC4::String("8")),
       NodeManager::currentNM()->mkConst(::CVC4::String("9")))))))))));
     Node c22 = pret.eqNode( NodeManager::currentNM()->mkNode(kind::STRING_CONCAT, b21, ch, b22) );
-    Node cc5 = NodeManager::currentNM()->mkNode(kind::EXISTS, b2v, NodeManager::currentNM()->mkNode(kind::AND, c21, c22));
+    Node cc5 = NodeManager::currentNM()->mkNode(kind::AND, c21, c22);
     std::vector< Node > svec;
     svec.push_back(cc1);svec.push_back(cc2);
     svec.push_back(cc21);

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -211,8 +211,7 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
     Node ux = nm->mkNode(APPLY_UF, u, x);
     Node ux1 = nm->mkNode(APPLY_UF, u, nm->mkNode(PLUS, x, d_one));
     Node c0 = nm->mkNode(STRING_CODE, nm->mkConst(String("0")));
-    Node c = nm->mkNode(
-        MINUS, nm->mkNode(STRING_CODE, udx), c0);
+    Node c = nm->mkNode(MINUS, nm->mkNode(STRING_CODE, udx), c0);
     Node usx = nm->mkNode(APPLY_UF, us, x);
     Node usx1 = nm->mkNode(APPLY_UF, us, nm->mkNode(PLUS, x, d_one));
 


### PR DESCRIPTION
This improves the reduction for int.to.str in two ways:
- Previously, we introduced unbounded nested quantification on strings, this is now explicitly skolemized. This fixes #2626.
- Use str.code instead of an ITE-chain, so that digits are handled symbolically instead of doing a literal case split on the 10 digits.