### PR TITLE
LratInstruction inheritance

### DIFF
--- a/src/proof/lrat/lrat_proof.h
+++ b/src/proof/lrat/lrat_proof.h
@@ -26,6 +26,7 @@
 #ifndef __CVC4__PROOF__LRAT__LRAT_PROOF_H
 #define __CVC4__PROOF__LRAT__LRAT_PROOF_H
 
+#include <iosfwd>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -41,22 +42,33 @@ namespace lrat {
 // Refers to clause position within an LRAT proof
 using ClauseIdx = size_t;
 
-enum LratInstructionKind
+// This is conceptually an Either<Addition,Deletion>
+class LratInstruction
 {
-  LRAT_DELETION,
-  LRAT_ADDITION,
+ public:
+  /**
+   * Write this LRAT instruction in textual format
+   *
+   * @param out the stream to write to
+   */
+  virtual void outputAsText(std::ostream& out) const = 0;
+  virtual ~LratInstruction() = default;
 };
 
-struct LratDeletionData
+class LratDeletion : public LratInstruction
 {
-  LratDeletionData(ClauseIdx idxOfClause, std::vector<ClauseIdx>&& clauses)
+ public:
+  LratDeletion(ClauseIdx idxOfClause, std::vector<ClauseIdx>&& clauses)
       : d_idxOfClause(idxOfClause), d_clauses(clauses)
   {
     // Nothing left to do
   }
 
-  ~LratDeletionData() = default;
+  LratDeletion() = default;
 
+  void outputAsText(std::ostream& out) const override;
+
+ private:
   // This idx doesn't really matter, but it's in the format anyway, so we parse
   // it.
   ClauseIdx d_idxOfClause;
@@ -69,12 +81,13 @@ struct LratDeletionData
 // propegation
 using LratUPTrace = std::vector<ClauseIdx>;
 
-struct LratAdditionData
+class LratAddition : public LratInstruction
 {
-  LratAdditionData(ClauseIdx idxOfClause,
-                   prop::SatClause&& clause,
-                   LratUPTrace&& atTrace,
-                   std::vector<std::pair<ClauseIdx, LratUPTrace>> resolvants)
+ public:
+  LratAddition(ClauseIdx idxOfClause,
+               prop::SatClause&& clause,
+               LratUPTrace&& atTrace,
+               std::vector<std::pair<ClauseIdx, LratUPTrace>> resolvants)
       : d_idxOfClause(idxOfClause),
         d_clause(clause),
         d_atTrace(atTrace),
@@ -83,8 +96,9 @@ struct LratAdditionData
     // Nothing left to do
   }
 
-  ~LratAdditionData() = default;
+  void outputAsText(std::ostream& out) const override;
 
+ private:
   // The idx for the new clause
   ClauseIdx d_idxOfClause;
   // The new clause
@@ -96,25 +110,6 @@ struct LratAdditionData
   // together with a UP trace after that resolution.
   // Used for RAT checks.
   std::vector<std::pair<ClauseIdx, LratUPTrace>> d_resolvants;
-};
-
-// This is conceptually an Either<Addition,Deletion>
-struct LratInstruction
-{
-  LratInstructionKind d_kind;
-  union LratInstructionData
-  {
-    LratAdditionData d_addition;
-    LratDeletionData d_deletion;
-    ~LratInstructionData(){/* Empty destructor */};
-    LratInstructionData(){/* Empty constructor */};
-  } d_data;
-
-  LratInstruction(LratInstruction&& instr);
-  LratInstruction(LratInstruction& instr);
-  LratInstruction(LratAdditionData&& addition);
-  LratInstruction(LratDeletionData&& deletion);
-  ~LratInstruction();
 };
 
 class LratProof
@@ -142,18 +137,30 @@ class LratProof
    */
   LratProof(std::istream& textualProof);
 
-  const std::vector<LratInstruction>& getInstructions() const
+  /**
+   * Construct a LRAT proof from an explicit instruction list
+   *
+   * @param instructions
+   */
+  LratProof(std::vector<std::unique_ptr<LratInstruction>>&& instructions)
+      : d_instructions(std::move(instructions))
+  {
+    // Nothing else
+  }
+
+  const std::vector<std::unique_ptr<LratInstruction>>& getInstructions() const
   {
     return d_instructions;
   }
 
  private:
   // The instructions in the proof. Each is a deletion or addition.
-  std::vector<LratInstruction> d_instructions;
+  std::vector<std::unique_ptr<LratInstruction>> d_instructions;
 };
 
 // Prints the LRAT proof in textual format
 std::ostream& operator<<(std::ostream& o, const LratProof& p);
+std::ostream& operator<<(std::ostream& o, const LratInstruction& i);
 
 }  // namespace lrat
 }  // namespace proof


### PR DESCRIPTION
While implementing and testing LRAT proof output as LFSC, I discovered
that my implementation of LratInstruction as a tagged union was subtly
broken for reasons related to move/copy assignment/constructors.

While I could have figured out how to fix it, I decided to stop fighting
the system and use inheritance.

This PR makes that change. It is not intended to change any functionality (save a new constructor which creates an LratProof from a list of instructions). 

This PR will be followed by one using the inheritance-based
LratInstruction to implement output to LFSC. That PR will also contain a unit test of LRAT printing.