### PR TITLE
Sketch of refactoring the Commands to use new API

### DIFF
--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -2520,16 +2520,20 @@ class CVC4_PUBLIC Solver
    * Get the value of the given term.
    * SMT-LIB: ( get-value ( <term> ) )
    * @param term the term for which the value is queried
-   * @return the value of the given term
+   * @return a pair (t v) where t is \p term (or its expanded definition) and v
+   * is an equivalent value term according to the current model
    */
   Term getValue(Term term) const;
+
   /**
    * Get the values of the given terms.
    * SMT-LIB: ( get-value ( <term>+ ) )
    * @param terms the terms for which the value is queried
-   * @return the values of the given terms
+   * @return a sequnece of pairs ((t1 v1) ... (tn vn)) where each ti
+   * corresponds to one of the \p terms (or its expanded definition) and vi is
+   * is an equivalent value term according to the current model
    */
-  std::vector<Term> getValue(const std::vector<Term>& terms) const;
+  Term getValue(const std::vector<Term>& terms) const;
 
   /**
    * Pop (a) level(s) from the assertion stack.
@@ -2594,6 +2598,10 @@ class CVC4_PUBLIC Solver
   // !!! This is only temporarily available until the parser is fully migrated
   // to the new API. !!!
   SmtEngine* getSmtEngine(void) const;
+
+  // !!! This is only temporarily available until the parser is fully migrated
+  // to the new API. !!!
+  static std::vector<Term> exprVectorToTerms(const std::vector<Expr>& exprs);
 
  private:
   /* Helper to convert a vector of internal types to sorts. */

--- a/src/api/cvc4cppkind.h
+++ b/src/api/cvc4cppkind.h
@@ -149,9 +149,9 @@ enum CVC4_PUBLIC Kind : int32_t
 #if 0
   /* Skolem variable (internal only) */
   SKOLEM,
+#endif
   /* Symbolic expression (any arity) */
   SEXPR,
-#endif
   /**
    * Lambda expression.
    * Parameters: 2

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -118,9 +118,9 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
 {
   bool status = true;
   if(d_options.getVerbosity() >= -1) {
-    status = smtEngineInvoke(d_smtEngine, cmd, d_options.getOut());
+    status = smtEngineInvoke(d_solver, cmd, d_options.getOut());
   } else {
-    status = smtEngineInvoke(d_smtEngine, cmd, NULL);
+    status = smtEngineInvoke(d_solver, cmd, NULL);
   }
 
   Result res;
@@ -192,17 +192,18 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
   return status;
 }
 
-bool smtEngineInvoke(SmtEngine* smt, Command* cmd, std::ostream *out)
+bool smtEngineInvoke(api::Solver* solver, Command* cmd, std::ostream* out)
 {
   if(out == NULL) {
-    cmd->invoke(smt);
+    cmd->invoke(solver);
   } else {
-    cmd->invoke(smt, *out);
+    cmd->invoke(solver, *out);
   }
   // ignore the error if the command-verbosity is 0 for this command
   std::string commandName =
       std::string("command-verbosity:") + cmd->getCommandName();
-  if(smt->getOption(commandName).getIntegerValue() == 0) {
+  if (solver->getSmtEngine()->getOption(commandName).getIntegerValue() == 0)
+  {
     return true;
   }
   return !cmd->fail();

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -99,7 +99,7 @@ private:
 
 };/* class CommandExecutor */
 
-bool smtEngineInvoke(SmtEngine* smt, Command* cmd, std::ostream *out);
+bool smtEngineInvoke(api::Solver* smt, Command* cmd, std::ostream* out);
 
 }/* CVC4::main namespace */
 }/* CVC4 namespace */

--- a/src/main/command_executor_portfolio.cpp
+++ b/src/main/command_executor_portfolio.cpp
@@ -228,7 +228,8 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
       cmd : cmd->exportTo(d_exprMgrs[d_lastWinner], *(d_vmaps[d_lastWinner]) );
     std::ostream* winnersOut =  d_options.getVerbosity() >= -1 ?
         (d_threadOptions[d_lastWinner]).getOut() : NULL;
-    bool ret = smtEngineInvoke(d_smts[d_lastWinner], cmdExported, winnersOut);
+    bool ret =
+        smtEngineInvoke(d_solvers[d_lastWinner], cmdExported, winnersOut);
     if(d_lastWinner != 0) delete cmdExported;
     return ret;
   } else if(mode == 1) {               // portfolio
@@ -297,8 +298,8 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
       std::ostream* current_out_or_null = d_options.getVerbosity() >= -1 ?
           d_threadOptions[i].getOut() : NULL;
 
-      fns[i] = boost::bind(smtEngineInvoke, d_smts[i], seqs[i],
-                           current_out_or_null);
+      fns[i] = boost::bind(
+          smtEngineInvoke, d_solvers[i], seqs[i], current_out_or_null);
     }
 
     assert(d_channelsIn.size() == d_numThreads
@@ -408,8 +409,8 @@ bool CommandExecutorPortfolio::doCommandSingleton(Command* cmd)
         cmd : cmd->exportTo(d_exprMgrs[d_lastWinner], *(d_vmaps[d_lastWinner]));
     std::ostream* winner_out_if_verbose = d_options.getVerbosity() >= -1 ?
         d_threadOptions[d_lastWinner].getOut() : NULL;
-    bool ret = smtEngineInvoke(d_smts[d_lastWinner], cmdExported,
-                               winner_out_if_verbose);
+    bool ret = smtEngineInvoke(
+        d_solvers[d_lastWinner], cmdExported, winner_out_if_verbose);
     if(d_lastWinner != 0){
       delete cmdExported;
     }

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -112,6 +112,7 @@ namespace CVC4 {
 #include <unordered_set>
 #include <vector>
 
+#include "api/cvc4cpp.h"
 #include "base/output.h"
 #include "expr/expr.h"
 #include "expr/kind.h"
@@ -403,7 +404,9 @@ command [std::unique_ptr<CVC4::Command>* cmd]
   | /* value query */
     GET_VALUE_TOK { PARSER_STATE->checkThatLogicIsSet(); }
     ( LPAREN_TOK termList[terms,expr] RPAREN_TOK
-      { cmd->reset(new GetValueCommand(terms)); }
+      { 
+        cmd->reset(new GetValueCommand(api::Solver::exprVectorToTerms(terms))); 
+      }
     | ~LPAREN_TOK
       { PARSER_STATE->parseError("The get-value command expects a list of "
                                  "terms.  Perhaps you forgot a pair of "

--- a/src/printer/ast/ast_printer.cpp
+++ b/src/printer/ast/ast_printer.cpp
@@ -20,6 +20,7 @@
 #include <typeinfo>
 #include <vector>
 
+#include "api/cvc4cpp.h"  // for ExprSetDepth etc..
 #include "expr/expr.h" // for ExprSetDepth etc..
 #include "expr/node_manager_attributes.h" // for VarNameAttr
 #include "options/language.h" // for LANG_AST
@@ -340,8 +341,8 @@ static void toStream(std::ostream& out, const SimplifyCommand* c)
 static void toStream(std::ostream& out, const GetValueCommand* c)
 {
   out << "GetValue( << ";
-  const vector<Expr>& terms = c->getTerms();
-  copy(terms.begin(), terms.end(), ostream_iterator<Expr>(out, ", "));
+  const vector<api::Term>& terms = c->getTerms();
+  copy(terms.begin(), terms.end(), ostream_iterator<api::Term>(out, ", "));
   out << ">> )";
 }
 

--- a/src/printer/cvc/cvc_printer.cpp
+++ b/src/printer/cvc/cvc_printer.cpp
@@ -24,11 +24,12 @@
 #include <typeinfo>
 #include <vector>
 
-#include "expr/expr.h" // for ExprSetDepth etc..
-#include "expr/node_manager_attributes.h" // for VarNameAttr
-#include "options/language.h" // for LANG_AST
-#include "printer/dagification_visitor.h"
+#include "api/cvc4cpp.h"                   // for ExprSetDepth etc..
+#include "expr/expr.h"                     // for ExprSetDepth etc..
+#include "expr/node_manager_attributes.h"  // for VarNameAttr
+#include "options/language.h"              // for LANG_AST
 #include "options/smt_options.h"
+#include "printer/dagification_visitor.h"
 #include "smt/command.h"
 #include "smt/smt_engine.h"
 #include "smt_util/node_visitor.h"
@@ -1345,10 +1346,12 @@ static void toStream(std::ostream& out, const SimplifyCommand* c, bool cvc3Mode)
 
 static void toStream(std::ostream& out, const GetValueCommand* c, bool cvc3Mode)
 {
-  const vector<Expr>& terms = c->getTerms();
+  const vector<api::Term>& terms = c->getTerms();
   Assert(!terms.empty());
   out << "GET_VALUE ";
-  copy(terms.begin(), terms.end() - 1, ostream_iterator<Expr>(out, ";\nGET_VALUE "));
+  copy(terms.begin(),
+       terms.end() - 1,
+       ostream_iterator<api::Term>(out, ";\nGET_VALUE "));
   out << terms.back() << ";";
 }
 

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -21,6 +21,7 @@
 #include <typeinfo>
 #include <vector>
 
+#include "api/cvc4cpp.h"
 #include "expr/node_manager_attributes.h"
 #include "options/language.h"
 #include "options/smt_options.h"
@@ -1754,8 +1755,8 @@ static void toStream(std::ostream& out, const SimplifyCommand* c)
 static void toStream(std::ostream& out, const GetValueCommand* c)
 {
   out << "(get-value ( ";
-  const vector<Expr>& terms = c->getTerms();
-  copy(terms.begin(), terms.end(), ostream_iterator<Expr>(out, " "));
+  const vector<api::Term>& terms = c->getTerms();
+  copy(terms.begin(), terms.end(), ostream_iterator<api::Term>(out, " "));
   out << "))";
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2497,7 +2497,7 @@ void SmtEngine::defineFunction(Expr func,
       c, ExprManager::VAR_FLAG_DEFINED, true, "declarations");
 
   PROOF(if (options::checkUnsatCores()) {
-    d_defineCommands.push_back(c.clone());
+    d_defineCommands.push_back(static_cast<DefineFunctionCommand*>(c.clone()));
   });
 
   // type check body
@@ -4359,12 +4359,10 @@ void SmtEngine::checkUnsatCore() {
   SmtEngine coreChecker(d_exprManager);
   coreChecker.setLogic(getLogicInfo());
 
-  PROOF(
-  std::vector<Command*>::const_iterator itg = d_defineCommands.begin();
-  for (; itg != d_defineCommands.end();  ++itg) {
-    (*itg)->invoke(&coreChecker);
-  }
-  );
+  PROOF(std::vector<DefineFunctionCommand*>::const_iterator itg =
+            d_defineCommands.begin();
+        for (; itg != d_defineCommands.end();
+             ++itg) { (*itg)->invoke(&coreChecker); });
 
   Notice() << "SmtEngine::checkUnsatCore(): pushing core assertions (size == " << core.size() << ")" << endl;
   for(UnsatCore::iterator i = core.begin(); i != core.end(); ++i) {

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -53,6 +53,7 @@ typedef NodeTemplate<false> TNode;
 struct NodeHashFunction;
 
 class Command;
+class DefineFunctionCommand;
 class GetModelCommand;
 
 class SmtEngine;
@@ -197,7 +198,7 @@ class CVC4_PUBLIC SmtEngine {
    * A vector of command definitions to be imported in the new
    * SmtEngine when checking unsat-cores.
    */
-  std::vector<Command*> d_defineCommands;
+  std::vector<DefineFunctionCommand*> d_defineCommands;
 
   /**
    * The logic we're in.


### PR DESCRIPTION
This commit is a sketch of how we can transform `Command`s to use the
new API and transform the parser bit-by-bit. The overall idea is that
`Command::invoke()` now takes an `Solver*` as an argument instead of an
`SmtEngine*`. The default implementation `Command::invoke()` just calls
the old implementation. As an example, the PR transforms the
`GetValueCommand`.