### PR TITLE
 Fix type enumerator for FP

### DIFF
--- a/src/theory/fp/type_enumerator.h
+++ b/src/theory/fp/type_enumerator.h
@@ -66,8 +66,9 @@ class FloatingPointEnumerator
     // Rotate the LSB into the sign so that NaN is the last value
     uint64_t vone = 1;
     uint64_t vmax = d_state.getSize() - 1;
-    BitVector bva = d_state.logicalRightShift(BitVector(d_state.getSize(),vone));
-    BitVector bvb = d_state.leftShift(BitVector(d_state.getSize(),vmax));
+    BitVector bva =
+        d_state.logicalRightShift(BitVector(d_state.getSize(), vone));
+    BitVector bvb = d_state.leftShift(BitVector(d_state.getSize(), vmax));
     const BitVector value = (bva | bvb);
 
     return FloatingPoint(d_e, d_s, value);

--- a/src/theory/fp/type_enumerator.h
+++ b/src/theory/fp/type_enumerator.h
@@ -64,8 +64,11 @@ class FloatingPointEnumerator
  protected:
   FloatingPoint createFP(void) const {
     // Rotate the LSB into the sign so that NaN is the last value
-    const BitVector value =
-        d_state.logicalRightShift(1) | d_state.leftShift(d_state.getSize() - 1);
+    uint64_t vone = 1;
+    uint64_t vmax = d_state.getSize() - 1;
+    BitVector bva = d_state.logicalRightShift(BitVector(d_state.getSize(),vone));
+    BitVector bvb = d_state.leftShift(BitVector(d_state.getSize(),vmax));
+    const BitVector value = (bva | bvb);
 
     return FloatingPoint(d_e, d_s, value);
   }


### PR DESCRIPTION
As discussed with @martin-cs , the FP enumerator had a bug where it would not generate negative FPs due to incorrect use of the BitVector class. This fixes the issue.