### PR TITLE
Incorporate static PBE symmetry breaking lemmas into SygusEnumerator

### DIFF
--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -1545,15 +1545,31 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
       {
         // symmetry breaking lemmas should only be for enumerators
         Assert(d_register_st[a]);
-        std::vector<Node> sbl;
-        d_tds->getSymBreakLemmas(a, sbl);
-        for (const Node& lem : sbl)
+        // If this is a non-basic enumerator, process its symmetry breaking
+        // clauses. Since this class is not responsible for basic enumerators,
+        // their symmetry breaking clauses are ignored.
+        if( !d_tds->isBasicEnumerator(a) )
         {
-          TypeNode tn = d_tds->getTypeForSymBreakLemma(lem);
-          unsigned sz = d_tds->getSizeForSymBreakLemma(lem);
-          registerSymBreakLemma(tn, lem, sz, a, lemmas);
+          std::vector<Node> sbl;
+          d_tds->getSymBreakLemmas(a, sbl);
+          for (const Node& lem : sbl)
+          {
+            if( d_tds->isSymBreakLemmaTemplate(lem) )
+            {
+              // register the lemma template
+              TypeNode tn = d_tds->getTypeForSymBreakLemma(lem);
+              unsigned sz = d_tds->getSizeForSymBreakLemma(lem);
+              registerSymBreakLemma(tn, lem, sz, a, lemmas);
+            }
+            else
+            {
+              Trace("dt-sygus-debug") << "DT sym break lemma : " << lem << std::endl;
+              // it is a normal lemma
+              lemmas.push_back(lem);
+            }
+          }
+          d_tds->clearSymBreakLemmas(a);
         }
-        d_tds->clearSymBreakLemmas(a);
       }
     }
     if (!lemmas.empty())

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -1304,7 +1304,8 @@ void SygusSymBreakNew::preRegisterTerm( TNode n, std::vector< Node >& lemmas  ) 
   }
 }
 
-bool SygusSymBreakNew::registerSizeTerm( Node e, std::vector< Node >& lemmas ) {
+bool SygusSymBreakNew::registerSizeTerm(Node e, std::vector<Node>& lemmas)
+{
   if (d_register_st.find(e) != d_register_st.end())
   {
     // already registered
@@ -1549,13 +1550,13 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
         // If this is a non-basic enumerator, process its symmetry breaking
         // clauses. Since this class is not responsible for basic enumerators,
         // their symmetry breaking clauses are ignored.
-        if( !d_tds->isBasicEnumerator(a) )
+        if (!d_tds->isBasicEnumerator(a))
         {
           std::vector<Node> sbl;
           d_tds->getSymBreakLemmas(a, sbl);
           for (const Node& lem : sbl)
           {
-            if( d_tds->isSymBreakLemmaTemplate(lem) )
+            if (d_tds->isSymBreakLemmaTemplate(lem))
             {
               // register the lemma template
               TypeNode tn = d_tds->getTypeForSymBreakLemma(lem);
@@ -1564,7 +1565,8 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
             }
             else
             {
-              Trace("dt-sygus-debug") << "DT sym break lemma : " << lem << std::endl;
+              Trace("dt-sygus-debug")
+                  << "DT sym break lemma : " << lem << std::endl;
               // it is a normal lemma
               lemmas.push_back(lem);
             }
@@ -1646,16 +1648,17 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
   std::vector< Node > mts;
   d_tds->getEnumerators(mts);
   bool needsRecheck = false;
-  for( const Node& e : mts ){
-    if( registerSizeTerm( e, lemmas ) )
+  for (const Node& e : mts)
+  {
+    if (registerSizeTerm(e, lemmas))
     {
       needsRecheck = true;
     }
   }
   Trace("sygus-sb") << "SygusSymBreakNew::check: finished." << std::endl;
-  if( needsRecheck )
+  if (needsRecheck)
   {
-    Trace("sygus-sb") << " SygusSymBreakNew::rechecking..."  << std::endl;
+    Trace("sygus-sb") << " SygusSymBreakNew::rechecking..." << std::endl;
     return check(lemmas);
   }
 

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -1581,13 +1581,13 @@ void SygusSymBreakNew::check( std::vector< Node >& lemmas ) {
   }
 
   // register search values, add symmetry breaking lemmas if applicable
-  std::vector< Node > es;
+  std::vector<Node> es;
   d_tds->getEnumerators(es);
   bool needsRecheck = false;
   // for each enumerator registered to d_tds
   for (Node& prog : es)
   {
-    if( d_register_st.find(prog)==d_register_st.end() )
+    if (d_register_st.find(prog) == d_register_st.end())
     {
       // not yet registered, do so now
       registerSizeTerm(prog, lemmas);

--- a/src/theory/datatypes/datatypes_sygus.h
+++ b/src/theory/datatypes/datatypes_sygus.h
@@ -542,8 +542,7 @@ private:
   //----------------------search size information
   /**
    * Checks whether e is a sygus enumerator, that is, a term for which this
-   * class will track size for. This method returns true if e was previously
-   * unregistered and is a sygus enumerator.
+   * class will track size for.
    *
    * We associate each sygus enumerator e with a "measure term", which is used
    * for bounding the size of terms for the models of e. The measure term for a
@@ -554,7 +553,7 @@ private:
    * After determining the measure term m for e, if applicable, we initialize
    * SygusSizeDecisionStrategy for m below. This may result in lemmas
    */
-  bool registerSizeTerm(Node e, std::vector<Node>& lemmas);
+  void registerSizeTerm(Node e, std::vector<Node>& lemmas);
   /** A decision strategy for each measure term allocated by this class */
   class SygusSizeDecisionStrategy : public DecisionStrategyFmf
   {

--- a/src/theory/datatypes/datatypes_sygus.h
+++ b/src/theory/datatypes/datatypes_sygus.h
@@ -542,7 +542,8 @@ private:
   //----------------------search size information
   /**
    * Checks whether e is a sygus enumerator, that is, a term for which this
-   * class will track size for.
+   * class will track size for. This method returns true if e was previously
+   * unregistered and is a sygus enumerator.
    *
    * We associate each sygus enumerator e with a "measure term", which is used
    * for bounding the size of terms for the models of e. The measure term for a
@@ -553,7 +554,7 @@ private:
    * After determining the measure term m for e, if applicable, we initialize
    * SygusSizeDecisionStrategy for m below. This may result in lemmas
    */
-  void registerSizeTerm(Node e, std::vector<Node>& lemmas);
+  bool registerSizeTerm(Node e, std::vector<Node>& lemmas);
   /** A decision strategy for each measure term allocated by this class */
   class SygusSizeDecisionStrategy : public DecisionStrategyFmf
   {

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -44,7 +44,8 @@ void SygusEnumerator::initialize(Node e)
   NodeManager* nm = NodeManager::currentNM();
   std::vector<Node> sbl;
   d_tds->getSymBreakLemmas(e, sbl);
-  TNode ag = d_tds->getActiveGuardForEnumerator(e);
+  Node ag = d_tds->getActiveGuardForEnumerator(e);
+  TNode agt = ag;
   Node truen = nm->mkConst(true);
   TNode truent = truent;
   Assert(d_tcache.find(d_etype) != d_tcache.end());
@@ -54,7 +55,7 @@ void SygusEnumerator::initialize(Node e)
     if (!d_tds->isSymBreakLemmaTemplate(lem))
     {
       // substitute its active guard by true and rewrite
-      Node slem = lem.substitute(ag, truen);
+      Node slem = lem.substitute(agt, truent);
       slem = Rewriter::rewrite(slem);
       // break into conjuncts
       std::vector<Node> sblc;

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -45,8 +45,9 @@ void SygusEnumerator::initialize(Node e)
   std::vector<Node> sbl;
   d_tds->getSymBreakLemmas(e, sbl);
   Node ag = d_tds->getActiveGuardForEnumerator(e);
-  TNode agt = ag;
   Node truen = nm->mkConst(true);
+  // use TNode for substitute below
+  TNode agt = ag;
   TNode truent = truent;
   Assert(d_tcache.find(d_etype) != d_tcache.end());
   const Datatype& dt = d_etype.getDatatype();

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -48,7 +48,7 @@ void SygusEnumerator::initialize(Node e)
   Node truen = nm->mkConst(true);
   // use TNode for substitute below
   TNode agt = ag;
-  TNode truent = truent;
+  TNode truent = truen;
   Assert(d_tcache.find(d_etype) != d_tcache.end());
   const Datatype& dt = d_etype.getDatatype();
   for (const Node& lem : sbl)

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -34,33 +34,33 @@ void SygusEnumerator::initialize(Node e)
   Trace("sygus-enum") << "SygusEnumerator::initialize " << e << std::endl;
   d_enum = e;
   d_etype = d_enum.getType();
-  Assert( d_etype.isDatatype() );
-  Assert( d_etype.getDatatype().isSygus() );
+  Assert(d_etype.isDatatype());
+  Assert(d_etype.getDatatype().isSygus());
   d_tlEnum = getMasterEnumForType(d_etype);
   d_abortSize = options::sygusAbortSize();
-  
+
   // Get the statically registered symmetry breaking clauses for e, see if they
   // can be used for speeding up the enumeration.
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   std::vector<Node> sbl;
   d_tds->getSymBreakLemmas(e, sbl);
   TNode ag = d_tds->getActiveGuardForEnumerator(e);
   Node truen = nm->mkConst(true);
   TNode truent = truent;
-  Assert( d_tcache.find(d_etype)!=d_tcache.end() );
+  Assert(d_tcache.find(d_etype) != d_tcache.end());
   const Datatype& dt = d_etype.getDatatype();
-  for( const Node& lem : sbl )
+  for (const Node& lem : sbl)
   {
-    if( !d_tds->isSymBreakLemmaTemplate(lem) )
+    if (!d_tds->isSymBreakLemmaTemplate(lem))
     {
       // substitute its active guard by true and rewrite
-      Node slem = lem.substitute(ag,truen);
+      Node slem = lem.substitute(ag, truen);
       slem = Rewriter::rewrite(slem);
       // break into conjuncts
-      std::vector< Node > sblc;
-      if( slem.getKind()==AND )
+      std::vector<Node> sblc;
+      if (slem.getKind() == AND)
       {
-        for( const Node& slemc : slem )
+        for (const Node& slemc : slem)
         {
           sblc.push_back(slemc);
         }
@@ -69,22 +69,24 @@ void SygusEnumerator::initialize(Node e)
       {
         sblc.push_back(slem);
       }
-      for( const Node& sbl : sblc )
+      for (const Node& sbl : sblc)
       {
-        Trace("sygus-enum") << "  symmetry breaking lemma : " << sbl << std::endl;
+        Trace("sygus-enum")
+            << "  symmetry breaking lemma : " << sbl << std::endl;
         // if its a negation of a unit top-level tester, then this specifies
         // that we should not enumerate terms whose top symbol is that
         // constructor
-        if( sbl.getKind()==NOT )
+        if (sbl.getKind() == NOT)
         {
           Node a;
-          int tst = datatypes::DatatypesRewriter::isTester(sbl[0],a);
-          if( tst>=0 )
+          int tst = datatypes::DatatypesRewriter::isTester(sbl[0], a);
+          if (tst >= 0)
           {
-            if( a==e )
+            if (a == e)
             {
-              Node cons = Node::fromExpr( dt[tst].getConstructor() );
-              Trace("sygus-enum") << "  ...unit exclude constructor #" << tst << ", constructor " << cons << std::endl;
+              Node cons = Node::fromExpr(dt[tst].getConstructor());
+              Trace("sygus-enum") << "  ...unit exclude constructor #" << tst
+                                  << ", constructor " << cons << std::endl;
               d_sbExcTlCons.insert(cons);
             }
           }
@@ -114,13 +116,14 @@ Node SygusEnumerator::getCurrent()
     }
   }
   Node ret = d_tlEnum->getCurrent();
-  if( !ret.isNull() && !d_sbExcTlCons.empty() )
+  if (!ret.isNull() && !d_sbExcTlCons.empty())
   {
-    Assert( ret.hasOperator() );
+    Assert(ret.hasOperator());
     // might be excluded by an externally provided symmetry breaking clause
-    if( d_sbExcTlCons.find(ret.getOperator())!=d_sbExcTlCons.end() )
+    if (d_sbExcTlCons.find(ret.getOperator()) != d_sbExcTlCons.end())
     {
-      Trace("sygus-enum-exc") << "Exclude (external) : " << d_tds->sygusToBuiltin(ret) << std::endl;
+      Trace("sygus-enum-exc")
+          << "Exclude (external) : " << d_tds->sygusToBuiltin(ret) << std::endl;
       ret = Node::null();
     }
   }

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -31,10 +31,67 @@ SygusEnumerator::SygusEnumerator(TermDbSygus* tds, SynthConjecture* p)
 
 void SygusEnumerator::initialize(Node e)
 {
+  Trace("sygus-enum") << "SygusEnumerator::initialize " << e << std::endl;
   d_enum = e;
   d_etype = d_enum.getType();
+  Assert( d_etype.isDatatype() );
+  Assert( d_etype.getDatatype().isSygus() );
   d_tlEnum = getMasterEnumForType(d_etype);
   d_abortSize = options::sygusAbortSize();
+  
+  // Get the statically registered symmetry breaking clauses for e, see if they
+  // can be used for speeding up the enumeration.
+  NodeManager * nm = NodeManager::currentNM();
+  std::vector<Node> sbl;
+  d_tds->getSymBreakLemmas(e, sbl);
+  TNode ag = d_tds->getActiveGuardForEnumerator(e);
+  Node truen = nm->mkConst(true);
+  TNode truent = truent;
+  Assert( d_tcache.find(d_etype)!=d_tcache.end() );
+  const Datatype& dt = d_etype.getDatatype();
+  for( const Node& lem : sbl )
+  {
+    if( !d_tds->isSymBreakLemmaTemplate(lem) )
+    {
+      // substitute its active guard by true and rewrite
+      Node slem = lem.substitute(ag,truen);
+      slem = Rewriter::rewrite(slem);
+      // break into conjuncts
+      std::vector< Node > sblc;
+      if( slem.getKind()==AND )
+      {
+        for( const Node& slemc : slem )
+        {
+          sblc.push_back(slemc);
+        }
+      }
+      else
+      {
+        sblc.push_back(slem);
+      }
+      for( const Node& sbl : sblc )
+      {
+        Trace("sygus-enum") << "  symmetry breaking lemma : " << sbl << std::endl;
+        // if its a negation of a unit top-level tester, then this specifies
+        // that we should not enumerate terms whose top symbol is that
+        // constructor
+        if( sbl.getKind()==NOT )
+        {
+          Node a;
+          int tst = datatypes::DatatypesRewriter::isTester(sbl[0],a);
+          if( tst>=0 )
+          {
+            if( a==e )
+            {
+              Node cons = Node::fromExpr( dt[tst].getConstructor() );
+              Trace("sygus-enum") << "  ...unit exclude constructor #" << tst << ", constructor " << cons << std::endl;
+              d_sbExcTlCons.insert(cons);
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 void SygusEnumerator::addValue(Node v)
@@ -57,6 +114,16 @@ Node SygusEnumerator::getCurrent()
     }
   }
   Node ret = d_tlEnum->getCurrent();
+  if( !ret.isNull() && !d_sbExcTlCons.empty() )
+  {
+    Assert( ret.hasOperator() );
+    // might be excluded by an externally provided symmetry breaking clause
+    if( d_sbExcTlCons.find(ret.getOperator())!=d_sbExcTlCons.end() )
+    {
+      Trace("sygus-enum-exc") << "Exclude (external) : " << d_tds->sygusToBuiltin(ret) << std::endl;
+      ret = Node::null();
+    }
+  }
   if (Trace.isOn("sygus-enum"))
   {
     Trace("sygus-enum") << "Enumerate : ";

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -93,6 +93,7 @@ void SygusEnumerator::initialize(Node e)
             }
           }
         }
+        // other symmetry breaking lemmas such as disjunctions are not used
       }
     }
   }

--- a/src/theory/quantifiers/sygus/sygus_enumerator.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.h
@@ -436,7 +436,12 @@ class SygusEnumerator : public EnumValGenerator
   /** get master enumerator for type tn */
   TermEnum* getMasterEnumForType(TypeNode tn);
   //-------------------------------- externally specified symmetry breaking
-  /** set of operators we disallow at top level */
+  /** set of constructors we disallow at top level
+   *
+   * A constructor C is disallowed at the top level if a symmetry breaking
+   * lemma that entails ~is-C( d_enum ) was registered to
+   * TermDbSygus::registerSymBreakLemma.
+   */
   std::unordered_set<Node, NodeHashFunction> d_sbExcTlCons;
   //-------------------------------- end externally specified symmetry breaking
 };

--- a/src/theory/quantifiers/sygus/sygus_enumerator.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.h
@@ -437,7 +437,7 @@ class SygusEnumerator : public EnumValGenerator
   TermEnum* getMasterEnumForType(TypeNode tn);
   //-------------------------------- externally specified symmetry breaking
   /** set of operators we disallow at top level */
-  std::unordered_set< Node, NodeHashFunction > d_sbExcTlCons;
+  std::unordered_set<Node, NodeHashFunction> d_sbExcTlCons;
   //-------------------------------- end externally specified symmetry breaking
 };
 

--- a/src/theory/quantifiers/sygus/sygus_enumerator.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.h
@@ -435,6 +435,10 @@ class SygusEnumerator : public EnumValGenerator
   int d_abortSize;
   /** get master enumerator for type tn */
   TermEnum* getMasterEnumForType(TypeNode tn);
+  //-------------------------------- externally specified symmetry breaking
+  /** set of operators we disallow at top level */
+  std::unordered_set< Node, NodeHashFunction > d_sbExcTlCons;
+  //-------------------------------- end externally specified symmetry breaking
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -241,8 +241,8 @@ bool SygusPbe::initialize(Node n,
         Node lem = disj.size() == 1 ? disj[0] : nm->mkNode(OR, disj);
         Trace("sygus-pbe") << "  static redundant op lemma : " << lem
                            << std::endl;
-        // Register as a symmetry breaking lemma with the term database
-        // this will either be processed via a lemma on the output channel
+        // Register as a symmetry breaking lemma with the term database.
+        // This will either be processed via a lemma on the output channel
         // of the sygus extension of the datatypes solver, or internally
         // encoded as a constraint to an active enumerator.
         d_tds->registerSymBreakLemma(e, lem, etn, 0, false);

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -228,13 +228,24 @@ bool SygusPbe::initialize(Node n,
             {
               lem = lem.substitute(tsp, te);
             }
-            disj.push_back(lem);
+            if( std::find( disj.begin(), disj.end(), lem )==disj.end() )
+            {
+              disj.push_back(lem);
+            }
           }
         }
+        // add its active guard
+        Node ag = d_tds->getActiveGuardForEnumerator(e);
+        Assert( !ag.isNull() );
+        disj.push_back(ag.negate());
         Node lem = disj.size() == 1 ? disj[0] : nm->mkNode(OR, disj);
         Trace("sygus-pbe") << "  static redundant op lemma : " << lem
                            << std::endl;
-        lemmas.push_back(lem);
+        // Register as a symmetry breaking lemma with the term database
+        // this will either be processed via a lemma on the output channel
+        // of the sygus extension of the datatypes solver, or internally
+        // encoded as a constraint to an active enumerator.
+        d_tds->registerSymBreakLemma(e,lem,etn,0,false);
       }
     }
     Trace("sygus-pbe") << "Initialize " << d_examples[c].size()

--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -228,7 +228,7 @@ bool SygusPbe::initialize(Node n,
             {
               lem = lem.substitute(tsp, te);
             }
-            if( std::find( disj.begin(), disj.end(), lem )==disj.end() )
+            if (std::find(disj.begin(), disj.end(), lem) == disj.end())
             {
               disj.push_back(lem);
             }
@@ -236,7 +236,7 @@ bool SygusPbe::initialize(Node n,
         }
         // add its active guard
         Node ag = d_tds->getActiveGuardForEnumerator(e);
-        Assert( !ag.isNull() );
+        Assert(!ag.isNull());
         disj.push_back(ag.negate());
         Node lem = disj.size() == 1 ? disj[0] : nm->mkNode(OR, disj);
         Trace("sygus-pbe") << "  static redundant op lemma : " << lem
@@ -245,7 +245,7 @@ bool SygusPbe::initialize(Node n,
         // this will either be processed via a lemma on the output channel
         // of the sygus extension of the datatypes solver, or internally
         // encoded as a constraint to an active enumerator.
-        d_tds->registerSymBreakLemma(e,lem,etn,0,false);
+        d_tds->registerSymBreakLemma(e, lem, etn, 0, false);
       }
     }
     Trace("sygus-pbe") << "Initialize " << d_examples[c].size()

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -774,11 +774,14 @@ void TermDbSygus::getEnumerators(std::vector<Node>& mts)
 void TermDbSygus::registerSymBreakLemma(Node e,
                                         Node lem,
                                         TypeNode tn,
-                                        unsigned sz)
+                                        unsigned sz,
+                                        bool isTempl
+                                       )
 {
   d_enum_to_sb_lemmas[e].push_back(lem);
   d_sb_lemma_to_type[lem] = tn;
   d_sb_lemma_to_size[lem] = sz;
+  d_sb_lemma_to_isTempl[lem] = isTempl;
 }
 
 bool TermDbSygus::hasSymBreakLemmas(std::vector<Node>& enums) const
@@ -813,6 +816,13 @@ TypeNode TermDbSygus::getTypeForSymBreakLemma(Node lem) const
 unsigned TermDbSygus::getSizeForSymBreakLemma(Node lem) const
 {
   std::map<Node, unsigned>::const_iterator it = d_sb_lemma_to_size.find(lem);
+  Assert(it != d_sb_lemma_to_size.end());
+  return it->second;
+}
+
+bool TermDbSygus::isSymBreakLemmaTemplate(Node lem) const
+{
+  std::map<Node, bool>::const_iterator it = d_sb_lemma_to_isTempl.find(lem);
   Assert(it != d_sb_lemma_to_size.end());
   return it->second;
 }

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -683,8 +683,8 @@ void TermDbSygus::registerEnumerator(Node e,
     // must ensure it is a literal immediately here
     ag = d_quantEngine->getValuation().ensureLiteral(ag);
     // must ensure that it is asserted as a literal before we begin solving
-    Node lem = nm->mkNode(OR,ag, ag.negate());
-    d_quantEngine->getOutputChannel().requirePhase(ag,true);
+    Node lem = nm->mkNode(OR, ag, ag.negate());
+    d_quantEngine->getOutputChannel().requirePhase(ag, true);
     d_quantEngine->getOutputChannel().lemma(lem);
     d_enum_to_active_guard[e] = ag;
   }
@@ -775,12 +775,8 @@ void TermDbSygus::getEnumerators(std::vector<Node>& mts)
   }
 }
 
-void TermDbSygus::registerSymBreakLemma(Node e,
-                                        Node lem,
-                                        TypeNode tn,
-                                        unsigned sz,
-                                        bool isTempl
-                                       )
+void TermDbSygus::registerSymBreakLemma(
+    Node e, Node lem, TypeNode tn, unsigned sz, bool isTempl)
 {
   d_enum_to_sb_lemmas[e].push_back(lem);
   d_sb_lemma_to_type[lem] = tn;

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -823,7 +823,7 @@ unsigned TermDbSygus::getSizeForSymBreakLemma(Node lem) const
 bool TermDbSygus::isSymBreakLemmaTemplate(Node lem) const
 {
   std::map<Node, bool>::const_iterator it = d_sb_lemma_to_isTempl.find(lem);
-  Assert(it != d_sb_lemma_to_size.end());
+  Assert(it != d_sb_lemma_to_isTempl.end());
   return it->second;
 }
 

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -682,6 +682,10 @@ void TermDbSygus::registerEnumerator(Node e,
     Node ag = nm->mkSkolem("eG", nm->booleanType());
     // must ensure it is a literal immediately here
     ag = d_quantEngine->getValuation().ensureLiteral(ag);
+    // must ensure that it is asserted as a literal before we begin solving
+    Node lem = nm->mkNode(OR,ag, ag.negate());
+    d_quantEngine->getOutputChannel().requirePhase(ag,true);
+    d_quantEngine->getOutputChannel().lemma(lem);
     d_enum_to_active_guard[e] = ag;
   }
 }

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -170,12 +170,14 @@ class TermDbSygus {
    *
    * tn : the (sygus datatype) type that lem applies to, i.e. the
    * type of terms that lem blocks models for,
-   * sz : the minimum size of terms that the lem blocks.
+   * sz : the minimum size of terms that the lem blocks,
+   * isTempl : if this flag is false, then lem is a literal
    *
-   * Notice that the symmetry breaking lemma template should be relative to x,
-   * where x is returned by the call to getFreeVar( tn, 0 ) in this class.
+   * If isTempl is true, then lem is a symmetry breaking lemma template
+   * involving x, where x is returned by the call to getFreeVar( tn, 0 ) in this
+   * class.
    */
-  void registerSymBreakLemma(Node e, Node lem, TypeNode tn, unsigned sz);
+  void registerSymBreakLemma(Node e, Node lem, TypeNode tn, unsigned sz, bool isTempl=true);
   /** Has symmetry breaking lemmas been added for any enumerator? */
   bool hasSymBreakLemmas(std::vector<Node>& enums) const;
   /** Get symmetry breaking lemmas
@@ -188,6 +190,8 @@ class TermDbSygus {
   TypeNode getTypeForSymBreakLemma(Node lem) const;
   /** Get the minimum size of terms symmetry breaking lemma lem applies to */
   unsigned getSizeForSymBreakLemma(Node lem) const;
+  /** Returns true if lem is a lemma template, false if lem is a lemma */
+  bool isSymBreakLemmaTemplate(Node lem) const;
   /** Clear information about symmetry breaking lemmas for enumerator e */
   void clearSymBreakLemmas(Node e);
   //------------------------------end enumerators
@@ -344,6 +348,8 @@ class TermDbSygus {
   std::map<Node, TypeNode> d_sb_lemma_to_type;
   /** mapping from symmetry breaking lemmas to size */
   std::map<Node, unsigned> d_sb_lemma_to_size;
+  /** mapping from symmetry breaking lemmas to whether they are templates */
+  std::map<Node, bool> d_sb_lemma_to_isTempl;
   /** enumerators to whether they are actively-generated */
   std::map<Node, bool> d_enum_active_gen;
   /** enumerators to whether they are variable agnostic */

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -177,7 +177,8 @@ class TermDbSygus {
    * involving x, where x is returned by the call to getFreeVar( tn, 0 ) in this
    * class.
    */
-  void registerSymBreakLemma(Node e, Node lem, TypeNode tn, unsigned sz, bool isTempl=true);
+  void registerSymBreakLemma(
+      Node e, Node lem, TypeNode tn, unsigned sz, bool isTempl = true);
   /** Has symmetry breaking lemmas been added for any enumerator? */
   bool hasSymBreakLemmas(std::vector<Node>& enums) const;
   /** Get symmetry breaking lemmas

--- a/src/theory/quantifiers/sygus/term_database_sygus.h
+++ b/src/theory/quantifiers/sygus/term_database_sygus.h
@@ -171,11 +171,9 @@ class TermDbSygus {
    * tn : the (sygus datatype) type that lem applies to, i.e. the
    * type of terms that lem blocks models for,
    * sz : the minimum size of terms that the lem blocks,
-   * isTempl : if this flag is false, then lem is a literal
-   *
-   * If isTempl is true, then lem is a symmetry breaking lemma template
-   * involving x, where x is returned by the call to getFreeVar( tn, 0 ) in this
-   * class.
+   * isTempl : if this flag is false, then lem is a (concrete) lemma.
+   * If this flag is true, then lem is a symmetry breaking lemma template
+   * over x, where x is returned by the call to getFreeVar( tn, 0 ).
    */
   void registerSymBreakLemma(
       Node e, Node lem, TypeNode tn, unsigned sz, bool isTempl = true);


### PR DESCRIPTION
This PR makes the SygusEnumerator capable of interpreting symmetry breaking lemmas provided by an external source such as SygusPbe as an explicit filter on the value it should generate.

This required a bit of refactoring to the sygus extension of datatypes so that it does not process symmetry breaking lemmas for basic enumerators. It also refactors this class a bit to correct some initialization issues where the active guard for enumerators could be uninitialized after the first call to SygusSymBreakNew::check.

This is +2-0 on PBE strings and +0-0 on PBE BV.