### PR TITLE
Clause proof printing

### DIFF
--- a/src/proof/lfsc_proof_printer.cpp
+++ b/src/proof/lfsc_proof_printer.cpp
@@ -16,7 +16,9 @@
 
 #include "proof/lfsc_proof_printer.h"
 
+#include <algorithm>
 #include <iostream>
+#include <iterator>
 
 #include "prop/bvminisat/core/Solver.h"
 #include "prop/minisat/core/Solver.h"
@@ -142,6 +144,32 @@ void LFSCProofPrinter::printResolutionEmptyClause(TSatProof<Solver>* satProof,
                                                   std::ostream& paren)
 {
   printResolution(satProof, satProof->getEmptyClauseId(), out, paren);
+}
+
+void LFSCProofPrinter::printSatInputProof(const std::vector<ClauseId>& clauses,
+                                          std::ostream& out,
+                                          const std::string& namingPrefix)
+{
+  for (auto i = clauses.cbegin(); i != clauses.cend(); ++i)
+  {
+    out << "\n    (proof_of_cnfc _ _ "
+        << ProofManager::getInputClauseName(*i, namingPrefix) << " ";
+  }
+  out << "proof_of_cnfn";
+  std::fill_n(std::ostream_iterator<char>(out), clauses.size(), ')');
+}
+
+void LFSCProofPrinter::printSatClause(const prop::SatClause& clause,
+                                      std::ostream& out,
+                                      const std::string& namingPrefix)
+{
+  for (auto i = clause.cbegin(); i != clause.cend(); ++i)
+  {
+    out << "(clc " << (i->isNegated() ? "(neg " : "(pos ")
+        << ProofManager::getVarName(i->getSatVariable(), namingPrefix) << ") ";
+  }
+  out << "cln";
+  std::fill_n(std::ostream_iterator<char>(out), clause.size(), ')');
 }
 
 // Template specializations

--- a/src/proof/lfsc_proof_printer.cpp
+++ b/src/proof/lfsc_proof_printer.cpp
@@ -147,15 +147,28 @@ void LFSCProofPrinter::printResolutionEmptyClause(TSatProof<Solver>* satProof,
 }
 
 void LFSCProofPrinter::printSatInputProof(const std::vector<ClauseId>& clauses,
-                                          std::ostream& out,
-                                          const std::string& namingPrefix)
+                                      std::ostream& out,
+                                      const std::string& namingPrefix)
 {
-  for (auto i = clauses.cbegin(); i != clauses.cend(); ++i)
+  for (auto i = clauses.begin(), end = clauses.end(); i != end; ++i)
   {
-    out << "\n    (proof_of_cnfc _ _ "
+    out << "\n    (cnfc_proof _ _ _ "
         << ProofManager::getInputClauseName(*i, namingPrefix) << " ";
   }
-  out << "proof_of_cnfn";
+  out << "cnfn_proof";
+  std::fill_n(std::ostream_iterator<char>(out), clauses.size(), ')');
+}
+
+void LFSCProofPrinter::printCMapProof(const std::vector<ClauseId>& clauses,
+                                      std::ostream& out,
+                                      const std::string& namingPrefix)
+{
+  for (size_t i = 0, n = clauses.size(); i < n; ++i)
+  {
+    out << "\n    (CMapc_proof " << (i + 1) << " _ _ _ "
+        << ProofManager::getInputClauseName(clauses[i], namingPrefix) << " ";
+  }
+  out << "CMapn_proof";
   std::fill_n(std::ostream_iterator<char>(out), clauses.size(), ')');
 }
 

--- a/src/proof/lfsc_proof_printer.h
+++ b/src/proof/lfsc_proof_printer.h
@@ -79,8 +79,8 @@ class LFSCProofPrinter
    * Assuming that each clause has alreay been individually proven,
    * defines a proof of the input to the SAT solver.
    *
-   * Returns the name of the LFSC value holding the proof, i.e. a value of type
-   * (clauses_hold ...)
+   * Prints an LFSC value corresponding to the proof, i.e. a value of type
+   * (cnf_holds ...)
    *
    * @param clauses The clauses to print a proof of
    * @param out The stream to print to
@@ -89,6 +89,27 @@ class LFSCProofPrinter
   static void printSatInputProof(const std::vector<ClauseId>& clauses,
                                  std::ostream& out,
                                  const std::string& namingPrefix);
+
+  /**
+   * The LRAT proof signature uses the concept of a _clause map_ (CMap), which
+   * represents an indexed collection of (conjoined) clauses.
+   *
+   * Specifically, the signatures rely on a proof that a CMap containing the
+   * clauses given to the SAT solver hold.
+   *
+   * Assuming that the individual clauses already have proofs, this function
+   * prints a proof of the CMap mapping 1 to the first clause, 2 to the second,
+   * and so on.
+   *
+   * That is, it prints a value of type (CMap_holds ...)
+   *
+   * @param clauses The clauses to print a proof of
+   * @param out The stream to print to
+   * @param namingPrefix The prefix for LFSC names
+   */
+  static void printCMapProof(const std::vector<ClauseId>& clauses,
+                             std::ostream& out,
+                             const std::string& namingPrefix);
 
   /**
    * Prints a clause

--- a/src/proof/lfsc_proof_printer.h
+++ b/src/proof/lfsc_proof_printer.h
@@ -74,7 +74,35 @@ class LFSCProofPrinter
                                          std::ostream& out,
                                          std::ostream& paren);
 
+  /**
+   * The SAT solver is given a list of clauses.
+   * Assuming that each clause has alreay been individually proven,
+   * defines a proof of the input to the SAT solver.
+   *
+   * Returns the name of the LFSC value holding the proof, i.e. a value of type
+   * (clauses_hold ...)
+   *
+   * @param clauses The clauses to print a proof of
+   * @param out The stream to print to
+   * @param namingPrefix The prefix for LFSC names
+   */
+  static void printSatInputProof(const std::vector<ClauseId>& clauses,
+                                 std::ostream& out,
+                                 const std::string& namingPrefix);
+
+  /**
+   * Prints a clause
+   *
+   * @param clause The clause to print
+   * @param out The stream to print to
+   * @param namingPrefix The prefix for LFSC names
+   */
+  static void printSatClause(const prop::SatClause& clause,
+                             std::ostream& out,
+                             const std::string& namingPrefix);
+
  private:
+
   /**
    * Maps a clause id to a string identifier used in the LFSC proof.
    *

--- a/test/unit/proof/CMakeLists.txt
+++ b/test/unit/proof/CMakeLists.txt
@@ -2,3 +2,4 @@
 # Add unit tests
 
 cvc4_add_unit_test_black(drat_proof_black proof)
+cvc4_add_unit_test_black(lfsc_proof_printer_black proof)

--- a/test/unit/proof/lfsc_proof_printer_black.h
+++ b/test/unit/proof/lfsc_proof_printer_black.h
@@ -1,0 +1,47 @@
+/*********************                                                        */
+/*! \file lfsc_proof_printer_black.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Alex Ozdemir
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Black box testing of LFSC proof printing
+ **/
+
+#include <cxxtest/TestSuite.h>
+
+#include "proof/lfsc_proof_printer.h"
+#include "prop/sat_solver_types.h"
+
+using namespace CVC4::proof;
+using namespace CVC4::prop;
+
+class LfscProofPrinterBlack : public CxxTest::TestSuite
+{
+ public:
+  void setUp() override {}
+  void tearDown() override {}
+
+  void testPrintClause();
+};
+
+void LfscProofPrinterBlack::testPrintClause()
+{
+  SatClause clause{
+      SatLiteral(0, false), SatLiteral(1, true), SatLiteral(3, false)};
+  std::ostringstream lfsc;
+
+  LFSCProofPrinter::printSatClause(clause, lfsc, "");
+
+  std::string expectedLfsc =
+      "(clc (pos .v0) "
+      "(clc (neg .v1) "
+      "(clc (pos .v3) "
+      "cln)))";
+
+  TS_ASSERT_EQUALS(lfsc.str(), expectedLfsc);
+}

--- a/test/unit/proof/lfsc_proof_printer_black.h
+++ b/test/unit/proof/lfsc_proof_printer_black.h
@@ -16,6 +16,7 @@
 
 #include "proof/lfsc_proof_printer.h"
 #include "prop/sat_solver_types.h"
+#include "proof/clause_id.h"
 
 using namespace CVC4::proof;
 using namespace CVC4::prop;
@@ -27,6 +28,7 @@ class LfscProofPrinterBlack : public CxxTest::TestSuite
   void tearDown() override {}
 
   void testPrintClause();
+  void testPrintSatInputProof();
 };
 
 void LfscProofPrinterBlack::testPrintClause()
@@ -44,4 +46,38 @@ void LfscProofPrinterBlack::testPrintClause()
       "cln)))";
 
   TS_ASSERT_EQUALS(lfsc.str(), expectedLfsc);
+}
+
+void LfscProofPrinterBlack::testPrintSatInputProof()
+{
+  std::vector<CVC4::ClauseId> ids{2, 40, 3};
+  std::ostringstream lfsc;
+
+  LFSCProofPrinter::printSatInputProof(ids, lfsc, "");
+
+  std::string expectedLfsc =
+      "(proof_of_cnfc _ _ .pb2 "
+      "(proof_of_cnfc _ _ .pb40 "
+      "(proof_of_cnfc _ _ .pb3 "
+      "proof_of_cnfn)))";
+
+  std::ostringstream lfscWithoutWhitespace;
+  for (char c : lfsc.str())
+  {
+    if (!std::isspace(c))
+    {
+      lfscWithoutWhitespace << c;
+    }
+  }
+  std::ostringstream expectedLfscWithoutWhitespace;
+  for (char c : expectedLfsc)
+  {
+    if (!std::isspace(c))
+    {
+      expectedLfscWithoutWhitespace << c;
+    }
+  }
+
+  TS_ASSERT_EQUALS(lfscWithoutWhitespace.str(),
+                   expectedLfscWithoutWhitespace.str());
 }

--- a/test/unit/proof/lfsc_proof_printer_black.h
+++ b/test/unit/proof/lfsc_proof_printer_black.h
@@ -29,6 +29,7 @@ class LfscProofPrinterBlack : public CxxTest::TestSuite
 
   void testPrintClause();
   void testPrintSatInputProof();
+  void testPrintCMapProof();
 };
 
 void LfscProofPrinterBlack::testPrintClause()
@@ -56,10 +57,44 @@ void LfscProofPrinterBlack::testPrintSatInputProof()
   LFSCProofPrinter::printSatInputProof(ids, lfsc, "");
 
   std::string expectedLfsc =
-      "(proof_of_cnfc _ _ .pb2 "
-      "(proof_of_cnfc _ _ .pb40 "
-      "(proof_of_cnfc _ _ .pb3 "
-      "proof_of_cnfn)))";
+      "(cnfc_proof _ _ _ .pb2 "
+      "(cnfc_proof _ _ _ .pb40 "
+      "(cnfc_proof _ _ _ .pb3 "
+      "cnfn_proof)))";
+
+  std::ostringstream lfscWithoutWhitespace;
+  for (char c : lfsc.str())
+  {
+    if (!std::isspace(c))
+    {
+      lfscWithoutWhitespace << c;
+    }
+  }
+  std::ostringstream expectedLfscWithoutWhitespace;
+  for (char c : expectedLfsc)
+  {
+    if (!std::isspace(c))
+    {
+      expectedLfscWithoutWhitespace << c;
+    }
+  }
+
+  TS_ASSERT_EQUALS(lfscWithoutWhitespace.str(),
+                   expectedLfscWithoutWhitespace.str());
+}
+
+void LfscProofPrinterBlack::testPrintCMapProof()
+{
+  std::vector<CVC4::ClauseId> ids{2, 40, 3};
+  std::ostringstream lfsc;
+
+  LFSCProofPrinter::printCMapProof(ids, lfsc, "");
+
+  std::string expectedLfsc =
+      "(CMapc_proof 1 _ _ _ .pb2 "
+      "(CMapc_proof 2 _ _ _ .pb40 "
+      "(CMapc_proof 3 _ _ _ .pb3 "
+      "CMapn_proof)))";
 
   std::ostringstream lfscWithoutWhitespace;
   for (char c : lfsc.str())


### PR DESCRIPTION
Adds two features to the LFSC proof printer:
1. A function for printing LFSC clauses
2. A function for printing proofs of cnf formulas (given that the constituent clauses have already been printed)

Also a unit test.