### PR TITLE
BV rewrites (mined): Rule 35: ConcatPullUp (BITVECTOR_OR) with special const.

### DIFF
--- a/src/theory/bv/theory_bv_rewrite_rules.h
+++ b/src/theory/bv/theory_bv_rewrite_rules.h
@@ -119,7 +119,7 @@ enum RewriteRuleId
   BitwiseIdemp,
   AndZero,
   AndOne,
-  AndConcatPullUp,
+  AndOrConcatPullUp,
   OrZero,
   OrOne,
   XorDuplicate,
@@ -201,7 +201,7 @@ inline std::ostream& operator << (std::ostream& out, RewriteRuleId ruleId) {
   case ConcatFlatten:       out << "ConcatFlatten";       return out;
   case ConcatExtractMerge:  out << "ConcatExtractMerge";  return out;
   case ConcatConstantMerge: out << "ConcatConstantMerge"; return out;
-  case AndConcatPullUp:     out << "AndConcatPullUp";     return out;
+  case AndOrConcatPullUp:   out << "AndOrConcatPullUp";   return out;
   case ExtractExtract:      out << "ExtractExtract";      return out;
   case ExtractWhole:        out << "ExtractWhole";        return out;
   case ExtractConcat:       out << "ExtractConcat";       return out;
@@ -581,7 +581,7 @@ struct AllRewriteRules {
   RewriteRule<BvIteMergeElseIf>               rule136;
   RewriteRule<BvIteMergeThenElse>             rule137;
   RewriteRule<BvIteMergeElseElse>             rule138;
-  RewriteRule<AndConcatPullUp>                rule139;
+  RewriteRule<AndOrConcatPullUp>              rule139;
 };
 
 template<> inline

--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -571,7 +571,7 @@ inline Node RewriteRule<AndOrConcatPullUp>::apply(TNode node)
   NodeBuilder<> yb(kind::BITVECTOR_CONCAT);
   NodeBuilder<> zb(kind::BITVECTOR_CONCAT);
   NodeBuilder<> res(kind::BITVECTOR_CONCAT);
-  NodeManager *nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
 
   for (const TNode& child : node)
   {
@@ -647,20 +647,20 @@ inline Node RewriteRule<AndOrConcatPullUp>::apply(TNode node)
     else
     {
       Assert(kind == kind::BITVECTOR_OR);
-      res << utils::mkExtract(x, m-my-1, mz);
+      res << utils::mkExtract(x, m - my - 1, mz);
     }
   }
   else if (is_const == 1)
   {
     if (kind == kind::BITVECTOR_AND)
     {
-      if (n > 1) res << utils::mkZero(n-1);
+      if (n > 1) res << utils::mkZero(n - 1);
       res << utils::mkExtract(x, mz, mz);
     }
     else
     {
       Assert(kind == kind::BITVECTOR_OR);
-      if (n > 1) res << utils::mkExtract(x, m-my-1, mz+1);
+      if (n > 1) res << utils::mkExtract(x, m - my - 1, mz + 1);
       res << utils::mkOne(1);
     }
   }
@@ -669,7 +669,7 @@ inline Node RewriteRule<AndOrConcatPullUp>::apply(TNode node)
     Assert(is_const == -1);
     if (kind == kind::BITVECTOR_AND)
     {
-      res << utils::mkExtract(x, m-my-1, mz);
+      res << utils::mkExtract(x, m - my - 1, mz);
     }
     else
     {
@@ -679,7 +679,7 @@ inline Node RewriteRule<AndOrConcatPullUp>::apply(TNode node)
   }
   if (mz)
   {
-    res << nm->mkNode(kind, utils::mkExtract(x, m - my - n - 1, 0), z);
+    res << nm->mkNode(kind, utils::mkExtract(x, mz - 1, 0), z);
   }
   return res;
 }

--- a/src/theory/bv/theory_bv_rewrite_rules_simplification.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_simplification.h
@@ -489,27 +489,51 @@ Node RewriteRule<AndOne>::apply(TNode node) {
 /* -------------------------------------------------------------------------- */
 
 /**
- * AndConcatPullUp
+ * AndOrConcatPullUp
  *
- * Match:       x_m & concat(y_my, 0_n, z_mz)
- * Rewrites to: concat(x[m-1:m-my] & y, 0_n, x[m-my-n-1:0] & z)
+ * And:
+ * ----------------------------------------------------------------
+ *   Match:       x_m & concat(y_my, 0_n, z_mz)
+ *   Rewrites to: concat(x[m-1:m-my] & y, 0_n, x[m-my-n-1:0] & z)
  *
- * Match:       x_m & concat(y_my, 1_n, z_mz)
- * Rewrites to: concat(x[m-1:m-my] & y,
- *                     0_[n-1],
- *                     x[m-my-n:m-my-n],
- *                     x[m-my-n-1:0] & z)
+ *   Match:       x_m & concat(y_my, 1_n, z_mz)
+ *   Rewrites to: concat(x[m-1:m-my] & y,
+ *                       0_[n-1],
+ *                       x[m-my-n:m-my-n],
+ *                       x[m-my-n-1:0] & z)
  *
- * Match:       x_m & concat(y_my, ~0_n, z_mz)
- * Rewrites to: concat(x[m-1:m-my] & y,
+ *   Match:       x_m & concat(y_my, ~0_n, z_mz)
+ *   Rewrites to: concat(x[m-1:m-my] & y,
  *                     x[m-my-1:m-my-n],
  *                     x[m-my-n-1:0] & z)
+ *
+ * Or:
+ * ----------------------------------------------------------------
+ *   Match:       x_m | concat(y_my, 0_n, z_mz)
+ *   Rewrites to: concat(x[m-1:m-my] | y,
+ *                       x[m-my-1:m-my-n],
+ *                       x[m-my-n-1:0] | z)
+ *
+ *   Match:       x_m | concat(y_my, 1_n, z_mz)
+ *   Rewrites to: concat(x[m-1:m-my] | y,
+ *                       x[m-my-1:m-my-n+1],
+ *                       1_1,
+ *                       x[m-my-n-1:0] | z)
+ *
+ *   Match:       x_m | concat(y_my, ~0_n, z_mz)
+ *   Rewrites to: concat(x[m-1:m-my] | y,
+ *                       ~0_n,
+ *                       x[m-my-n-1:0] | z)
  */
 
 template <>
-inline bool RewriteRule<AndConcatPullUp>::applies(TNode node)
+inline bool RewriteRule<AndOrConcatPullUp>::applies(TNode node)
 {
-  if (node.getKind() != kind::BITVECTOR_AND) return false;
+  if (node.getKind() != kind::BITVECTOR_AND
+      && node.getKind() != kind::BITVECTOR_OR)
+  {
+    return false;
+  }
 
   TNode n;
 
@@ -533,20 +557,24 @@ inline bool RewriteRule<AndConcatPullUp>::applies(TNode node)
 }
 
 template <>
-inline Node RewriteRule<AndConcatPullUp>::apply(TNode node)
+inline Node RewriteRule<AndOrConcatPullUp>::apply(TNode node)
 {
-  Debug("bv-rewrite") << "RewriteRule<AndConcatPullUp>(" << node << ")"
+  Debug("bv-rewrite") << "RewriteRule<AndOrConcatPullUp>(" << node << ")"
                       << std::endl;
   int32_t is_const;
   uint32_t m, my, mz, n;
   size_t nc;
+  Kind kind;
   TNode concat;
   Node x, y, z, c;
-  NodeBuilder<> xb(kind::BITVECTOR_AND);
+  NodeBuilder<> xb;
   NodeBuilder<> yb(kind::BITVECTOR_CONCAT);
   NodeBuilder<> zb(kind::BITVECTOR_CONCAT);
   NodeBuilder<> res(kind::BITVECTOR_CONCAT);
   NodeManager *nm = NodeManager::currentNM();
+
+  kind = node.getKind();
+  xb.clear(kind);
 
   for (const TNode& child : node)
   {
@@ -611,27 +639,50 @@ inline Node RewriteRule<AndConcatPullUp>::apply(TNode node)
 
   if (my)
   {
-    res << nm->mkNode(
-        kind::BITVECTOR_AND, utils::mkExtract(x, m - 1, m - my), y);
+    res << nm->mkNode(kind, utils::mkExtract(x, m - 1, m - my), y);
   }
   if (is_const == 0)
   {
-    res << c;
+    if (kind == kind::BITVECTOR_AND)
+    {
+      res << c;
+    }
+    else
+    {
+      Assert(kind == kind::BITVECTOR_OR);
+      res << utils::mkExtract(x, m-my-1, m-my-n);
+    }
   }
   else if (is_const == 1)
   {
-    if (n > 1) res << utils::mkZero(n-1);
-    res << utils::mkExtract(x, m-my-n, m-my-n);
+    if (kind == kind::BITVECTOR_AND)
+    {
+      if (n > 1) res << utils::mkZero(n-1);
+      res << utils::mkExtract(x, m-my-n, m-my-n);
+    }
+    else
+    {
+      Assert(kind == kind::BITVECTOR_OR);
+      if (n > 1) res << utils::mkExtract(x, m-my-1, m-my-n+1);
+      res << utils::mkOne(1);
+    }
   }
   else
   {
     Assert(is_const == -1);
-    res << utils::mkExtract(x, m-my-1, m-my-n);
+    if (kind == kind::BITVECTOR_AND)
+    {
+      res << utils::mkExtract(x, m-my-1, m-my-n);
+    }
+    else
+    {
+      Assert(kind == kind::BITVECTOR_OR);
+      res << c;
+    }
   }
   if (mz)
   {
-    res << nm->mkNode(
-        kind::BITVECTOR_AND, utils::mkExtract(x, m - my - n - 1, 0), z);
+    res << nm->mkNode(kind, utils::mkExtract(x, m - my - n - 1, 0), z);
   }
   return res;
 }

--- a/src/theory/bv/theory_bv_rewriter.cpp
+++ b/src/theory/bv/theory_bv_rewriter.cpp
@@ -253,8 +253,7 @@ RewriteResponse TheoryBVRewriter::RewriteAnd(TNode node, bool prerewrite)
   resultNode =
       LinearRewriteStrategy<RewriteRule<FlattenAssocCommutNoDuplicates>,
                             RewriteRule<AndSimplify>,
-                            RewriteRule<AndConcatPullUp>>::apply(node);
-
+                            RewriteRule<AndOrConcatPullUp>>::apply(node);
   if (!prerewrite)
   {
     resultNode =
@@ -269,24 +268,26 @@ RewriteResponse TheoryBVRewriter::RewriteAnd(TNode node, bool prerewrite)
   return RewriteResponse(REWRITE_DONE, resultNode);
 }
 
-RewriteResponse TheoryBVRewriter::RewriteOr(TNode node, bool prerewrite){
+RewriteResponse TheoryBVRewriter::RewriteOr(TNode node, bool prerewrite)
+{
   Node resultNode = node;
-  resultNode = LinearRewriteStrategy
-    < RewriteRule<FlattenAssocCommutNoDuplicates>,
-      RewriteRule<OrSimplify>
-      >::apply(node);
+  resultNode =
+      LinearRewriteStrategy<RewriteRule<FlattenAssocCommutNoDuplicates>,
+                            RewriteRule<OrSimplify>,
+                            RewriteRule<AndOrConcatPullUp>>::apply(node);
 
-  if (!prerewrite) {
-    resultNode = LinearRewriteStrategy
-      < RewriteRule<BitwiseSlicing>
-        >::apply(resultNode);
-    
-    if (resultNode.getKind() != node.getKind()) {
-      return RewriteResponse(REWRITE_AGAIN_FULL, resultNode); 
+  if (!prerewrite)
+  {
+    resultNode =
+        LinearRewriteStrategy<RewriteRule<BitwiseSlicing>>::apply(resultNode);
+
+    if (resultNode.getKind() != node.getKind())
+    {
+      return RewriteResponse(REWRITE_AGAIN_FULL, resultNode);
     }
   }
-  
-  return RewriteResponse(REWRITE_DONE, resultNode); 
+
+  return RewriteResponse(REWRITE_DONE, resultNode);
 }
 
 RewriteResponse TheoryBVRewriter::RewriteXor(TNode node, bool prerewrite) {


### PR DESCRIPTION
Match:       `x_m | concat(y_my, 0_n, z_mz)`
Rewrites to: `concat(x[m-1:m-my] | y, x[m-my-1:m-my-n], x[m-my-n-1:0] | z)`

Match:       `x_m | concat(y_my, 1_n, z_mz)`
Rewrites to: `concat(x[m-1:m-my] | y, x[m-my-1:m-my-n+1], 1_1, x[m-my-n-1:0] | z)`

Match:       `x_m | concat(y_my, ~0_n, z_mz)`
Rewrites to: `concat(x[m-1:m-my] | y, ~0_n, x[m-my-n-1:0] | z)`

On QF_BV with eager and CaDiCaL (time limit 600s, penalty 600s):
```
          | CVC4-base                              | CVC4-concatpullup-or                     |
BENCHMARK | SLVD   SAT   UNSAT   TO   MO   CPU[s]  | SLVD   SAT   UNSAT   TO  MO   CPU[s]  |
   totals | 38992 13844  25148  1082  28  984887.4 | 39028 13845  25183  1046 28  974819.1 |
```
