### PR TITLE
Update QF_BV options for SMT-COMP 2019.

### DIFF
--- a/contrib/run-script-smtcomp2019
+++ b/contrib/run-script-smtcomp2019
@@ -39,11 +39,11 @@ QF_NIA)
   trywith 30 --nl-ext-tplanes --decision=justification
   trywith 30 --no-nl-ext-tplanes --decision=internal
   # this totals up to more than 20 minutes, although notice that smaller bit-widths may quickly fail
-  trywith 300 --solve-int-as-bv=2 --bitblast=eager --bv-sat-solver=cadical --bitblast-aig --no-bv-abstraction
-  trywith 300 --solve-int-as-bv=4 --bitblast=eager --bv-sat-solver=cadical --bitblast-aig --no-bv-abstraction
-  trywith 300 --solve-int-as-bv=8 --bitblast=eager --bv-sat-solver=cadical --bitblast-aig --no-bv-abstraction
-  trywith 300 --solve-int-as-bv=16 --bitblast=eager --bv-sat-solver=cadical --bitblast-aig --no-bv-abstraction
-  trywith 600 --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cadical --bitblast-aig --no-bv-abstraction
+  trywith 300 --solve-int-as-bv=2 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 300 --solve-int-as-bv=4 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 300 --solve-int-as-bv=8 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 300 --solve-int-as-bv=16 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
   finishwith --nl-ext-tplanes --decision=internal
   ;;
 QF_NRA)
@@ -122,7 +122,7 @@ QF_UFBV)
   finishwith --bitblast=eager --bv-sat-solver=cadical
   ;;
 QF_BV)
-  finishwith --unconstrained-simp --bv-div-zero-const --bv-intro-pow2 --bitblast=eager --bv-sat-solver=cadical --bitblast-aig --bv-eq-slicer=auto --no-bv-abstraction
+  finishwith --bv-div-zero-const --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
   ;;
 QF_AUFLIA)
   finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification

--- a/contrib/run-script-smtcomp2019-model-validation
+++ b/contrib/run-script-smtcomp2019-model-validation
@@ -14,7 +14,7 @@ function finishwith {
 case "$logic" in
 
 QF_BV)
-  finishwith --bv-div-zero-const --bv-intro-pow2 --bitblast=eager --bv-sat-solver=cadical --bv-eq-slicer=auto --no-bv-abstraction
+  finishwith --bv-div-zero-const --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
   ;;
 *)
   # just run the default


### PR DESCRIPTION
I ran jobs with combinations of the options from previous years to determine the configuration for this year's SMT-COMP.

Base configuration is: `--bv-div-zero-const --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction`

We don't need ABC anymore:
```
                     DIRECTORY |    Tot |   Slvd |    Sat |  Unsat |  Uniq |  Unk |   To |  Mo |  Err |     Cpu[s] |    Mem[MB] |
    2019-05-31-cvc4-qf_bv-base |  41696 |  41023 |  14248 |  26775 |   123 |    0 |  639 |  34 |    0 |  1208926.3 |  3776374.0 |
2019-05-31-cvc4-qf_bv-base-abc |  41696 |  40951 |  14228 |  26723 |    51 |    0 |  722 |  23 |    0 |  1322780.4 |  2910325.1 |
```
Diff:
```
                         DIRECTORY |                       2019-05-31-cvc4-qf_bv-base |                   2019-05-31-cvc4-qf_bv-base-abc |
                         Benchmark |   Stat Slvd Tot To Mo Err   Cpu[s]  Mem[MB] Uniq |  Stat Slvd Tot  To Mo Err   Cpu[s]  Mem[MB] Uniq |
 20190311-bv-term-small-rw-Noetzli |     to    0   4  4  0   0   4800.1    387.6    0 |    ok    4   4   0  0   0      0.4     41.6    4 |
                               asp |     ok    3   6  3  0   0   5606.4  13977.9    3 |    ok    3   6   3  0   0   6778.9  12218.8    3 |
                   bmc-bv-svcomp14 |     ok    1   1  0  0   0   1116.9    857.9    1 |    to    0   1   1  0   0   1200.1    612.8    0 |
                    brummayerbiere |  to/mo    0   3  1  2   0   1916.3  17346.0    0 |    ok    2   3   1  0   0   2881.2   4572.5    2 |
                   brummayerbiere2 |     to    0   6  6  0   0   7200.7   8347.2    0 |    ok    6   6   0  0   0    492.4   3759.7    6 |
                   brummayerbiere3 |     ok    3   3  0  0   0   2682.8   1168.9    3 |    to    0   3   3  0   0   3600.1   1110.6    0 |
                       bruttomesso |     to    0   2  2  0   0   2400.2   1311.0    0 |    ok    2   2   0  0   0    626.6    871.0    2 |
                           calypto |     ok    1   1  0  0   0   1139.7     99.0    1 |    to    0   1   1  0   0   1200.1     97.7    0 |
                               fft |     to    0   2  2  0   0   2400.0    260.6    0 |    ok    2   2   0  0   0    475.1    154.2    2 |
                             float |     ok    2  22 13  7   0  18387.2  74427.2    2 |    ok   13  22   9  0   0  21183.1  45106.1   13 |
                       log-slicing |     ok    9  13  4  0   0  11453.8   6291.9    9 |    ok    4  13   9  0   0  13926.4   5054.1    4 |
                               mcm |     ok    9  14  4  1   0   9733.4  17949.9    9 |    ok    4  14  10  0   0  15737.6  13246.8    4 |
                            pspace |     ok    3   4  1  0   0   3905.0   4796.1    3 |    ok    1   4   3  0   0   4517.5   4536.1    1 |
                               RWS |     to    0   2  2  0   0   2400.2   2482.0    0 |    ok    2   2   0  0   0    906.1    579.5    2 |
                             Sage2 |     ok   91  99  8  0   0  71385.3  56789.0   91 |    ok    8  99  91  0   0 110240.6  34821.9    8 |
                             spear |     ok    1   1  0  0   0     15.1   1018.3    1 |    to    0   1   1  0   0   1200.1    887.7    0 |
                               VS3 |     mo    0   1  0  1   0    259.1   8002.5    0 |    to    0   1   1  0   0   1200.3   4677.5    0 |
                          __totals |     ok  123 184 50 11   0 146802.2 215513.0  123 |    ok   51 184 133  0   0 186166.5 132348.6   51 |
```

The slicer does not improve performance:
```
                        DIRECTORY |    Tot |   Slvd |    Sat |  Unsat |  Uniq |  Unk |   To |  Mo |  Err |     Cpu[s] |    Mem[MB] |
       2019-05-31-cvc4-qf_bv-base |  41696 |  41023 |  14248 |  26775 |     1 |    0 |  639 |  34 |    0 |  1208926.3 |  3776374.0 |
2019-05-31-cvc4-qf_bv-slicer-auto |  41696 |  41023 |  14247 |  26776 |     1 |    0 |  639 |  34 |    0 |  1209058.6 |  3774763.4 |
```
Diff:
```
   DIRECTORY |                   2019-05-31-cvc4-qf_bv-base |            2019-05-31-cvc4-qf_bv-slicer-auto |
   Benchmark |  Stat Slvd Tot To Mo Err Cpu[s] Mem[MB] Uniq |  Stat Slvd Tot To Mo Err Cpu[s] Mem[MB] Uniq |
 log-slicing |    to    0   1  1  0   0 1200.1   560.6    0 |    ok    1   1  0  0   0 1182.3   563.4    1 |
       Sage2 |    ok    1   1  0  0   0 1166.2   643.5    1 |    to    0   1  1  0   0 1200.1   643.5    0 |
    __totals |    ok    1   2  1  0   0 2366.3  1204.1    1 |    ok    1   2  1  0   0 2382.4  1206.9    1 |
```

We actually lose instances with unconstrained (even though it helps on the one benchmark family where it matters, brummayerbiere4, whith 9/10 solved instead of 0/10):
```
                 DIRECTORY |    Tot |   Slvd |    Sat |  Unsat |  Uniq |  Unk |   To |  Mo |  Err |     Cpu[s] |    Mem[MB] |
2019-05-31-cvc4-qf_bv-base |  41696 |  41023 |  14248 |  26775 |    55 |    0 |  639 |  34 |    0 |  1208926.3 |  3776374.0 |
  2019-05-31-cvc4-qf_bv-uc |  41696 |  40990 |  14252 |  26738 |    22 |    0 |  681 |  25 |    0 |  1318707.3 |  3595999.9 |
```
Diff:
```
       DIRECTORY |                     2019-05-31-cvc4-qf_bv-base |                      2019-05-31-cvc4-qf_bv-uc |
       Benchmark |  Stat Slvd Tot To Mo Err  Cpu[s]  Mem[MB] Uniq |  Stat Slvd Tot To Mo Err  Cpu[s] Mem[MB] Uniq |
             asp |    ok    5   8  3  0   0  7544.5  19296.8    5 |    ok    3   8  5  0   0  8503.4 19648.3    3 |
 bmc-bv-svcomp14 |    ok    1   1  0  0   0  1116.9    857.9    1 |    to    0   1  1  0   0  1200.1   784.0    0 |
 brummayerbiere3 |    ok    1   1  0  0   0  1135.8    210.5    1 |    to    0   1  1  0   0  1200.0   201.7    0 |
 brummayerbiere4 |    mo    0   9  0  9   0  1066.4  72163.5    0 |    ok    9   9  0  0   0     0.0     0.0    9 |
         calypto |    ok    3   4  1  0   0  4644.9    528.3    3 |    ok    1   4  3  0   0  3600.2   418.2    1 |
           float |    ok    3   3  0  0   0  3395.4   6367.8    3 |    to    0   3  3  0   0  3600.3  6385.5    0 |
     log-slicing |    ok    4   4  0  0   0  4506.5   2293.7    4 |    to    0   4  4  0   0  4800.3  2262.7    0 |
             mcm |    ok    1   1  0  0   0   981.5    644.6    1 |    to    0   1  1  0   0  1200.0   644.4    0 |
          pspace |    ok    1   1  0  0   0  1016.0    921.0    1 |    to    0   1  1  0   0  1200.1   921.0    0 |
           Sage2 |    ok   36  45  9  0   0 18989.1  12719.8   36 |    ok    9  45 36  0   0 47033.2 14303.8    9 |
        __totals |    ok   55  77 13  9   0 44397.0 116003.9   55 |    ok   22  77 55  0   0 72337.5 45569.6   22 |
```

And with `--bv-intro-pow2` we actually lose instances, too:
```
                 DIRECTORY |    Tot |   Slvd |    Sat |  Unsat |  Uniq |  Unk |   To |  Mo |  Err |     Cpu[s] |    Mem[MB] |
2019-05-31-cvc4-qf_bv-base |  41696 |  41023 |  14248 |  26775 |    26 |    0 |  639 |  34 |    0 |  1208926.3 |  3776374.0 |
2019-05-31-cvc4-qf_bv-pow2 |  41696 |  41002 |  14239 |  26763 |     5 |    0 |  660 |  34 |    0 |  1268805.7 |  3777249.3 |
```
Diff:
```
       DIRECTORY |                    2019-05-31-cvc4-qf_bv-base |                    2019-05-31-cvc4-qf_bv-pow2 |
       Benchmark |  Stat Slvd Tot To Mo Err  Cpu[s] Mem[MB] Uniq |  Stat Slvd Tot To Mo Err  Cpu[s] Mem[MB] Uniq |
             asp |    ok    2   2  0  0   0  2123.3  4485.3    2 |    to    0   2  2  0   0  2400.3  4484.8    0 |
 bmc-bv-svcomp14 |    ok    1   1  0  0   0  1116.9   857.9    1 |    to    0   1  1  0   0  1200.1   838.5    0 |
 brummayerbiere3 |    ok    1   1  0  0   0  1135.8   210.5    1 |    to    0   1  1  0   0  1200.0   197.3    0 |
         calypto |    ok    3   3  0  0   0  3444.8   445.1    3 |    to    0   3  3  0   0  3600.3   437.8    0 |
           float |    ok    3   3  0  0   0  3395.4  6367.8    3 |    to    0   3  3  0   0  3600.4  6366.7    0 |
     log-slicing |    ok    4   4  0  0   0  4506.5  2293.7    4 |    to    0   4  4  0   0  4800.2  2246.9    0 |
             mcm |    ok    2   2  0  0   0  1925.8  1314.9    2 |    to    0   2  2  0   0  2400.1  1309.5    0 |
          pspace |    to    0   3  3  0   0  3600.2  4489.7    0 |    ok    3   3  0  0   0    92.8  3654.6    3 |
           Sage2 |    ok   10  12  2  0   0 12421.4  5089.5   10 |    ok    2  12 10  0   0 12875.9  4969.8    2 |
        __totals |    ok   26  31  5  0   0 33670.1 25554.4   26 |    ok    5  31 26  0   0 32170.1 24505.9    5 |
```