### PR TITLE
 Expand definitions prior to model core computation

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4308,10 +4308,10 @@ Model* SmtEngine::getModel() {
     std::vector<Expr> easserts = getAssertions();
     // must expand definitions
     std::vector<Expr> eassertsProc;
+    std::unordered_map<Node, Node, NodeHashFunction> cache;
     for (unsigned i = 0, nasserts = easserts.size(); i < nasserts; i++)
     {
       Node ea = Node::fromExpr(easserts[i]);
-      std::unordered_map<Node, Node, NodeHashFunction> cache;
       Node eae = d_private->expandDefinitions(ea, cache);
       eassertsProc.push_back(eae.toExpr());
     }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4308,9 +4308,9 @@ Model* SmtEngine::getModel() {
     std::vector<Expr> easserts = getAssertions();
     // must expand definitions
     std::vector<Expr> eassertsProc;
-    for( unsigned i=0, nasserts = easserts.size(); i<nasserts; i++ )
+    for (unsigned i = 0, nasserts = easserts.size(); i < nasserts; i++)
     {
-      Node ea = Node::fromExpr( easserts[i] );
+      Node ea = Node::fromExpr(easserts[i]);
       std::unordered_map<Node, Node, NodeHashFunction> cache;
       Node eae = d_private->expandDefinitions(ea, cache);
       eassertsProc.push_back(eae.toExpr());

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4306,7 +4306,16 @@ Model* SmtEngine::getModel() {
     // If we enabled model cores, we compute a model core for m based on our
     // assertions using the model core builder utility
     std::vector<Expr> easserts = getAssertions();
-    ModelCoreBuilder::setModelCore(easserts, m, options::modelCoresMode());
+    // must expand definitions
+    std::vector<Expr> eassertsProc;
+    for( unsigned i=0, nasserts = easserts.size(); i<nasserts; i++ )
+    {
+      Node ea = Node::fromExpr( easserts[i] );
+      std::unordered_map<Node, Node, NodeHashFunction> cache;
+      Node eae = d_private->expandDefinitions(ea, cache);
+      eassertsProc.push_back(eae.toExpr());
+    }
+    ModelCoreBuilder::setModelCore(eassertsProc, m, options::modelCoresMode());
   }
   m->d_inputName = d_filename;
   return m;


### PR DESCRIPTION
Currently, the model cores computed are highly suboptimal when definitions are present since expand definitions is not called on the input formula. This PR fixes this issue.