### PR TITLE
Enable BV proofs when using an eager bitblaster

### DIFF
--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -1632,7 +1632,14 @@ void OptionsHandler::setProduceAssertions(std::string option, bool value)
 
 void OptionsHandler::proofEnabledBuild(std::string option, bool value)
 {
-#ifndef CVC4_PROOF
+#ifdef CVC4_PROOF
+  if (options::bitblastMode() == theory::bv::BITBLAST_MODE_EAGER
+      && options::bvSatSolver() != theory::bv::SAT_SOLVER_MINISAT)
+  {
+    throw OptionException(
+        "Eager BV proofs only supported when minisat is used");
+  }
+#else
   if(value) {
     std::stringstream ss;
     ss << "option `" << option << "' requires a proofs-enabled build of CVC4; this binary was not built with proof support";

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -1633,7 +1633,7 @@ void OptionsHandler::setProduceAssertions(std::string option, bool value)
 void OptionsHandler::proofEnabledBuild(std::string option, bool value)
 {
 #ifdef CVC4_PROOF
-  if (options::bitblastMode() == theory::bv::BITBLAST_MODE_EAGER
+  if (value && options::bitblastMode() == theory::bv::BITBLAST_MODE_EAGER
       && options::bvSatSolver() != theory::bv::SAT_SOLVER_MINISAT)
   {
     throw OptionException(

--- a/src/proof/bitvector_proof.cpp
+++ b/src/proof/bitvector_proof.cpp
@@ -81,7 +81,9 @@ void BitVectorProof::registerTerm(Expr term) {
   Debug("pf::bv") << "BitVectorProof::registerTerm( " << term << " )"
                   << std::endl;
 
-  if (options::lfscLetification() && term.isConst()) {
+  if (options::lfscLetification() && term.isConst()
+      && term.getType().isBitVector())
+  {
     if (d_constantLetMap.find(term) == d_constantLetMap.end()) {
       std::ostringstream name;
       name << "letBvc" << d_constantLetMap.size();
@@ -623,8 +625,6 @@ void BitVectorProof::printBitblasting(std::ostream& os, std::ostream& paren)
         << std::endl;
     std::vector<Expr>::const_iterator it = d_bbTerms.begin();
     std::vector<Expr>::const_iterator end = d_bbTerms.end();
-
-    Assert(options::bitblastMode() != theory::bv::BITBLAST_MODE_EAGER);
 
     for (; it != end; ++it) {
       if (d_usedBB.find(*it) == d_usedBB.end()) {

--- a/src/proof/proof_manager.cpp
+++ b/src/proof/proof_manager.cpp
@@ -559,8 +559,6 @@ void LFSCProof::toStream(std::ostream& out, const ProofLetMap& map) const
 
 void LFSCProof::toStream(std::ostream& out) const
 {
-  Assert(options::bitblastMode() != theory::bv::BITBLAST_MODE_EAGER);
-
   Assert(!d_satProof->proofConstructed());
   d_satProof->constructProof();
 
@@ -730,6 +728,7 @@ void LFSCProof::toStream(std::ostream& out) const
   d_theoryProof->printTheoryLemmas(used_lemmas, out, paren, globalLetMap);
   Debug("pf::pm") << "Proof manager: printing theory lemmas DONE!" << std::endl;
 
+  out << ";; Printing final unsat proof \n";
   if (options::bitblastMode() == theory::bv::BITBLAST_MODE_EAGER && ProofManager::getBitVectorProof()) {
     proof::LFSCProofPrinter::printResolutionEmptyClause(
         ProofManager::getBitVectorProof()->getSatProof(), out, paren);

--- a/src/theory/bv/bitblast/eager_bitblaster.cpp
+++ b/src/theory/bv/bitblast/eager_bitblaster.cpp
@@ -99,9 +99,8 @@ void EagerBitblaster::bbFormula(TNode node)
 void EagerBitblaster::bbAtom(TNode node)
 {
   node = node.getKind() == kind::NOT ? node[0] : node;
-  if (node.getKind() == kind::BITVECTOR_BITOF ||
-      node.getKind() == kind::CONST_BOOLEAN ||
-      hasBBAtom(node))
+  if (node.getKind() == kind::BITVECTOR_BITOF
+      || node.getKind() == kind::CONST_BOOLEAN || hasBBAtom(node))
   {
     return;
   }

--- a/src/theory/bv/bitblast/eager_bitblaster.cpp
+++ b/src/theory/bv/bitblast/eager_bitblaster.cpp
@@ -99,8 +99,9 @@ void EagerBitblaster::bbFormula(TNode node)
 void EagerBitblaster::bbAtom(TNode node)
 {
   node = node.getKind() == kind::NOT ? node[0] : node;
-  if (node.getKind() == kind::BITVECTOR_BITOF) return;
-  if (hasBBAtom(node))
+  if (node.getKind() == kind::BITVECTOR_BITOF ||
+      node.getKind() == kind::CONST_BOOLEAN ||
+      hasBBAtom(node))
   {
     return;
   }

--- a/test/regress/regress0/bv/ackermann1.smt2
+++ b/test/regress/regress0/bv/ackermann1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --bitblast=eager --no-check-models --no-check-proofs --no-check-unsat-cores
+; COMMAND-LINE: --bitblast=eager --no-check-models  --no-check-unsat-cores
 ; EXPECT: sat
 (set-logic QF_UFBV)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/bv/ackermann2.smt2
+++ b/test/regress/regress0/bv/ackermann2.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --bitblast=eager --no-check-models --no-check-proofs --no-check-unsat-cores
+; COMMAND-LINE: --bitblast=eager --no-check-models  --no-check-unsat-cores
 ; EXPECT: unsat
 (set-logic QF_UFBV)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress1/bv/bug787.smt2
+++ b/test/regress/regress1/bv/bug787.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --bitblast=eager --no-check-proofs
+; COMMAND-LINE: --bitblast=eager 
 ; EXPECT: unsat
 (set-logic QF_BV)
 (set-info :status unsat)


### PR DESCRIPTION
Specifically:
   * Removed assertions that blocked them.
   * Made sure that only bitvectors were stored in the BV const let-map
   * Prevented true/false from being bit-blasted by the eager bitblaster

Also:
   * uncommented "no-check-proofs" from relevant tests

Tested with `make check` which (after this PR) includes 3 tests of eager bitblasting proofs.