### PR TITLE
cmake: Install JAR and JNI files for Java bindings.

### DIFF
--- a/src/bindings/java/CMakeLists.txt
+++ b/src/bindings/java/CMakeLists.txt
@@ -241,5 +241,12 @@ set(gen_java_files
   ${CMAKE_CURRENT_BINARY_DIR}/vectorVectorExpr.java
 )
 
-add_jar(cvc4jar SOURCES ${gen_java_files} OUTPUT_NAME CVC4)
+set(CMAKE_JNI_TARGET TRUE)
+add_jar(cvc4jar
+        SOURCES ${gen_java_files}
+        VERSION ${CVC4_MAJOR}.${CVC4_MINOR}.${CVC4_RELEASE}
+        OUTPUT_NAME CVC4)
 add_dependencies(cvc4jar cvc4jni)
+install_jar(cvc4jar DESTINATION share/java/cvc4)
+install_jni_symlink(cvc4jar DESTINATION share/java/cvc4)
+install(TARGETS cvc4jni DESTINATION lib)


### PR DESCRIPTION
Install paths are:
  - `${CMAKE_INSTALL_PREFIX}/lib/` for `libcvc4jni.so`
  - `${CMAKE_INSTALL_PREFIX}/share/java/cvc4/` for `CVC4.jar`

Fixes #2990.