### PR TITLE
Reduce lookahead when parsing string literals

### DIFF
--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -183,6 +183,13 @@ private:
 
   bool sygus() const { return getLanguage() == language::input::LANG_SYGUS; }
 
+  /**
+   * Returns true if the language that we are parsing (SMT-LIB version >=2.5
+   * and SyGuS) treats duplicate double quotes ("") as an escape sequence
+   * denoting a single double quote (").
+   */
+  bool escapeDupDblQuote() const { return v2_5() || sygus(); }
+
   void setInfo(const std::string& flag, const SExpr& sexpr);
 
   void setOption(const std::string& flag, const SExpr& sexpr);


### PR DESCRIPTION
Fixes issue #2720. Between versions 2.0 and 2.5, the SMT-LIB standard changed
the way that string literals esacpe double quotes (") within strings from \" to
"". As a consequence, we have two different ways of lexing string literals
depending on the language used. The code produced by ANTLR first uses a
Deterministic Finite Automata (DFA) to predict the next token. Because the DFA
is static, it considers both versions of the string literal. If we are parsing
a string without escape sequences, e.g. "foo", it ends up reading three
characters past the closing double quote (I am not sure whether this is by
design or a bug). This is problematic in interactive mode because the third
character may be on the next line, which may not be available yet. Consider the
example from the issue mentioned above:

```
import subprocess

p = subprocess.Popen(['cvc4', '--lang', 'smt'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
p.stdin.write(b'(echo "foo")\n')
p.stdin.flush()
print(p.stdout.readline())
```

In this example, "foo" is a valid string for both types of string literals and
ANTLR reads ", \n, and then tries to access the character on the next line,
which leads to a deadlock because CVC4 is waiting for the next line on stdin
and the Python program is waiting for the output of CVC4. Note: this is why
writing `(echo "foo")\n\n` or `(echo "foo" )\n` both do not lead to a deadlock.

The solution this commit implements is to reorganize the way the string
literals are parsed: we now have a single token `STRING_LITERAL` for both types
of string literals, which is actually a bit simpler because it allows us to
share common code for processing the literal. The code that ANTLR generates
for that pattern does not exhibit the problem described above. Additionally, the
commit removes `SYGUS_QUOTED_LITERAL`, which was unused and was also
had overlapping matches with the string literals.

As to why it worked with older versions: we allocated memory for the input in
increments of 1024 bytes and in our `myConsume` method, we did not actually
check whether we were reading a character from the input or just from the
buffer that had not been filled in yet---so I am assuming that we got lucky.