### PR TITLE
Do not rewrite 1-constructor sygus testers to true

### DIFF
--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -428,7 +428,7 @@ RewriteResponse DatatypesRewriter::rewriteTester(TNode in)
                            NodeManager::currentNM()->mkConst(result));
   }
   const Datatype& dt = static_cast<DatatypeType>(in[0].getType().toType()).getDatatype();
-  if (dt.getNumConstructors() == 1)
+  if (dt.getNumConstructors() == 1 && !dt.isSygus())
   {
     // only one constructor, so it must be
     Trace("datatypes-rewrite")

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -1715,22 +1715,11 @@ bool SygusSymBreakNew::checkValue(Node n,
   // ensure that the expected size bound is met
   int cindex = DatatypesRewriter::indexOf(vn.getOperator());
   Node tst = DatatypesRewriter::mkTester( n, cindex, dt );
-  bool hastst = false;
+  bool hastst = d_td->getEqualityEngine()->hasTerm(tst);
   Node tstrep;
-  if (dt.getNumConstructors() == 1)
+  if (hastst)
   {
-    // since 1-constructor datatypes have testers that are rewritten to true,
-    // we explicitly assume that this term has a tester.
-    hastst = true;
-    tstrep = d_true;
-  }
-  else
-  {
-    hastst = d_td->getEqualityEngine()->hasTerm(tst);
-    if (hastst)
-    {
-      tstrep = d_td->getEqualityEngine()->getRepresentative(tst);
-    }
+    tstrep = d_td->getEqualityEngine()->getRepresentative(tst);
   }
   if (!hastst || tstrep != d_true)
   {

--- a/src/theory/datatypes/datatypes_sygus.cpp
+++ b/src/theory/datatypes/datatypes_sygus.cpp
@@ -1715,11 +1715,22 @@ bool SygusSymBreakNew::checkValue(Node n,
   // ensure that the expected size bound is met
   int cindex = DatatypesRewriter::indexOf(vn.getOperator());
   Node tst = DatatypesRewriter::mkTester( n, cindex, dt );
-  bool hastst = d_td->getEqualityEngine()->hasTerm(tst);
+  bool hastst = false;
   Node tstrep;
-  if (hastst)
+  if (dt.getNumConstructors() == 1)
   {
-    tstrep = d_td->getEqualityEngine()->getRepresentative(tst);
+    // since 1-constructor datatypes have testers that are rewritten to true,
+    // we explicitly assume that this term has a tester.
+    hastst = true;
+    tstrep = d_true;
+  }
+  else
+  {
+    hastst = d_td->getEqualityEngine()->hasTerm(tst);
+    if (hastst)
+    {
+      tstrep = d_td->getEqualityEngine()->getRepresentative(tst);
+    }
   }
   if (!hastst || tstrep != d_true)
   {

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1748,6 +1748,7 @@ set(regress_2_tests
   regress2/sygus/inv_gen_n_c11.sy
   regress2/sygus/lustre-real.sy
   regress2/sygus/max2-univ.sy
+  regress2/sygus/min_IC_1.sy
   regress2/sygus/mpg_guard1-dd.sy
   regress2/sygus/multi-udiv.sy
   regress2/sygus/nia-max-square.sy

--- a/test/regress/regress2/sygus/min_IC_1.sy
+++ b/test/regress/regress2/sygus/min_IC_1.sy
@@ -1,3 +1,4 @@
+; REQUIRES: symfpu
 ; EXPECT: unsat
 ; COMMAND-LINE: --sygus-out=status
 (set-logic ALL)

--- a/test/regress/regress2/sygus/min_IC_1.sy
+++ b/test/regress/regress2/sygus/min_IC_1.sy
@@ -1,0 +1,24 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+(set-logic ALL)
+(define-sort FP () (_ FloatingPoint 3 5))
+(define-fun IC ((t FP)) Bool (=> (fp.isInfinite t) (fp.isNegative t)))
+
+(synth-fun simpIC ((t FP)) Bool
+  ((Start Bool (
+     (and Start Start)
+     (not Start)
+
+     (fp.isInfinite StartFP)
+     (fp.isNegative StartFP)
+     
+     (ite Start Start Start)
+   ))
+   (StartFP FP (
+     t
+   ))
+))
+
+(declare-var x FP)
+(constraint (= (simpIC x) (IC x)))
+(check-synth)


### PR DESCRIPTION
Very slight positive + no negative impact on known sygus benchmarks https://www.starexec.org/starexec/secure/details/job.jsp?id=32002

This was leading to spurious "unknown" cases, due to testers not being asserted to the sygus solver, which it assumes is done for all shared selector chains.