### PR TITLE
Adding capture avoiding substitution

### DIFF
--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -239,9 +239,17 @@ class NodeTemplate {
 
 public:
 
+  /**
+   * Cache-aware, recursive version of substituteCaptureAvoiding() used by the
+   * public member function with a similar signature.
+   */
   Node substituteCaptureAvoiding(Node node, Node replacement,
                   std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
 
+  /**
+   * Cache-aware, recursive version of substituteCaptureAvoiding() used by the
+   * public member function with a similar signature.
+   */
   Node substituteCaptureAvoiding(
       std::vector<Node> source,
       std::vector<Node> dest,
@@ -467,7 +475,7 @@ public:
     assertTNodeNotExpired();
     return getMetaKind() == kind::metakind::VARIABLE;
   }
-  
+
   /**
    * Returns true if this node represents a nullary operator
    */
@@ -475,7 +483,7 @@ public:
     assertTNodeNotExpired();
     return getMetaKind() == kind::metakind::NULLARY_OPERATOR;
   }
-  
+
   inline bool isClosure() const {
     assertTNodeNotExpired();
     return getKind() == kind::LAMBDA ||
@@ -532,8 +540,16 @@ public:
    */
   TypeNode getType(bool check = false) const;
 
+  /**
+   * Substitution of Nodes in a capture avoiding way.
+   */
   Node substituteCaptureAvoiding(Node node, Node replacement) const;
 
+  /**
+   * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
+   * source will be replaced by their corresponding element in dest.  Both
+   * vectors should have the same size.
+   */
   Node substituteCaptureAvoiding(std::vector<Node> source,
                                  std::vector<Node> dest) const;
 
@@ -1388,8 +1404,8 @@ Node NodeTemplate<ref_count>::substituteCaptureAvoiding(
     std::unordered_map<Node, Node, NodeHashFunction>& cache) const
 {
   // in cache?
-  typename std::unordered_map<Node, Node, NodeHashFunction>::const_iterator
-      i = cache.find(*this);
+  typename std::unordered_map<Node, Node, NodeHashFunction>::const_iterator i =
+      cache.find(*this);
   if (i != cache.end())
   {
     return (*i).second;
@@ -1402,83 +1418,58 @@ Node NodeTemplate<ref_count>::substituteCaptureAvoiding(
   auto it = std::find(source.begin(), source.end(), (*this));
   if (it != source.end())
   {
-    // Debug("sub-capavoid") << ".. found " << (*this) << " in pos " << (*j2) << "\n";
     Assert(std::distance(source.begin(), it) >= 0
            && std::distance(source.begin(), it) < dest.size());
     Node n = dest[std::distance(source.begin(), it)];
     cache[*this] = n;
     return n;
   }
-  else if (getNumChildren() == 0)
+  if (getNumChildren() == 0)
   {
     cache[*this] = *this;
     return *this;
   }
-  else
+  bool binder = isClosure();
+  // if binder, rename variables to avoid capture
+  if (binder)
   {
-    // if binder, rename variables to avoid capture
-    Kind k = getKind();
-    bool binder = false;
+    std::vector<Node> vars;
+    std::vector<Node> renames;
 
-    if (k == kind::FORALL || k == kind::EXISTS || k == kind::LAMBDA
-        || k == kind::CHOICE)
+    NodeManager* nm = NodeManager::currentNM();
+    for (const Node& v : (*this)[0])
     {
-      binder = true;
-      std::vector<Node> vars;
-      std::vector<Node> renames;
-
-      NodeManager* nm = NodeManager::currentNM();
-      for (const Node& v : (*this)[0])
-      {
-        vars.push_back(v);
-        renames.push_back(nm->mkBoundVar(v.getType()));
-      }
-      // have new vars -> renames subs in the beginning of current sub
-      source.insert(source.begin(), vars.begin(), vars.end());
-      dest.insert(dest.begin(), renames.begin(), renames.end());
-
-      Debug("sub-capavoid") << "Substitution after:\n";
-      for (unsigned i = 0, size = source.size(); i < size; ++i)
-      {
-        Debug("sub-capavoid")
-            << ".. " << source[i] << " --> " << dest[i] << "\n";
-      }
+      vars.push_back(v);
+      renames.push_back(nm->mkBoundVar(v.getType()));
     }
-    NodeBuilder<> nb(getKind());
-    if (getMetaKind() == kind::metakind::PARAMETERIZED)
-    {
-      // push the operator
-      nb << getOperator().substituteCaptureAvoiding(source, dest, cache);
-    }
-    for (const_iterator i = begin(), iend = end(); i != iend; ++i)
-    {
-      nb << (*i).substituteCaptureAvoiding(source, dest, cache);
-    }
-    Node n = nb;
-    cache[*this] = n;
-
-    // remove renaming
-    if (binder)
-    {
-      // remove beginning of sub which correspond to renaming of variables in
-      // this binder
-      unsigned nchildren = (*this)[0].getNumChildren();
-      source.erase(source.begin(), source.begin() + nchildren);
-      dest.erase(dest.begin(), dest.begin() + nchildren);
-
-      Debug("sub-capavoid") << "Recovering sub after going out of " << (*this)
-                            << " with result " << n << ":\n";
-      for (unsigned i = 0, size = source.size(); i < size; ++i)
-      {
-        Debug("sub-capavoid")
-            << ".. " << source[i] << " --> " << dest[i] << "\n";
-      }
-    }
-    return n;
+    // have new vars -> renames subs in the beginning of current sub
+    source.insert(source.begin(), vars.begin(), vars.end());
+    dest.insert(dest.begin(), renames.begin(), renames.end());
   }
+  NodeBuilder<> nb(getKind());
+  if (getMetaKind() == kind::metakind::PARAMETERIZED)
+  {
+    // push the operator
+    nb << getOperator().substituteCaptureAvoiding(source, dest, cache);
+  }
+  for (const_iterator i = begin(), iend = end(); i != iend; ++i)
+  {
+    nb << (*i).substituteCaptureAvoiding(source, dest, cache);
+  }
+  Node n = nb;
+  cache[*this] = n;
+
+  // remove renaming
+  if (binder)
+  {
+    // remove beginning of sub which correspond to renaming of variables in
+    // this binder
+    unsigned nchildren = (*this)[0].getNumChildren();
+    source.erase(source.begin(), source.begin() + nchildren);
+    dest.erase(dest.begin(), dest.begin() + nchildren);
+  }
+  return n;
 }
-
-
 
 template <bool ref_count>
 inline Node

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -240,22 +240,6 @@ class NodeTemplate {
 public:
 
   /**
-   * Cache-aware, recursive version of substituteCaptureAvoiding() used by the
-   * public member function with a similar signature.
-   */
-  Node substituteCaptureAvoiding(Node node, Node replacement,
-                  std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
-
-  /**
-   * Cache-aware, recursive version of substituteCaptureAvoiding() used by the
-   * public member function with a similar signature.
-   */
-  Node substituteCaptureAvoiding(
-      std::vector<Node> source,
-      std::vector<Node> dest,
-      std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
-
-  /**
    * Cache-aware, recursive version of substitute() used by the public
    * member function with a similar signature.
    */
@@ -539,19 +523,6 @@ public:
    * (default: false)
    */
   TypeNode getType(bool check = false) const;
-
-  /**
-   * Substitution of Nodes in a capture avoiding way.
-   */
-  Node substituteCaptureAvoiding(Node node, Node replacement) const;
-
-  /**
-   * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
-   * source will be replaced by their corresponding element in dest.  Both
-   * vectors should have the same size.
-   */
-  Node substituteCaptureAvoiding(std::vector<Node> source,
-                                 std::vector<Node> dest) const;
 
   /**
    * Substitution of Nodes.
@@ -1358,117 +1329,6 @@ TypeNode NodeTemplate<ref_count>::getType(bool check) const
   assertTNodeNotExpired();
 
   return NodeManager::currentNM()->getType(*this, check);
-}
-
-template <bool ref_count>
-inline Node NodeTemplate<ref_count>::substituteCaptureAvoiding(
-    Node node, Node replacement) const
-{
-  if (node == *this)
-  {
-    return replacement;
-  }
-  std::vector<Node> source;
-  std::vector<Node> dest;
-  source.push_back(node);
-  dest.push_back(replacement);
-  std::unordered_map<Node, Node, NodeHashFunction> cache;
-  return substituteCaptureAvoiding(source, dest, cache);
-}
-
-template <bool ref_count>
-Node NodeTemplate<ref_count>::substituteCaptureAvoiding(
-    Node node,
-    Node replacement,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache) const
-{
-  std::vector<Node> source;
-  std::vector<Node> dest;
-  source.push_back(node);
-  dest.push_back(replacement);
-  return substituteCaptureAvoiding(source, dest, cache);
-}
-
-template <bool ref_count>
-inline Node NodeTemplate<ref_count>::substituteCaptureAvoiding(
-    std::vector<Node> source, std::vector<Node> dest) const
-{
-  std::unordered_map<Node, Node, NodeHashFunction> cache;
-  return substituteCaptureAvoiding(source, dest, cache);
-}
-
-template <bool ref_count>
-Node NodeTemplate<ref_count>::substituteCaptureAvoiding(
-    std::vector<Node> source,
-    std::vector<Node> dest,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache) const
-{
-  // in cache?
-  typename std::unordered_map<Node, Node, NodeHashFunction>::const_iterator i =
-      cache.find(*this);
-  if (i != cache.end())
-  {
-    return (*i).second;
-  }
-
-  // otherwise compute
-  Assert(source.size() == dest.size(),
-         "Substitution domain and range must be equal size");
-
-  auto it = std::find(source.begin(), source.end(), (*this));
-  if (it != source.end())
-  {
-    Assert(std::distance(source.begin(), it) >= 0
-           && std::distance(source.begin(), it) < dest.size());
-    Node n = dest[std::distance(source.begin(), it)];
-    cache[*this] = n;
-    return n;
-  }
-  if (getNumChildren() == 0)
-  {
-    cache[*this] = *this;
-    return *this;
-  }
-  bool binder = isClosure();
-  // if binder, rename variables to avoid capture
-  if (binder)
-  {
-    std::vector<Node> vars;
-    std::vector<Node> renames;
-
-    NodeManager* nm = NodeManager::currentNM();
-    for (const Node& v : (*this)[0])
-    {
-      vars.push_back(v);
-      renames.push_back(nm->mkBoundVar(v.getType()));
-    }
-    // have new vars -> renames subs in the beginning of current sub
-    source.insert(source.begin(), vars.begin(), vars.end());
-    dest.insert(dest.begin(), renames.begin(), renames.end());
-  }
-  NodeBuilder<> nb(getKind());
-  if (getMetaKind() == kind::metakind::PARAMETERIZED)
-  {
-    // push the operator
-    nb << getOperator().substituteCaptureAvoiding(source, dest, cache);
-  }
-  for (const_iterator i = begin(), iend = end(); i != iend; ++i)
-  {
-    nb << (*i).substituteCaptureAvoiding(source, dest, cache);
-  }
-  Node n = nb;
-  cache[*this] = n;
-
-  // remove renaming
-  if (binder)
-  {
-    // remove beginning of sub which correspond to renaming of variables in
-    // this binder
-    unsigned nchildren = (*this)[0].getNumChildren();
-    source.erase(source.begin(), source.begin() + nchildren);
-    dest.erase(dest.begin(), dest.begin() + nchildren);
-  }
-  return n;
 }
 
 template <bool ref_count>

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -471,7 +471,7 @@ public:
   inline bool isClosure() const {
     assertTNodeNotExpired();
     return getKind() == kind::LAMBDA || getKind() == kind::FORALL
-           || getKind() == kind::EXISTS || getKind() == kind::REWRITE_RULE
+           || getKind() == kind::EXISTS
            || getKind() == kind::CHOICE;
   }
 

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -471,8 +471,7 @@ public:
   inline bool isClosure() const {
     assertTNodeNotExpired();
     return getKind() == kind::LAMBDA || getKind() == kind::FORALL
-           || getKind() == kind::EXISTS
-           || getKind() == kind::CHOICE;
+           || getKind() == kind::EXISTS || getKind() == kind::CHOICE;
   }
 
   /**

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -273,7 +273,7 @@ void getSymbols(TNode n,
   } while (!visit.empty());
 }
 
-Node substituteCaptureAvoiding(TNode n, TNode src, TNode dest)
+Node substituteCaptureAvoiding(TNode n, Node src, Node dest)
 {
   if (n == src)
   {
@@ -283,16 +283,16 @@ Node substituteCaptureAvoiding(TNode n, TNode src, TNode dest)
   {
     return n;
   }
-  std::vector<TNode> srcs;
-  std::vector<TNode> dests;
+  std::vector<Node> srcs;
+  std::vector<Node> dests;
   srcs.push_back(src);
   dests.push_back(dest);
   return substituteCaptureAvoiding(n, srcs, dests);
 }
 
 Node substituteCaptureAvoiding(TNode n,
-                               std::vector<TNode>& src,
-                               std::vector<TNode>& dest)
+                               std::vector<Node>& src,
+                               std::vector<Node>& dest)
 {
   std::unordered_map<TNode, Node, TNodeHashFunction> visited;
   std::unordered_map<TNode, Node, TNodeHashFunction>::iterator it;
@@ -329,15 +329,14 @@ Node substituteCaptureAvoiding(TNode n,
       // if binder, rename variables to avoid capture
       if (curr.isClosure())
       {
-        std::vector<TNode> vars;
-        std::vector<TNode> renames;
+        std::vector<Node> vars;
+        std::vector<Node> renames;
 
         NodeManager* nm = NodeManager::currentNM();
-        for (const TNode& v : curr[0])
+        for (const Node& v : curr[0])
         {
           vars.push_back(v);
-          TNode rename = nm->mkBoundVar(v.getType());
-          renames.push_back(rename);
+          renames.push_back(nm->mkBoundVar(v.getType()));
         }
         // have new vars -> renames subs in the beginning of current sub
         src.insert(src.begin(), vars.begin(), vars.end());

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -345,12 +345,17 @@ Node substituteCaptureAvoiding(TNode n,
       // save for post-visit
       visit.push_back(curr);
       // visit children
+      if (curr.getMetaKind() == kind::metakind::PARAMETERIZED)
+      {
+        // push the operator
+        visit.push_back(curr.getOperator());
+      }
       for (unsigned i = 0, size = curr.getNumChildren(); i < size; ++i)
       {
         visit.push_back(curr[i]);
       }
     }
-    else if (!it->second.isNull())
+    else if (it->second.isNull())
     {
       // build node
       NodeBuilder<> nb(curr.getKind());

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -273,7 +273,7 @@ void getSymbols(TNode n,
   } while (!visit.empty());
 }
 
-Node substituteCaptureAvoiding(Node node, Node replacement) const
+Node substituteCaptureAvoiding(Node node, Node replacement)
 {
   if (node == *this)
   {
@@ -290,7 +290,7 @@ Node substituteCaptureAvoiding(Node node, Node replacement) const
 Node substituteCaptureAvoiding(
     Node node,
     Node replacement,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache) const
+    std::unordered_map<Node, Node, NodeHashFunction>& cache)
 {
   std::vector<Node> source;
   std::vector<Node> dest;
@@ -300,7 +300,7 @@ Node substituteCaptureAvoiding(
 }
 
 Node substituteCaptureAvoiding(std::vector<Node>& source,
-                               std::vector<Node>& dest) const
+                               std::vector<Node>& dest)
 {
   std::unordered_map<Node, Node, NodeHashFunction> cache;
   return substituteCaptureAvoiding(source, dest, cache);
@@ -309,7 +309,7 @@ Node substituteCaptureAvoiding(std::vector<Node>& source,
 Node substituteCaptureAvoiding(
     std::vector<Node>& source,
     std::vector<Node>& dest,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache) const
+    std::unordered_map<Node, Node, NodeHashFunction>& cache)
 {
   // in cache?
   typename std::unordered_map<Node, Node, NodeHashFunction>::const_iterator i =

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -273,8 +273,7 @@ void getSymbols(TNode n,
   } while (!visit.empty());
 }
 
-Node substituteCaptureAvoiding(
-    Node node, Node replacement) const
+Node substituteCaptureAvoiding(Node node, Node replacement) const
 {
   if (node == *this)
   {
@@ -300,8 +299,8 @@ Node substituteCaptureAvoiding(
   return substituteCaptureAvoiding(source, dest, cache);
 }
 
-Node substituteCaptureAvoiding(
-    std::vector<Node>& source, std::vector<Node>& dest) const
+Node substituteCaptureAvoiding(std::vector<Node>& source,
+                               std::vector<Node>& dest) const
 {
   std::unordered_map<Node, Node, NodeHashFunction> cache;
   return substituteCaptureAvoiding(source, dest, cache);

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -86,7 +86,7 @@ void getSymbols(TNode n,
 /**
  * Substitution of Nodes in a capture avoiding way.
  */
-Node substituteCaptureAvoiding(TNode n, TNode src, TNode dest);
+Node substituteCaptureAvoiding(TNode n, Node src, Node dest);
 
 /**
  * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
@@ -94,8 +94,8 @@ Node substituteCaptureAvoiding(TNode n, TNode src, TNode dest);
  * vectors should have the same size.
  */
 Node substituteCaptureAvoiding(TNode n,
-                               std::vector<TNode>& src,
-                               std::vector<TNode>& dest);
+                               std::vector<Node>& src,
+                               std::vector<Node>& dest);
 
 }  // namespace expr
 }  // namespace CVC4

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -83,33 +83,35 @@ void getSymbols(TNode n, std::unordered_set<Node, NodeHashFunction>& syms);
 void getSymbols(TNode n,
                 std::unordered_set<Node, NodeHashFunction>& syms,
                 std::unordered_set<TNode, TNodeHashFunction>& visited);
-  /**
-   * Substitution of Nodes in a capture avoiding way.
-   */
-  Node substituteCaptureAvoiding(Node node, Node replacement) const;
+/**
+ * Substitution of Nodes in a capture avoiding way.
+ */
+Node substituteCaptureAvoiding(Node node, Node replacement) const;
 
-  /**
-   * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
-   * source will be replaced by their corresponding element in dest.  Both
-   * vectors should have the same size.
-   */
-  Node substituteCaptureAvoiding(std::vector<Node>& source,
-                                 std::vector<Node>& dest) const;
+/**
+ * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
+ * source will be replaced by their corresponding element in dest.  Both
+ * vectors should have the same size.
+ */
+Node substituteCaptureAvoiding(std::vector<Node>& source,
+                               std::vector<Node>& dest) const;
 
-  /**
-   * Cache-aware, recursive version of substituteCaptureAvoiding()
-   */
-  Node substituteCaptureAvoiding(Node node, Node replacement,
-                  std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
+/**
+ * Cache-aware, recursive version of substituteCaptureAvoiding()
+ */
+Node substituteCaptureAvoiding(
+    Node node,
+    Node replacement,
+    std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
 
-  /**
-   * Cache-aware, recursive version of the simultaneous substituteCaptureAvoiding()
-   */
-  Node substituteCaptureAvoiding(
-      std::vector<Node>& source,
-      std::vector<Node>& dest,
-      std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
-
+/**
+ * Cache-aware, recursive version of the simultaneous
+ * substituteCaptureAvoiding()
+ */
+Node substituteCaptureAvoiding(
+    std::vector<Node>& source,
+    std::vector<Node>& dest,
+    std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
 
 }  // namespace expr
 }  // namespace CVC4

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -86,7 +86,7 @@ void getSymbols(TNode n,
 /**
  * Substitution of Nodes in a capture avoiding way.
  */
-Node substituteCaptureAvoiding(Node node, Node replacement) const;
+Node substituteCaptureAvoiding(Node node, Node replacement);
 
 /**
  * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
@@ -94,7 +94,7 @@ Node substituteCaptureAvoiding(Node node, Node replacement) const;
  * vectors should have the same size.
  */
 Node substituteCaptureAvoiding(std::vector<Node>& source,
-                               std::vector<Node>& dest) const;
+                               std::vector<Node>& dest);
 
 /**
  * Cache-aware, recursive version of substituteCaptureAvoiding()
@@ -102,7 +102,7 @@ Node substituteCaptureAvoiding(std::vector<Node>& source,
 Node substituteCaptureAvoiding(
     Node node,
     Node replacement,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
+    std::unordered_map<Node, Node, NodeHashFunction>& cache);
 
 /**
  * Cache-aware, recursive version of the simultaneous
@@ -111,7 +111,7 @@ Node substituteCaptureAvoiding(
 Node substituteCaptureAvoiding(
     std::vector<Node>& source,
     std::vector<Node>& dest,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
+    std::unordered_map<Node, Node, NodeHashFunction>& cache);
 
 }  // namespace expr
 }  // namespace CVC4

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -86,32 +86,16 @@ void getSymbols(TNode n,
 /**
  * Substitution of Nodes in a capture avoiding way.
  */
-Node substituteCaptureAvoiding(Node node, Node replacement);
+Node substituteCaptureAvoiding(TNode n, TNode src, TNode dest);
 
 /**
  * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
  * source will be replaced by their corresponding element in dest.  Both
  * vectors should have the same size.
  */
-Node substituteCaptureAvoiding(std::vector<Node>& source,
-                               std::vector<Node>& dest);
-
-/**
- * Cache-aware, recursive version of substituteCaptureAvoiding()
- */
-Node substituteCaptureAvoiding(
-    Node node,
-    Node replacement,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache);
-
-/**
- * Cache-aware, recursive version of the simultaneous
- * substituteCaptureAvoiding()
- */
-Node substituteCaptureAvoiding(
-    std::vector<Node>& source,
-    std::vector<Node>& dest,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache);
+Node substituteCaptureAvoiding(TNode n,
+                               std::vector<TNode>& src,
+                               std::vector<TNode>& dest);
 
 }  // namespace expr
 }  // namespace CVC4

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -83,6 +83,33 @@ void getSymbols(TNode n, std::unordered_set<Node, NodeHashFunction>& syms);
 void getSymbols(TNode n,
                 std::unordered_set<Node, NodeHashFunction>& syms,
                 std::unordered_set<TNode, TNodeHashFunction>& visited);
+  /**
+   * Substitution of Nodes in a capture avoiding way.
+   */
+  Node substituteCaptureAvoiding(Node node, Node replacement) const;
+
+  /**
+   * Simultaneous substitution of Nodes in a capture avoiding way.  Elements in
+   * source will be replaced by their corresponding element in dest.  Both
+   * vectors should have the same size.
+   */
+  Node substituteCaptureAvoiding(std::vector<Node>& source,
+                                 std::vector<Node>& dest) const;
+
+  /**
+   * Cache-aware, recursive version of substituteCaptureAvoiding()
+   */
+  Node substituteCaptureAvoiding(Node node, Node replacement,
+                  std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
+
+  /**
+   * Cache-aware, recursive version of the simultaneous substituteCaptureAvoiding()
+   */
+  Node substituteCaptureAvoiding(
+      std::vector<Node>& source,
+      std::vector<Node>& dest,
+      std::unordered_map<Node, Node, NodeHashFunction>& cache) const;
+
 
 }  // namespace expr
 }  // namespace CVC4


### PR DESCRIPTION
Introduces utility functions to perform capture avoiding substitution in nodes. Whenever a binder is found during the recursive application of a substitution, a renaming is prepended to the substitution when "going into" the binder, so that bound variables are renamed. Getting out of the binder, the renaming is removed.

Since we are modifying the substitution during the recursion, this new function uses vectors and Nodes.