### PR TITLE
Show if ASAN build in --show-config

### DIFF
--- a/src/base/configuration.cpp
+++ b/src/base/configuration.cpp
@@ -82,6 +82,8 @@ bool Configuration::isProfilingBuild() {
   return IS_PROFILING_BUILD;
 }
 
+bool Configuration::isAsanBuild() { return IS_ASAN_BUILD; }
+
 bool Configuration::isCompetitionBuild() {
   return IS_COMPETITION_BUILD;
 }

--- a/src/base/configuration.h
+++ b/src/base/configuration.h
@@ -63,6 +63,8 @@ public:
 
   static bool isProfilingBuild();
 
+  static bool isAsanBuild();
+
   static bool isCompetitionBuild();
 
   static std::string getPackageName();

--- a/src/base/configuration_private.h
+++ b/src/base/configuration_private.h
@@ -150,6 +150,22 @@ namespace CVC4 {
 #  define IS_GPL_BUILD false
 #endif /* CVC4_GPL_DEPS */
 
+#define IS_ASAN_BUILD false
+
+// GCC test
+#if defined(__SANITIZE_ADDRESS__)
+#  undef IS_ASAN_BUILD
+#  define IS_ASAN_BUILD true
+#endif /* defined(__SANITIZE_ADDRESS__) */
+
+// Clang test
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+#    undef IS_ASAN_BUILD
+#    define IS_ASAN_BUILD true
+#  endif /* __has_feature(address_sanitizer) */
+#endif /* defined(__has_feature) */
+
 }/* CVC4 namespace */
 
 #endif /* __CVC4__CONFIGURATION_PRIVATE_H */

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -1685,6 +1685,7 @@ void OptionsHandler::showConfiguration(std::string option) {
   print_config_cond("proof", Configuration::isProofBuild());
   print_config_cond("coverage", Configuration::isCoverageBuild());
   print_config_cond("profiling", Configuration::isProfilingBuild());
+  print_config_cond("asan", Configuration::isAsanBuild());
   print_config_cond("competition", Configuration::isCompetitionBuild());
   
   std::cout << std::endl;

--- a/test/unit/memory.h
+++ b/test/unit/memory.h
@@ -36,6 +36,7 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 
+#include "base/configuration_private.h"
 #include "base/cvc4_assert.h"
 
 // Conditionally define CVC4_MEMORY_LIMITING_DISABLED.
@@ -43,28 +44,14 @@
 #  define CVC4_MEMORY_LIMITING_DISABLED 1
 #  define CVC4_MEMORY_LIMITING_DISABLED_REASON "setrlimit() is broken on Mac."
 #else /* __APPLE__ */
-// Clang test
-#  if defined(__has_feature)
-#    if __has_feature(address_sanitizer)
-#      define _IS_ASAN_BUILD
-#    endif /* __has_feature(address_sanitizer) */
-#  endif /* defined(__has_feature) */
-
-// GCC test
-#  if defined(__SANITIZE_ADDRESS__)
-#    define _IS_ASAN_BUILD
-#  endif /* defined(__SANITIZE_ADDRESS__) */
 
 // Tests cannot expect bad_alloc to be thrown due to limit memory using
 // setrlimit when ASAN is enable. ASAN instead aborts on mmap failures.
-#  if defined(_IS_ASAN_BUILD)
+#  if IS_ASAN_BUILD
 #    define CVC4_MEMORY_LIMITING_DISABLED 1
 #    define CVC4_MEMORY_LIMITING_DISABLED_REASON "ASAN's mmap failures abort."
-#    undef _IS_ASAN_BUILD
-#  endif /* defined(_IS_ASAN_BUILD) */
+#  endif
 #endif
-
-
 
 namespace CVC4 {
 namespace test {


### PR DESCRIPTION
This commit extends `--show-config` to show whether the current build is
an ASAN build or not. This is done by moving a detection that was
previously done for the unit tests into base/configuration_private.h.

In addition to being convenient, this allows us to easily exclude
regression tests from ASAN builds.