### PR TITLE
Fix fairness issue with fast sygus enumerator

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -840,6 +840,7 @@ bool SygusEnumerator::TermEnumMaster::incrementInternal()
           Trace("sygus-enum-debug2") << "master(" << d_tn
                                      << "): failed addTerm\n";
           // we will return null (d_currTermSet is true at this point)
+          Assert(d_currTermSet);
           d_currTerm = Node::null();
         }
       }

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -479,7 +479,7 @@ bool SygusEnumerator::TermEnumSlave::validateIndex()
     // if the size of the master is larger than the size limit, then
     // there is no use continuing, since there are no more terms that this
     // slave enumerator can return.
-    if( d_master->getCurrentSize()>d_sizeLim )
+    if (d_master->getCurrentSize() > d_sizeLim)
     {
       return false;
     }
@@ -664,11 +664,14 @@ bool SygusEnumerator::TermEnumMaster::increment()
   {
     return false;
   }
-  Trace("sygus-enum-summary") << "SygusEnumerator::TermEnumMaster: increment " << d_tn << "..." << std::endl;
+  Trace("sygus-enum-summary") << "SygusEnumerator::TermEnumMaster: increment "
+                              << d_tn << "..." << std::endl;
   d_isIncrementing = true;
   bool ret = incrementInternal();
   d_isIncrementing = false;
-  Trace("sygus-enum-summary") << "SygusEnumerator::TermEnumMaster: finished increment " << d_tn << std::endl;
+  Trace("sygus-enum-summary")
+      << "SygusEnumerator::TermEnumMaster: finished increment " << d_tn
+      << std::endl;
   return ret;
 }
 
@@ -892,7 +895,7 @@ bool SygusEnumerator::TermEnumMaster::incrementInternal()
   return incrementInternal();
 }
 
-void SygusEnumerator::TermEnumMaster::setSizeLimit( unsigned u )
+void SygusEnumerator::TermEnumMaster::setSizeLimit(unsigned u)
 {
   d_isSizeLimit = true;
   d_sizeLimit = u;

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -590,8 +590,6 @@ SygusEnumerator::TermEnumMaster::TermEnumMaster()
     : TermEnum(),
       d_isIncrementing(false),
       d_currTermSet(false),
-      d_isSizeLimit(false),
-      d_sizeLimit(0),
       d_consClassNum(0),
       d_ccWeight(0),
       d_consNum(0),
@@ -893,18 +891,6 @@ bool SygusEnumerator::TermEnumMaster::incrementInternal()
   d_ccCons.clear();
   d_ccTypes.clear();
   return incrementInternal();
-}
-
-void SygusEnumerator::TermEnumMaster::setSizeLimit(unsigned u)
-{
-  d_isSizeLimit = true;
-  d_sizeLimit = u;
-}
-
-void SygusEnumerator::TermEnumMaster::clearSizeLimit()
-{
-  d_isSizeLimit = false;
-  d_sizeLimit = 0;
 }
 
 bool SygusEnumerator::TermEnumMaster::initializeChildren()

--- a/src/theory/quantifiers/sygus/sygus_enumerator.cpp
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.cpp
@@ -583,6 +583,8 @@ SygusEnumerator::TermEnumMaster::TermEnumMaster()
     : TermEnum(),
       d_isIncrementing(false),
       d_currTermSet(false),
+      d_isSizeLimit(false),
+      d_sizeLimit(0),
       d_consClassNum(0),
       d_ccWeight(0),
       d_consNum(0),
@@ -655,9 +657,11 @@ bool SygusEnumerator::TermEnumMaster::increment()
   {
     return false;
   }
+  Trace("sygus-enum-summary") << "SygusEnumerator::TermEnumMaster: increment " << d_tn << "..." << std::endl;
   d_isIncrementing = true;
   bool ret = incrementInternal();
   d_isIncrementing = false;
+  Trace("sygus-enum-summary") << "SygusEnumerator::TermEnumMaster: finished increment " << d_tn << std::endl;
   return ret;
 }
 
@@ -771,6 +775,12 @@ bool SygusEnumerator::TermEnumMaster::incrementInternal()
     }
 
     // increment the size bound
+    if( d_isSizeLimit && d_currSize>=d_sizeLimit )
+    {
+      // If we are at the bounds, we are done. We return true to indicate
+      // that there may be more terms to enumerate.
+      return true;
+    }
     d_currSize++;
     Trace("sygus-enum-debug2") << "master(" << d_tn
                                << "): size++ : " << d_currSize << "\n";
@@ -870,6 +880,18 @@ bool SygusEnumerator::TermEnumMaster::incrementInternal()
   d_ccCons.clear();
   d_ccTypes.clear();
   return incrementInternal();
+}
+
+void SygusEnumerator::TermEnumMaster::setSizeLimit( unsigned u )
+{
+  d_isSizeLimit = true;
+  d_sizeLimit = u;
+}
+
+void SygusEnumerator::TermEnumMaster::clearSizeLimit()
+{
+  d_isSizeLimit = false;
+  d_sizeLimit = 0;
 }
 
 bool SygusEnumerator::TermEnumMaster::initializeChildren()

--- a/src/theory/quantifiers/sygus/sygus_enumerator.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.h
@@ -322,14 +322,15 @@ class SygusEnumerator : public EnumValGenerator
      * return false.
      */
     bool increment() override;
-    /** set size limit 
-     * 
+    /** set size limit
+     *
      * This indicates that this enumerator should not generate terms that
      * have size that are greater than u.
      */
-    void setSizeLimit( unsigned u );
+    void setSizeLimit(unsigned u);
     /** clear the size limit on this enumerator */
     void clearSizeLimit();
+
    private:
     /** are we currently inside a increment() call? */
     bool d_isIncrementing;

--- a/src/theory/quantifiers/sygus/sygus_enumerator.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.h
@@ -322,14 +322,6 @@ class SygusEnumerator : public EnumValGenerator
      * return false.
      */
     bool increment() override;
-    /** set size limit
-     *
-     * This indicates that this enumerator should not generate terms that
-     * have size that are greater than u.
-     */
-    void setSizeLimit(unsigned u);
-    /** clear the size limit on this enumerator */
-    void clearSizeLimit();
 
    private:
     /** are we currently inside a increment() call? */
@@ -338,10 +330,6 @@ class SygusEnumerator : public EnumValGenerator
     Node d_currTerm;
     /** is d_currTerm set */
     bool d_currTermSet;
-    /** is a size limit currently imposed on this enumerator? */
-    bool d_isSizeLimit;
-    /** the size limit current imposed on this enumerator */
-    unsigned d_sizeLimit;
     //----------------------------- current constructor class information
     /** the next constructor class we are using */
     unsigned d_consClassNum;

--- a/src/theory/quantifiers/sygus/sygus_enumerator.h
+++ b/src/theory/quantifiers/sygus/sygus_enumerator.h
@@ -322,7 +322,14 @@ class SygusEnumerator : public EnumValGenerator
      * return false.
      */
     bool increment() override;
-
+    /** set size limit 
+     * 
+     * This indicates that this enumerator should not generate terms that
+     * have size that are greater than u.
+     */
+    void setSizeLimit( unsigned u );
+    /** clear the size limit on this enumerator */
+    void clearSizeLimit();
    private:
     /** are we currently inside a increment() call? */
     bool d_isIncrementing;
@@ -330,6 +337,10 @@ class SygusEnumerator : public EnumValGenerator
     Node d_currTerm;
     /** is d_currTerm set */
     bool d_currTermSet;
+    /** is a size limit currently imposed on this enumerator? */
+    bool d_isSizeLimit;
+    /** the size limit current imposed on this enumerator */
+    unsigned d_sizeLimit;
     //----------------------------- current constructor class information
     /** the next constructor class we are using */
     unsigned d_consClassNum;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1603,6 +1603,7 @@ set(regress_1_tests
   regress1/sygus/crci-ssb-unk.sy
   regress1/sygus/crcy-si-rcons.sy
   regress1/sygus/crcy-si.sy
+  regress1/sygus/cube-nia.sy
   regress1/sygus/dt-test-ns.sy
   regress1/sygus/dup-op.sy
   regress1/sygus/fg_polynomial3.sy

--- a/test/regress/regress1/sygus/cube-nia.sy
+++ b/test/regress/regress1/sygus/cube-nia.sy
@@ -1,0 +1,27 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+
+(set-logic NIA)
+
+(synth-fun cube ((x Int)) Int
+  (
+    (Start Int (ntInt))
+  
+    (ntBool Bool
+      ( 
+        (> ntInt ntInt)
+        (= ntInt ntInt)
+      )
+    )
+    (ntInt Int
+      (1 x
+        (* ntInt ntInt)
+        (ite ntBool ntInt ntInt)
+      )
+    )
+  )
+)
+
+(constraint (= (cube 1) 1))
+(constraint (= (cube 2) 8))
+(check-synth)


### PR DESCRIPTION
Previously, a sygus enumerator could exhibit non-terminating behavior if there was a sygus type with infinite cardinality and had a subfield type with infinite cardinality but admitted only finitely many semantically unique terms based on PBE symmetry breaking.

This commit makes two changes to the optimized enumerator for ensuring we are fair for these cases:
- Master enumerators now "break" (i.e. they return the null term while indicating increment success) once at each size boundary,
- Slave enumerators now abort their increment method based on the current size of master enumerators.

This corrects a non-termination bug from the cvc-users mailing list.