### PR TITLE
Extract DIMACS Printing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,8 @@ libcvc4_add_sources(
   proof/clause_id.h
   proof/cnf_proof.cpp
   proof/cnf_proof.h
+  proof/dimacs_printer.cpp
+  proof/dimacs_printer.h
   proof/drat/drat_proof.cpp
   proof/drat/drat_proof.h
   proof/lemma_proof.cpp

--- a/src/proof/dimacs_printer.cpp
+++ b/src/proof/dimacs_printer.cpp
@@ -1,0 +1,77 @@
+/*********************                                                        */
+/*! \file dimacs_printer.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Alex Ozdemir
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief DIMACS SAT Problem Format
+ **
+ ** Defines serialization for SAT problems as DIMACS
+ **/
+
+#include "proof/dimacs_printer.h"
+
+#include <iostream>
+
+namespace CVC4 {
+namespace proof {
+
+// Prints the literal as a (+) or (-) int
+// Not operator<< b/c that represents negation as ~
+std::ostream& textOut(std::ostream& o, const prop::SatLiteral& l)
+{
+  if (l.isNegated())
+  {
+    o << "-";
+  }
+  return o << l.getSatVariable() + 1;
+}
+
+// Prints the clause as a space-separated list of ints
+// Not operator<< b/c that represents negation as ~
+std::ostream& textOut(std::ostream& o, const prop::SatClause& c)
+{
+  for (const auto l : c)
+  {
+    textOut(o, l) << " ";
+  }
+  return o << "0";
+}
+
+void printDimacs(
+    std::ostream& o,
+    const std::vector<std::pair<ClauseId, prop::SatClause>>& usedClauses)
+{
+  size_t maxVar = 0;
+  for (auto& c : usedClauses)
+  {
+    for (auto l : c.second)
+    {
+      if (l.getSatVariable() + 1 > maxVar)
+      {
+        maxVar = l.getSatVariable() + 1;
+      }
+    }
+  }
+  o << "p cnf " << maxVar << " " << usedClauses.size() << '\n';
+  for (const auto& idAndClause : usedClauses)
+  {
+    for (auto l : idAndClause.second)
+    {
+      if (l.isNegated())
+      {
+        o << '-';
+      }
+      o << l.getSatVariable() + 1 << " ";
+    }
+    o << "0\n";
+  }
+}
+
+}  // namespace proof
+}  // namespace CVC4

--- a/src/proof/dimacs_printer.cpp
+++ b/src/proof/dimacs_printer.cpp
@@ -36,7 +36,7 @@ std::ostream& textOut(std::ostream& o, const prop::SatLiteral& l)
 // Not operator<< b/c that represents negation as ~
 std::ostream& textOut(std::ostream& o, const prop::SatClause& c)
 {
-  for (const auto l : c)
+  for (const auto& l : c)
   {
     textOut(o, l) << " ";
   }
@@ -48,9 +48,9 @@ void printDimacs(
     const std::vector<std::pair<ClauseId, prop::SatClause>>& usedClauses)
 {
   size_t maxVar = 0;
-  for (auto& c : usedClauses)
+  for (const auto& c : usedClauses)
   {
-    for (auto l : c.second)
+    for (const auto& l : c.second)
     {
       if (l.getSatVariable() + 1 > maxVar)
       {
@@ -61,7 +61,7 @@ void printDimacs(
   o << "p cnf " << maxVar << " " << usedClauses.size() << '\n';
   for (const auto& idAndClause : usedClauses)
   {
-    for (auto l : idAndClause.second)
+    for (const auto& l : idAndClause.second)
     {
       if (l.isNegated())
       {

--- a/src/proof/dimacs_printer.h
+++ b/src/proof/dimacs_printer.h
@@ -28,14 +28,34 @@
 namespace CVC4 {
 namespace proof {
 
-// Prints the literal as a (+) or (-) int
-// Not operator<< b/c that represents negation as ~
+/**
+ * Prints the literal as a (+) or (-) int
+ * Not operator<< b/c that represents negation as ~
+ *
+ * @param o where to print
+ * @param l the literal to print
+ *
+ * @return the original stream
+ */
 std::ostream& textOut(std::ostream& o, const prop::SatLiteral& l);
 
-// Prints the clause as a space-separated list of ints
-// Not operator<< b/c that represents negation as ~
+/**
+ * Prints the clause as a space-separated list of ints
+ * Not operator<< b/c that represents literal negation as ~
+ *
+ * @param o where to print
+ * @param c the clause to print
+ *
+ * @return the original stream
+ */
 std::ostream& textOut(std::ostream& o, const prop::SatClause& c);
 
+/**
+ * Prints a CNF formula in DIMACS format
+ *
+ * @param o where to print to
+ * @param usedClauses the CNF formula
+ */
 void printDimacs(
     std::ostream& o,
     const std::vector<std::pair<ClauseId, prop::SatClause>>& usedClauses);

--- a/src/proof/dimacs_printer.h
+++ b/src/proof/dimacs_printer.h
@@ -1,0 +1,46 @@
+/*********************                                                        */
+/*! \file dimacs_printer.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Alex Ozdemir
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2018 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief DIMACS SAT Problem Format
+ **
+ ** Defines serialization for SAT problems as DIMACS
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef __CVC4__PROOF__DIMACS_PRINTER_H
+#define __CVC4__PROOF__DIMACS_PRINTER_H
+
+#include <iosfwd>
+#include <memory>
+
+#include "proof/clause_id.h"
+#include "prop/sat_solver_types.h"
+
+namespace CVC4 {
+namespace proof {
+
+// Prints the literal as a (+) or (-) int
+// Not operator<< b/c that represents negation as ~
+std::ostream& textOut(std::ostream& o, const prop::SatLiteral& l);
+
+// Prints the clause as a space-separated list of ints
+// Not operator<< b/c that represents negation as ~
+std::ostream& textOut(std::ostream& o, const prop::SatClause& c);
+
+void printDimacs(
+    std::ostream& o,
+    const std::vector<std::pair<ClauseId, prop::SatClause>>& usedClauses);
+
+}  // namespace proof
+}  // namespace CVC4
+
+#endif  // __CVC4__PROOF__DIMACS_PRINTER_H

--- a/src/proof/lrat/lrat_proof.h
+++ b/src/proof/lrat/lrat_proof.h
@@ -137,8 +137,7 @@ class LratProof
    * @param dratBinary  The DRAT proof from the SAT solver, as a binary stream.
    */
   static LratProof fromDratProof(
-      const std::unordered_map<ClauseId, prop::SatClause*>& usedClauses,
-      const std::vector<ClauseId>& clauseOrder,
+      const std::vector<std::pair<ClauseId, prop::SatClause>>& usedClauses,
       const std::string& dratBinary);
   /**
    * @brief Construct an LRAT proof from its textual representation


### PR DESCRIPTION
Creating LRAT proofs requires writing SAT problems in the DIMACS format.
Before this code was in the LRAT class.

However, since creating ER proofs will also require writing DIMACS, I
decided to extract it this code into helper functions.

At the same time I realized that my prior representation of used clauses
was unnecessarily poor. I had chosen it to interface with
`CnfProof::collectAtomsForClauses`, but I have since discovered that the
aforementioned method is super simple, so choosing a poor representation to re-use it is not the right call.