### PR TITLE
 Less aggressive caching in equality engine when proofs are enabled

### DIFF
--- a/src/proof/uf_proof.cpp
+++ b/src/proof/uf_proof.cpp
@@ -141,7 +141,7 @@ Node ProofUF::toStreamRecLFSC(std::ostream& out,
 
     return Node();
   }
-
+  // TODO (#2965): improve this code, which is highly complicated.
   switch(pf.d_id) {
   case theory::eq::MERGED_THROUGH_CONGRUENCE: {
     Debug("pf::uf") << "\nok, looking at congruence:\n";

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1069,7 +1069,9 @@ void EqualityEngine::getExplanation(
   else
   {
     // If proofs are enabled, note that proofs are sensitive to the order of t1
-    // and t2, so we don't sort the ids in this case.
+    // and t2, so we don't sort the ids in this case. Depending on how issue
+    // #2965 is resolved, we may be able to revisit this, if it is the case
+    // that proof/uf_proof.h,cpp is robust to equality ordering.
     cacheKey = std::pair<EqualityNodeId, EqualityNodeId>(t1Id, t2Id);
     it = cache.find(cacheKey);
     if (it != cache.end())

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1052,23 +1052,35 @@ void EqualityEngine::getExplanation(
   Trace("eq-exp") << d_name << "::eq::getExplanation(" << d_nodes[t1Id] << ","
                   << d_nodes[t2Id] << ") size = " << cache.size() << std::endl;
 
-  // We order the ids, since explaining t1 = t2 is the same as explaining
-  // t2 = t1.
-  std::pair<EqualityNodeId, EqualityNodeId> cacheKey = std::minmax(t1Id, t2Id);
-  std::map<std::pair<EqualityNodeId, EqualityNodeId>, EqProof*>::iterator it =
-      cache.find(cacheKey);
-  if (it != cache.end())
+  // determine if we have already computed the explanation.
+  std::pair<EqualityNodeId, EqualityNodeId> cacheKey;
+  std::map<std::pair<EqualityNodeId, EqualityNodeId>, EqProof*>::iterator it;
+  if (!eqp)
   {
-    // copy one level
-    if (eqp)
+    // We order the ids, since explaining t1 = t2 is the same as explaining
+    // t2 = t1.
+    cacheKey = std::minmax(t1Id, t2Id);
+    it = cache.find(cacheKey);
+    if (it != cache.end())
+    {
+      return;
+    }
+  }
+  else
+  {
+    // Proofs are sensitive to the order of t1 and t2, so we don't sort the ids
+    // in this case.
+    cacheKey = std::pair<EqualityNodeId, EqualityNodeId>(t1Id,t2Id);
+    it = cache.find(cacheKey);
+    if (it != cache.end())
     {
       if (it->second)
       {
-        eqp->d_node = it->second->d_node;
         eqp->d_id = it->second->d_id;
         eqp->d_children.insert(eqp->d_children.end(),
-                               it->second->d_children.begin(),
-                               it->second->d_children.end());
+                              it->second->d_children.begin(),
+                              it->second->d_children.end());
+        eqp->d_node = it->second->d_node;
       }
       else
       {
@@ -1077,8 +1089,8 @@ void EqualityEngine::getExplanation(
         Assert(eqp->d_id == MERGED_THROUGH_REFLEXIVITY);
         eqp->d_node = d_nodes[t1Id];
       }
+      return;
     }
-    return;
   }
   cache[cacheKey] = eqp;
 

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1070,7 +1070,7 @@ void EqualityEngine::getExplanation(
   {
     // Proofs are sensitive to the order of t1 and t2, so we don't sort the ids
     // in this case.
-    cacheKey = std::pair<EqualityNodeId, EqualityNodeId>(t1Id,t2Id);
+    cacheKey = std::pair<EqualityNodeId, EqualityNodeId>(t1Id, t2Id);
     it = cache.find(cacheKey);
     if (it != cache.end())
     {
@@ -1078,8 +1078,8 @@ void EqualityEngine::getExplanation(
       {
         eqp->d_id = it->second->d_id;
         eqp->d_children.insert(eqp->d_children.end(),
-                              it->second->d_children.begin(),
-                              it->second->d_children.end());
+                               it->second->d_children.begin(),
+                               it->second->d_children.end());
         eqp->d_node = it->second->d_node;
       }
       else

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1057,8 +1057,8 @@ void EqualityEngine::getExplanation(
   std::map<std::pair<EqualityNodeId, EqualityNodeId>, EqProof*>::iterator it;
   if (!eqp)
   {
-    // We order the ids, since explaining t1 = t2 is the same as explaining
-    // t2 = t1.
+    // If proofs are disabled, we order the ids, since explaining t1 = t2 is the
+    // same as explaining t2 = t1.
     cacheKey = std::minmax(t1Id, t2Id);
     it = cache.find(cacheKey);
     if (it != cache.end())
@@ -1068,8 +1068,8 @@ void EqualityEngine::getExplanation(
   }
   else
   {
-    // Proofs are sensitive to the order of t1 and t2, so we don't sort the ids
-    // in this case.
+    // If proofs are enabled, note that proofs are sensitive to the order of t1
+    // and t2, so we don't sort the ids in this case.
     cacheKey = std::pair<EqualityNodeId, EqualityNodeId>(t1Id, t2Id);
     it = cache.find(cacheKey);
     if (it != cache.end())

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1069,9 +1069,9 @@ void EqualityEngine::getExplanation(
   else
   {
     // If proofs are enabled, note that proofs are sensitive to the order of t1
-    // and t2, so we don't sort the ids in this case. Depending on how issue
-    // #2965 is resolved, we may be able to revisit this, if it is the case
-    // that proof/uf_proof.h,cpp is robust to equality ordering.
+    // and t2, so we don't sort the ids in this case. TODO: Depending on how
+    // issue #2965 is resolved, we may be able to revisit this, if it is the
+    // case that proof/uf_proof.h,cpp is robust to equality ordering.
     cacheKey = std::pair<EqualityNodeId, EqualityNodeId>(t1Id, t2Id);
     it = cache.find(cacheKey);
     if (it != cache.end())


### PR DESCRIPTION
This fixes the nightlies.

The recent caching in getExplanation #2937 led to a failure for UF proof checking. The issue is that a proof of t1 = t2 could be cached as a proof for t2 = t1. The proof code in src/proof/uf_proof.cpp is unfortunately not robust to this.

The solution is to make the caching order-dependent when proofs are enabled. We should still maintain most of the benefits of caching when proofs are enabled (we still expect cache hits when the order of equalities is correct). 

The performance of this method when proofs are disabled is unchanged with this PR.

If src/proof/uf_proof.cpp was made more robust to ordering in proofs, then we could make the caching more aggressive in this call, but I consider this to be low priority.