### PR TITLE
cmake: Add option to explicitely enable/disable static binaries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ cvc4_option(ENABLE_TRACING       "Enable tracing")
 cvc4_option(ENABLE_UNIT_TESTING  "Enable unit testing")
 cvc4_option(ENABLE_VALGRIND      "Enable valgrind instrumentation")
 cvc4_option(ENABLE_SHARED        "Build as shared library")
+cvc4_option(ENABLE_STATIC_BINARY
+            "Build static binaries with statically linked system libraries")
 # >> 2-valued: ON OFF
 #    > for options where we don't need to detect if set by user (default: OFF)
 option(ENABLE_BEST             "Enable dependencies known to give best performance")
@@ -184,7 +186,11 @@ add_check_cxx_flag("-Wno-class-memaccess")
 # These options are only set if their value is IGNORE. Otherwise, the user
 # already set the option, which we don't want to overwrite.
 
-cvc4_set_option(ENABLE_SHARED ON)
+if(ENABLE_STATIC_BINARY)
+  cvc4_set_option(ENABLE_SHARED OFF)
+else()
+  cvc4_set_option(ENABLE_SHARED ON)
+endif()
 
 #-----------------------------------------------------------------------------#
 # Set options for best configuration
@@ -221,11 +227,16 @@ endif()
 
 if(ENABLE_SHARED)
   set(BUILD_SHARED_LIBS ON)
+  if(ENABLE_STATIC_BINARY)
+    set(ENABLE_STATIC_BINARY OFF)
+    message(WARNING "Disabling static binary since shared build is enabled.")
+  endif()
 else()
   set(CMAKE_FIND_LIBRARY_SUFFIXES ".a ${CMAKE_FIND_LIBRARY_SUFFIXES}")
   set(BUILD_SHARED_LIBS OFF)
   # This is required to force find_package(Boost) to use static libraries.
   set(Boost_USE_STATIC_LIBS ON)
+  cvc4_set_option(ENABLE_STATIC_BINARY ON)
 endif()
 
 #-----------------------------------------------------------------------------#
@@ -501,6 +512,7 @@ print_config("Unit tests           :" ENABLE_UNIT_TESTING)
 print_config("Valgrind             :" ENABLE_VALGRIND)
 message("")
 print_config("Shared libs          :" ENABLE_SHARED)
+print_config("Static binary        :" ENABLE_STATIC_BINARY)
 print_config("Java bindings        :" BUILD_BINDINGS_JAVA)
 print_config("Python bindings      :" BUILD_BINDINGS_PYTHON)
 print_config("Python2              :" USE_PYTHON2)

--- a/configure.sh
+++ b/configure.sh
@@ -25,6 +25,7 @@ General options;
 Features:
 The following flags enable optional features (disable with --no-<option name>).
   --static                 build static libraries and binaries [default=no]
+  --static-binary          enable/disable static binaries
   --proofs                 support for proof generation
   --optimized              optimize the build
   --debug-symbols          include debug symbols
@@ -122,6 +123,7 @@ portfolio=default
 proofs=default
 replay=default
 shared=default
+static_binary=default
 statistics=default
 symfpu=default
 tracing=default
@@ -230,8 +232,11 @@ do
     --replay) replay=ON;;
     --no-replay) replay=OFF;;
 
-    --static) shared=OFF;;
+    --static) shared=OFF; static_binary=ON;;
     --no-static) shared=ON;;
+
+    --static-binary) static_binary=ON;;
+    --no-static-binary) static_binary=OFF;;
 
     --statistics) statistics=ON;;
     --no-statistics) statistics=OFF;;
@@ -355,6 +360,8 @@ cmake_opts=""
   && cmake_opts="$cmake_opts -DENABLE_REPLAY=$replay"
 [ $shared != default ] \
   && cmake_opts="$cmake_opts -DENABLE_SHARED=$shared"
+[ $static_binary != default ] \
+  && cmake_opts="$cmake_opts -DENABLE_STATIC_BINARY=$static_binary"
 [ $statistics != default ] \
   && cmake_opts="$cmake_opts -DENABLE_STATISTICS=$statistics"
 [ $tracing != default ] \

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 # use the static system libraries.
 #   https://cmake.org/cmake/help/v3.0/prop_tgt/LINK_SEARCH_START_STATIC.html
 #   https://cmake.org/cmake/help/v3.0/prop_tgt/LINK_SEARCH_END_STATIC.html
-if(NOT ENABLE_SHARED)
+if(ENABLE_STATIC_BINARY)
   set_target_properties(cvc4-bin PROPERTIES LINK_FLAGS -static)
   set_target_properties(cvc4-bin PROPERTIES LINK_SEARCH_START_STATIC ON)
   set_target_properties(cvc4-bin PROPERTIES LINK_SEARCH_END_STATIC ON)
@@ -90,7 +90,7 @@ if(ENABLE_PORTFOLIO)
     install(TARGETS pcvc4-bin DESTINATION bin)
   endif()
 
-  if(NOT ENABLE_SHARED)
+  if(ENABLE_STATIC_BINARY)
     set_target_properties(pcvc4-bin PROPERTIES LINK_FLAGS -static)
     set_target_properties(pcvc4-bin PROPERTIES LINK_SEARCH_START_STATIC ON)
     set_target_properties(pcvc4-bin PROPERTIES LINK_SEARCH_END_STATIC ON)


### PR DESCRIPTION
With `--static` we build fully static binaries (system libraries linked statically). With `--no-static-binary` it is possible to dynamically link against system libraries (and still build static libraries).