### PR TITLE
RNG: Avoid modulo bias in random numbers

### DIFF
--- a/src/util/random.cpp
+++ b/src/util/random.cpp
@@ -19,6 +19,8 @@
 #include "util/random.h"
 
 #include <cfloat>
+#include <random>
+
 #include "base/cvc4_assert.h"
 
 namespace CVC4 {
@@ -48,14 +50,17 @@ uint64_t Random::pick(uint64_t from, uint64_t to)
 {
   Assert(from <= to);
   Assert(to < UINT64_MAX);
-  return (Random::rand() % (to - from + 1)) + from;
+  std::uniform_int_distribution<> dis(from, to);
+  return dis(*this);
 }
 
 double Random::pickDouble(double from, double to)
 {
   Assert(from <= to);
   Assert(to <= DBL_MAX);
-  return Random::rand() * (to - from) + from;
+  std::uniform_real_distribution<> dis(
+      from, std::nextafter(to, std::numeric_limits<double>::max()));
+  return dis(*this);
 }
 
 bool Random::pickWithProb(double probability)

--- a/test/regress/regress1/quantifiers/qe-partial.smt2
+++ b/test/regress/regress1/quantifiers/qe-partial.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE:
-; SCRUBBER: sed -e 's/(not (>= (+ .* (\* (- 1) .*)) 1))$/(not (>= (+ TERMA (\* (- 1) TERMB)) 1))/'
-; EXPECT: (not (>= (+ TERMA (* (- 1) TERMB)) 1))
+; SCRUBBER: sed -e 's/(not (>= (+ [a-c] (\* (- 1) [a-c])) 1))/(not (>= (+ TERMA (\* (- 1) TERMB)) 1))/g'
+; EXPECT: (or (not (>= (+ TERMA (* (- 1) TERMB)) 1)) (not (>= (+ TERMA (* (- 1) TERMB)) 1)))
 (set-logic LIA)
 (set-info :status unsat)
 (declare-fun a () Int)


### PR DESCRIPTION
Computing `rand() % range` is problematic because it is biased if the
range does not evenly divide the largest possible random value [0].
This commit uses `std::uniform_int_distribution` to generate a random
value within a given range, avoiding the problem. Similarly, generating
floating-point values in an unbiased matter is tricky, and the commit
uses `std::uniform_real_distribution` to avoid those issues. Note that
`std::uniform_real_distribution` generates values in the range [a, b).
The commit uses the suggested solution in [1] to generate values in [a,
b].

[0] https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Modulo_bias
[1] https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution#Notes

*Note:* I am adding @ajreynol as a reviewer because the output of one of the quantifier regressions changed.