### PR TITLE
Recover from wrong use of get-info :reason-unknown

### DIFF
--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -2438,6 +2438,10 @@ void GetInfoCommand::invoke(SmtEngine* smtEngine)
   {
     d_commandStatus = new CommandUnsupported();
   }
+  catch (RecoverableModalException& e)
+  {
+    d_commandStatus = new CommandRecoverableFailure(e.what());
+  }
   catch (exception& e)
   {
     d_commandStatus = new CommandFailure(e.what());

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2412,8 +2412,9 @@ CVC4::SExpr SmtEngine::getInfo(const std::string& key) const {
       transform(s.begin(), s.end(), s.begin(), ::tolower);
       return SExpr(SExpr::Keyword(s));
     } else {
-      throw ModalException("Can't get-info :reason-unknown when the "
-                           "last result wasn't unknown!");
+      throw RecoverableModalException(
+          "Can't get-info :reason-unknown when the "
+          "last result wasn't unknown!");
     }
   } else if(key == "assertion-stack-levels") {
     AlwaysAssert(d_userLevels.size() <=

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -801,6 +801,7 @@ set(regress_0_tests
   regress0/smallcnf.cvc
   regress0/smt2output.smt2
   regress0/smtlib/get-unsat-assumptions.smt2
+  regress0/smtlib/reason-unknown.smt2
   regress0/strings/bug001.smt2
   regress0/strings/bug002.smt2
   regress0/strings/bug612.smt2

--- a/test/regress/regress0/smtlib/reason-unknown.smt2
+++ b/test/regress/regress0/smtlib/reason-unknown.smt2
@@ -1,0 +1,5 @@
+; EXPECT: (error "Can't get-info :reason-unknown when the last result wasn't unknown!")
+; EXPECT: sat
+(set-logic QF_SAT)
+(get-info :reason-unknown)
+(check-sat)


### PR DESCRIPTION
Fixes #2584. Currently, we are immediately terminating CVC4 if the user
issues a `(get-info :reason-unknown)` command if it didn't succeed a
`(check-sat)` call returning `unknown`. This commit changes the behavior
to return an `(error ...)` but continue executing afterwards. It turns
the `ModalException` thrown in this case into a
`RecoverableModalException` and adds a check in
`GetInfoCommand::invoke()` to turn it into a
`CommandRecoverableFailure`, which solves the issue.