### PR TITLE
Enable regular expression elimination by default.

### DIFF
--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -205,7 +205,7 @@ header = "options/strings_options.h"
   category   = "regular"
   long       = "re-elim"
   type       = "bool"
-  default    = "false"
+  default    = "true"
   help       = "elimination techniques for regular expressions"
 
 [[option]]


### PR DESCRIPTION
Seems to have no impact on Norn, and is helpful for a number of applications.