### PR TITLE
Fix iterators in Java API

### DIFF
--- a/examples/api/java/CMakeLists.txt
+++ b/examples/api/java/CMakeLists.txt
@@ -12,7 +12,9 @@ set(EXAMPLES_API_JAVA
   LinearArith
   ## disabled until bindings for the new API are in place (issue #2284)
   #PipedInput
+  Statistics
   Strings
+  UnsatCores
 )
 
 foreach(example ${EXAMPLES_API_JAVA})

--- a/examples/api/java/Statistics.java
+++ b/examples/api/java/Statistics.java
@@ -1,0 +1,45 @@
+/*********************                                                        */
+/*! \file Statistics.java
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andres Noetzli
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief An example of accessing CVC4's statistics using the Java API
+ **
+ ** An example of accessing CVC4's statistics using the Java API.
+ **/
+
+import edu.nyu.acsys.CVC4.*;
+import java.util.Iterator;
+
+public class Statistics {
+  public static void main(String[] args) {
+    System.loadLibrary("cvc4jni");
+
+    ExprManager em = new ExprManager();
+    SmtEngine smt = new SmtEngine(em);
+
+    Type boolType = em.booleanType();
+    Expr a = em.mkVar("A", boolType);
+    Expr b = em.mkVar("B", boolType);
+
+    // A ^ B
+    smt.assertFormula(em.mkExpr(Kind.AND, a, b));
+
+    Result res = smt.checkSat();
+
+    // Get the statistics from the `SmtEngine` and iterate over them. The
+    // `Statistics` class implements the `Iterable<Statistic>` interface. A
+    // `Statistic` is a pair that consists of a name and an `SExpr` that stores
+    // the value of the statistic.
+    edu.nyu.acsys.CVC4.Statistics stats = smt.getStatistics();
+    for (Statistic stat : stats) {
+      System.out.println(stat.getFirst() + " = " + stat.getSecond());
+    }
+  }
+}

--- a/examples/api/java/UnsatCores.java
+++ b/examples/api/java/UnsatCores.java
@@ -1,0 +1,54 @@
+/*********************                                                        */
+/*! \file UnsatCore.java
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andres Noetzli
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief An example of interacting with unsat cores using CVC4's Java API
+ **
+ ** An example of interacting with unsat cores using CVC4's Java API.
+ **/
+
+import edu.nyu.acsys.CVC4.*;
+import java.util.Iterator;
+
+public class UnsatCores {
+  public static void main(String[] args) {
+    System.loadLibrary("cvc4jni");
+
+    ExprManager em = new ExprManager();
+    SmtEngine smt = new SmtEngine(em);
+
+    // Enable the production of unsat cores
+    smt.setOption("produce-unsat-cores", new SExpr(true));
+
+    Type boolType = em.booleanType();
+    Expr a = em.mkVar("A", boolType);
+    Expr b = em.mkVar("B", boolType);
+
+    // A ^ B
+    smt.assertFormula(em.mkExpr(Kind.AND, a, b));
+    // ~(A v B)
+    smt.assertFormula(em.mkExpr(Kind.NOT, em.mkExpr(Kind.OR, a, b)));
+
+    Result res = smt.checkSat(); // result is unsat
+
+    // Retrieve the unsat core
+    UnsatCore unsatCore = smt.getUnsatCore();
+    
+    // Print the unsat core
+    System.out.println("Unsat Core: " + unsatCore);
+
+    // Iterate over expressions in the unsat core. The `UnsatCore` class
+    // implements the `Iterable<Expr>` interface.
+    System.out.println("--- Unsat Core ---");
+    for (Expr e : unsatCore) {
+      System.out.println(e);
+    }
+  }
+}

--- a/src/bindings/java/CMakeLists.txt
+++ b/src/bindings/java/CMakeLists.txt
@@ -165,6 +165,7 @@ set(gen_java_files
   ${CMAKE_CURRENT_BINARY_DIR}/SExpr.java
   ${CMAKE_CURRENT_BINARY_DIR}/SExprKeyword.java
   ${CMAKE_CURRENT_BINARY_DIR}/SExprType.java
+  ${CMAKE_CURRENT_BINARY_DIR}/Statistic.java
   ${CMAKE_CURRENT_BINARY_DIR}/SWIGTYPE_p_CVC4__Model.java
   ${CMAKE_CURRENT_BINARY_DIR}/SWIGTYPE_p_CVC4__Printer.java
   ${CMAKE_CURRENT_BINARY_DIR}/SWIGTYPE_p_CVC4__api__Solver.java

--- a/src/bindings/java_iterator_adapter.h
+++ b/src/bindings/java_iterator_adapter.h
@@ -30,30 +30,34 @@
 #ifndef CVC4__BINDINGS__JAVA_ITERATOR_ADAPTER_H
 #define CVC4__BINDINGS__JAVA_ITERATOR_ADAPTER_H
 
+#include <type_traits>
+
 namespace CVC4 {
 
-template <class T>
-class JavaIteratorAdapter {
-  const T& d_t;
-  typename T::const_iterator d_it;
-
-public:
-  JavaIteratorAdapter(const T& t) :
-    d_t(t),
-    d_it(d_t.begin()) {
+template <class T, class value_type>
+class JavaIteratorAdapter
+{
+ public:
+  JavaIteratorAdapter(const T& t) : d_t(t), d_it(d_t.begin())
+  {
+    static_assert(std::is_convertible<typename T::const_iterator::value_type,
+                                      value_type>());
   }
 
-  bool hasNext() {
-    return d_it != d_t.end();
-  }
+  bool hasNext() { return d_it != d_t.end(); }
 
-  typename T::const_iterator::value_type getNext() {
-    typename T::const_iterator::value_type ret = *d_it;
+  value_type getNext()
+  {
+    value_type ret = *d_it;
     ++d_it;
     return ret;
   }
-};/* class JavaIteratorAdapter<T> */
 
-}/* CVC4 namespace */
+ private:
+  const T& d_t;
+  typename T::const_iterator d_it;
+}; /* class JavaIteratorAdapter<T, value_type> */
+
+}  // namespace CVC4
 
 #endif /* CVC4__BINDINGS__JAVA_ITERATOR_ADAPTER_H */

--- a/src/bindings/java_iterator_adapter.h
+++ b/src/bindings/java_iterator_adapter.h
@@ -40,8 +40,10 @@ class JavaIteratorAdapter
  public:
   JavaIteratorAdapter(const T& t) : d_t(t), d_it(d_t.begin())
   {
-    static_assert(std::is_convertible<typename T::const_iterator::value_type,
-                                      value_type>());
+    static_assert(
+        std::is_convertible<typename T::const_iterator::value_type,
+                            value_type>(),
+        "value_type must be convertible from T::const_iterator::value_type");
   }
 
   bool hasNext() { return d_it != d_t.end(); }

--- a/src/expr/datatype.i
+++ b/src/expr/datatype.i
@@ -95,8 +95,11 @@
 // iterator() method on the Java side that returns a Java-style
 // Iterator.
 %extend CVC4::Datatype {
-  CVC4::JavaIteratorAdapter<CVC4::Datatype> iterator() {
-    return CVC4::JavaIteratorAdapter<CVC4::Datatype>(*$self);
+  CVC4::JavaIteratorAdapter<CVC4::Datatype, CVC4::DatatypeConstructor>
+  iterator()
+  {
+    return CVC4::JavaIteratorAdapter<CVC4::Datatype, CVC4::DatatypeConstructor>(
+        *$self);
   }
 
   std::string toString() const {
@@ -106,8 +109,12 @@
   }
 }
 %extend CVC4::DatatypeConstructor {
-  CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor> iterator() {
-    return CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor>(*$self);
+  CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor,
+                            CVC4::DatatypeConstructorArg>
+  iterator()
+  {
+    return CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor,
+                                     CVC4::DatatypeConstructorArg>(*$self);
   }
 
   std::string toString() const {
@@ -129,12 +136,12 @@
 %typemap(javainterfaces) CVC4::DatatypeConstructor "java.lang.Iterable<DatatypeConstructorArg>";
 
 // the JavaIteratorAdapter should not be public, and implements Iterator
-%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::Datatype> "class";
-%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor> "class";
-%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::Datatype> "java.util.Iterator<DatatypeConstructor>";
-%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor> "java.util.Iterator<DatatypeConstructorArg>";
+%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::Datatype, CVC4::DatatypeConstructor> "class";
+%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor, CVC4::DatatypeConstructorArg> "class";
+%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::Datatype, CVC4::DatatypeConstructor> "java.util.Iterator<DatatypeConstructor>";
+%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor, CVC4::DatatypeConstructorArg> "java.util.Iterator<DatatypeConstructorArg>";
 // add some functions to the Java side (do it here because there's no way to do these in C++)
-%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::Datatype> "
+%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::Datatype, CVC4::DatatypeConstructor> "
   public void remove() {
     throw new java.lang.UnsupportedOperationException();
   }
@@ -147,7 +154,7 @@
     }
   }
 "
-%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor> "
+%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor, CVC4::DatatypeConstructorArg> "
   public void remove() {
     throw new java.lang.UnsupportedOperationException();
   }
@@ -161,18 +168,8 @@
   }
 "
 // getNext() just allows C++ iterator access from Java-side next(), make it private
-%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::Datatype>::getNext() "private";
-%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor>::getNext() "private";
-
-// map the types appropriately.
-%typemap(jni) CVC4::Datatype::iterator::value_type "jobject";
-%typemap(jtype) CVC4::Datatype::iterator::value_type "edu.nyu.acsys.CVC4.DatatypeConstructor";
-%typemap(jstype) CVC4::Datatype::iterator::value_type "edu.nyu.acsys.CVC4.DatatypeConstructor";
-%typemap(javaout) CVC4::Datatype::iterator::value_type { return $jnicall; }
-%typemap(jni) CVC4::DatatypeConstructor::iterator::value_type "jobject";
-%typemap(jtype) CVC4::DatatypeConstructor::iterator::value_type "edu.nyu.acsys.CVC4.DatatypeConstructorArg";
-%typemap(jstype) CVC4::DatatypeConstructor::iterator::value_type "edu.nyu.acsys.CVC4.DatatypeConstructorArg";
-%typemap(javaout) CVC4::DatatypeConstructor::iterator::value_type { return $jnicall; }
+%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::Datatype, CVC4::DatatypeConstructor>::getNext() "private";
+%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor, CVC4::DatatypeConstructorArg>::getNext() "private";
 
 #endif /* SWIGJAVA */
 
@@ -183,7 +180,7 @@
 %include "bindings/java_iterator_adapter.h"
 %include "bindings/java_stream_adapters.h"
 
-%template(JavaIteratorAdapter_Datatype) CVC4::JavaIteratorAdapter<CVC4::Datatype>;
-%template(JavaIteratorAdapter_DatatypeConstructor) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor>;
+%template(JavaIteratorAdapter_Datatype) CVC4::JavaIteratorAdapter<CVC4::Datatype, CVC4::DatatypeConstructor>;
+%template(JavaIteratorAdapter_DatatypeConstructor) CVC4::JavaIteratorAdapter<CVC4::DatatypeConstructor, CVC4::DatatypeConstructorArg>;
 
 #endif /* SWIGJAVA */

--- a/src/expr/expr.i
+++ b/src/expr/expr.i
@@ -92,8 +92,9 @@ namespace CVC4 {
 %ignore CVC4::Expr::begin() const;
 %ignore CVC4::Expr::end() const;
 %extend CVC4::Expr {
-  CVC4::JavaIteratorAdapter<CVC4::Expr> iterator() {
-    return CVC4::JavaIteratorAdapter<CVC4::Expr>(*$self);
+  CVC4::JavaIteratorAdapter<CVC4::Expr, CVC4::Expr> iterator()
+  {
+    return CVC4::JavaIteratorAdapter<CVC4::Expr, CVC4::Expr>(*$self);
   }
 }
 
@@ -101,10 +102,10 @@ namespace CVC4 {
 %typemap(javainterfaces) CVC4::Expr "java.lang.Iterable<edu.nyu.acsys.CVC4.Expr>";
 
 // the JavaIteratorAdapter should not be public, and implements Iterator
-%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::Expr> "class";
-%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::Expr> "java.util.Iterator<edu.nyu.acsys.CVC4.Expr>";
+%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::Expr, CVC4::Expr> "class";
+%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::Expr, CVC4::Expr> "java.util.Iterator<edu.nyu.acsys.CVC4.Expr>";
 // add some functions to the Java side (do it here because there's no way to do these in C++)
-%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::Expr> "
+%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::Expr, CVC4::Expr> "
   public void remove() {
     throw new java.lang.UnsupportedOperationException();
   }
@@ -118,13 +119,7 @@ namespace CVC4 {
   }
 "
 // getNext() just allows C++ iterator access from Java-side next(), make it private
-%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::Expr>::getNext() "private";
-
-// map the types appropriately
-%typemap(jni) CVC4::Expr::const_iterator::value_type "jobject";
-%typemap(jtype) CVC4::Expr::const_iterator::value_type "edu.nyu.acsys.CVC4.Expr";
-%typemap(jstype) CVC4::Expr::const_iterator::value_type "edu.nyu.acsys.CVC4.Expr";
-%typemap(javaout) CVC4::Expr::const_iterator::value_type { return $jnicall; }
+%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::Expr, CVC4::Expr>::getNext() "private";
 
 #endif /* SWIGJAVA */
 
@@ -161,7 +156,7 @@ namespace CVC4 {
 %include "bindings/java_iterator_adapter.h"
 %include "bindings/java_stream_adapters.h"
 
-%template(JavaIteratorAdapter_Expr) CVC4::JavaIteratorAdapter<CVC4::Expr>;
+%template(JavaIteratorAdapter_Expr) CVC4::JavaIteratorAdapter<CVC4::Expr, CVC4::Expr>;
 
 #endif /* SWIGJAVA */
 

--- a/src/proof/unsat_core.i
+++ b/src/proof/unsat_core.i
@@ -21,8 +21,16 @@
 %ignore CVC4::UnsatCore::begin() const;
 %ignore CVC4::UnsatCore::end() const;
 %extend CVC4::UnsatCore {
-  CVC4::JavaIteratorAdapter<CVC4::UnsatCore> iterator() {
-    return CVC4::JavaIteratorAdapter<CVC4::UnsatCore>(*$self);
+  CVC4::JavaIteratorAdapter<CVC4::UnsatCore, CVC4::Expr> iterator()
+  {
+    return CVC4::JavaIteratorAdapter<CVC4::UnsatCore, CVC4::Expr>(*$self);
+  }
+
+  std::string toString()
+  {
+    std::stringstream ss;
+    ss << (*$self);
+    return ss.str();
   }
 }
 
@@ -30,10 +38,10 @@
 %typemap(javainterfaces) CVC4::UnsatCore "java.lang.Iterable<edu.nyu.acsys.CVC4.Expr>";
 
 // the JavaIteratorAdapter should not be public, and implements Iterator
-%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::UnsatCore> "class";
-%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::UnsatCore> "java.util.Iterator<edu.nyu.acsys.CVC4.Expr>";
+%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::UnsatCore, CVC4::Expr> "class";
+%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::UnsatCore, CVC4::Expr> "java.util.Iterator<edu.nyu.acsys.CVC4.Expr>";
 // add some functions to the Java side (do it here because there's no way to do these in C++)
-%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::UnsatCore> "
+%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::UnsatCore, CVC4::Expr> "
   public void remove() {
     throw new java.lang.UnsupportedOperationException();
   }
@@ -47,13 +55,7 @@
   }
 "
 // getNext() just allows C++ iterator access from Java-side next(), make it private
-%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::UnsatCore>::getNext() "private";
-
-// map the types appropriately
-%typemap(jni) CVC4::UnsatCore::const_iterator::value_type "jobject";
-%typemap(jtype) CVC4::UnsatCore::const_iterator::value_type "edu.nyu.acsys.CVC4.Expr";
-%typemap(jstype) CVC4::UnsatCore::const_iterator::value_type "edu.nyu.acsys.CVC4.Expr";
-%typemap(javaout) CVC4::UnsatCore::const_iterator::value_type { return $jnicall; }
+%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::UnsatCore, CVC4::Expr>::getNext() "private";
 
 #endif /* SWIGJAVA */
 
@@ -61,9 +63,10 @@
 
 #ifdef SWIGJAVA
 
-%include "bindings/java_iterator_adapter.h"
-%include "bindings/java_stream_adapters.h"
+%include <std_vector.i>
 
-%template(JavaIteratorAdapter_UnsatCore) CVC4::JavaIteratorAdapter<CVC4::UnsatCore>;
+%include "bindings/java_iterator_adapter.h"
+
+%template(JavaIteratorAdapter_UnsatCore) CVC4::JavaIteratorAdapter<CVC4::UnsatCore, CVC4::Expr>;
 
 #endif /* SWIGJAVA */

--- a/src/smt/command.i
+++ b/src/smt/command.i
@@ -28,8 +28,10 @@
 %ignore CVC4::CommandSequence::begin() const;
 %ignore CVC4::CommandSequence::end() const;
 %extend CVC4::CommandSequence {
-  CVC4::JavaIteratorAdapter<CVC4::CommandSequence> iterator() {
-    return CVC4::JavaIteratorAdapter<CVC4::CommandSequence>(*$self);
+  CVC4::JavaIteratorAdapter<CVC4::CommandSequence, CVC4::Command*> iterator()
+  {
+    return CVC4::JavaIteratorAdapter<CVC4::CommandSequence, CVC4::Command*>(
+        *$self);
   }
 }
 
@@ -37,10 +39,10 @@
 %typemap(javainterfaces) CVC4::CommandSequence "java.lang.Iterable<edu.nyu.acsys.CVC4.Command>";
 
 // the JavaIteratorAdapter should not be public, and implements Iterator
-%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::CommandSequence> "class";
-%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::CommandSequence> "java.util.Iterator<edu.nyu.acsys.CVC4.Command>";
+%typemap(javaclassmodifiers) CVC4::JavaIteratorAdapter<CVC4::CommandSequence, CVC4::Command*> "class";
+%typemap(javainterfaces) CVC4::JavaIteratorAdapter<CVC4::CommandSequence, CVC4::Command*> "java.util.Iterator<edu.nyu.acsys.CVC4.Command>";
 // add some functions to the Java side (do it here because there's no way to do these in C++)
-%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::CommandSequence> "
+%typemap(javacode) CVC4::JavaIteratorAdapter<CVC4::CommandSequence, CVC4::Command*> "
   public void remove() {
     throw new java.lang.UnsupportedOperationException();
   }
@@ -54,13 +56,7 @@
   }
 "
 // getNext() just allows C++ iterator access from Java-side next(), make it private
-%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::CommandSequence>::getNext() "private";
-
-// map the types appropriately
-%typemap(jni) CVC4::CommandSequence::const_iterator::value_type "jobject";
-%typemap(jtype) CVC4::CommandSequence::const_iterator::value_type "edu.nyu.acsys.CVC4.Command";
-%typemap(jstype) CVC4::CommandSequence::const_iterator::value_type "edu.nyu.acsys.CVC4.Command";
-%typemap(javaout) CVC4::CommandSequence::const_iterator::value_type { return $jnicall; }
+%javamethodmodifiers CVC4::JavaIteratorAdapter<CVC4::CommandSequence, CVC4::Command*>::getNext() "private";
 
 #endif /* SWIGJAVA */
 
@@ -71,6 +67,6 @@
 %include "bindings/java_iterator_adapter.h"
 %include "bindings/java_stream_adapters.h"
 
-%template(JavaIteratorAdapter_CommandSequence) CVC4::JavaIteratorAdapter<CVC4::CommandSequence>;
+%template(JavaIteratorAdapter_CommandSequence) CVC4::JavaIteratorAdapter<CVC4::CommandSequence, CVC4::Command*>;
 
 #endif /* SWIGJAVA */


### PR DESCRIPTION
Fixes #2989. SWIG 3 seems to have an issue properly resolving
`T::const_iterator::value_type` if that type itself is a `typedef`.
This is for example the case in the `UnsatCore` class, which `typedef`s
`const_iterator` to `std::vector<Expr>::const_iterator`. As a
workaround, this commit changes the `JavaIteratorAdapter` class to take
two template parameters, one of which is the `value_type`. The commit
also adds a compile-time assertion that `T::const_iterator::value_type`
can be converted to `value_type` to avoid nasty surprises. A nice
side-effect of this solution is that explicit `typemap`s are not
necessary anymore, so they are removed. Additionally, the commit adds a
`toString()` method for the Java API of `UnsatCore` and adds examples
that show and test the iteration over the unsat core and the statistics.
Iterating over `Statistics` now returns instances of `Statistic` instead
of `Object[]`, which is a bit cleaner and requires less glue code.