### PR TITLE
Modify strategy in sets+cardinality

### DIFF
--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -700,10 +700,11 @@ void TheorySetsPrivate::fullEffortCheck(){
           checkUpwardsClosure( lemmas );
           flushLemmas( lemmas );
           if( !hasProcessed() ){
-            checkDisequalities( lemmas );
-            flushLemmas( lemmas );
-            if( !hasProcessed() && d_card_enabled ){
-              //for cardinality
+            checkDisequalities(lemmas);
+            flushLemmas(lemmas);
+            if (!hasProcessed() && d_card_enabled)
+            {
+              // for cardinality
               checkCardBuildGraph( lemmas );
               flushLemmas( lemmas );
               if( !hasProcessed() ){
@@ -713,16 +714,18 @@ void TheorySetsPrivate::fullEffortCheck(){
                   checkCardCycles( lemmas );
                   flushLemmas( lemmas );
                   if( !hasProcessed() ){
-                    std::vector< Node > intro_sets;
+                    std::vector<Node> intro_sets;
                     checkNormalForms( lemmas, intro_sets );
                     flushLemmas( lemmas );
-                    if( !hasProcessed() && !intro_sets.empty() ){
-                      Assert( intro_sets.size()==1 );
-                      Trace("sets-intro") << "Introduce term : " << intro_sets[0] << std::endl;
+                    if (!hasProcessed() && !intro_sets.empty())
+                    {
+                      Assert(intro_sets.size() == 1);
+                      Trace("sets-intro")
+                          << "Introduce term : " << intro_sets[0] << std::endl;
                       Trace("sets-intro") << "  Actual Intro : ";
-                      debugPrintSet( intro_sets[0], "sets-nf" );
+                      debugPrintSet(intro_sets[0], "sets-nf");
                       Trace("sets-nf") << std::endl;
-                      Node k = getProxy( intro_sets[0] );
+                      Node k = getProxy(intro_sets[0]);
                       d_sentLemma = true;
                     }
                   }
@@ -1489,7 +1492,9 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
       }
     }else{
       // must ensure disequal from empty
-      if (!eqc.isConst() && !ee_areDisequal(eqc, emp_set) && ( d_pol_mems[0].find( eqc )==d_pol_mems[0].end() || d_pol_mems[0][eqc].empty() ))
+      if (!eqc.isConst() && !ee_areDisequal(eqc, emp_set)
+          && (d_pol_mems[0].find(eqc) == d_pol_mems[0].end()
+              || d_pol_mems[0][eqc].empty()))
       {
         Trace("sets-nf-debug") << "Split on leaf " << eqc << std::endl;
         split(eqc.eqNode(emp_set));

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -1541,8 +1541,6 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
           }
         }
       }
-    }else{
-      Assert( hasProcessed() );
     }
   }
 }

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -1481,7 +1481,6 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
               }
             }
           }
-          //should never get here
           success = false;
         }
       }
@@ -1491,7 +1490,6 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
         Trace("sets-nf") << "----> N " << eqc << " => F " << base << std::endl;
       }else{
         Trace("sets-nf") << "failed to build N " << eqc << std::endl;
-        Assert( false );
       }
     }else{
       // must ensure disequal from empty

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -1481,6 +1481,7 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
               }
             }
           }
+          //should never get here
           success = false;
         }
       }
@@ -1496,10 +1497,14 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
       if (!eqc.isConst() && !ee_areDisequal(eqc, emp_set))
       {
         split(eqc.eqNode(emp_set));
+        success = false;
       }
-      //normal form is this equivalence class
-      d_nf[eqc].push_back( eqc );
-      Trace("sets-nf") << "----> N " << eqc << " => { " << eqc << " }" << std::endl;
+      else
+      {
+        //normal form is this equivalence class
+        d_nf[eqc].push_back( eqc );
+        Trace("sets-nf") << "----> N " << eqc << " => { " << eqc << " }" << std::endl;
+      }
     }
     if( success ){
       //send to parents

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -1501,9 +1501,10 @@ void TheorySetsPrivate::checkNormalForm( Node eqc, std::vector< Node >& intro_se
       }
       else
       {
-        //normal form is this equivalence class
-        d_nf[eqc].push_back( eqc );
-        Trace("sets-nf") << "----> N " << eqc << " => { " << eqc << " }" << std::endl;
+        // normal form is this equivalence class
+        d_nf[eqc].push_back(eqc);
+        Trace("sets-nf") << "----> N " << eqc << " => { " << eqc << " }"
+                         << std::endl;
       }
     }
     if( success ){


### PR DESCRIPTION
The last PR broke a few assumptions, this PR cleans up some spurious assertions and makes an improvement to the strategy.

The strategy now favors processing disequalities before processing cardinality, since the last sets PR now is more eager with split on equality with empty. Processing disequalities first ensures that when we process the cardinality graph only when we have a proper configuration of nodes wrt emptiness/non-emptiness.

This fixes regress1.