### PR TITLE
 Eliminate Boolean ITE within terms, fixes 2947

### DIFF
--- a/src/smt/term_formula_removal.cpp
+++ b/src/smt/term_formula_removal.cpp
@@ -86,7 +86,8 @@ Node RemoveTermFormulas::run(TNode node, std::vector<Node>& output,
   Node newAssertion;
   // Handle non-Boolean ITEs here. Boolean ones (within terms) are handled
   // in the "non-variable Boolean term within term" case below.
-  if(node.getKind() == kind::ITE && !nodeType.isBoolean()) {
+  if (node.getKind() == kind::ITE && !nodeType.isBoolean())
+  {
     // Here, we eliminate the ITE if we are not Boolean and if we do not contain
     // a bound variable.
     if (!inQuant || !expr::hasBoundVar(node))

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -933,6 +933,7 @@ set(regress_0_tests
   regress0/uf/euf_simp12.smt
   regress0/uf/euf_simp13.smt
   regress0/uf/iso_brn001.smt
+  regress0/uf/issue2947.smt2
   regress0/uf/pred.smt
   regress0/uf/simple.01.cvc
   regress0/uf/simple.02.cvc

--- a/test/regress/regress0/uf/issue2947.smt2
+++ b/test/regress/regress0/uf/issue2947.smt2
@@ -1,0 +1,11 @@
+(set-logic QF_UF)
+(set-info :status unsat)
+(declare-fun f (Bool) Bool)
+(assert
+  (not (f true))
+)
+(assert
+  (f (ite (f true) true (f false)))
+)
+(check-sat)
+(exit)


### PR DESCRIPTION
Fixes #2947.

This bug dates back as early as 2010: https://github.com/CVC4/CVC4/commit/acc653383ea5dbb3a4e9cffa5c2735a9d2f22dca and even earlier.

The condition for when we eliminated ITEs in the "term_formula_removal" pass said we should eliminate exactly the ITEs that did not have Boolean type.  This is wrong: we should eliminate ITEs that either have non-Boolean type *or* appear within a term. Issue #2947 uncovered a case where the latter was a necessary condition for eliminating an ITE. The current version of CVC4 was *not* eliminating the ite `(ite (f true) true (f false))` in this example, where it was necessary to properly reason about this term to show unsat.

This PR ensures that ITE elimination is only run on non-Boolean terms, while the case for non-variable Boolean terms within terms is run on Boolean ITEs. This ensures variables introduced for Boolean ITE terms are given kind BOOLEAN_TERM_VARIABLE, which is necessary for theory combination involving Bool.