### PR TITLE
Add missing type rules for parameterized operator kinds.

### DIFF
--- a/src/theory/arith/kinds
+++ b/src/theory/arith/kinds
@@ -107,6 +107,7 @@ typerule ABS ::CVC4::theory::arith::IntOperatorTypeRule
 typerule INTS_DIVISION ::CVC4::theory::arith::IntOperatorTypeRule
 typerule INTS_MODULUS ::CVC4::theory::arith::IntOperatorTypeRule
 typerule DIVISIBLE ::CVC4::theory::arith::IntUnaryPredicateTypeRule
+typerule DIVISIBLE_OP ::CVC4::theory::arith::DivisibleOpTypeRule
 
 typerule DIVISION_TOTAL ::CVC4::theory::arith::ArithOperatorTypeRule
 typerule INTS_DIVISION_TOTAL ::CVC4::theory::arith::IntOperatorTypeRule

--- a/src/theory/arith/theory_arith_type_rules.h
+++ b/src/theory/arith/theory_arith_type_rules.h
@@ -169,6 +169,18 @@ public:
   }
 };/* class RealNullaryOperatorTypeRule */
 
+class DivisibleOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::DIVISIBLE_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class DivisibleOpTypeRule */
+
 }/* CVC4::theory::arith namespace */
 }/* CVC4::theory namespace */
 }/* CVC4 namespace */

--- a/src/theory/bv/kinds
+++ b/src/theory/bv/kinds
@@ -36,101 +36,118 @@ well-founded BITVECTOR_TYPE \
     "(*CVC4::theory::TypeEnumerator(%TYPE%))" \
     "theory/type_enumerator.h"
 
+### non-parameterized operator kinds ------------------------------------------
+
+## concatentation kind
 operator BITVECTOR_CONCAT 2: "concatenation of two or more bit-vectors"
+
+## bit-wise kinds
 operator BITVECTOR_AND 2: "bitwise and of two or more bit-vectors"
+operator BITVECTOR_COMP 2 "equality comparison of two bit-vectors (returns one bit)"
 operator BITVECTOR_OR 2: "bitwise or of two or more bit-vectors"
 operator BITVECTOR_XOR 2: "bitwise xor of two or more bit-vectors"
 operator BITVECTOR_NOT 1 "bitwise not of a bit-vector"
 operator BITVECTOR_NAND 2 "bitwise nand of two bit-vectors"
 operator BITVECTOR_NOR 2 "bitwise nor of two bit-vectors"
 operator BITVECTOR_XNOR 2 "bitwise xnor of two bit-vectors"
-operator BITVECTOR_COMP 2 "equality comparison of two bit-vectors (returns one bit)"
+
+## arithmetic kinds
 operator BITVECTOR_MULT 2: "multiplication of two or more bit-vectors"
+operator BITVECTOR_NEG 1 "unary negation of a bit-vector"
 operator BITVECTOR_PLUS 2: "addition of two or more bit-vectors"
 operator BITVECTOR_SUB 2 "subtraction of two bit-vectors"
-operator BITVECTOR_NEG 1 "unary negation of a bit-vector"
 operator BITVECTOR_UDIV 2 "unsigned division of two bit-vectors, truncating towards 0 (undefined if divisor is 0)"
 operator BITVECTOR_UREM 2 "unsigned remainder from truncating division of two bit-vectors (undefined if divisor is 0)"
 operator BITVECTOR_SDIV 2 "2's complement signed division"
-operator BITVECTOR_SREM 2 "2's complement signed remainder (sign follows dividend)"
 operator BITVECTOR_SMOD 2 "2's complement signed remainder (sign follows divisor)"
+operator BITVECTOR_SREM 2 "2's complement signed remainder (sign follows dividend)"
 # total division kinds
 operator BITVECTOR_UDIV_TOTAL 2 "unsigned division of two bit-vectors, truncating towards 0 (defined to be the all-ones bit pattern, if divisor is 0)"
 operator BITVECTOR_UREM_TOTAL 2 "unsigned remainder from truncating division of two bit-vectors (defined to be equal to the dividend, if divisor is 0)"
 
-operator BITVECTOR_SHL 2 "bit-vector shift left (the two bit-vector parameters must have same width)"
-operator BITVECTOR_LSHR 2 "bit-vector logical shift right (the two bit-vector parameters must have same width)"
+## shift kinds
 operator BITVECTOR_ASHR 2 "bit-vector arithmetic shift right (the two bit-vector parameters must have same width)"
+operator BITVECTOR_LSHR 2 "bit-vector logical shift right (the two bit-vector parameters must have same width)"
+operator BITVECTOR_SHL 2 "bit-vector shift left (the two bit-vector parameters must have same width)"
 
-operator BITVECTOR_ULT 2 "bit-vector unsigned less than (the two bit-vector parameters must have same width)"
+## inequality kinds
 operator BITVECTOR_ULE 2 "bit-vector unsigned less than or equal (the two bit-vector parameters must have same width)"
-operator BITVECTOR_UGT 2 "bit-vector unsigned greater than (the two bit-vector parameters must have same width)"
+operator BITVECTOR_ULT 2 "bit-vector unsigned less than (the two bit-vector parameters must have same width)"
 operator BITVECTOR_UGE 2 "bit-vector unsigned greater than or equal (the two bit-vector parameters must have same width)"
-operator BITVECTOR_SLT 2 "bit-vector signed less than (the two bit-vector parameters must have same width)"
+operator BITVECTOR_UGT 2 "bit-vector unsigned greater than (the two bit-vector parameters must have same width)"
 operator BITVECTOR_SLE 2 "bit-vector signed less than or equal (the two bit-vector parameters must have same width)"
-operator BITVECTOR_SGT 2 "bit-vector signed greater than (the two bit-vector parameters must have same width)"
+operator BITVECTOR_SLT 2 "bit-vector signed less than (the two bit-vector parameters must have same width)"
 operator BITVECTOR_SGE 2 "bit-vector signed greater than or equal (the two bit-vector parameters must have same width)"
-
+operator BITVECTOR_SGT 2 "bit-vector signed greater than (the two bit-vector parameters must have same width)"
+# inequalities with return type bit-vector of size 1
 operator BITVECTOR_ULTBV 2 "bit-vector unsigned less than but returns bv of size 1 instead of boolean"
 operator BITVECTOR_SLTBV 2 "bit-vector signed less than but returns bv of size 1 instead of boolean"
+
+## reduction kinds
+operator BITVECTOR_REDAND 1 "bit-vector redand"
+operator BITVECTOR_REDOR 1 "bit-vector redor"
+
+## if-then-else kind
 operator BITVECTOR_ITE 3 "same semantics as regular ITE, but condition is bv of size 1 instead of Boolean"
 
-operator BITVECTOR_REDOR 1 "bit-vector redor"
-operator BITVECTOR_REDAND 1 "bit-vector redand"
+## conversion kinds
+operator BITVECTOR_TO_NAT 1 "bit-vector conversion to (nonnegative) integer; parameter is a bit-vector"
 
-operator BITVECTOR_EAGER_ATOM 1 "formula to be treated as a bv atom via eager bit-blasting (internal-only symbol)"
+## internal kinds
 operator BITVECTOR_ACKERMANNIZE_UDIV 1 "term to be treated as a variable; used for eager bit-blasting Ackermann expansion of bvudiv (internal-only symbol)"
 operator BITVECTOR_ACKERMANNIZE_UREM 1 "term to be treated as a variable; used for eager bit-blasting Ackermann expansion of bvurem (internal-only symbol)"
+operator BITVECTOR_EAGER_ATOM 1 "formula to be treated as a bv atom via eager bit-blasting (internal-only symbol)"
+
+### parameterized operator kinds ----------------------------------------------
 
 constant BITVECTOR_BITOF_OP \
 	::CVC4::BitVectorBitOf \
 	::CVC4::BitVectorBitOfHashFunction \
 	"util/bitvector.h" \
 	"operator for the bit-vector boolean bit extract; payload is an instance of the CVC4::BitVectorBitOf class"
+parameterized BITVECTOR_BITOF BITVECTOR_BITOF_OP 1 "bit-vector boolean bit extract; first parameter is a BITVECTOR_BITOF_OP, second is a bit-vector term"
 
 constant BITVECTOR_EXTRACT_OP \
 	::CVC4::BitVectorExtract \
 	::CVC4::BitVectorExtractHashFunction \
 	"util/bitvector.h" \
 	"operator for the bit-vector extract; payload is an instance of the CVC4::BitVectorExtract class"
+parameterized BITVECTOR_EXTRACT BITVECTOR_EXTRACT_OP 1 "bit-vector extract; first parameter is a BITVECTOR_EXTRACT_OP, second is a bit-vector term"
 
 constant BITVECTOR_REPEAT_OP \
 	::CVC4::BitVectorRepeat \
 	"::CVC4::UnsignedHashFunction< ::CVC4::BitVectorRepeat >" \
 	"util/bitvector.h" \
 	"operator for the bit-vector repeat; payload is an instance of the CVC4::BitVectorRepeat class"
-
-constant BITVECTOR_ZERO_EXTEND_OP \
-	::CVC4::BitVectorZeroExtend \
-	"::CVC4::UnsignedHashFunction< ::CVC4::BitVectorZeroExtend >" \
-	"util/bitvector.h" \
-	"operator for the bit-vector zero-extend; payload is an instance of the CVC4::BitVectorZeroExtend class"
-
-constant BITVECTOR_SIGN_EXTEND_OP \
-	::CVC4::BitVectorSignExtend \
-	"::CVC4::UnsignedHashFunction< ::CVC4::BitVectorSignExtend >" \
-	"util/bitvector.h" \
-	"operator for the bit-vector sign-extend; payload is an instance of the CVC4::BitVectorSignExtend class"
+parameterized BITVECTOR_REPEAT BITVECTOR_REPEAT_OP 1 "bit-vector repeat; first parameter is a BITVECTOR_REPEAT_OP, second is a bit-vector term"
 
 constant BITVECTOR_ROTATE_LEFT_OP \
 	::CVC4::BitVectorRotateLeft \
 	"::CVC4::UnsignedHashFunction< ::CVC4::BitVectorRotateLeft >" \
 	"util/bitvector.h" \
 	"operator for the bit-vector rotate left; payload is an instance of the CVC4::BitVectorRotateLeft class"
+parameterized BITVECTOR_ROTATE_LEFT BITVECTOR_ROTATE_LEFT_OP 1 "bit-vector rotate left; first parameter is a BITVECTOR_ROTATE_LEFT_OP, second is a bit-vector term"
 
 constant BITVECTOR_ROTATE_RIGHT_OP \
 	::CVC4::BitVectorRotateRight \
 	"::CVC4::UnsignedHashFunction< ::CVC4::BitVectorRotateRight >" \
 	"util/bitvector.h" \
 	"operator for the bit-vector rotate right; payload is an instance of the CVC4::BitVectorRotateRight class"
-
-parameterized BITVECTOR_BITOF BITVECTOR_BITOF_OP 1 "bit-vector boolean bit extract; first parameter is a BITVECTOR_BITOF_OP, second is a bit-vector term"
-parameterized BITVECTOR_EXTRACT BITVECTOR_EXTRACT_OP 1 "bit-vector extract; first parameter is a BITVECTOR_EXTRACT_OP, second is a bit-vector term"
-parameterized BITVECTOR_REPEAT BITVECTOR_REPEAT_OP 1 "bit-vector repeat; first parameter is a BITVECTOR_REPEAT_OP, second is a bit-vector term"
-parameterized BITVECTOR_ZERO_EXTEND BITVECTOR_ZERO_EXTEND_OP 1 "bit-vector zero-extend; first parameter is a BITVECTOR_ZERO_EXTEND_OP, second is a bit-vector term"
-parameterized BITVECTOR_SIGN_EXTEND BITVECTOR_SIGN_EXTEND_OP 1 "bit-vector sign-extend; first parameter is a BITVECTOR_SIGN_EXTEND_OP, second is a bit-vector term"
-parameterized BITVECTOR_ROTATE_LEFT BITVECTOR_ROTATE_LEFT_OP 1 "bit-vector rotate left; first parameter is a BITVECTOR_ROTATE_LEFT_OP, second is a bit-vector term"
 parameterized BITVECTOR_ROTATE_RIGHT BITVECTOR_ROTATE_RIGHT_OP 1 "bit-vector rotate right; first parameter is a BITVECTOR_ROTATE_RIGHT_OP, second is a bit-vector term"
+
+constant BITVECTOR_SIGN_EXTEND_OP \
+	::CVC4::BitVectorSignExtend \
+	"::CVC4::UnsignedHashFunction< ::CVC4::BitVectorSignExtend >" \
+	"util/bitvector.h" \
+	"operator for the bit-vector sign-extend; payload is an instance of the CVC4::BitVectorSignExtend class"
+parameterized BITVECTOR_SIGN_EXTEND BITVECTOR_SIGN_EXTEND_OP 1 "bit-vector sign-extend; first parameter is a BITVECTOR_SIGN_EXTEND_OP, second is a bit-vector term"
+
+constant BITVECTOR_ZERO_EXTEND_OP \
+	::CVC4::BitVectorZeroExtend \
+	"::CVC4::UnsignedHashFunction< ::CVC4::BitVectorZeroExtend >" \
+	"util/bitvector.h" \
+	"operator for the bit-vector zero-extend; payload is an instance of the CVC4::BitVectorZeroExtend class"
+parameterized BITVECTOR_ZERO_EXTEND BITVECTOR_ZERO_EXTEND_OP 1 "bit-vector zero-extend; first parameter is a BITVECTOR_ZERO_EXTEND_OP, second is a bit-vector term"
 
 constant INT_TO_BITVECTOR_OP \
 	::CVC4::IntToBitVector \
@@ -138,61 +155,77 @@ constant INT_TO_BITVECTOR_OP \
 	"util/bitvector.h" \
 	"operator for the integer conversion to bit-vector; payload is an instance of the CVC4::IntToBitVector class"
 parameterized INT_TO_BITVECTOR INT_TO_BITVECTOR_OP 1 "integer conversion to bit-vector; first parameter is an INT_TO_BITVECTOR_OP, second is an integer term"
-operator BITVECTOR_TO_NAT 1 "bit-vector conversion to (nonnegative) integer; parameter is a bit-vector"
+
+### type rules for non-parameterized operator kinds ---------------------------
 
 typerule CONST_BITVECTOR ::CVC4::theory::bv::BitVectorConstantTypeRule
 
-typerule BITVECTOR_AND ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_OR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_XOR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_NOT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_NAND ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_NOR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_XNOR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-
-typerule BITVECTOR_MULT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_PLUS ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_SUB ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_NEG ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-
-typerule BITVECTOR_UDIV ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_UREM ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_UDIV_TOTAL ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_UREM_TOTAL ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_SDIV ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_SREM ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_SMOD ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_SHL ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_LSHR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_ASHR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-
-typerule BITVECTOR_ULT ::CVC4::theory::bv::BitVectorPredicateTypeRule
-typerule BITVECTOR_ULE ::CVC4::theory::bv::BitVectorPredicateTypeRule
-typerule BITVECTOR_UGT ::CVC4::theory::bv::BitVectorPredicateTypeRule
-typerule BITVECTOR_UGE ::CVC4::theory::bv::BitVectorPredicateTypeRule
-typerule BITVECTOR_SLT ::CVC4::theory::bv::BitVectorPredicateTypeRule
-typerule BITVECTOR_SLE ::CVC4::theory::bv::BitVectorPredicateTypeRule
-typerule BITVECTOR_SGT ::CVC4::theory::bv::BitVectorPredicateTypeRule
-typerule BITVECTOR_SGE ::CVC4::theory::bv::BitVectorPredicateTypeRule
-
-typerule BITVECTOR_COMP ::CVC4::theory::bv::BitVectorBVPredTypeRule
-typerule BITVECTOR_ULTBV ::CVC4::theory::bv::BitVectorBVPredTypeRule
-typerule BITVECTOR_SLTBV ::CVC4::theory::bv::BitVectorBVPredTypeRule
-typerule BITVECTOR_ITE ::CVC4::theory::bv::BitVectorITETypeRule
-
-typerule BITVECTOR_REDOR ::CVC4::theory::bv::BitVectorUnaryPredicateTypeRule
-typerule BITVECTOR_REDAND ::CVC4::theory::bv::BitVectorUnaryPredicateTypeRule
-
+## concatentation kind
 typerule BITVECTOR_CONCAT ::CVC4::theory::bv::BitVectorConcatTypeRule
 
-typerule BITVECTOR_EAGER_ATOM ::CVC4::theory::bv::BitVectorEagerAtomTypeRule
+## bit-wise kinds
+typerule BITVECTOR_AND ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_COMP ::CVC4::theory::bv::BitVectorBVPredTypeRule
+typerule BITVECTOR_NAND ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_NOR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_NOT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_OR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_XNOR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_XOR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+
+## arithmetic kinds
+typerule BITVECTOR_MULT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_NEG ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_PLUS ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_SUB ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_UDIV ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_UREM ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_SDIV ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_SMOD ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_SREM ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+# total division kinds
+typerule BITVECTOR_UDIV_TOTAL ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_UREM_TOTAL ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+
+## shift kinds
+typerule BITVECTOR_ASHR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_LSHR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_SHL ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+
+## inequality kinds
+typerule BITVECTOR_ULE ::CVC4::theory::bv::BitVectorPredicateTypeRule
+typerule BITVECTOR_ULT ::CVC4::theory::bv::BitVectorPredicateTypeRule
+typerule BITVECTOR_UGE ::CVC4::theory::bv::BitVectorPredicateTypeRule
+typerule BITVECTOR_UGT ::CVC4::theory::bv::BitVectorPredicateTypeRule
+typerule BITVECTOR_SLE ::CVC4::theory::bv::BitVectorPredicateTypeRule
+typerule BITVECTOR_SLT ::CVC4::theory::bv::BitVectorPredicateTypeRule
+typerule BITVECTOR_SGE ::CVC4::theory::bv::BitVectorPredicateTypeRule
+typerule BITVECTOR_SGT ::CVC4::theory::bv::BitVectorPredicateTypeRule
+# inequalities with return type bit-vector of size 1
+typerule BITVECTOR_ULTBV ::CVC4::theory::bv::BitVectorBVPredTypeRule
+typerule BITVECTOR_SLTBV ::CVC4::theory::bv::BitVectorBVPredTypeRule
+
+## if-then-else kind
+typerule BITVECTOR_ITE ::CVC4::theory::bv::BitVectorITETypeRule
+
+## reduction kinds
+typerule BITVECTOR_REDAND ::CVC4::theory::bv::BitVectorUnaryPredicateTypeRule
+typerule BITVECTOR_REDOR ::CVC4::theory::bv::BitVectorUnaryPredicateTypeRule
+
+## conversion kinds
+typerule BITVECTOR_TO_NAT ::CVC4::theory::bv::BitVectorConversionTypeRule
+
+## internal kinds
 typerule BITVECTOR_ACKERMANNIZE_UDIV ::CVC4::theory::bv::BitVectorAckermanizationUdivTypeRule
 typerule BITVECTOR_ACKERMANNIZE_UREM ::CVC4::theory::bv::BitVectorAckermanizationUremTypeRule
+typerule BITVECTOR_EAGER_ATOM ::CVC4::theory::bv::BitVectorEagerAtomTypeRule
 
-typerule BITVECTOR_EXTRACT_OP ::CVC4::theory::bv::BitVectorExtractOpTypeRule
-typerule BITVECTOR_EXTRACT ::CVC4::theory::bv::BitVectorExtractTypeRule
+### type rules for parameterized operator kinds -------------------------------
+
 typerule BITVECTOR_BITOF_OP ::CVC4::theory::bv::BitVectorBitOfOpTypeRule
 typerule BITVECTOR_BITOF ::CVC4::theory::bv::BitVectorBitOfTypeRule
+typerule BITVECTOR_EXTRACT_OP ::CVC4::theory::bv::BitVectorExtractOpTypeRule
+typerule BITVECTOR_EXTRACT ::CVC4::theory::bv::BitVectorExtractTypeRule
 typerule BITVECTOR_REPEAT_OP ::CVC4::theory::bv::BitVectorRepeatOpTypeRule
 typerule BITVECTOR_REPEAT ::CVC4::theory::bv::BitVectorRepeatTypeRule
 typerule BITVECTOR_ROTATE_LEFT_OP ::CVC4::theory::bv::BitVectorRotateLeftOpTypeRule
@@ -203,8 +236,6 @@ typerule BITVECTOR_SIGN_EXTEND_OP ::CVC4::theory::bv::BitVectorSignExtendOpTypeR
 typerule BITVECTOR_SIGN_EXTEND ::CVC4::theory::bv::BitVectorExtendTypeRule
 typerule BITVECTOR_ZERO_EXTEND_OP ::CVC4::theory::bv::BitVectorZeroExtendOpTypeRule
 typerule BITVECTOR_ZERO_EXTEND ::CVC4::theory::bv::BitVectorExtendTypeRule
-
-typerule BITVECTOR_TO_NAT ::CVC4::theory::bv::BitVectorConversionTypeRule
 typerule INT_TO_BITVECTOR_OP ::CVC4::theory::bv::IntToBitVectorOpTypeRule
 typerule INT_TO_BITVECTOR ::CVC4::theory::bv::BitVectorConversionTypeRule
 

--- a/src/theory/bv/kinds
+++ b/src/theory/bv/kinds
@@ -165,8 +165,6 @@ typerule BITVECTOR_SMOD ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
 typerule BITVECTOR_SHL ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
 typerule BITVECTOR_LSHR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
 typerule BITVECTOR_ASHR ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_ROTATE_LEFT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
-typerule BITVECTOR_ROTATE_RIGHT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
 
 typerule BITVECTOR_ULT ::CVC4::theory::bv::BitVectorPredicateTypeRule
 typerule BITVECTOR_ULE ::CVC4::theory::bv::BitVectorPredicateTypeRule
@@ -185,6 +183,7 @@ typerule BITVECTOR_ITE ::CVC4::theory::bv::BitVectorITETypeRule
 typerule BITVECTOR_REDOR ::CVC4::theory::bv::BitVectorUnaryPredicateTypeRule
 typerule BITVECTOR_REDAND ::CVC4::theory::bv::BitVectorUnaryPredicateTypeRule
 
+typerule BITVECTOR_CONCAT ::CVC4::theory::bv::BitVectorConcatTypeRule
 
 typerule BITVECTOR_EAGER_ATOM ::CVC4::theory::bv::BitVectorEagerAtomTypeRule
 typerule BITVECTOR_ACKERMANNIZE_UDIV ::CVC4::theory::bv::BitVectorAckermanizationUdivTypeRule
@@ -192,11 +191,18 @@ typerule BITVECTOR_ACKERMANNIZE_UREM ::CVC4::theory::bv::BitVectorAckermanizatio
 
 typerule BITVECTOR_EXTRACT_OP ::CVC4::theory::bv::BitVectorExtractOpTypeRule
 typerule BITVECTOR_EXTRACT ::CVC4::theory::bv::BitVectorExtractTypeRule
-typerule BITVECTOR_BITOF   ::CVC4::theory::bv::BitVectorBitOfTypeRule
-typerule BITVECTOR_CONCAT ::CVC4::theory::bv::BitVectorConcatTypeRule
+typerule BITVECTOR_BITOF_OP ::CVC4::theory::bv::BitVectorBitOfOpTypeRule
+typerule BITVECTOR_BITOF ::CVC4::theory::bv::BitVectorBitOfTypeRule
+typerule BITVECTOR_REPEAT_OP ::CVC4::theory::bv::BitVectorRepeatOpTypeRule
 typerule BITVECTOR_REPEAT ::CVC4::theory::bv::BitVectorRepeatTypeRule
-typerule BITVECTOR_ZERO_EXTEND ::CVC4::theory::bv::BitVectorExtendTypeRule
+typerule BITVECTOR_ROTATE_LEFT_OP ::CVC4::theory::bv::BitVectorRotateLeftOpTypeRule
+typerule BITVECTOR_ROTATE_LEFT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_ROTATE_RIGHT_OP ::CVC4::theory::bv::BitVectorRotateRightOpTypeRule
+typerule BITVECTOR_ROTATE_RIGHT ::CVC4::theory::bv::BitVectorFixedWidthTypeRule
+typerule BITVECTOR_SIGN_EXTEND_OP ::CVC4::theory::bv::BitVectorSignExtendOpTypeRule
 typerule BITVECTOR_SIGN_EXTEND ::CVC4::theory::bv::BitVectorExtendTypeRule
+typerule BITVECTOR_ZERO_EXTEND_OP ::CVC4::theory::bv::BitVectorZeroExtendOpTypeRule
+typerule BITVECTOR_ZERO_EXTEND ::CVC4::theory::bv::BitVectorExtendTypeRule
 
 typerule BITVECTOR_TO_NAT ::CVC4::theory::bv::BitVectorConversionTypeRule
 typerule INT_TO_BITVECTOR_OP ::CVC4::theory::bv::IntToBitVectorOpTypeRule

--- a/src/theory/bv/theory_bv_type_rules.h
+++ b/src/theory/bv/theory_bv_type_rules.h
@@ -2,7 +2,7 @@
 /*! \file theory_bv_type_rules.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Dejan Jovanovic, Morgan Deters, Tim King
+ **   Aina Niemetz, Dejan Jovanovic, Morgan Deters
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -25,12 +25,38 @@ namespace CVC4 {
 namespace theory {
 namespace bv {
 
-class BitVectorConstantTypeRule {
+/* -------------------------------------------------------------------------- */
+
+class CardinalityComputer
+{
  public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    if (check) {
-      if (n.getConst<BitVector>().getSize() == 0) {
+  inline static Cardinality computeCardinality(TypeNode type)
+  {
+    Assert(type.getKind() == kind::BITVECTOR_TYPE);
+
+    unsigned size = type.getConst<BitVectorSize>();
+    if (size == 0)
+    {
+      return 0;
+    }
+    Integer i = Integer(2).pow(size);
+    return i;
+  }
+}; /* class CardinalityComputer */
+
+/* -------------------------------------------------------------------------- */
+
+class BitVectorConstantTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (check)
+    {
+      if (n.getConst<BitVector>().getSize() == 0)
+      {
         throw TypeCheckingExceptionPrivate(n, "constant of size 0");
       }
     }
@@ -38,25 +64,165 @@ class BitVectorConstantTypeRule {
   }
 }; /* class BitVectorConstantTypeRule */
 
-class BitVectorBitOfTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    if (check) {
-      BitVectorBitOf info = n.getOperator().getConst<BitVectorBitOf>();
-      TypeNode t = n[0].getType(check);
+/* -------------------------------------------------------------------------- */
 
-      if (!t.isBitVector()) {
-        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
+class BitVectorFixedWidthTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    TNode::iterator it = n.begin();
+    TypeNode t = (*it).getType(check);
+    if (check)
+    {
+      if (!t.isBitVector())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
       }
-      if (info.bitIndex >= t.getBitVectorSize()) {
+      TNode::iterator it_end = n.end();
+      for (++it; it != it_end; ++it)
+      {
+        if ((*it).getType(check) != t)
+        {
+          throw TypeCheckingExceptionPrivate(
+              n, "expecting bit-vector terms of the same width");
+        }
+      }
+    }
+    return t;
+  }
+}; /* class BitVectorFixedWidthTypeRule */
+
+/* -------------------------------------------------------------------------- */
+
+class BitVectorPredicateTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (check)
+    {
+      TypeNode lhsType = n[0].getType(check);
+      if (!lhsType.isBitVector())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
+      }
+      TypeNode rhsType = n[1].getType(check);
+      if (lhsType != rhsType)
+      {
         throw TypeCheckingExceptionPrivate(
-            n, "extract index is larger than the bitvector size");
+            n, "expecting bit-vector terms of the same width");
       }
     }
     return nodeManager->booleanType();
   }
-}; /* class BitVectorBitOfTypeRule */
+}; /* class BitVectorPredicateTypeRule */
+
+class BitVectorUnaryPredicateTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (check)
+    {
+      TypeNode type = n[0].getType(check);
+      if (!type.isBitVector())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
+      }
+    }
+    return nodeManager->booleanType();
+  }
+}; /* class BitVectorUnaryPredicateTypeRule */
+
+class BitVectorBVPredTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (check)
+    {
+      TypeNode lhs = n[0].getType(check);
+      TypeNode rhs = n[1].getType(check);
+      if (!lhs.isBitVector() || lhs != rhs)
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "expecting bit-vector terms of the same width");
+      }
+    }
+    return nodeManager->mkBitVectorType(1);
+  }
+}; /* class BitVectorBVPredTypeRule */
+
+/* -------------------------------------------------------------------------- */
+/* non-parameterized operator kinds                                           */
+/* -------------------------------------------------------------------------- */
+
+class BitVectorConcatTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    unsigned size = 0;
+    TNode::iterator it = n.begin();
+    TNode::iterator it_end = n.end();
+    for (; it != it_end; ++it)
+    {
+      TypeNode t = (*it).getType(check);
+      // NOTE: We're throwing a type-checking exception here even
+      // when check is false, bc if we don't check that the arguments
+      // are bit-vectors the result type will be inaccurate
+      if (!t.isBitVector())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
+      }
+      size += t.getBitVectorSize();
+    }
+    return nodeManager->mkBitVectorType(size);
+  }
+}; /* class BitVectorConcatTypeRule */
+
+class BitVectorITETypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getNumChildren() == 3);
+    TypeNode thenpart = n[1].getType(check);
+    if (check)
+    {
+      TypeNode cond = n[0].getType(check);
+      if (cond != nodeManager->mkBitVectorType(1))
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "expecting condition to be bit-vector term size 1");
+      }
+      TypeNode elsepart = n[2].getType(check);
+      if (thenpart != elsepart)
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "expecting then and else parts to have same type");
+      }
+    }
+    return thenpart;
+  }
+}; /* class BitVectorITETypeRule */
+
+/* -------------------------------------------------------------------------- */
+/* parameterized operator kinds                                               */
+/* -------------------------------------------------------------------------- */
 
 class BitVectorBitOfOpTypeRule
 {
@@ -70,161 +236,71 @@ class BitVectorBitOfOpTypeRule
   }
 }; /* class BitVectorBitOfOpTypeRule */
 
-class BitVectorBVPredTypeRule {
+class BitVectorBitOfTypeRule
+{
  public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    if (check) {
-      TypeNode lhs = n[0].getType(check);
-      TypeNode rhs = n[1].getType(check);
-      if (!lhs.isBitVector() || lhs != rhs) {
-        throw TypeCheckingExceptionPrivate(
-            n, "expecting bit-vector terms of the same width");
-      }
-    }
-    return nodeManager->mkBitVectorType(1);
-  }
-}; /* class BitVectorBVPredTypeRule */
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (check)
+    {
+      BitVectorBitOf info = n.getOperator().getConst<BitVectorBitOf>();
+      TypeNode t = n[0].getType(check);
 
-class BitVectorITETypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    Assert(n.getNumChildren() == 3);
-    TypeNode thenpart = n[1].getType(check);
-    if (check) {
-      TypeNode cond = n[0].getType(check);
-      if (cond != nodeManager->mkBitVectorType(1)) {
-        throw TypeCheckingExceptionPrivate(
-            n, "expecting condition to be bit-vector term size 1");
-      }
-      TypeNode elsepart = n[2].getType(check);
-      if (thenpart != elsepart) {
-        throw TypeCheckingExceptionPrivate(
-            n, "expecting then and else parts to have same type");
-      }
-    }
-    return thenpart;
-  }
-}; /* class BitVectorITETypeRule */
-
-class BitVectorFixedWidthTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    TNode::iterator it = n.begin();
-    TypeNode t = (*it).getType(check);
-    if (check) {
-      if (!t.isBitVector()) {
-        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
-      }
-      TNode::iterator it_end = n.end();
-      for (++it; it != it_end; ++it) {
-        if ((*it).getType(check) != t) {
-          throw TypeCheckingExceptionPrivate(
-              n, "expecting bit-vector terms of the same width");
-        }
-      }
-    }
-    return t;
-  }
-}; /* class BitVectorFixedWidthTypeRule */
-
-class BitVectorPredicateTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    if (check) {
-      TypeNode lhsType = n[0].getType(check);
-      if (!lhsType.isBitVector()) {
-        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
-      }
-      TypeNode rhsType = n[1].getType(check);
-      if (lhsType != rhsType) {
-        throw TypeCheckingExceptionPrivate(
-            n, "expecting bit-vector terms of the same width");
-      }
-    }
-    return nodeManager->booleanType();
-  }
-}; /* class BitVectorPredicateTypeRule */
-
-class BitVectorUnaryPredicateTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    if (check) {
-      TypeNode type = n[0].getType(check);
-      if (!type.isBitVector()) {
-        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
-      }
-    }
-    return nodeManager->booleanType();
-  }
-}; /* class BitVectorUnaryPredicateTypeRule */
-
-class BitVectorEagerAtomTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    if (check) {
-      TypeNode lhsType = n[0].getType(check);
-      if (!lhsType.isBoolean()) {
-        throw TypeCheckingExceptionPrivate(n, "expecting boolean term");
-      }
-    }
-    return nodeManager->booleanType();
-  }
-}; /* class BitVectorEagerAtomTypeRule */
-
-class BitVectorAckermanizationUdivTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    TypeNode lhsType = n[0].getType(check);
-    if (check) {
-      if (!lhsType.isBitVector()) {
+      if (!t.isBitVector())
+      {
         throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
       }
-    }
-    return lhsType;
-  }
-}; /* class BitVectorAckermanizationUdivTypeRule */
-
-class BitVectorAckermanizationUremTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    TypeNode lhsType = n[0].getType(check);
-    if (check) {
-      if (!lhsType.isBitVector()) {
-        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
+      if (info.bitIndex >= t.getBitVectorSize())
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "extract index is larger than the bitvector size");
       }
     }
-    return lhsType;
+    return nodeManager->booleanType();
   }
-}; /* class BitVectorAckermanizationUremTypeRule */
+}; /* class BitVectorBitOfTypeRule */
 
-class BitVectorExtractTypeRule {
+class BitVectorExtractOpTypeRule
+{
  public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_EXTRACT_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorExtractOpTypeRule */
+
+class BitVectorExtractTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
     BitVectorExtract extractInfo = n.getOperator().getConst<BitVectorExtract>();
 
     // NOTE: We're throwing a type-checking exception here even
     // if check is false, bc if we allow high < low the resulting
     // type will be illegal
-    if (extractInfo.high < extractInfo.low) {
+    if (extractInfo.high < extractInfo.low)
+    {
       throw TypeCheckingExceptionPrivate(
           n, "high extract index is smaller than the low extract index");
     }
 
-    if (check) {
+    if (check)
+    {
       TypeNode t = n[0].getType(check);
-      if (!t.isBitVector()) {
+      if (!t.isBitVector())
+      {
         throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
       }
-      if (extractInfo.high >= t.getBitVectorSize()) {
+      if (extractInfo.high >= t.getBitVectorSize())
+      {
         throw TypeCheckingExceptionPrivate(
             n, "high extract index is bigger than the size of the bit-vector");
       }
@@ -232,36 +308,6 @@ class BitVectorExtractTypeRule {
     return nodeManager->mkBitVectorType(extractInfo.high - extractInfo.low + 1);
   }
 }; /* class BitVectorExtractTypeRule */
-
-class BitVectorExtractOpTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    Assert(n.getKind() == kind::BITVECTOR_EXTRACT_OP);
-    return nodeManager->builtinOperatorType();
-  }
-}; /* class BitVectorExtractOpTypeRule */
-
-class BitVectorConcatTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    unsigned size = 0;
-    TNode::iterator it = n.begin();
-    TNode::iterator it_end = n.end();
-    for (; it != it_end; ++it) {
-      TypeNode t = (*it).getType(check);
-      // NOTE: We're throwing a type-checking exception here even
-      // when check is false, bc if we don't check that the arguments
-      // are bit-vectors the result type will be inaccurate
-      if (!t.isBitVector()) {
-        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector terms");
-      }
-      size += t.getBitVectorSize();
-    }
-    return nodeManager->mkBitVectorType(size);
-  }
-}; /* class BitVectorConcatTypeRule */
 
 class BitVectorRepeatOpTypeRule
 {
@@ -275,64 +321,25 @@ class BitVectorRepeatOpTypeRule
   }
 }; /* class BitVectorRepeatOpTypeRule */
 
-class BitVectorRepeatTypeRule {
+class BitVectorRepeatTypeRule
+{
  public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
     TypeNode t = n[0].getType(check);
     // NOTE: We're throwing a type-checking exception here even
     // when check is false, bc if the argument isn't a bit-vector
     // the result type will be inaccurate
-    if (!t.isBitVector()) {
+    if (!t.isBitVector())
+    {
       throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
     }
     unsigned repeatAmount = n.getOperator().getConst<BitVectorRepeat>();
     return nodeManager->mkBitVectorType(repeatAmount * t.getBitVectorSize());
   }
 }; /* class BitVectorRepeatTypeRule */
-
-class BitVectorZeroExtendOpTypeRule
-{
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager,
-                                     TNode n,
-                                     bool check)
-  {
-    Assert(n.getKind() == kind::BITVECTOR_ZERO_EXTEND_OP);
-    return nodeManager->builtinOperatorType();
-  }
-}; /* class BitVectorZeroExtendOpTypeRule */
-
-class BitVectorSignExtendOpTypeRule
-{
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager,
-                                     TNode n,
-                                     bool check)
-  {
-    Assert(n.getKind() == kind::BITVECTOR_SIGN_EXTEND_OP);
-    return nodeManager->builtinOperatorType();
-  }
-}; /* class BitVectorSignExtendOpTypeRule */
-
-class BitVectorExtendTypeRule {
- public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    TypeNode t = n[0].getType(check);
-    // NOTE: We're throwing a type-checking exception here even
-    // when check is false, bc if the argument isn't a bit-vector
-    // the result type will be inaccurate
-    if (!t.isBitVector()) {
-      throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
-    }
-    unsigned extendAmount =
-        n.getKind() == kind::BITVECTOR_SIGN_EXTEND
-            ? (unsigned)n.getOperator().getConst<BitVectorSignExtend>()
-            : (unsigned)n.getOperator().getConst<BitVectorZeroExtend>();
-    return nodeManager->mkBitVectorType(extendAmount + t.getBitVectorSize());
-  }
-}; /* class BitVectorExtendTypeRule */
 
 class BitVectorRotateLeftOpTypeRule
 {
@@ -358,20 +365,92 @@ class BitVectorRotateRightOpTypeRule
   }
 }; /* class BitVectorRotateRightOpTypeRule */
 
-class BitVectorConversionTypeRule {
+class BitVectorSignExtendOpTypeRule
+{
  public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
-                                     bool check) {
-    if (n.getKind() == kind::BITVECTOR_TO_NAT) {
-      if (check && !n[0].getType(check).isBitVector()) {
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_SIGN_EXTEND_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorSignExtendOpTypeRule */
+
+class BitVectorZeroExtendOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_ZERO_EXTEND_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorZeroExtendOpTypeRule */
+
+class BitVectorExtendTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    TypeNode t = n[0].getType(check);
+    // NOTE: We're throwing a type-checking exception here even
+    // when check is false, bc if the argument isn't a bit-vector
+    // the result type will be inaccurate
+    if (!t.isBitVector())
+    {
+      throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
+    }
+    unsigned extendAmount =
+        n.getKind() == kind::BITVECTOR_SIGN_EXTEND
+            ? (unsigned)n.getOperator().getConst<BitVectorSignExtend>()
+            : (unsigned)n.getOperator().getConst<BitVectorZeroExtend>();
+    return nodeManager->mkBitVectorType(extendAmount + t.getBitVectorSize());
+  }
+}; /* class BitVectorExtendTypeRule */
+
+class IntToBitVectorOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (n.getKind() == kind::INT_TO_BITVECTOR_OP)
+    {
+      size_t bvSize = n.getConst<IntToBitVector>();
+      return nodeManager->mkFunctionType(nodeManager->integerType(),
+                                         nodeManager->mkBitVectorType(bvSize));
+    }
+
+    InternalError("bv-conversion typerule invoked for non-bv-conversion kind");
+  }
+}; /* class IntToBitVectorOpTypeRule */
+
+class BitVectorConversionTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (n.getKind() == kind::BITVECTOR_TO_NAT)
+    {
+      if (check && !n[0].getType(check).isBitVector())
+      {
         throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
       }
       return nodeManager->integerType();
     }
 
-    if (n.getKind() == kind::INT_TO_BITVECTOR) {
+    if (n.getKind() == kind::INT_TO_BITVECTOR)
+    {
       size_t bvSize = n.getOperator().getConst<IntToBitVector>();
-      if (check && !n[0].getType(check).isInteger()) {
+      if (check && !n[0].getType(check).isInteger())
+      {
         throw TypeCheckingExceptionPrivate(n, "expecting integer term");
       }
       return nodeManager->mkBitVectorType(bvSize);
@@ -381,35 +460,69 @@ class BitVectorConversionTypeRule {
   }
 }; /* class BitVectorConversionTypeRule */
 
-class IntToBitVectorOpTypeRule {
-public:
-  inline static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check) {
+/* -------------------------------------------------------------------------- */
+/* internal                                                                   */
+/* -------------------------------------------------------------------------- */
 
-    if(n.getKind() == kind::INT_TO_BITVECTOR_OP) {
-      size_t bvSize = n.getConst<IntToBitVector>();
-      return nodeManager->mkFunctionType( nodeManager->integerType(), nodeManager->mkBitVectorType(bvSize) );
-    }
-
-    InternalError("bv-conversion typerule invoked for non-bv-conversion kind");
-  }
-}; /* class IntToBitVectorOpTypeRule */
-
-class CardinalityComputer {
+class BitVectorEagerAtomTypeRule
+{
  public:
-  inline static Cardinality computeCardinality(TypeNode type) {
-    Assert(type.getKind() == kind::BITVECTOR_TYPE);
-
-    unsigned size = type.getConst<BitVectorSize>();
-    if (size == 0) {
-      return 0;
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    if (check)
+    {
+      TypeNode lhsType = n[0].getType(check);
+      if (!lhsType.isBoolean())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting boolean term");
+      }
     }
-    Integer i = Integer(2).pow(size);
-    return i;
+    return nodeManager->booleanType();
   }
-}; /* class CardinalityComputer */
+}; /* class BitVectorEagerAtomTypeRule */
 
-} /* CVC4::theory::bv namespace */
-} /* CVC4::theory namespace */
-} /* CVC4 namespace */
+class BitVectorAckermanizationUdivTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    TypeNode lhsType = n[0].getType(check);
+    if (check)
+    {
+      if (!lhsType.isBitVector())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
+      }
+    }
+    return lhsType;
+  }
+}; /* class BitVectorAckermanizationUdivTypeRule */
+
+class BitVectorAckermanizationUremTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    TypeNode lhsType = n[0].getType(check);
+    if (check)
+    {
+      if (!lhsType.isBitVector())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
+      }
+    }
+    return lhsType;
+  }
+}; /* class BitVectorAckermanizationUremTypeRule */
+
+}  // namespace bv
+}  // namespace theory
+}  // namespace CVC4
 
 #endif /* __CVC4__THEORY__BV__THEORY_BV_TYPE_RULES_H */

--- a/src/theory/bv/theory_bv_type_rules.h
+++ b/src/theory/bv/theory_bv_type_rules.h
@@ -58,6 +58,18 @@ class BitVectorBitOfTypeRule {
   }
 }; /* class BitVectorBitOfTypeRule */
 
+class BitVectorBitOfOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_BITOF_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorBitOfOpTypeRule */
+
 class BitVectorBVPredTypeRule {
  public:
   inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
@@ -251,6 +263,18 @@ class BitVectorConcatTypeRule {
   }
 }; /* class BitVectorConcatTypeRule */
 
+class BitVectorRepeatOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_REPEAT_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorRepeatOpTypeRule */
+
 class BitVectorRepeatTypeRule {
  public:
   inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
@@ -266,6 +290,30 @@ class BitVectorRepeatTypeRule {
     return nodeManager->mkBitVectorType(repeatAmount * t.getBitVectorSize());
   }
 }; /* class BitVectorRepeatTypeRule */
+
+class BitVectorZeroExtendOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_ZERO_EXTEND_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorZeroExtendOpTypeRule */
+
+class BitVectorSignExtendOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_SIGN_EXTEND_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorSignExtendOpTypeRule */
 
 class BitVectorExtendTypeRule {
  public:
@@ -285,6 +333,30 @@ class BitVectorExtendTypeRule {
     return nodeManager->mkBitVectorType(extendAmount + t.getBitVectorSize());
   }
 }; /* class BitVectorExtendTypeRule */
+
+class BitVectorRotateLeftOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_ROTATE_LEFT);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorRotateLeftOpTypeRule */
+
+class BitVectorRotateRightOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::BITVECTOR_ROTATE_RIGHT);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class BitVectorRotateRightOpTypeRule */
 
 class BitVectorConversionTypeRule {
  public:

--- a/src/theory/datatypes/kinds
+++ b/src/theory/datatypes/kinds
@@ -91,6 +91,7 @@ constant TUPLE_UPDATE_OP \
         "util/tuple.h" \
         "operator for a tuple update; payload is an instance of the CVC4::TupleUpdate class"
 parameterized TUPLE_UPDATE TUPLE_UPDATE_OP 2 "tuple update; first parameter is a TUPLE_UPDATE_OP (which references an index), second is the tuple, third is the element to store in the tuple at the given index"
+typerule TUPLE_UPDATE_OP ::CVC4::theory::datatypes::TupleUpdateOpTypeRule
 typerule TUPLE_UPDATE ::CVC4::theory::datatypes::TupleUpdateTypeRule
 
 constant RECORD_UPDATE_OP \
@@ -99,6 +100,7 @@ constant RECORD_UPDATE_OP \
         "expr/record.h" \
         "operator for a record update; payload is an instance CVC4::RecordUpdate class"
 parameterized RECORD_UPDATE RECORD_UPDATE_OP 2 "record update; first parameter is a RECORD_UPDATE_OP (which references a field), second is a record term to update, third is the element to store in the record in the given field"
+typerule RECORD_UPDATE_OP ::CVC4::theory::datatypes::RecordUpdateOpTypeRule
 typerule RECORD_UPDATE ::CVC4::theory::datatypes::RecordUpdateTypeRule
 
 

--- a/src/theory/datatypes/theory_datatypes_type_rules.h
+++ b/src/theory/datatypes/theory_datatypes_type_rules.h
@@ -273,6 +273,18 @@ struct TupleUpdateTypeRule {
   }
 }; /* struct TupleUpdateTypeRule */
 
+class TupleUpdateOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::TUPLE_UPDATE_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class TupleUpdateOpTypeRule */
+
 struct RecordUpdateTypeRule {
   inline static TypeNode computeType(NodeManager* nodeManager, TNode n,
                                      bool check) {
@@ -297,6 +309,18 @@ struct RecordUpdateTypeRule {
     return recordType;
   }
 }; /* struct RecordUpdateTypeRule */
+
+class RecordUpdateOpTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    Assert(n.getKind() == kind::RECORD_UPDATE_OP);
+    return nodeManager->builtinOperatorType();
+  }
+}; /* class RecordUpdateOpTypeRule */
 
 class DtSizeTypeRule {
  public:


### PR DESCRIPTION
Currently 'do not merge' since I'll do some reordering of the bv/kinds and bv/type_rules files (still ready to review).