### PR TITLE
Improve strings reductions including skolem caching for contains

### DIFF
--- a/src/theory/strings/skolem_cache.cpp
+++ b/src/theory/strings/skolem_cache.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/strings/skolem_cache.h"
 
+#include "theory/rewriter.h"
+
 namespace CVC4 {
 namespace theory {
 namespace strings {
@@ -22,6 +24,8 @@ SkolemCache::SkolemCache() {}
 
 Node SkolemCache::mkSkolemCached(Node a, Node b, SkolemId id, const char* c)
 {
+  a = Rewriter::rewrite( a );
+  b = Rewriter::rewrite( b );
   std::map<SkolemId, Node>::iterator it = d_skolemCache[a][b].find(id);
   if (it == d_skolemCache[a][b].end())
   {

--- a/src/theory/strings/skolem_cache.cpp
+++ b/src/theory/strings/skolem_cache.cpp
@@ -24,8 +24,8 @@ SkolemCache::SkolemCache() {}
 
 Node SkolemCache::mkSkolemCached(Node a, Node b, SkolemId id, const char* c)
 {
-  a = Rewriter::rewrite(a);
-  b = Rewriter::rewrite(b);
+  a = a.isNull() ? a : Rewriter::rewrite(a);
+  b = b.isNull() ? b : Rewriter::rewrite(b);
   std::map<SkolemId, Node>::iterator it = d_skolemCache[a][b].find(id);
   if (it == d_skolemCache[a][b].end())
   {

--- a/src/theory/strings/skolem_cache.cpp
+++ b/src/theory/strings/skolem_cache.cpp
@@ -24,8 +24,8 @@ SkolemCache::SkolemCache() {}
 
 Node SkolemCache::mkSkolemCached(Node a, Node b, SkolemId id, const char* c)
 {
-  a = Rewriter::rewrite( a );
-  b = Rewriter::rewrite( b );
+  a = Rewriter::rewrite(a);
+  b = Rewriter::rewrite(b);
   std::map<SkolemId, Node>::iterator it = d_skolemCache[a][b].find(id);
   if (it == d_skolemCache[a][b].end())
   {

--- a/src/theory/strings/skolem_cache.h
+++ b/src/theory/strings/skolem_cache.h
@@ -65,10 +65,6 @@ class SkolemCache
     //    exists k. len( k )>0 ^ ( a ++ k = b OR a = b ++ k )
     SK_ID_V_SPT,
     SK_ID_V_SPT_REV,
-    // contains( a, b ) =>
-    //    exists k_pre, k_post. a = k_pre ++ b ++ k_post
-    SK_ID_CTN_PRE,
-    SK_ID_CTN_POST,
     // a != ""  ^ b = "c" ^ a ++ a' != b ++ b' =>
     //    exists k, k_rem.
     //         len( k ) = 1 ^
@@ -85,6 +81,15 @@ class SkolemCache
     // contains( a, b ) =>
     //    exists k_pre, k_post. a = k_pre ++ b ++ k_post ^
     //                          ~contains(k_pre ++ substr( b, 0, len(b)-1 ), b)
+    //
+    // As an optimization, these skolems are reused for positive occurrences of
+    // contains, where they have the semantics:
+    //
+    //   contains( a, b ) =>
+    //      exists k_pre, k_post. a = k_pre ++ b ++ k_post
+    //
+    // We reuse them since it is sound to consider w.l.o.g. the first occurrence
+    // of b in a as the witness for contains( a, b ).
     SK_FIRST_CTN_PRE,
     SK_FIRST_CTN_POST,
     // For integer b,

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -453,9 +453,9 @@ int TheoryStrings::getReduction( int effort, Node n, Node& nr ) {
           Node s = n[1];
           //positive contains reduces to a equality
           Node sk1 = d_sk_cache.mkSkolemCached(
-              x, s, SkolemCache::SK_ID_CTN_PRE, "sc1");
+              x, s, SkolemCache::SK_FIRST_CTN_PRE, "sc1");
           Node sk2 = d_sk_cache.mkSkolemCached(
-              x, s, SkolemCache::SK_ID_CTN_POST, "sc2");
+              x, s, SkolemCache::SK_FIRST_CTN_POST, "sc2");
           Node eq = Rewriter::rewrite( x.eqNode( mkConcat( sk1, s, sk2 ) ) );
           std::vector< Node > exp_vec;
           exp_vec.push_back( n );

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -983,7 +983,7 @@ void TheoryStrings::checkExtfReductions( int effort ) {
     int ret = getReduction( effort, n, nr );
     Assert( nr.isNull() );
     if( ret!=0 ){
-      getExtTheory()->markReduced( extf[i] );
+      getExtTheory()->markReduced( extf[i], false );
       if (hasProcessed())
       {
         return;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -395,7 +395,8 @@ bool TheoryStrings::getCurrentSubstitution( int effort, std::vector< Node >& var
   return true;
 }
 
-bool TheoryStrings::doReduction( int effort, Node n, bool& isCd ) {
+bool TheoryStrings::doReduction(int effort, Node n, bool& isCd)
+{
   //determine the effort level to process the extf at
   // 0 - at assertion time, 1+ - after no other reduction is applicable
   Assert( d_extf_info_tmp.find( n )!=d_extf_info_tmp.end() );
@@ -419,9 +420,10 @@ bool TheoryStrings::doReduction( int effort, Node n, bool& isCd ) {
           Node lens = getLength( s, lexp );
           if( areEqual( lenx, lens ) ){
             Trace("strings-extf-debug") << "  resolve extf : " << n << " based on equal lengths disequality." << std::endl;
-            Trace("strings-extf-debug") << "Lengths : " << lenx << " " << lens << std::endl;
-            // We can reduce negative contains to a disequality when lengths are equal.
-            // In other words, len( x ) = len( s ) implies 
+            Trace("strings-extf-debug")
+                << "Lengths : " << lenx << " " << lens << std::endl;
+            // We can reduce negative contains to a disequality when lengths are
+            // equal. In other words, len( x ) = len( s ) implies
             //   ~contains( x, s ) reduces to x != s.
             if( !areDisequal( x, s ) ){
               // len( x ) = len( s ) ^ ~contains( x, s ) => x != s
@@ -430,7 +432,8 @@ bool TheoryStrings::doReduction( int effort, Node n, bool& isCd ) {
               Node xneqs = x.eqNode(s).negate();
               sendInference( lexp, xneqs, "NEG-CTN-EQL", true );
             }
-            // this depends on the current assertions, so we set that this inference is context-dependent.
+            // this depends on the current assertions, so we set that this
+            // inference is context-dependent.
             isCd = true;
             return true;
           }else{
@@ -988,9 +991,10 @@ void TheoryStrings::checkExtfReductions( int effort ) {
                              << d_extf_info_tmp[n].d_model_active << std::endl;
     // whether the reduction was context-dependent
     bool isCd = false;
-    bool ret = doReduction( effort, n, isCd );
-    if( ret ){
-      getExtTheory()->markReduced( extf[i], isCd );
+    bool ret = doReduction(effort, n, isCd);
+    if (ret)
+    {
+      getExtTheory()->markReduced(extf[i], isCd);
       if (hasProcessed())
       {
         return;

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -163,7 +163,13 @@ class TheoryStrings : public Theory {
                               std::vector<Node>& vars,
                               std::vector<Node>& subs,
                               std::map<Node, std::vector<Node> >& exp) override;
-  int getReduction(int effort, Node n, Node& nr) override;
+  //--------------------------for checkExtfReductions
+  /** do reduction 
+   * 
+   * 
+   */
+  bool doReduction(int effort, Node n, bool& isCd);
+  //--------------------------end for checkExtfReductions
 
   // NotifyClass for equality engine
   class NotifyClass : public eq::EqualityEngineNotify {

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -164,9 +164,9 @@ class TheoryStrings : public Theory {
                               std::vector<Node>& subs,
                               std::map<Node, std::vector<Node> >& exp) override;
   //--------------------------for checkExtfReductions
-  /** do reduction 
-   * 
-   * 
+  /** do reduction
+   *
+   *
    */
   bool doReduction(int effort, Node n, bool& isCd);
   //--------------------------end for checkExtfReductions

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -166,7 +166,12 @@ class TheoryStrings : public Theory {
   //--------------------------for checkExtfReductions
   /** do reduction
    *
-   *
+   * This is called when an extended function application n is not able to be
+   * simplified by context-depdendent simplification, and we are resorting to
+   * expanding n to its full semantics via a reduction. This method returns
+   * true if it successfully reduced n by some reduction and sets isCd to
+   * true if the reduction was (SAT)-context-dependent, and false otherwise.
+   * The argument effort has the same meaning as in checkExtfReductions.
    */
   bool doReduction(int effort, Node n, bool& isCd);
   //--------------------------end for checkExtfReductions

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -120,6 +120,8 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
                          x,
                          n,
                          nm->mkNode(MINUS, nm->mkNode(STRING_LENGTH, x), n));
+    // must rewrite before looking into cache
+    st = Rewriter::rewrite(st);
     Node io2 =
         d_sc->mkSkolemCached(st, y, SkolemCache::SK_FIRST_CTN_PRE, "iopre");
     Node io4 =

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -120,8 +120,6 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
                          x,
                          n,
                          nm->mkNode(MINUS, nm->mkNode(STRING_LENGTH, x), n));
-    // must rewrite before looking into cache
-    st = Rewriter::rewrite(st);
     Node io2 =
         d_sc->mkSkolemCached(st, y, SkolemCache::SK_FIRST_CTN_PRE, "iopre");
     Node io4 =


### PR DESCRIPTION
This PR:
- Merges the skolems for positive contains and replace/indexof.
- Rewrites terms before looking up skolems in the cache.
- Marks (when appropriate) reductions as SAT-context-independent, which leads to fewer extraneous inferences.

It is a net +250 on the CMU CAV 2017 set. As an estimate, +220 of these or so can be attributed to the first optimization, +30 to the third.