### PR TITLE
CMake: Set RPATH on installed binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,17 @@ set(CMAKE_CXX_STANDARD 11)
 # plugins.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Embed the installation prefix as an RPATH in the executable such that the
+# linker can find our libraries (such as libcvc4parser) when executing the cvc4
+# binary. This is for example useful when installing CVC4 with a custom prefix
+# on macOS (e.g. when using homebrew in a non-standard directory). If we do not
+# set this option, then the linker will not be able to find the required
+# libraries when trying to run CVC4.
+#
+# More information on RPATH in CMake:
+# https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
 #-----------------------------------------------------------------------------#
 
 include(Helpers)


### PR DESCRIPTION
Currently, when installing CVC4 with a custom installation directory on
macOS, the resulting binary cannot be executed because the linker cannot
find the required libraries (e.g. our parser). This commit changes our
build system to use the `CMAKE_INSTALL_RPATH` variable to add the
installation directory to the RPATH list in the exectuable.