### PR TITLE
unreachable code removal

### DIFF
--- a/src/preprocessing/passes/bv_to_bool.cpp
+++ b/src/preprocessing/passes/bv_to_bool.cpp
@@ -106,9 +106,6 @@ bool BVToBool::isConvertibleBvAtom(TNode node)
 
 bool BVToBool::isConvertibleBvTerm(TNode node)
 {
-  if (!node.getType().isBitVector() || node.getType().getBitVectorSize() != 1)
-    return false;
-
   Kind kind = node.getKind();
 
   if (kind == kind::CONST_BITVECTOR || kind == kind::ITE

--- a/src/preprocessing/passes/bv_to_bool.cpp
+++ b/src/preprocessing/passes/bv_to_bool.cpp
@@ -106,6 +106,8 @@ bool BVToBool::isConvertibleBvAtom(TNode node)
 
 bool BVToBool::isConvertibleBvTerm(TNode node)
 {
+  Assert(node.getType().isBitVector()
+         && node.getType().getBitVectorSize() == 1);
   Kind kind = node.getKind();
 
   if (kind == kind::CONST_BITVECTOR || kind == kind::ITE
@@ -138,8 +140,6 @@ Node BVToBool::convertBvAtom(TNode node)
 
 Node BVToBool::convertBvTerm(TNode node)
 {
-  Assert(node.getType().isBitVector()
-         && node.getType().getBitVectorSize() == 1);
 
   if (hasBoolCache(node)) return getBoolCache(node);
 


### PR DESCRIPTION
The PR removes [this](https://github.com/CVC4/CVC4/blob/050747cbceef232b11f1226081bc3dbc74c8ff77/src/preprocessing/passes/bv_to_bool.cpp#L109) `if` statement, which always resolves to `false`:
The `if` statement is executed after the negation of its condition is [asserted](https://github.com/CVC4/CVC4/blob/050747cbceef232b11f1226081bc3dbc74c8ff77/src/preprocessing/passes/bv_to_bool.cpp#L144).

Note, however, that this statement might be reachable in production, as we use `Assert` and not `AlwaysAssert`.