### PR TITLE
[SMT-COMP] Increase sequential portfolio timeouts

### DIFF
--- a/contrib/run-script-smtcomp2019
+++ b/contrib/run-script-smtcomp2019
@@ -27,7 +27,7 @@ function finishwith {
 case "$logic" in
 
 QF_LRA)
-  trywith 200 --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi
+  trywith 400 --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi
   finishwith --no-restrict-pivots --use-soi --new-prop --unconstrained-simp
   ;;
 QF_LIA)
@@ -35,53 +35,53 @@ QF_LIA)
   finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi --pb-rewrites
   ;;
 QF_NIA)
-  trywith 300 --nl-ext-tplanes --decision=internal
-  trywith 30 --nl-ext-tplanes --decision=justification
-  trywith 30 --no-nl-ext-tplanes --decision=internal
-  # this totals up to more than 20 minutes, although notice that smaller bit-widths may quickly fail
-  trywith 300 --solve-int-as-bv=2 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 300 --solve-int-as-bv=4 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 300 --solve-int-as-bv=8 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 300 --solve-int-as-bv=16 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 600 --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --nl-ext-tplanes --decision=internal
+  trywith 60 --nl-ext-tplanes --decision=justification
+  trywith 60 --no-nl-ext-tplanes --decision=internal
+  # this totals up to more than 40 minutes, although notice that smaller bit-widths may quickly fail
+  trywith 600 --solve-int-as-bv=2 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=4 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=8 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=16 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 1200 --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
   finishwith --nl-ext-tplanes --decision=internal
   ;;
 QF_NRA)
-  trywith 300 --nl-ext-tplanes --decision=internal
-  trywith 300 --nl-ext-tplanes --decision=justification --no-nl-ext-factor
-  trywith 30 --nl-ext-tplanes --decision=internal --solve-real-as-int
+  trywith 600 --nl-ext-tplanes --decision=internal
+  trywith 600 --nl-ext-tplanes --decision=justification --no-nl-ext-factor
+  trywith 60 --nl-ext-tplanes --decision=internal --solve-real-as-int
   finishwith --nl-ext-tplanes --decision=justification
   ;;
 # all logics with UF + quantifiers should either fall under this or special cases below
 ALIA|AUFLIA|AUFLIRA|AUFNIRA|UF|UFIDL|UFLIA|UFLRA|UFNIA|UFDT|UFDTLIA|AUFDTLIA|AUFBVDTLIA|AUFNIA)
   # the following is designed for a run time of 20 min.
-  # initial runs 1min
-  trywith 30 --simplification=none --full-saturate-quant
-  trywith 30 --no-e-matching --full-saturate-quant
-  # trigger selections 3min
-  trywith 30 --relevant-triggers --full-saturate-quant
-  trywith 30 --trigger-sel=max --full-saturate-quant
-  trywith 30 --multi-trigger-when-single --full-saturate-quant
-  trywith 30 --multi-trigger-when-single --multi-trigger-priority --full-saturate-quant
-  trywith 30 --multi-trigger-cache --full-saturate-quant
-  trywith 30 --no-multi-trigger-linear --full-saturate-quant
-  # other 4min
-  trywith 30 --pre-skolem-quant --full-saturate-quant
-  trywith 30 --inst-when=full --full-saturate-quant
-  trywith 30 --no-e-matching --no-quant-cf --full-saturate-quant
-  trywith 30 --full-saturate-quant --quant-ind
-  trywith 30 --decision=internal --simplification=none --no-inst-no-entail --no-quant-cf --full-saturate-quant
-  trywith 30 --decision=internal --full-saturate-quant
-  trywith 30 --term-db-mode=relevant --full-saturate-quant
-  trywith 30 --fs-interleave --full-saturate-quant
-  # finite model find 3min
-  trywith 30 --finite-model-find --mbqi=none
-  trywith 30 --finite-model-find --decision=internal
-  trywith 30 --finite-model-find --macros-quant --macros-quant-mode=all
-  trywith 30 --finite-model-find --uf-ss=no-minimal
-  trywith 60 --finite-model-find --fmf-inst-engine
-  # long runs 9min
-  trywith 240 --finite-model-find --decision=internal
+  # initial runs 2min
+  trywith 60 --simplification=none --full-saturate-quant
+  trywith 60 --no-e-matching --full-saturate-quant
+  # trigger selections 6min
+  trywith 60 --relevant-triggers --full-saturate-quant
+  trywith 60 --trigger-sel=max --full-saturate-quant
+  trywith 60 --multi-trigger-when-single --full-saturate-quant
+  trywith 60 --multi-trigger-when-single --multi-trigger-priority --full-saturate-quant
+  trywith 60 --multi-trigger-cache --full-saturate-quant
+  trywith 60 --no-multi-trigger-linear --full-saturate-quant
+  # other 8min
+  trywith 60 --pre-skolem-quant --full-saturate-quant
+  trywith 60 --inst-when=full --full-saturate-quant
+  trywith 60 --no-e-matching --no-quant-cf --full-saturate-quant
+  trywith 60 --full-saturate-quant --quant-ind
+  trywith 60 --decision=internal --simplification=none --no-inst-no-entail --no-quant-cf --full-saturate-quant
+  trywith 60 --decision=internal --full-saturate-quant
+  trywith 60 --term-db-mode=relevant --full-saturate-quant
+  trywith 60 --fs-interleave --full-saturate-quant
+  # finite model find 6min
+  trywith 60 --finite-model-find --mbqi=none
+  trywith 60 --finite-model-find --decision=internal
+  trywith 60 --finite-model-find --macros-quant --macros-quant-mode=all
+  trywith 60 --finite-model-find --uf-ss=no-minimal
+  trywith 120 --finite-model-find --fmf-inst-engine
+  # long runs 8min
+  trywith 480 --finite-model-find --decision=internal
   finishwith --full-saturate-quant
   ;;
 ABVFP|BVFP|FP)
@@ -89,33 +89,33 @@ ABVFP|BVFP|FP)
   ;;
 UFBV)
   # most problems in UFBV are essentially BV
-  trywith 300 --full-saturate-quant --decision=internal
-  trywith 300 --full-saturate-quant --cbqi-nested-qe --decision=internal
-  trywith 30 --full-saturate-quant --no-cbqi-innermost --global-negate
+  trywith 600 --full-saturate-quant --decision=internal
+  trywith 600 --full-saturate-quant --cbqi-nested-qe --decision=internal
+  trywith 60 --full-saturate-quant --no-cbqi-innermost --global-negate
   finishwith --finite-model-find
   ;;
 BV)
-  trywith 120 --full-saturate-quant
-  trywith 120 --full-saturate-quant --no-cbqi-innermost
-  trywith 300 --full-saturate-quant --cbqi-nested-qe --decision=internal
-  trywith 30 --full-saturate-quant --no-cbqi-bv
-  trywith 30 --full-saturate-quant --cbqi-bv-ineq=eq-slack
+  trywith 240 --full-saturate-quant
+  trywith 240 --full-saturate-quant --no-cbqi-innermost
+  trywith 600 --full-saturate-quant --cbqi-nested-qe --decision=internal
+  trywith 60 --full-saturate-quant --no-cbqi-bv
+  trywith 60 --full-saturate-quant --cbqi-bv-ineq=eq-slack
   # finish 10min
   finishwith --full-saturate-quant --no-cbqi-innermost --global-negate
   ;;
 LIA|LRA|NIA|NRA)
-  trywith 30 --full-saturate-quant --nl-ext-tplanes
-  trywith 300 --full-saturate-quant --no-cbqi-innermost
-  trywith 300 --full-saturate-quant --cbqi-nested-qe
+  trywith 60 --full-saturate-quant --nl-ext-tplanes
+  trywith 600 --full-saturate-quant --no-cbqi-innermost
+  trywith 600 --full-saturate-quant --cbqi-nested-qe
   finishwith --full-saturate-quant --cbqi-nested-qe --decision=internal
   ;;
 QF_AUFBV)
-  trywith 600
+  trywith 1200
   finishwith --decision=justification-stoponly
   ;;
 QF_ABV)
-  trywith 50 --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
-  trywith 500 --arrays-weak-equiv
+  trywith 100 --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
+  trywith 1000 --arrays-weak-equiv
   finishwith --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
   ;;
 QF_UFBV)
@@ -137,7 +137,7 @@ QF_AUFNIA)
   finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
   ;;
 QF_ALIA)
-  trywith 70 --decision=justification --arrays-weak-equiv
+  trywith 140 --decision=justification --arrays-weak-equiv
   finishwith --decision=justification-stoponly --no-arrays-eager-index --arrays-eager-lemmas
   ;;
 QF_S|QF_SLIA)


### PR DESCRIPTION
This year's timeout is 40min up from 20min last year. This commit scales
the timeouts accordingly.