### PR TITLE
Fix use of APPLY kind in examples

### DIFF
--- a/examples/sets-translate/sets_translate.cpp
+++ b/examples/sets-translate/sets_translate.cpp
@@ -204,7 +204,7 @@ class Mapper {
     } else {
       vector<Expr> children = e.getChildren();
       children.insert(children.begin(), setoperators[ make_pair(t, e.getKind()) ]);
-      ret = em->mkExpr(kind::APPLY, children);
+      ret = em->mkExpr(kind::APPLY_UF, children);
     }
     // cout << "returning " << ret  << endl;
     return ret;


### PR DESCRIPTION
19a93d5e0f924c70e7f77719e0310c730c8fbc61 removed `kind::APPLY` but there
was a remaining use in the sets_translate example. This commit changes
that occurrence to a `kind::APPLY_UF`.