### PR TITLE
[SMT-COMP 2019] Better strings configuration

### DIFF
--- a/contrib/run-script-smtcomp2019
+++ b/contrib/run-script-smtcomp2019
@@ -135,9 +135,9 @@ QF_ALIA)
   trywith 70 --decision=justification --arrays-weak-equiv
   finishwith --decision=justification-stoponly --no-arrays-eager-index --arrays-eager-lemmas
   ;;
-QF_SLIA)
-  trywith 500 --strings-exp --rewrite-divk --lang=smt2.6.1
-  finishwith --strings-exp --rewrite-divk --lang=smt2.6.1 --strings-fmf
+QF_S|QF_SLIA)
+  trywith 300 --strings-exp --rewrite-divk --lang=smt2.6.1 --strings-fmf
+  finishwith --strings-exp --rewrite-divk --lang=smt2.6.1
   ;;
 QF_ABVFP)
   finishwith


### PR DESCRIPTION
Our experiments have shown that for the string solver, it is better to
run `--strings-fmf` for a short time in the beginning and then give the
configuration without `--strings-fmf` the rest of the time.