### PR TITLE
ClangFormat: Disable DerivePointerAlignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,5 +15,5 @@ BraceWrapping:
   BeforeCatch: true
   BeforeElse: true
 BreakBeforeBraces: Custom
+DerivePointerAlignment: false
 ...
-


### PR DESCRIPTION
The option `DerivePointerAlignment` tries to automatically determine the
pointer alignment used by the input. In our case, we would eventually
like the code base to be consistent throughtout, so this commit disables
that option.