### PR TITLE
More fixes for PBE with datatypes

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -644,20 +644,20 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
         // The value of this term for this example, or the truth value of
         // the I/O pair if the role of this enumerator is enum_io.
         Node resb;
-        // If the result is not constant, then we cannot determine its value
-        // on this point. In this case, resb remains null.
-        if (res.isConst())
+        if (eiv.getRole() == enum_io)
         {
-          if (eiv.getRole() == enum_io)
-          {
-            Node out = d_examples_out[j];
-            Assert(out.isConst());
-            resb = res == out ? d_true : d_false;
-          }
-          else
-          {
-            resb = res;
-          }
+          Node out = d_examples_out[j];
+          Assert(out.isConst());
+          // If the result is not constant, then we assume that it does
+          // not satisfy the example. This is a safe underapproximation
+          // of the good behavior of the current term, that is, we only
+          // produce solutions whose values are fully evaluatable on all input
+          // points.
+          resb = ( res.isConst() && res == out) ? d_true : d_false;
+        }
+        else
+        {
+          resb = res;
         }
         cond_vals[resb] = true;
         results.push_back(resb);
@@ -687,6 +687,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
           std::vector<Node> subsume;
           if (cond_vals.find(d_false) == cond_vals.end())
           {
+            Assert( cond_vals.size()==1 );
             // it is the entire solution, we are done
             Trace("sygus-sui-enum")
                 << "  ...success, full solution added to PBE pool : "

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -454,7 +454,7 @@ void SubsumeTrie::getLeavesInternal(const std::vector<Node>& vals,
       {
         if (status != 0)
         {
-          if( it->first.isNull() )
+          if (it->first.isNull())
           {
             // The value of this child is unknown on this point, hence we
             // ignore it.
@@ -471,7 +471,7 @@ void SubsumeTrie::getLeavesInternal(const std::vector<Node>& vals,
           }
         }
       }
-      if( success )
+      if (success)
       {
         it->second.getLeavesInternal(vals, pol, v, index + 1, new_status);
       }
@@ -675,7 +675,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
         {
           // We only set resb if it is constant, otherwise it remains null.
           // This indicates its value cannot be determined.
-          if( res.isConst() )
+          if (res.isConst())
           {
             resb = res;
           }

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -653,7 +653,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
           // of the good behavior of the current term, that is, we only
           // produce solutions whose values are fully evaluatable on all input
           // points.
-          resb = ( res.isConst() && res == out) ? d_true : d_false;
+          resb = (res.isConst() && res == out) ? d_true : d_false;
         }
         else
         {
@@ -687,7 +687,7 @@ void SygusUnifIo::notifyEnumeration(Node e, Node v, std::vector<Node>& lemmas)
           std::vector<Node> subsume;
           if (cond_vals.find(d_false) == cond_vals.end())
           {
-            Assert( cond_vals.size()==1 );
+            Assert(cond_vals.size() == 1);
             // it is the entire solution, we are done
             Trace("sygus-sui-enum")
                 << "  ...success, full solution added to PBE pool : "

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1656,6 +1656,7 @@ set(regress_1_tests
   regress1/sygus/sygus-uf-ex.sy
   regress1/sygus/t8.sy
   regress1/sygus/temp_input_to_synth_ic-error-121418.sy
+  regress1/sygus/tester.sy
   regress1/sygus/tl-type-0.sy
   regress1/sygus/tl-type-4x.sy
   regress1/sygus/tl-type.sy

--- a/test/regress/regress1/sygus/tester.sy
+++ b/test/regress/regress1/sygus/tester.sy
@@ -1,0 +1,37 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+
+(set-logic SLIA)
+(declare-datatype DT ((A (a Int)) (B (b String)) (JSBool (jsBool Bool))))
+
+(define-fun isA ((i DT)) Bool ((_ is A) i) )
+(define-fun isB ((i DT)) Bool ((_ is B) i) )
+
+(synth-fun add ((x1 DT)) DT
+	(
+		(Start DT (ntDT))
+		(ntDT DT
+			( x1 x2
+				(JSBool ntBool)
+				(A ntInt)
+				(ite ntBool ntDT ntDT)
+			)
+		)
+		(ntBool Bool
+			(
+				(isA ntDT)
+				(isB ntDT)
+				(jsBool ntDT)
+			)
+		)
+		(ntInt Int
+			(1
+				(a ntDT)
+				(+ ntInt ntInt)
+			)
+		)
+	)
+)
+(constraint (= (add (A 6)) (A 7)))
+(constraint (= (add (B "j")) (B "j")))
+(check-synth)


### PR DESCRIPTION
Modifies the behavior from the previous commit https://github.com/CVC4/CVC4/commit/6c8a2652605b031182b3c2c25d237719470f5620 to properly handle PBE with datatypes: we now assume that examples rewrite to false if they don't rewrite to true. This fixes an invariant of the PBE solver that assumed all examples were true/false, and makes the overall behavior more conservative.

It also makes it so that the function getLeavesInternal ignores terms whose evaluation is unknown on any relevant point. This ensures, for instance, that we do not choose conditionals of decision trees that result in undefined behavior.

This fixes #2881.