### PR TITLE
Fix model of Boolean vars with eager bit-blaster

### DIFF
--- a/src/theory/bv/bitblast/eager_bitblaster.cpp
+++ b/src/theory/bv/bitblast/eager_bitblaster.cpp
@@ -271,25 +271,12 @@ bool EagerBitblaster::collectModelInfo(TheoryModel* m, bool fullModel)
   d_cnfStream->getBooleanVariables(vars);
   for (TNode var : vars)
   {
-    Node const_value;
-
-    if (d_cnfStream->hasLiteral(var))
-    {
-      prop::SatLiteral bit = d_cnfStream->getLiteral(var);
-      prop::SatValue bit_value = d_satSolver->value(bit);
-      Assert(bit_value != prop::SAT_VALUE_UNKNOWN);
-      const_value = nm->mkConst(bit_value == prop::SAT_VALUE_TRUE);
-    }
-    else
-    {
-      if (!fullModel)
-      {
-        continue;
-      }
-      const_value = nm->mkConst(false);
-    }
-
-    if (!m->assertEquality(var, const_value, true))
+    Assert(d_cnfStream->hasLiteral(var));
+    prop::SatLiteral bit = d_cnfStream->getLiteral(var);
+    prop::SatValue value = d_satSolver->value(bit);
+    Assert(value != prop::SAT_VALUE_UNKNOWN);
+    if (!m->assertEquality(
+            var, nm->mkConst(value == prop::SAT_VALUE_TRUE), true))
     {
       return false;
     }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -161,6 +161,7 @@ set(regress_0_tests
   regress0/bv/ackermann4.smt2
   regress0/bv/bool-to-bv-all.smt2
   regress0/bv/bool-to-bv-ite.smt2
+  regress0/bv/bool-model.smt2
   regress0/bv/bug260a.smt
   regress0/bv/bug260b.smt
   regress0/bv/bug440.smt

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -159,9 +159,9 @@ set(regress_0_tests
   regress0/bv/ackermann2.smt2
   regress0/bv/ackermann3.smt2
   regress0/bv/ackermann4.smt2
+  regress0/bv/bool-model.smt2
   regress0/bv/bool-to-bv-all.smt2
   regress0/bv/bool-to-bv-ite.smt2
-  regress0/bv/bool-model.smt2
   regress0/bv/bug260a.smt
   regress0/bv/bug260b.smt
   regress0/bv/bug440.smt

--- a/test/regress/regress0/bv/bool-model.smt2
+++ b/test/regress/regress0/bv/bool-model.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --bitblast=eager
+(set-info :status sat)
+(set-logic QF_BV)
+(declare-fun x () Bool)
+(declare-fun y () Bool)
+(assert (xor y x))
+(check-sat)


### PR DESCRIPTION
When bit-blasting eagerly, we were not assigning values to the Boolean
variables in the `TheoryModel`. With eager bit-blasting, the BV SAT
solver gets all (converted) terms, including the Boolean ones, so
`EagerBitblaster::collectModelInfo()` is responsible for assigning
values to Boolean variables. However, it has only been assigning values
to bit-vector variables, which lead to wrong models. This commit fixes
the issue by asking the `CnfStream` for the Boolean variables, querying
the SAT solver for their value, and assigning them in the `TheoryModel`.