### PR TITLE
SatClauseSetHashFunction

### DIFF
--- a/src/prop/sat_solver_types.h
+++ b/src/prop/sat_solver_types.h
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 namespace CVC4 {
 namespace prop {
@@ -166,6 +167,17 @@ struct SatLiteralHashFunction {
  * A SAT clause is a vector of literals.
  */
 typedef std::vector<SatLiteral> SatClause;
+
+struct SatClauseSetHashFunction {
+  inline size_t operator() (const std::unordered_set<SatLiteral, SatLiteralHashFunction>& clause) const {
+    size_t acc = 0;
+    for (const auto& l : clause)
+    {
+        acc ^= l.hash();
+    }
+    return acc;
+  }
+};
 
 /**
  * Each object in the SAT solver, such as as variables and clauses, can be assigned a life span,

--- a/src/prop/sat_solver_types.h
+++ b/src/prop/sat_solver_types.h
@@ -26,8 +26,8 @@
 
 #include <sstream>
 #include <string>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 namespace CVC4 {
 namespace prop {
@@ -168,12 +168,16 @@ struct SatLiteralHashFunction {
  */
 typedef std::vector<SatLiteral> SatClause;
 
-struct SatClauseSetHashFunction {
-  inline size_t operator() (const std::unordered_set<SatLiteral, SatLiteralHashFunction>& clause) const {
+struct SatClauseSetHashFunction
+{
+  inline size_t operator()(
+      const std::unordered_set<SatLiteral, SatLiteralHashFunction>& clause)
+      const
+  {
     size_t acc = 0;
     for (const auto& l : clause)
     {
-        acc ^= l.hash();
+      acc ^= l.hash();
     }
     return acc;
   }


### PR DESCRIPTION
Called "SatClauseSetHashFunction" because it's a hash function for a SAT clause encoded as a set.

Added to the same file as SatLiteralHashFunction.

Some SAT proof optimization machinery needs to (temporarily) build a map which is keyed by clause, which is why this is needed.

I wish there was a way to lift a user-defined hash for `T` into a hash for `unordered_set<T>` using a standardized lift, but I don't know how to do so.