### PR TITLE
 Fix bad comparison in RE solver's addMembership

### DIFF
--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -5108,7 +5108,7 @@ void TheoryStrings::addMembership(Node assertion) {
   if(polarity) {
     int index = 0;
     NodeIntMap::const_iterator it = d_pos_memberships.find( x );
-    if( it!=d_nf_pairs.end() ){
+    if( it!=d_pos_memberships.end() ){
       index = (*it).second;
       for( int k=0; k<index; k++ ){
         if( k<(int)d_pos_memberships_data[x].size() ){
@@ -5134,7 +5134,7 @@ void TheoryStrings::addMembership(Node assertion) {
     }*/
     int index = 0;
     NodeIntMap::const_iterator it = d_neg_memberships.find( x );
-    if( it!=d_nf_pairs.end() ){
+    if( it!=d_neg_memberships.end() ){
       index = (*it).second;
       for( int k=0; k<index; k++ ){
         if( k<(int)d_neg_memberships_data[x].size() ){

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -5108,7 +5108,8 @@ void TheoryStrings::addMembership(Node assertion) {
   if(polarity) {
     int index = 0;
     NodeIntMap::const_iterator it = d_pos_memberships.find( x );
-    if( it!=d_pos_memberships.end() ){
+    if (it != d_pos_memberships.end())
+    {
       index = (*it).second;
       for( int k=0; k<index; k++ ){
         if( k<(int)d_pos_memberships_data[x].size() ){
@@ -5134,7 +5135,8 @@ void TheoryStrings::addMembership(Node assertion) {
     }*/
     int index = 0;
     NodeIntMap::const_iterator it = d_neg_memberships.find( x );
-    if( it!=d_neg_memberships.end() ){
+    if (it != d_neg_memberships.end())
+    {
       index = (*it).second;
       for( int k=0; k<index; k++ ){
         if( k<(int)d_neg_memberships_data[x].size() ){


### PR DESCRIPTION
Seems to have been a harmless mistake since (I guess) NodeIntMap can be deferenced when a find is unsucessful? This corrects the issue.