### PR TITLE
Disable relational triggers by default

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -247,7 +247,7 @@ header = "options/quantifiers_options.h"
   category   = "regular"
   long       = "relational-triggers"
   type       = "bool"
-  default    = "true"
+  default    = "false"
   read_only  = true
   help       = "choose relational triggers such as x = f(y), x >= f(y)"
 


### PR DESCRIPTION
Fixes the nightlies (caused by a timeout on a strings benchmark).

Relational triggers has some unforeseen consequences when used in combination with bounded integer quantifiers, e.g. for strings: `forall x. 0 <= x < str.len(s) => P( x )`.  I believe they should be disabled by default.