### PR TITLE
CVC: Fix printing of tuple and record selectors

### DIFF
--- a/src/printer/cvc/cvc_printer.cpp
+++ b/src/printer/cvc/cvc_printer.cpp
@@ -404,20 +404,26 @@ void CvcPrinter::toStream(
       }
       break;
     case kind::APPLY_SELECTOR:
-    case kind::APPLY_SELECTOR_TOTAL: {
-        TypeNode t = n[0].getType();
-        Node opn = n.getOperator();
-        if( t.isTuple() ){
-          toStream(out, n[0], depth, types, true);
-          const Datatype& dt = ((DatatypeType)t.toType()).getDatatype();
-          int sindex = dt[0].getSelectorIndexInternal( opn.toExpr() );
-          Assert( sindex>=0 );
-          out << '.' << sindex;
-        }else{
-          toStream(op, opn, depth, types, false);
-        }
+    case kind::APPLY_SELECTOR_TOTAL:
+    {
+      TypeNode t = n[0].getType();
+      Node opn = n.getOperator();
+      toStream(out, n[0], depth, types, true);
+      out << '.';
+      if (t.isTuple())
+      {
+        const Datatype& dt = ((DatatypeType)t.toType()).getDatatype();
+        int sindex = dt[0].getSelectorIndexInternal(opn.toExpr());
+        Assert(sindex >= 0);
+        out << sindex;
       }
-      break;
+      else
+      {
+        toStream(out, opn, depth, types, false);
+      }
+      return;
+    }
+    break;
     case kind::APPLY_TESTER: {
       Assert( !n.getType().isTuple() && !n.getType().isRecord() );
       op << "is_";

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -572,6 +572,7 @@ set(regress_0_tests
   regress0/print_lambda.cvc
   regress0/printer/bv_consts_bin.smt2
   regress0/printer/bv_consts_dec.smt2
+  regress0/printer/tuples_and_records.cvc
   regress0/push-pop/boolean/fuzz_12.smt2
   regress0/push-pop/boolean/fuzz_13.smt2
   regress0/push-pop/boolean/fuzz_14.smt2

--- a/test/regress/regress0/printer/tuples_and_records.cvc
+++ b/test/regress/regress0/printer/tuples_and_records.cvc
@@ -1,0 +1,19 @@
+% COMMAND-LINE: --no-dt-share-sel
+% EXPECT: invalid
+% EXPECT: ((r.a, "active"))
+% EXPECT: ((y.1, 9))
+OPTION "produce-models";
+
+R : TYPE = [#
+   a : STRING,
+   b : STRING
+#];
+r : R;
+
+y: [REAL, INT, REAL];
+
+ASSERT r = (# a := "active", b := "who knows?" #);
+ASSERT y = ( 4/5, 9, 11/9 );
+QUERY r.a = "what?";
+GET_VALUE r.a;
+GET_VALUE y.1;


### PR DESCRIPTION
Previously, tuple and record selectors were printed as postifx
operations, e.g. `a(r)` instead of `r.a`. This commit fixes the issue.
The commit also adds a regression test. Note that the test uses
`--no-dt-share-sel` because shared selectors make
`getSelectorIndexInternal()` return -1, which should be fixed in a
future commit.