### PR TITLE
Optimizations for PBE strings

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_invariance.cpp
+++ b/src/theory/quantifiers/sygus/sygus_invariance.cpp
@@ -218,15 +218,22 @@ bool NegContainsSygusInvarianceTest::invariant(TermDbSygus* tds,
           NodeManager::currentNM()->mkNode(kind::STRING_STRCTN, out, nbvre);
       Trace("sygus-pbe-cterm-debug") << "Check: " << cont << std::endl;
       Node contr = Rewriter::rewrite(cont);
-      if (contr == tds->d_false)
+      if (!contr.isConst())
+      {
+        if (d_isUniversal)
+        {
+          return false;
+        }
+      }
+      else if (contr.getConst<bool>() == d_isUniversal)
       {
         if (Trace.isOn("sygus-pbe-cterm"))
         {
           Trace("sygus-pbe-cterm")
               << "PBE-cterm : enumerator : do not consider ";
-          Trace("sygus-pbe-cterm") << nbv << " for any "
-                                   << tds->sygusToBuiltin(x) << " since "
-                                   << std::endl;
+          Trace("sygus-pbe-cterm")
+              << nbv << " for any " << tds->sygusToBuiltin(x) << " since "
+              << std::endl;
           Trace("sygus-pbe-cterm") << "   PBE-cterm :    for input example : ";
           for (unsigned j = 0, size = d_ex[ii].size(); j < size; j++)
           {
@@ -238,13 +245,13 @@ bool NegContainsSygusInvarianceTest::invariant(TermDbSygus* tds,
           Trace("sygus-pbe-cterm")
               << "   PBE-cterm : and is not in output : " << out << std::endl;
         }
-        return true;
+        return !d_isUniversal;
       }
       Trace("sygus-pbe-cterm-debug2")
           << "...check failed, rewrites to : " << contr << std::endl;
     }
   }
-  return false;
+  return d_isUniversal;
 }
 
 } /* CVC4::theory::quantifiers namespace */

--- a/src/theory/quantifiers/sygus/sygus_invariance.h
+++ b/src/theory/quantifiers/sygus/sygus_invariance.h
@@ -249,7 +249,7 @@ class DivByZeroSygusInvarianceTest : public SygusInvarianceTest
 class NegContainsSygusInvarianceTest : public SygusInvarianceTest
 {
  public:
-  NegContainsSygusInvarianceTest() {}
+  NegContainsSygusInvarianceTest() : d_isUniversal(false) {}
 
   /** initialize this invariance test
    *  e is the enumerator which we are reasoning about (associated with a synth
@@ -266,6 +266,8 @@ class NegContainsSygusInvarianceTest : public SygusInvarianceTest
             std::vector<std::vector<Node> >& ex,
             std::vector<Node>& exo,
             std::vector<unsigned>& ncind);
+  /** set universal */
+  void setUniversal() { d_isUniversal = true; }
 
  protected:
   /** checks if contains( out_i, nvn[in_i] ) --> false for some I/O pair i. */
@@ -282,6 +284,8 @@ class NegContainsSygusInvarianceTest : public SygusInvarianceTest
    *    contains( out_i, nvn[in_i] ) ---> false
    */
   std::vector<unsigned> d_neg_con_indices;
+  /** requires not being in all examples */
+  bool d_isUniversal;
 };
 
 } /* CVC4::theory::quantifiers namespace */

--- a/src/theory/quantifiers/sygus/sygus_invariance.h
+++ b/src/theory/quantifiers/sygus/sygus_invariance.h
@@ -266,11 +266,19 @@ class NegContainsSygusInvarianceTest : public SygusInvarianceTest
             std::vector<std::vector<Node> >& ex,
             std::vector<Node>& exo,
             std::vector<unsigned>& ncind);
-  /** set universal */
+  /** set universal 
+   *
+   * This updates the semantics of this check such that *all* instead of some
+   * examples must fail the containment test.
+   */
   void setUniversal() { d_isUniversal = true; }
 
  protected:
-  /** checks if contains( out_i, nvn[in_i] ) --> false for some I/O pair i. */
+  /** 
+   * Checks if contains( out_i, nvn[in_i] ) --> false for some I/O pair i; if
+   * d_isUniversal is true, then we check if the rewrite holds for *all* I/O
+   * pairs.
+   */
   bool invariant(TermDbSygus* tds, Node nvn, Node x) override;
 
  private:

--- a/src/theory/quantifiers/sygus/sygus_invariance.h
+++ b/src/theory/quantifiers/sygus/sygus_invariance.h
@@ -266,7 +266,7 @@ class NegContainsSygusInvarianceTest : public SygusInvarianceTest
             std::vector<std::vector<Node> >& ex,
             std::vector<Node>& exo,
             std::vector<unsigned>& ncind);
-  /** set universal 
+  /** set universal
    *
    * This updates the semantics of this check such that *all* instead of some
    * examples must fail the containment test.
@@ -274,7 +274,7 @@ class NegContainsSygusInvarianceTest : public SygusInvarianceTest
   void setUniversal() { d_isUniversal = true; }
 
  protected:
-  /** 
+  /**
    * Checks if contains( out_i, nvn[in_i] ) --> false for some I/O pair i; if
    * d_isUniversal is true, then we check if the rewrite holds for *all* I/O
    * pairs.

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -1465,7 +1465,7 @@ Node SygusUnifIo::constructSol(
   {
     if (!retValMod && !ret_dt.isNull())
     {
-      for (unsigned i = 0, nvals = x.d_vals.size(); i < nvals; i++)
+      for (size_t i = 0, nvals = x.d_vals.size(); i < nvals; i++)
       {
         if (x.d_vals[i].getConst<bool>())
         {

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -1380,10 +1380,9 @@ Node SygusUnifIo::constructSol(
               // TODO (#1250) : degenerate case where children have different
               // types?
               indent("sygus-sui-dt", ind);
-              Trace("sygus-sui-dt")
-                  << "return PBE: failed ITE strategy, "
-                      "cannot find a distinguishable condition"
-                  << std::endl;
+              Trace("sygus-sui-dt") << "return PBE: failed ITE strategy, "
+                                       "cannot find a distinguishable condition"
+                                    << std::endl;
             }
             if (!rec_c.isNull())
             {

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -903,7 +903,6 @@ bool SygusUnifIo::getExplanationForEnumeratorExclude(
         << "Check enumerator exclusion for " << e << " -> "
         << d_tds->sygusToBuiltin(v) << " based on str.contains." << std::endl;
     std::vector<unsigned> cmp_indices;
-    std::vector<bool> cmpRes;
     for (unsigned i = 0, size = results.size(); i < size; i++)
     {
       Assert(results[i].isConst());
@@ -914,13 +913,11 @@ bool SygusUnifIo::getExplanationForEnumeratorExclude(
       Node contr = Rewriter::rewrite(cont);
       if (contr == d_false)
       {
-        cmpRes.push_back(false);
         cmp_indices.push_back(i);
         Trace("sygus-sui-cterm-debug") << "...not contained." << std::endl;
       }
       else
       {
-        cmpRes.push_back(true);
         Trace("sygus-sui-cterm-debug") << "...contained." << std::endl;
         if (isConditional)
         {
@@ -944,8 +941,6 @@ bool SygusUnifIo::getExplanationForEnumeratorExclude(
           << " due to negative containment." << std::endl;
       return true;
     }
-    // if we're using it, we add it now
-    addSearchVal(e, v, results);
   }
   return false;
 }
@@ -1382,6 +1377,8 @@ Node SygusUnifIo::constructSol(
             }
             else
             {
+              // TODO (#1250) : degenerate case where children have different
+              // types?
               indent("sygus-sui-dt", ind);
               Trace("sygus-sui-dt")
                   << "return PBE: failed ITE strategy, "

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -1340,8 +1340,9 @@ Node SygusUnifIo::constructSol(
             x.updateContext(this,
                             ecache_cond.d_enum_vals_res[split_cond_res_index],
                             sc == 1);
-            // ret may be false in corner cases where we must choose
-            // a non-separating condition to traverse to another strategy node
+            // return value of above call may be false in corner cases where we
+            // must choose a non-separating condition to traverse to another
+            // strategy node
           }
 
           // recurse
@@ -1380,7 +1381,7 @@ Node SygusUnifIo::constructSol(
                 Assert(!rec_c.isNull());
                 indent("sygus-sui-dt", ind);
                 Trace("sygus-sui-dt")
-                    << "PBE: ITE strategy : choose random conditional "
+                    << "PBE: ITE strategy : choose best conditional "
                     << d_tds->sygusToBuiltin(rec_c) << std::endl;
               }
             }
@@ -1407,11 +1408,7 @@ Node SygusUnifIo::constructSol(
           else
           {
             did_recurse = true;
-            // Store the previous visit role, this ensures a strategy node can
-            // be visited on multiple paths in the solution in the same context.
-            // std::map<Node, std::map<NodeRole, bool>> pvr = x.d_visit_role;
             rec_c = constructSol(f, cenum.first, cenum.second, ind + 2, lemmas);
-            // x.d_visit_role = pvr;
           }
 
           // undo update the context

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -1091,7 +1091,7 @@ Node SygusUnifIo::constructSol(
     {
       bool firstTime = true;
       std::unordered_set<Node, NodeHashFunction> intersection;
-      std::map<unsigned, std::unordered_set<Node, NodeHashFunction>>::iterator
+      std::map<size_t, std::unordered_set<Node, NodeHashFunction>>::iterator
           pit;
       for (unsigned i = 0, nvals = x.d_vals.size(); i < nvals; i++)
       {

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -809,10 +809,13 @@ Node SygusUnifIo::constructSolutionNode(std::vector<Node>& lemmas)
               || (!d_solution.isNull()
                   && d_tds->getSygusTermSize(vcc) < d_sol_term_size)))
       {
-        Trace("sygus-pbe") << "**** SygusUnif SOLVED : " << c << " = ";
-        TermDbSygus::toStreamSygus("sygus-pbe", vcc);
-        Trace("sygus-pbe") << std::endl;
-        Trace("sygus-pbe") << "...solved at iteration " << i << std::endl;
+        if( Trace.isOn("sygus-pbe") )
+        {
+          Trace("sygus-pbe") << "**** SygusUnif SOLVED : " << c << " = ";
+          TermDbSygus::toStreamSygus("sygus-pbe", vcc);
+          Trace("sygus-pbe") << std::endl;
+          Trace("sygus-pbe") << "...solved at iteration " << i << std::endl;
+        }
         d_solution = vcc;
         newSolution = vcc;
         d_sol_term_size = d_tds->getSygusTermSize(vcc);

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -809,7 +809,7 @@ Node SygusUnifIo::constructSolutionNode(std::vector<Node>& lemmas)
               || (!d_solution.isNull()
                   && d_tds->getSygusTermSize(vcc) < d_sol_term_size)))
       {
-        if( Trace.isOn("sygus-pbe") )
+        if (Trace.isOn("sygus-pbe"))
         {
           Trace("sygus-pbe") << "**** SygusUnif SOLVED : " << c << " = ";
           TermDbSygus::toStreamSygus("sygus-pbe", vcc);

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -21,6 +21,8 @@
 #include "theory/quantifiers/term_util.h"
 #include "util/random.h"
 
+#include <math.h>
+
 using namespace CVC4::kind;
 
 namespace CVC4 {
@@ -89,7 +91,6 @@ void UnifContextIo::initialize(SygusUnifIo* sui)
   d_str_pos.clear();
   d_curr_role = role_equal;
   d_visit_role.clear();
-  d_uinfo.clear();
 
   // initialize with #examples
   unsigned sz = sui->d_examples.size();
@@ -470,7 +471,10 @@ void SubsumeTrie::getLeaves(const std::vector<Node>& vals,
 }
 
 SygusUnifIo::SygusUnifIo()
-    : d_check_sol(false), d_cond_count(0), d_sol_cons_nondet(false)
+    : d_check_sol(false),
+      d_cond_count(0),
+      d_sol_cons_nondet(false),
+      d_solConsUsingInfoGain(false)
 {
   d_true = NodeManager::currentNM()->mkConst(true);
   d_false = NodeManager::currentNM()->mkConst(false);
@@ -781,6 +785,7 @@ Node SygusUnifIo::constructSolutionNode(std::vector<Node>& lemmas)
     Trace("sygus-pbe") << "Construct solution, #iterations = " << d_cond_count
                        << std::endl;
     d_check_sol = false;
+    d_solConsUsingInfoGain = false;
     // try multiple times if we have done multiple conditions, due to
     // non-determinism
     unsigned sol_term_size = 0;
@@ -806,6 +811,14 @@ Node SygusUnifIo::constructSolutionNode(std::vector<Node>& lemmas)
         Trace("sygus-pbe") << "...solved at iteration " << i << std::endl;
         d_solution = vcc;
         sol_term_size = d_tds->getSygusTermSize(vcc);
+        // We've determined its feasible, now, enable information gain and
+        // retry. We do this since information gain comes with an overhead,
+        // and we want testing feasibility to be fast.
+        if (!d_solConsUsingInfoGain)
+        {
+          d_solConsUsingInfoGain = true;
+          i = 0;
+        }
       }
       else if (!d_sol_cons_nondet)
       {
@@ -891,7 +904,6 @@ bool SygusUnifIo::getExplanationForEnumeratorExclude(
         << d_tds->sygusToBuiltin(v) << " based on str.contains." << std::endl;
     std::vector<unsigned> cmp_indices;
     std::vector<bool> cmpRes;
-    bool allConditionalFail = false;
     for (unsigned i = 0, size = results.size(); i < size; i++)
     {
       Assert(results[i].isConst());
@@ -912,113 +924,29 @@ bool SygusUnifIo::getExplanationForEnumeratorExclude(
         Trace("sygus-sui-cterm-debug") << "...contained." << std::endl;
         if (isConditional)
         {
-          allConditionalFail = true;
+          return false;
         }
       }
     }
     if (!cmp_indices.empty())
     {
-      if (allConditionalFail)
+      // we check invariance with respect to a negative contains test
+      NegContainsSygusInvarianceTest ncset;
+      if (isConditional)
       {
-        // we may be equivalent-to-examples on those we are contained in
-        bool res = existsSearchValSubset(e, v, results, cmpRes);
-        if (res)
-        {
-          // use basic non-generalized exclusion
-          d_tds->getExplain()->getExplanationForEquality(e, v, exp);
-          return true;
-        }
+        ncset.setUniversal();
       }
-      else
-      {
-        // we check invariance with respect to a negative contains test
-        NegContainsSygusInvarianceTest ncset;
-        if (isConditional)
-        {
-          ncset.setUniversal();
-        }
-        ncset.init(e, d_examples, d_examples_out, cmp_indices);
-        // construct the generalized explanation
-        d_tds->getExplain()->getExplanationFor(e, v, exp, ncset);
-        Trace("sygus-sui-cterm")
-            << "PBE-cterm : enumerator exclude " << d_tds->sygusToBuiltin(v)
-            << " due to negative containment." << std::endl;
-        return true;
-      }
+      ncset.init(e, d_examples, d_examples_out, cmp_indices);
+      // construct the generalized explanation
+      d_tds->getExplain()->getExplanationFor(e, v, exp, ncset);
+      Trace("sygus-sui-cterm")
+          << "PBE-cterm : enumerator exclude " << d_tds->sygusToBuiltin(v)
+          << " due to negative containment." << std::endl;
+      return true;
     }
     // if we're using it, we add it now
     addSearchVal(e, v, results);
   }
-  return false;
-}
-
-void SygusUnifIo::addSearchVal(Node e, Node v, std::vector<Node>& res)
-{
-  PbeTrie* curr = &d_pbe_trie[e];
-  for (const Node& eo : res)
-  {
-    curr = &(curr->d_children[eo]);
-  }
-  if (curr->d_children.empty())
-  {
-    curr->d_children[v].clear();
-  }
-}
-
-bool SygusUnifIo::existsSearchValSubset(Node e,
-                                        Node v,
-                                        std::vector<Node>& res,
-                                        std::vector<bool>& ss)
-{
-  Assert(res.size() == ss.size());
-  std::vector<PbeTrie*> visit;
-  std::vector<unsigned> visitIndex;
-  PbeTrie* cur = nullptr;
-  unsigned curIndex = 0;
-  visit.push_back(&d_pbe_trie[e]);
-  visitIndex.push_back(0);
-  std::map<Node, PbeTrie>::iterator cit;
-  do
-  {
-    cur = visit.back();
-    visit.pop_back();
-    curIndex = visitIndex.back();
-    visitIndex.pop_back();
-    // follow required paths
-    bool success = true;
-    while (success && curIndex < res.size() && ss[curIndex])
-    {
-      // must be the exact child
-      cit = cur->d_children.find(res[curIndex]);
-      if (cit != cur->d_children.end())
-      {
-        cur = &cit->second;
-        curIndex++;
-      }
-      else
-      {
-        success = false;
-      }
-    }
-    if (success)
-    {
-      if (curIndex == res.size())
-      {
-        return true;
-      }
-      else
-      {
-        Assert(!ss[curIndex]);
-        // branch and look at all children
-        for (cit = cur->d_children.begin(); cit != cur->d_children.end(); ++cit)
-        {
-          visit.push_back(&cit->second);
-          visitIndex.push_back(curIndex + 1);
-        }
-      }
-    }
-  } while (!visit.empty());
-
   return false;
 }
 
@@ -1098,7 +1026,7 @@ Node SygusUnifIo::constructSol(
         ecache.d_term_trie.getSubsumedBy(x.d_vals, true, subsumed_by);
         if (!subsumed_by.empty())
         {
-          ret_dt = constructBestSolvedTerm(subsumed_by);
+          ret_dt = constructBestSolvedTerm(e, subsumed_by);
           indent("sygus-sui-dt", ind);
           Trace("sygus-sui-dt") << "return PBE: success : conditionally solved"
                                 << d_tds->sygusToBuiltin(ret_dt) << std::endl;
@@ -1140,7 +1068,7 @@ Node SygusUnifIo::constructSol(
           }
           if (!str_solved.empty())
           {
-            ret_dt = constructBestStringSolvedTerm(str_solved);
+            ret_dt = constructBestSolvedTerm(e, str_solved);
             indent("sygus-sui-dt", ind);
             Trace("sygus-sui-dt") << "return PBE: success : string solved "
                                   << d_tds->sygusToBuiltin(ret_dt) << std::endl;
@@ -1419,145 +1347,46 @@ Node SygusUnifIo::constructSol(
 
             EnumCache& ecache_child = d_ecache[ce];
 
-            // only used if the return value is not modified
-            if (!x.isReturnValueModified())
-            {
-              if (x.d_uinfo.find(ce) == x.d_uinfo.end())
-              {
-                x.d_uinfo[ce].clear();
-                Trace("sygus-sui-dt-debug2")
-                    << "  reg : PBE: Look for direct solutions for conditional "
-                       "enumerator "
-                    << ce << " ... " << std::endl;
-                Assert(ecache_child.d_enum_vals.size()
-                       == ecache_child.d_enum_vals_res.size());
-                for (unsigned i = 1; i <= 2; i++)
-                {
-                  std::pair<Node, NodeRole>& te_pair = etis->d_cenum[i];
-                  Node te = te_pair.first;
-                  EnumCache& ecache_te = d_ecache[te];
-                  bool branch_pol = (i == 1);
-                  // for each condition, get terms that satisfy it in this
-                  // branch
-                  for (unsigned k = 0, size = ecache_child.d_enum_vals.size();
-                       k < size;
-                       k++)
-                  {
-                    Node cond = ecache_child.d_enum_vals[k];
-                    std::vector<Node> solved;
-                    ecache_te.d_term_trie.getSubsumedBy(
-                        ecache_child.d_enum_vals_res[k], branch_pol, solved);
-                    Trace("sygus-sui-dt-debug2")
-                        << "  reg : PBE: " << d_tds->sygusToBuiltin(cond)
-                        << " has " << solved.size() << " solutions in branch "
-                        << i << std::endl;
-                    if (!solved.empty())
-                    {
-                      Node slv = constructBestSolvedTerm(solved);
-                      Trace("sygus-sui-dt-debug2")
-                          << "  reg : PBE: ..." << d_tds->sygusToBuiltin(slv)
-                          << " is a solution under branch " << i;
-                      Trace("sygus-sui-dt-debug2")
-                          << " of condition " << d_tds->sygusToBuiltin(cond)
-                          << std::endl;
-                      x.d_uinfo[ce].d_look_ahead_sols[cond][i] = slv;
-                    }
-                  }
-                }
-              }
-            }
-
             // get the conditionals in the current context : they must be
             // distinguishable
             std::map<int, std::vector<Node> > possible_cond;
             std::map<Node, int> solved_cond;  // stores branch
             ecache_child.d_term_trie.getLeaves(x.d_vals, true, possible_cond);
 
-            // prefer distinguishable conditions, then we try true, false
-            // unsigned lastTest =
-            for (unsigned d = 0; d < 1; d++)
+            std::map<int, std::vector<Node>>::iterator itpc =
+                possible_cond.find(0);
+            if (itpc != possible_cond.end())
             {
-              unsigned pcv = d == 2 ? -1 : d;
-              std::map<int, std::vector<Node>>::iterator itpc =
-                  possible_cond.find(pcv);
-              if (itpc != possible_cond.end())
+              if (Trace.isOn("sygus-sui-dt-debug"))
               {
-                if (Trace.isOn("sygus-sui-dt-debug"))
+                indent("sygus-sui-dt-debug", ind + 1);
+                Trace("sygus-sui-dt-debug")
+                    << "PBE : We have " << itpc->second.size()
+                    << " distinguishable conditionals:" << std::endl;
+                for (Node& cond : itpc->second)
                 {
-                  indent("sygus-sui-dt-debug", ind + 1);
+                  indent("sygus-sui-dt-debug", ind + 2);
                   Trace("sygus-sui-dt-debug")
-                      << "PBE : We have " << itpc->second.size()
-                      << " distinguishable conditionals:" << std::endl;
-                  for (Node& cond : itpc->second)
-                  {
-                    indent("sygus-sui-dt-debug", ind + 2);
-                    Trace("sygus-sui-dt-debug")
-                        << d_tds->sygusToBuiltin(cond) << std::endl;
-                  }
+                      << d_tds->sygusToBuiltin(cond) << std::endl;
                 }
-
-                // static look ahead conditional : choose conditionals that have
-                // solved terms in at least one branch
-                //    only applicable if we have not modified the return value
-                std::map<int, std::vector<Node>> solved_cond;
-                if (!x.isReturnValueModified() && !x.d_uinfo[ce].empty())
-                {
-                  int solve_max = 0;
-                  for (Node& cond : itpc->second)
-                  {
-                    std::map<Node, std::map<unsigned, Node>>::iterator itla =
-                        x.d_uinfo[ce].d_look_ahead_sols.find(cond);
-                    if (itla != x.d_uinfo[ce].d_look_ahead_sols.end())
-                    {
-                      int nsolved = itla->second.size();
-                      solve_max = nsolved > solve_max ? nsolved : solve_max;
-                      solved_cond[nsolved].push_back(cond);
-                    }
-                  }
-                  int n = solve_max;
-                  while (n > 0)
-                  {
-                    if (!solved_cond[n].empty())
-                    {
-                      rec_c = constructBestSolvedConditional(solved_cond[n]);
-                      indent("sygus-sui-dt", ind + 1);
-                      Trace("sygus-sui-dt")
-                          << "PBE: ITE strategy : choose solved conditional "
-                          << d_tds->sygusToBuiltin(rec_c) << " with " << n
-                          << " solved children..." << std::endl;
-                      std::map<Node, std::map<unsigned, Node>>::iterator itla =
-                          x.d_uinfo[ce].d_look_ahead_sols.find(rec_c);
-                      Assert(itla != x.d_uinfo[ce].d_look_ahead_sols.end());
-                      for (std::pair<const unsigned, Node>& las : itla->second)
-                      {
-                        look_ahead_solved_children[las.first] = las.second;
-                      }
-                      break;
-                    }
-                    n--;
-                  }
-                }
-
-                // otherwise, guess a conditional
-                if (rec_c.isNull())
-                {
-                  rec_c = constructBestConditional(itpc->second);
-                  Assert(!rec_c.isNull());
-                  indent("sygus-sui-dt", ind);
-                  Trace("sygus-sui-dt")
-                      << "PBE: ITE strategy : choose random conditional "
-                      << d_tds->sygusToBuiltin(rec_c) << std::endl;
-                }
-                break;
               }
-              else
+              if (rec_c.isNull())
               {
+                rec_c = constructBestConditional(ce, itpc->second);
+                Assert(!rec_c.isNull());
                 indent("sygus-sui-dt", ind);
                 Trace("sygus-sui-dt")
-                    << "return PBE: failed ITE strategy, "
-                       "cannot find a distinguishable condition"
-                    << std::endl;
+                    << "PBE: ITE strategy : choose random conditional "
+                    << d_tds->sygusToBuiltin(rec_c) << std::endl;
               }
+            }
+            else
+            {
+              indent("sygus-sui-dt", ind);
+              Trace("sygus-sui-dt")
+                  << "return PBE: failed ITE strategy, "
+                      "cannot find a distinguishable condition"
+                  << std::endl;
             }
             if (!rec_c.isNull())
             {
@@ -1652,6 +1481,100 @@ Node SygusUnifIo::constructSol(
   }
 
   return ret_dt;
+}
+
+Node SygusUnifIo::constructBestConditional(Node ce,
+                                           const std::vector<Node>& conds)
+{
+  if (!d_solConsUsingInfoGain)
+  {
+    return SygusUnif::constructBestConditional(ce, conds);
+  }
+  UnifContextIo& x = d_context;
+  // use information gain heuristic
+  Trace("sygus-sui-dt-igain") << "Best information gain in context ";
+  print_val("sygus-sui-dt-igain", x.d_vals);
+  Trace("sygus-sui-dt-igain") << std::endl;
+  // set of indices that are active in this branch, i.e. x.d_vals[i] is true
+  std::vector<unsigned> activeIndices;
+  // map (j,t,s) -> n, such that the j^th condition in the vector conds
+  // evaluates to t (typically true/false) on n active I/O pairs with output s.
+  std::map<unsigned, std::map<Node, std::map<Node, unsigned>>> eval;
+  // map (j,t) -> m, such that the j^th condition in the vector conds
+  // evaluates to t (typically true/false) for m active I/O pairs.
+  std::map<unsigned, std::map<Node, unsigned>> evalCount;
+  unsigned nconds = conds.size();
+  EnumCache& ecache = d_ecache[ce];
+  // Get the index of conds[j] in the enumerator cache, this is to look up
+  // its evaluation on each point.
+  std::vector<unsigned> eindex;
+  for (unsigned j = 0; j < nconds; j++)
+  {
+    eindex.push_back(ecache.d_enum_val_to_index[conds[j]]);
+  }
+  unsigned activePoints = 0;
+  for (unsigned i = 0, npoints = x.d_vals.size(); i < npoints; i++)
+  {
+    if (x.d_vals[i].getConst<bool>())
+    {
+      activePoints++;
+      Node eo = d_examples_out[i];
+      for (unsigned j = 0; j < nconds; j++)
+      {
+        Node resn = ecache.d_enum_vals_res[eindex[j]][i];
+        Assert(resn.isConst());
+        eval[j][resn][eo]++;
+        evalCount[j][resn]++;
+      }
+    }
+  }
+  AlwaysAssert(activePoints > 0);
+  // find the condition that leads to the lowest entropy
+  // initially set minEntropy to > 1.0.
+  double minEntropy = 2.0;
+  unsigned bestIndex = 0;
+  for (unsigned j = 0; j < nconds; j++)
+  {
+    // To compute the entropy for a condition C, for pair of terms (s, t), let
+    //   prob(t) be the probability C evaluates to t on an active point,
+    //   prob(s|t) be the probability that an active point on which C
+    //     evaluates to t has output s.
+    // Then, the entropy of C is:
+    //   sum{t}. prob(t)*( sum{s}. -prob(s|t)*log2(prob(s|t)) )
+    // where notice this is always between 0 and 1.
+    double entropySum = 0.0;
+    Trace("sygus-sui-dt-igain") << j << " : ";
+    for (std::pair<const Node, std::map<Node, unsigned>>& ej : eval[j])
+    {
+      unsigned ecount = evalCount[j][ej.first];
+      if (ecount > 0)
+      {
+        double probBranch = double(ecount) / double(activePoints);
+        Trace("sygus-sui-dt-igain") << ej.first << " -> ( ";
+        for (std::pair<const Node, unsigned>& eej : ej.second)
+        {
+          if (eej.second > 0)
+          {
+            double probVal = double(eej.second) / double(ecount);
+            Trace("sygus-sui-dt-igain")
+                << eej.first << ":" << eej.second << " ";
+            double factor = -probVal * log2(probVal);
+            entropySum += probBranch * factor;
+          }
+        }
+        Trace("sygus-sui-dt-igain") << ") ";
+      }
+    }
+    Trace("sygus-sui-dt-igain") << "..." << entropySum << std::endl;
+    if (entropySum < minEntropy)
+    {
+      minEntropy = entropySum;
+      bestIndex = j;
+    }
+  }
+
+  Assert(!conds.empty());
+  return conds[bestIndex];
 }
 
 } /* CVC4::theory::quantifiers namespace */

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -1093,7 +1093,7 @@ Node SygusUnifIo::constructSol(
       std::unordered_set<Node, NodeHashFunction> intersection;
       std::map<size_t, std::unordered_set<Node, NodeHashFunction>>::iterator
           pit;
-      for (unsigned i = 0, nvals = x.d_vals.size(); i < nvals; i++)
+      for (size_t i = 0, nvals = x.d_vals.size(); i < nvals; i++)
       {
         if (x.d_vals[i].getConst<bool>())
         {

--- a/src/theory/quantifiers/sygus/sygus_unif_io.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.h
@@ -447,6 +447,14 @@ class SygusUnifIo : public SygusUnif
                     NodeRole nrole,
                     int ind,
                     std::vector<Node>& lemmas) override;
+  /** construct best conditional
+   *
+   * This returns the condition in conds that maximizes information gain with
+   * respect to the current active points in d_context. For example, see
+   * Alur et al. TACAS 2017 for an example of information gain.
+   */
+  Node constructBestConditional(Node ce,
+                                const std::vector<Node>& conds) override;
 };
 
 } /* CVC4::theory::quantifiers namespace */

--- a/src/theory/quantifiers/sygus/sygus_unif_io.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.h
@@ -124,33 +124,6 @@ class UnifContextIo : public UnifContext
   */
   std::map<Node, std::map<NodeRole, bool>> d_visit_role;
 
-  /** unif context enumerator information */
-  class UEnumInfo
-  {
-   public:
-    UEnumInfo() {}
-    /** map from conditions and branch positions to a solved node
-    *
-    * For example, if we have:
-    *   f( 1 ) = 2 ^ f( 3 ) = 4 ^ f( -1 ) = 1
-    * Then, valid entries in this map is:
-    *   d_look_ahead_sols[x>0][1] = x+1
-    *   d_look_ahead_sols[x>0][2] = 1
-    * For the first entry, notice that  for all input examples such that x>0
-    * evaluates to true, which are (1) and (3), we have that their output
-    * values for x+1 under the substitution that maps x to the input value,
-    * resulting in 2 and 4, are equal to the output value for the respective
-    * pairs.
-    */
-    std::map<Node, std::map<unsigned, Node>> d_look_ahead_sols;
-    /** clear */
-    void clear() { d_look_ahead_sols.clear(); }
-    /** is empty */
-    bool empty() { return d_look_ahead_sols.empty(); }
-  };
-  /** map from enumerators to the above info class */
-  std::map<Node, UEnumInfo> d_uinfo;
-
  private:
   /** true and false nodes */
   Node d_true;
@@ -353,6 +326,11 @@ class SygusUnifIo : public SygusUnif
    * which can be closed with "B", giving us (x ++ "B") as a solution.
    */
   bool d_sol_cons_nondet;
+  /**
+   * Whether we are using information gain heuristic during solution
+   * construction.
+   */
+  bool d_solConsUsingInfoGain;
   /** true and false nodes */
   Node d_true;
   Node d_false;
@@ -469,28 +447,6 @@ class SygusUnifIo : public SygusUnif
                     NodeRole nrole,
                     int ind,
                     std::vector<Node>& lemmas) override;
-
-  class PbeTrie
-  {
-   public:
-    PbeTrie() {}
-    ~PbeTrie() {}
-    /** the children for this node in the trie */
-    std::map<Node, PbeTrie> d_children;
-    /** clear this trie */
-    void clear() { d_children.clear(); }
-    /**
-     * Add term b whose value on examples is exOut to the trie. Return
-     * the first term registered to this trie whose evaluation was exOut.
-     */
-    Node addTerm(Node b, std::vector<Node>& exOut);
-  };
-  std::map<Node, PbeTrie> d_pbe_trie;
-  void addSearchVal(Node e, Node v, std::vector<Node>& res);
-  bool existsSearchValSubset(Node e,
-                             Node v,
-                             std::vector<Node>& res,
-                             std::vector<bool>& ss);
 };
 
 } /* CVC4::theory::quantifiers namespace */

--- a/src/theory/quantifiers/sygus/sygus_unif_io.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.h
@@ -306,7 +306,7 @@ class SygusUnifIo : public SygusUnif
    *
    * Maps indices for I/O points to a list of solutions for that point.
    */
-  std::map<unsigned, std::unordered_set<Node, NodeHashFunction>> d_psolutions;
+  std::map<size_t, std::unordered_set<Node, NodeHashFunction>> d_psolutions;
   /**
    * This flag is set to true if the solution construction was
    * non-deterministic with respect to failure/success.

--- a/src/theory/quantifiers/sygus/sygus_unif_io.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.h
@@ -434,7 +434,11 @@ class SygusUnifIo : public SygusUnif
   bool useStrContainsEnumeratorExclude(Node e);
   /** cache for the above function */
   std::map<Node, bool> d_use_str_contains_eexc;
-  /** cache for the above function */
+  /**
+   * cache for the above function, stores whether enumerators e are in
+   * a conditional context, e.g. used for enumerating the return values for
+   * leaves of ITE trees.
+   */
   std::map<Node, bool> d_use_str_contains_eexc_conditional;
 
   /** the unification context used within constructSolution */

--- a/src/theory/quantifiers/sygus/sygus_unif_io.h
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.h
@@ -124,6 +124,33 @@ class UnifContextIo : public UnifContext
   */
   std::map<Node, std::map<NodeRole, bool>> d_visit_role;
 
+  /** unif context enumerator information */
+  class UEnumInfo
+  {
+   public:
+    UEnumInfo() {}
+    /** map from conditions and branch positions to a solved node
+    *
+    * For example, if we have:
+    *   f( 1 ) = 2 ^ f( 3 ) = 4 ^ f( -1 ) = 1
+    * Then, valid entries in this map is:
+    *   d_look_ahead_sols[x>0][1] = x+1
+    *   d_look_ahead_sols[x>0][2] = 1
+    * For the first entry, notice that  for all input examples such that x>0
+    * evaluates to true, which are (1) and (3), we have that their output
+    * values for x+1 under the substitution that maps x to the input value,
+    * resulting in 2 and 4, are equal to the output value for the respective
+    * pairs.
+    */
+    std::map<Node, std::map<unsigned, Node>> d_look_ahead_sols;
+    /** clear */
+    void clear() { d_look_ahead_sols.clear(); }
+    /** is empty */
+    bool empty() { return d_look_ahead_sols.empty(); }
+  };
+  /** map from enumerators to the above info class */
+  std::map<Node, UEnumInfo> d_uinfo;
+
  private:
   /** true and false nodes */
   Node d_true;
@@ -183,12 +210,14 @@ class SubsumeTrie
                      bool pol,
                      std::vector<Node>& subsumed_by);
   /**
-  * Get the leaves of the trie, which we store in the map v.
-  * v[-1] stores the children that always evaluate to !pol,
-  * v[1] stores the children that always evaluate to pol,
-  * v[0] stores the children that both evaluate to true and false for at least
-  * one example.
-  */
+   * Get the leaves of the trie, which we store in the map v. We consider their
+   * evaluation on points such that (pol ? vals : !vals) is true.
+   *
+   * v[-1] stores the children that always evaluate to !pol,
+   * v[1] stores the children that always evaluate to pol,
+   * v[0] stores the children that both evaluate to true and false for at least
+   * one example.
+   */
   void getLeaves(const std::vector<Node>& vals,
                  bool pol,
                  std::map<int, std::vector<Node>>& v);
@@ -298,6 +327,11 @@ class SygusUnifIo : public SygusUnif
   unsigned d_cond_count;
   /** The solution for the function of this class, if one has been found */
   Node d_solution;
+  /** partial solutions
+   *
+   * Maps indices for I/O points to a list of solutions for that point.
+   */
+  std::map<unsigned, std::unordered_set<Node, NodeHashFunction>> d_psolutions;
   /**
    * This flag is set to true if the solution construction was
    * non-deterministic with respect to failure/success.
@@ -319,11 +353,6 @@ class SygusUnifIo : public SygusUnif
    * which can be closed with "B", giving us (x ++ "B") as a solution.
    */
   bool d_sol_cons_nondet;
-  /**
-   * Whether we are using information gain heuristic during solution
-   * construction.
-   */
-  bool d_solConsUsingInfoGain;
   /** true and false nodes */
   Node d_true;
   Node d_false;
@@ -425,6 +454,8 @@ class SygusUnifIo : public SygusUnif
   bool useStrContainsEnumeratorExclude(Node e);
   /** cache for the above function */
   std::map<Node, bool> d_use_str_contains_eexc;
+  /** cache for the above function */
+  std::map<Node, bool> d_use_str_contains_eexc_conditional;
 
   /** the unification context used within constructSolution */
   UnifContextIo d_context;
@@ -438,14 +469,28 @@ class SygusUnifIo : public SygusUnif
                     NodeRole nrole,
                     int ind,
                     std::vector<Node>& lemmas) override;
-  /** construct best conditional
-   *
-   * This returns the condition in conds that maximizes information gain with
-   * respect to the current active points in d_context. For example, see
-   * Alur et al. TACAS 2017 for an example of information gain.
-   */
-  Node constructBestConditional(Node ce,
-                                const std::vector<Node>& conds) override;
+
+  class PbeTrie
+  {
+   public:
+    PbeTrie() {}
+    ~PbeTrie() {}
+    /** the children for this node in the trie */
+    std::map<Node, PbeTrie> d_children;
+    /** clear this trie */
+    void clear() { d_children.clear(); }
+    /**
+     * Add term b whose value on examples is exOut to the trie. Return
+     * the first term registered to this trie whose evaluation was exOut.
+     */
+    Node addTerm(Node b, std::vector<Node>& exOut);
+  };
+  std::map<Node, PbeTrie> d_pbe_trie;
+  void addSearchVal(Node e, Node v, std::vector<Node>& res);
+  bool existsSearchValSubset(Node e,
+                             Node v,
+                             std::vector<Node>& res,
+                             std::vector<bool>& ss);
 };
 
 } /* CVC4::theory::quantifiers namespace */


### PR DESCRIPTION
This includes:
- Caching solutions that satisfy *some* but not all I/O pairs, which is useful for non-deterministic strategies that are combined with ITE,
- Not registering terms to concatenation PBE pool that are not contained in all examples.