### PR TITLE
Rewrite selectors correctly applied to constructors

### DIFF
--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -364,7 +364,7 @@ RewriteResponse DatatypesRewriter::rewriteSelector(TNode in)
       // APPLY_SELECTOR) is given by an attribute and obtained via indexOf below
       // The argument is only valid if it is the proper constructor.
       selectorIndex = Datatype::indexOf(selector);
-      if( selectorIndex<0 || selectorIndex>c.getNumArgs() )
+      if( selectorIndex<0 || selectorIndex>=c.getNumArgs() )
       {
         selectorIndex = -1;
       }

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -32,7 +32,7 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
   {
     return rewriteConstructor(in);
   }
-  else if (k == kind::APPLY_SELECTOR_TOTAL || k==kind::APPLY_SELECTOR)
+  else if (k == kind::APPLY_SELECTOR_TOTAL || k == kind::APPLY_SELECTOR)
   {
     return rewriteSelector(in);
   }
@@ -350,14 +350,16 @@ RewriteResponse DatatypesRewriter::rewriteSelector(TNode in)
                                      << ", selector is " << selector
                                      << std::endl;
     int selectorIndex;
-    if( k==kind::APPLY_SELECTOR_TOTAL )
+    if (k == kind::APPLY_SELECTOR_TOTAL)
     {
-      // the argument index of internal selectors is obtained by getSelectorIndexInternal
+      // the argument index of internal selectors is obtained by
+      // getSelectorIndexInternal
       selectorIndex = c.getSelectorIndexInternal(selector.toExpr());
     }
     else
     {
-      // the argument index of external selectors (applications of APPLY_SELECTOR) is given by an attribute and obtained via indexOf below
+      // the argument index of external selectors (applications of
+      // APPLY_SELECTOR) is given by an attribute and obtained via indexOf below
       selectorIndex = Datatype::indexOf(selector.toExpr());
     }
     Trace("datatypes-rewrite-debug") << "Internal selector index is "
@@ -385,7 +387,7 @@ RewriteResponse DatatypesRewriter::rewriteSelector(TNode in)
         return RewriteResponse(REWRITE_DONE, in[0][selectorIndex]);
       }
     }
-    else if( k==kind::APPLY_SELECTOR_TOTAL )
+    else if (k == kind::APPLY_SELECTOR_TOTAL)
     {
       Node gt;
       bool useTe = true;

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -32,7 +32,7 @@ RewriteResponse DatatypesRewriter::postRewrite(TNode in)
   {
     return rewriteConstructor(in);
   }
-  else if (k == kind::APPLY_SELECTOR_TOTAL)
+  else if (k == kind::APPLY_SELECTOR_TOTAL || k==kind::APPLY_SELECTOR)
   {
     return rewriteSelector(in);
   }
@@ -331,6 +331,7 @@ RewriteResponse DatatypesRewriter::rewriteConstructor(TNode in)
 
 RewriteResponse DatatypesRewriter::rewriteSelector(TNode in)
 {
+  Kind k = in.getKind();
   if (in[0].getKind() == kind::APPLY_CONSTRUCTOR)
   {
     // Have to be careful not to rewrite well-typed expressions
@@ -348,7 +349,17 @@ RewriteResponse DatatypesRewriter::rewriteSelector(TNode in)
     Trace("datatypes-rewrite-debug") << ", cindex = " << constructorIndex
                                      << ", selector is " << selector
                                      << std::endl;
-    int selectorIndex = c.getSelectorIndexInternal(selector.toExpr());
+    int selectorIndex;
+    if( k==kind::APPLY_SELECTOR_TOTAL )
+    {
+      // the argument index of internal selectors is obtained by getSelectorIndexInternal
+      selectorIndex = c.getSelectorIndexInternal(selector.toExpr());
+    }
+    else
+    {
+      // the argument index of external selectors (applications of APPLY_SELECTOR) is given by an attribute and obtained via indexOf below
+      selectorIndex = Datatype::indexOf(selector.toExpr());
+    }
     Trace("datatypes-rewrite-debug") << "Internal selector index is "
                                      << selectorIndex << std::endl;
     if (selectorIndex >= 0)
@@ -374,7 +385,7 @@ RewriteResponse DatatypesRewriter::rewriteSelector(TNode in)
         return RewriteResponse(REWRITE_DONE, in[0][selectorIndex]);
       }
     }
-    else
+    else if( k==kind::APPLY_SELECTOR_TOTAL )
     {
       Node gt;
       bool useTe = true;

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -364,11 +364,11 @@ RewriteResponse DatatypesRewriter::rewriteSelector(TNode in)
       // APPLY_SELECTOR) is given by an attribute and obtained via indexOf below
       // The argument is only valid if it is the proper constructor.
       selectorIndex = Datatype::indexOf(selector);
-      if( selectorIndex<0 || selectorIndex>=c.getNumArgs() )
+      if (selectorIndex < 0 || selectorIndex >= c.getNumArgs())
       {
         selectorIndex = -1;
       }
-      else if( c[selectorIndex].getSelector()!=selector )
+      else if (c[selectorIndex].getSelector() != selector)
       {
         selectorIndex = -1;
       }

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -642,7 +642,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
       {
         Node res = itsr->second[j];
         Trace("sygus-sui-enum") << "res(" << res << ")" << std::endl;
-        if( !res.isConst() )
+        if (!res.isConst())
         {
           AlwaysAssert(false);
         }
@@ -664,7 +664,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
         {
           if (resb.getType().isBoolean())
           {
-            if( resb.isConst() )
+            if (resb.isConst())
             {
               Assert(false);
             }

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -646,7 +646,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
         Node resb;
         // If the result is not constant, then we cannot determine its value
         // on this point. In this case, resb remains null.
-        if(res.isConst())
+        if (res.isConst())
         {
           if (eiv.getRole() == enum_io)
           {
@@ -663,7 +663,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
         results.push_back(resb);
         if (Trace.isOn("sygus-sui-enum"))
         {
-          if( resb.isNull() )
+          if (resb.isNull())
           {
             Trace("sygus-sui-enum") << "_";
           }

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -641,6 +641,11 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
       for (unsigned j = 0, size = itsr->second.size(); j < size; j++)
       {
         Node res = itsr->second[j];
+        Trace("sygus-sui-enum") << "res(" << res << ")" << std::endl;
+        if( !res.isConst() )
+        {
+          AlwaysAssert(false);
+        }
         Assert(res.isConst());
         Node resb;
         if (eiv.getRole() == enum_io)
@@ -659,6 +664,10 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
         {
           if (resb.getType().isBoolean())
           {
+            if( resb.isConst() )
+            {
+              Assert(false);
+            }
             Trace("sygus-sui-enum") << (resb == d_true ? "1" : "0");
           }
           else

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -641,23 +641,33 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
       for (unsigned j = 0, size = itsr->second.size(); j < size; j++)
       {
         Node res = itsr->second[j];
-        Assert(res.isConst());
+        // The value of this term for this example, or the truth value of
+        // the I/O pair if the role of this enumerator is enum_io.
         Node resb;
-        if (eiv.getRole() == enum_io)
+        // If the result is not constant, then we cannot determine its value
+        // on this point. In this case, resb remains null.
+        if(res.isConst())
         {
-          Node out = d_examples_out[j];
-          Assert(out.isConst());
-          resb = res == out ? d_true : d_false;
-        }
-        else
-        {
-          resb = res;
+          if (eiv.getRole() == enum_io)
+          {
+            Node out = d_examples_out[j];
+            Assert(out.isConst());
+            resb = res == out ? d_true : d_false;
+          }
+          else
+          {
+            resb = res;
+          }
         }
         cond_vals[resb] = true;
         results.push_back(resb);
         if (Trace.isOn("sygus-sui-enum"))
         {
-          if (resb.getType().isBoolean())
+          if( resb.isNull() )
+          {
+            Trace("sygus-sui-enum") << "_";
+          }
+          else if (resb.getType().isBoolean())
           {
             Trace("sygus-sui-enum") << (resb == d_true ? "1" : "0");
           }

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -641,11 +641,6 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
       for (unsigned j = 0, size = itsr->second.size(); j < size; j++)
       {
         Node res = itsr->second[j];
-        Trace("sygus-sui-enum") << "res(" << res << ")" << std::endl;
-        if (!res.isConst())
-        {
-          AlwaysAssert(false);
-        }
         Assert(res.isConst());
         Node resb;
         if (eiv.getRole() == enum_io)
@@ -664,10 +659,6 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
         {
           if (resb.getType().isBoolean())
           {
-            if (resb.isConst())
-            {
-              Assert(false);
-            }
             Trace("sygus-sui-enum") << (resb == d_true ? "1" : "0");
           }
           else

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1605,8 +1605,10 @@ set(regress_1_tests
   regress1/sygus/crcy-si-rcons.sy
   regress1/sygus/crcy-si.sy
   regress1/sygus/cube-nia.sy
+  regress1/sygus/double.sy
   regress1/sygus/dt-test-ns.sy
   regress1/sygus/dup-op.sy
+  regress1/sygus/extract.sy
   regress1/sygus/fg_polynomial3.sy
   regress1/sygus/find_sc_bvult_bvnot.sy
   regress1/sygus/hd-01-d1-prog.sy

--- a/test/regress/regress1/sygus/double.sy
+++ b/test/regress/regress1/sygus/double.sy
@@ -1,0 +1,26 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+
+(set-logic SLIA)
+(declare-datatype Ex ((Ex2 (ex Int))))
+
+(synth-fun double ((x1 Ex)) Int
+	(
+		(Start Int (ntInt))
+		(ntInt Int
+			(
+				(ex ntEx)
+				(+ ntInt ntInt)
+			)
+		)
+		(ntEx Ex
+			( 
+				x1
+				(Ex2 ntInt)
+			)
+		)
+	)
+)
+(constraint (= (double (Ex2 1)) 2))
+(constraint (= (double (Ex2 4)) 8))
+(check-synth)

--- a/test/regress/regress1/sygus/extract.sy
+++ b/test/regress/regress1/sygus/extract.sy
@@ -1,0 +1,19 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+
+(set-logic ALL_SUPPORTED)
+(declare-datatype Ex ((Ex2 (ex Int))))
+
+(synth-fun ident ((x1 Ex)) Int
+	(
+		(Start Int (ntInt))
+		(ntInt Int
+			(
+				(ex ntEx)
+ 			)
+		)
+		(ntEx Ex ( x1 ) )
+	)
+)
+(constraint (= (ident (Ex2 1)) 1))
+(check-synth)


### PR DESCRIPTION
Now, applications of APPLY_SELECTOR to the proper constructor are rewritten to their expected argument. Previously, they were not rewritten at all. (APPLY_SELECTOR applications are subsequently eliminated in expandDefinitions).

This fixes PBE examples that involve datatype selectors, which requires that applications of selectors are evaluated, when possible.

This PR additionally makes the PBE robust to the case when an input point in the specification does not rewrite to a constant.

Thanks to Bill Hallahan for this report.