### PR TITLE
 [LRA Proof] Storage for LRA proofs 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,8 @@ libcvc4_add_sources(
   printer/tptp/tptp_printer.h
   proof/arith_proof.cpp
   proof/arith_proof.h
+  proof/arith_proof_recorder.cpp
+  proof/arith_proof_recorder.h
   proof/array_proof.cpp
   proof/array_proof.h
   proof/bitvector_proof.cpp

--- a/src/proof/arith_proof.cpp
+++ b/src/proof/arith_proof.cpp
@@ -640,8 +640,10 @@ Node ProofArith::toStreamRecLFSC(std::ostream& out,
 }
 
 ArithProof::ArithProof(theory::arith::TheoryArith* arith, TheoryProofEngine* pe)
-  : TheoryProof(arith, pe), d_realMode(false)
-{}
+  : TheoryProof(arith, pe), d_recorder(), d_realMode(false)
+{
+  arith->setProofRecorder(&d_recorder);
+}
 
 theory::TheoryId ArithProof::getTheoryId() { return theory::THEORY_ARITH; }
 void ArithProof::registerTerm(Expr term) {

--- a/src/proof/arith_proof.h
+++ b/src/proof/arith_proof.h
@@ -63,6 +63,9 @@ protected:
   //   TypeSet d_sorts;        // all the uninterpreted sorts in this theory
   ExprSet d_declarations; // all the variable/function declarations
 
+  /**
+   * @brief Where farkas proofs of lemmas are stored.
+   */
   proof::ArithProofRecorder d_recorder;
 
   bool d_realMode;

--- a/src/proof/arith_proof.h
+++ b/src/proof/arith_proof.h
@@ -23,6 +23,7 @@
 #include <unordered_set>
 
 #include "expr/expr.h"
+#include "proof/arith_proof_recorder.h"
 #include "proof/proof_manager.h"
 #include "proof/theory_proof.h"
 #include "theory/uf/equality_engine.h"
@@ -61,6 +62,8 @@ protected:
 
   //   TypeSet d_sorts;        // all the uninterpreted sorts in this theory
   ExprSet d_declarations; // all the variable/function declarations
+
+  proof::ArithProofRecorder d_recorder;
 
   bool d_realMode;
   theory::TheoryId getTheoryId() override;

--- a/src/proof/arith_proof_recorder.cpp
+++ b/src/proof/arith_proof_recorder.cpp
@@ -29,13 +29,21 @@ void ArithProofRecorder::saveFarkasCoefficients(
 {
   Assert(conflict.getKind() == kind::AND);
   Assert(conflict.getNumChildren() == farkasCoefficients->size());
+    for (size_t i = 0; i < conflict.getNumChildren(); ++i)
+    {
+      const Node& child = conflict[i];
+      Assert(child.getType().isBoolean() && child[0].getType().isReal());
+    }
   Debug("pf::arith") << "Saved Farkas Coefficients:" << std::endl;
-  for (size_t i = 0; i < conflict.getNumChildren(); ++i)
+  if (Debug.isOn("pf::arith"))
   {
-    const Node& child = conflict[i];
-    const Rational& r = (*farkasCoefficients)[i];
-    Debug("pf::arith") << "  " << std::setw(8) << r;
-    Debug("pf::arith") << "  " << child << std::endl;
+    for (size_t i = 0; i < conflict.getNumChildren(); ++i)
+    {
+      const Node& child = conflict[i];
+      const Rational& r = (*farkasCoefficients)[i];
+      Debug("pf::arith") << "  " << std::setw(8) << r;
+      Debug("pf::arith") << "  " << child << std::endl;
+    }
   }
 
   std::set<Node> lits;

--- a/src/proof/arith_proof_recorder.cpp
+++ b/src/proof/arith_proof_recorder.cpp
@@ -29,11 +29,11 @@ void ArithProofRecorder::saveFarkasCoefficients(
 {
   Assert(conflict.getKind() == kind::AND);
   Assert(conflict.getNumChildren() == farkasCoefficients->size());
-    for (size_t i = 0; i < conflict.getNumChildren(); ++i)
-    {
-      const Node& child = conflict[i];
-      Assert(child.getType().isBoolean() && child[0].getType().isReal());
-    }
+  for (size_t i = 0; i < conflict.getNumChildren(); ++i)
+  {
+    const Node& child = conflict[i];
+    Assert(child.getType().isBoolean() && child[0].getType().isReal());
+  }
   Debug("pf::arith") << "Saved Farkas Coefficients:" << std::endl;
   if (Debug.isOn("pf::arith"))
   {

--- a/src/proof/arith_proof_recorder.cpp
+++ b/src/proof/arith_proof_recorder.cpp
@@ -9,7 +9,7 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief A class for saving the skeletons of a arithmetic proofs for later.
+ ** \brief A class for saving the skeletons of arithmetic proofs for later.
  **/
 
 #include "proof/arith_proof_recorder.h"

--- a/src/proof/arith_proof_recorder.cpp
+++ b/src/proof/arith_proof_recorder.cpp
@@ -9,13 +9,16 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief A class for saving the skeletons of arithmetic proofs for later.
+ ** \brief A class for recording the skeletons of arithmetic proofs at solve
+ ** time so they can later be used during proof-production time.
  **/
 
 #include "proof/arith_proof_recorder.h"
 
 #include <algorithm>
 #include <vector>
+
+#include "base/map_util.h"
 
 namespace CVC4 {
 namespace proof {
@@ -64,10 +67,9 @@ bool ArithProofRecorder::hasFarkasCoefficients(
 std::pair<Node, theory::arith::RationalVectorCP>
 ArithProofRecorder::getFarkasCoefficients(const std::set<Node>& conflict) const
 {
-  if (hasFarkasCoefficients(conflict))
+  if (auto *p = FindOrNull(d_lemmasToFarkasCoefficients, conflict))
   {
-    return std::make_pair(d_lemmasToFarkasCoefficients.at(conflict).first,
-                          &d_lemmasToFarkasCoefficients.at(conflict).second);
+    return std::make_pair(p->first, &p->second);
   }
   else
   {

--- a/src/proof/arith_proof_recorder.h
+++ b/src/proof/arith_proof_recorder.h
@@ -1,0 +1,101 @@
+/*********************                                                        */
+/*! \file arith_proof_recorder.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Alex Ozdemir
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief A class for saving the skeletons of a arithmetic proofs for later.
+ **
+ ** In particular, we're interested in proving bottom from a conjunction of
+ ** theory literals.
+ **
+ ** For now, we assume that this can be done using a Farkas combination, and if
+ ** that doesn't work for some reason, then we give up and "trust" the lemma.
+ ** In the future we'll build support for more sophisticated reasoning.
+ **
+ ** Given this scope, our task is to...
+ **   for each lemma (a set of literals)
+ **   save the farkas coefficients for those literals
+ **      which requires we save an ordering of the literals
+ **      and a parallel ordering of farkas coefficients.
+ **
+ ** Farkas proofs have the following cocre structure:
+ **    For a list of affine bounds: c[i] dot x >= b[i]
+ **    and a list of non-negative coefficients: f[i],
+ **    compute
+ **
+ **             sum_i{ (c[i] dot x) * f[i] }     and   sum_i{b[i]*f[i]}
+ **
+ **    and then verify that the left is actually < the right, a (=><=)
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef __CVC4__PROOF__ARITH_PROOF_RECORDER_H
+#define __CVC4__PROOF__ARITH_PROOF_RECORDER_H
+
+#include <map>
+#include <set>
+
+#include "expr/node.h"
+#include "theory/arith/constraint_forward.h"
+
+namespace CVC4 {
+namespace proof {
+
+class ArithProofRecorder
+{
+ public:
+  ArithProofRecorder();
+
+  /**
+   * @brief For a set of incompatible literal, save the Farkas coefficients
+   * demonstrating their incompatibilty
+   *
+   * @param conflict a bunch of conjoined literals which form a conflict
+   * @param farkasCoefficients a list of rational coefficients to multiple each
+   *        literal by
+   *
+   * The orders of the two vectors must agree!
+   */
+  void saveFarkasCoefficients(
+      Node conflict, theory::arith::RationalVectorCP farkasCoefficients);
+
+  /**
+   * @brief Determine whether some literals have a farkas proof of their
+   * incompatibility
+   *
+   * @param conflict the literals which if conjoined, putatively imply bottom
+   *
+   * @return whether or not there is actually a proof for them.
+   */
+  bool hasFarkasCoefficients(const std::set<Node>& conflict) const;
+
+  /**
+   * @brief Get the Farkas Coefficients object
+   *
+   * @param conflict a bunch of literals which if conjoined, form a conflict
+   * @return theory::arith::RationalVectorCP -- the farkas coefficients
+   *         Node -- a conjunction of the problem literals in coefficient order
+   *
+   *         theory::arith::RationalVectorCPSentinel if there is no entry for
+   * these lits
+   */
+  std::pair<Node, theory::arith::RationalVectorCP> getFarkasCoefficients(
+      const std::set<Node>& conflict) const;
+
+ protected:
+  // For each lemma, save the farkas coefficients of that lemma
+  std::map<std::set<Node>, std::pair<Node, theory::arith::RationalVector>>
+      d_lemmasToFarkasCoefficients;
+};
+
+}  // namespace proof
+}  // namespace CVC4
+
+#endif

--- a/src/proof/arith_proof_recorder.h
+++ b/src/proof/arith_proof_recorder.h
@@ -9,7 +9,8 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief A class for saving the skeletons of a arithmetic proofs for later.
+ ** \brief A class for recording the skeletons of arithmetic proofs at solve
+ ** time so they can later be used during proof-production time.
  **
  ** In particular, we're interested in proving bottom from a conjunction of
  ** theory literals.
@@ -20,9 +21,9 @@
  **
  ** Given this scope, our task is to...
  **   for each lemma (a set of literals)
- **   save the farkas coefficients for those literals
+ **   save the Farkas coefficients for those literals
  **      which requires we save an ordering of the literals
- **      and a parallel ordering of farkas coefficients.
+ **      and a parallel ordering of Farkas coefficients.
  **
  ** Farkas proofs have the following core structure:
  **    For a list of affine bounds: c[i] dot x >= b[i]
@@ -35,7 +36,7 @@
  **
  **    and then verify that the left is actually < the right, a contradiction
  **
- **    To be clear: this code does not check farkas proofs, it just stores the
+ **    To be clear: this code does not check Farkas proofs, it just stores the
  **    information needed to write them.
  **/
 
@@ -59,12 +60,12 @@ class ArithProofRecorder
   ArithProofRecorder();
 
   /**
-   * @brief For a set of incompatible literal, save the Farkas coefficients
-   * demonstrating their incompatibilty
+   * @brief For a set of incompatible literals, save the Farkas coefficients
+   * demonstrating their incompatibility
    *
-   * @param conflict a bunch of conjoined literals which form a conflict
-   * @param farkasCoefficients a list of rational coefficients to multiple each
-   *        literal by
+   * @param conflict a conjunction of conflicting literals
+   * @param farkasCoefficients a list of rational coefficients which the literals
+   *       should be multiplied by (pairwise) to produce a contradiction.
    *
    * The orders of the two vectors must agree!
    */
@@ -72,10 +73,10 @@ class ArithProofRecorder
       Node conflict, theory::arith::RationalVectorCP farkasCoefficients);
 
   /**
-   * @brief Determine whether some literals have a farkas proof of their
+   * @brief Determine whether some literals have a Farkas proof of their
    * incompatibility
    *
-   * @param conflict the literals which if conjoined, putatively imply bottom
+   * @param conflict a conjunction of (putatively) conflicting literals
    *
    * @return whether or not there is actually a proof for them.
    */
@@ -84,8 +85,8 @@ class ArithProofRecorder
   /**
    * @brief Get the Farkas Coefficients object
    *
-   * @param conflict a bunch of literals which if conjoined, form a conflict
-   * @return theory::arith::RationalVectorCP -- the farkas coefficients
+   * @param conflict a conjunction of conflicting literals
+   * @return theory::arith::RationalVectorCP -- the Farkas coefficients
    *         Node -- a conjunction of the problem literals in coefficient order
    *
    *         theory::arith::RationalVectorCPSentinel if there is no entry for
@@ -95,7 +96,7 @@ class ArithProofRecorder
       const std::set<Node>& conflict) const;
 
  protected:
-  // For each lemma, save the farkas coefficients of that lemma
+  // For each lemma, save the Farkas coefficients of that lemma
   std::map<std::set<Node>, std::pair<Node, theory::arith::RationalVector>>
       d_lemmasToFarkasCoefficients;
 };

--- a/src/proof/arith_proof_recorder.h
+++ b/src/proof/arith_proof_recorder.h
@@ -24,14 +24,19 @@
  **      which requires we save an ordering of the literals
  **      and a parallel ordering of farkas coefficients.
  **
- ** Farkas proofs have the following cocre structure:
+ ** Farkas proofs have the following core structure:
  **    For a list of affine bounds: c[i] dot x >= b[i]
+ **      (x is a vector of variables)
+ **      (c[i] is a vector of coefficients)
  **    and a list of non-negative coefficients: f[i],
  **    compute
  **
  **             sum_i{ (c[i] dot x) * f[i] }     and   sum_i{b[i]*f[i]}
  **
- **    and then verify that the left is actually < the right, a (=><=)
+ **    and then verify that the left is actually < the right, a contradiction
+ **
+ **    To be clear: this code does not check farkas proofs, it just stores the
+ **    information needed to write them.
  **/
 
 #include "cvc4_private.h"

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -36,6 +36,7 @@ TheoryArith::TheoryArith(context::Context* c, context::UserContext* u,
     : Theory(THEORY_ARITH, c, u, out, valuation, logicInfo)
     , d_internal(new TheoryArithPrivate(*this, c, u, out, valuation, logicInfo))
     , d_ppRewriteTimer("theory::arith::ppRewriteTimer")
+    , d_proofRecorder(nullptr)
 {
   smtStatisticsRegistry()->registerStat(&d_ppRewriteTimer);
   if (options::nlExt()) {

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -19,6 +19,7 @@
 
 #include "theory/theory.h"
 #include "expr/node.h"
+#include "proof/arith_proof_recorder.h"
 #include "theory/arith/theory_arith_private_forward.h"
 
 
@@ -39,6 +40,8 @@ private:
   TheoryArithPrivate* d_internal;
 
   TimerStat d_ppRewriteTimer;
+
+  proof::ArithProofRecorder * d_proofRecorder;
 
 public:
   TheoryArith(context::Context* c, context::UserContext* u, OutputChannel& out,
@@ -89,6 +92,11 @@ public:
       TNode lit,
       const EntailmentCheckParameters* params,
       EntailmentCheckSideEffects* out) override;
+
+  void setProofRecorder(proof::ArithProofRecorder * proofRecorder)
+  {
+    d_proofRecorder = proofRecorder;
+  }
 
 };/* class TheoryArith */
 

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -41,6 +41,9 @@ private:
 
   TimerStat d_ppRewriteTimer;
 
+  /**
+   * @brief Where to store Farkas proofs of lemmas
+   */
   proof::ArithProofRecorder * d_proofRecorder;
 
 public:


### PR DESCRIPTION
During LRA solving the `ConstraintDatabase` contains the reasoning
behind different constraints. Combinations of constraints are
periodically used to justify lemmas (conflict clauses, propegations, ...
?). `ConstraintDatabase` is SAT context-dependent.

ArithProofRecorder will be used to store concise representations of the
proof for each lemma raised by the (LR)A theory. The (LR)A theory will
write to it, and the ArithProof class will read from it to produce LFSC
proofs.

Right now, it's pretty simplistic -- it allows for only Farkas proofs.

In future PRs I'll:
   1. add logic that stores proofs therein
   2. add logic that retrieves and prints proofs
   3. enable LRA proof production, checking, and testing