### PR TITLE
NA Tangent reverse implication

### DIFF
--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3361,45 +3361,52 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                   lemmas.push_back(tlem);
                 }
 
-		// tangent plane reverse implication
+                // tangent plane reverse implication
 
-		// t <= tplane -> ( (a <= a_v ^ b >= b_v) v (a >= a_v ^ b <= b_v) )
-		// in clause form, the above becomes
-		// t <= tplane -> a <= a_v v b <= b_v
-		// t <= tplane -> b >= b_v v a >= a_v
-		Node a_leq_av = NodeManager::currentNM()->mkNode(LEQ, a, a_v);
-		Node b_leq_bv = NodeManager::currentNM()->mkNode(LEQ, b, b_v);
-		Node a_geq_av = NodeManager::currentNM()->mkNode(GEQ, a, a_v);
-		Node b_geq_bv = NodeManager::currentNM()->mkNode(GEQ, b, b_v);
+                // t <= tplane -> ( (a <= a_v ^ b >= b_v) v (a >= a_v ^ b <=
+                // b_v) ) in clause form, the above becomes t <= tplane -> a <=
+                // a_v v b <= b_v t <= tplane -> b >= b_v v a >= a_v
+                Node a_leq_av = NodeManager::currentNM()->mkNode(LEQ, a, a_v);
+                Node b_leq_bv = NodeManager::currentNM()->mkNode(LEQ, b, b_v);
+                Node a_geq_av = NodeManager::currentNM()->mkNode(GEQ, a, a_v);
+                Node b_geq_bv = NodeManager::currentNM()->mkNode(GEQ, b, b_v);
 
-		Node t_leq_tplane = NodeManager::currentNM()->mkNode(LEQ, t, tplane);
-		Node a_leq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_leq_bv);
-		Node b_geq_bv_or_a_geq_av = NodeManager::currentNM()->mkNode(OR, b_geq_bv, a_geq_av);
-		Node ub_reverse1 = NodeManager::currentNM()->mkNode(OR, t_leq_tplane.negate(), a_leq_av_or_b_leq_bv);
+                Node t_leq_tplane =
+                    NodeManager::currentNM()->mkNode(LEQ, t, tplane);
+                Node a_leq_av_or_b_leq_bv =
+                    NodeManager::currentNM()->mkNode(OR, a_leq_av, b_leq_bv);
+                Node b_geq_bv_or_a_geq_av =
+                    NodeManager::currentNM()->mkNode(OR, b_geq_bv, a_geq_av);
+                Node ub_reverse1 = NodeManager::currentNM()->mkNode(
+                    OR, t_leq_tplane.negate(), a_leq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
-                      << "Tangent plane lemma : " << ub_reverse1 << std::endl;
- 		lemmas.push_back(ub_reverse1);
-		Node ub_reverse2 = NodeManager::currentNM()->mkNode(OR, t_leq_tplane.negate(), b_geq_bv_or_a_geq_av);
+                    << "Tangent plane lemma : " << ub_reverse1 << std::endl;
+                lemmas.push_back(ub_reverse1);
+                Node ub_reverse2 = NodeManager::currentNM()->mkNode(
+                    OR, t_leq_tplane.negate(), b_geq_bv_or_a_geq_av);
                 Trace("nl-ext-tplanes")
-                      << "Tangent plane lemma : " << ub_reverse2 << std::endl;
-		lemmas.push_back(ub_reverse2);
+                    << "Tangent plane lemma : " << ub_reverse2 << std::endl;
+                lemmas.push_back(ub_reverse2);
 
-		
-		// t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >= b_v) )
-		// in clause form, the above becomes
-		// t >= tplane -> a <= a_v v b >= b_v
-		// t >= tplane -> b >= b_v v a <= a_v
-		Node t_geq_tplane = NodeManager::currentNM()->mkNode(GEQ, t, tplane);
-		Node a_leq_av_or_b_geq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_geq_bv);
-		Node a_geq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_geq_av, b_leq_bv);
-		Node lb_reverse1 = NodeManager::currentNM()->mkNode(OR, t_geq_tplane.negate(), a_leq_av_or_b_geq_bv);
+                // t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >=
+                // b_v) ) in clause form, the above becomes t >= tplane -> a <=
+                // a_v v b >= b_v t >= tplane -> b >= b_v v a <= a_v
+                Node t_geq_tplane =
+                    NodeManager::currentNM()->mkNode(GEQ, t, tplane);
+                Node a_leq_av_or_b_geq_bv =
+                    NodeManager::currentNM()->mkNode(OR, a_leq_av, b_geq_bv);
+                Node a_geq_av_or_b_leq_bv =
+                    NodeManager::currentNM()->mkNode(OR, a_geq_av, b_leq_bv);
+                Node lb_reverse1 = NodeManager::currentNM()->mkNode(
+                    OR, t_geq_tplane.negate(), a_leq_av_or_b_geq_bv);
                 Trace("nl-ext-tplanes")
-                      << "Tangent plane lemma : " << lb_reverse1 << std::endl;
-		lemmas.push_back(lb_reverse1);
-		Node lb_reverse2 = NodeManager::currentNM()->mkNode(OR, t_geq_tplane.negate(), a_geq_av_or_b_leq_bv);
+                    << "Tangent plane lemma : " << lb_reverse1 << std::endl;
+                lemmas.push_back(lb_reverse1);
+                Node lb_reverse2 = NodeManager::currentNM()->mkNode(
+                    OR, t_geq_tplane.negate(), a_geq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
-                      << "Tangent plane lemma : " << lb_reverse2 << std::endl;
-		lemmas.push_back(lb_reverse2);
+                    << "Tangent plane lemma : " << lb_reverse2 << std::endl;
+                lemmas.push_back(lb_reverse2);
               }
             }
           }

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3383,6 +3383,7 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << ub_reverse2 << std::endl;
 		lemmas.push_back(ub_reverse2);
+
 		
 		// t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >= b_v) )
 		// in clause form, the above becomes

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3375,11 +3375,11 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
 		Node t_leq_tplane = NodeManager::currentNM()->mkNode(LEQ, t, tplane);
 		Node a_leq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_leq_bv);
 		Node b_geq_bv_or_a_geq_av = NodeManager::currentNM()->mkNode(OR, b_geq_bv, a_geq_av);
-		Node ub_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, a_leq_av_or_b_leq_bv);
+		Node ub_reverse1 = NodeManager::currentNM()->mkNode(OR, t_leq_tplane.negate(), a_leq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << ub_reverse1 << std::endl;
  		lemmas.push_back(ub_reverse1);
-		Node ub_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, b_geq_bv_or_a_geq_av);
+		Node ub_reverse2 = NodeManager::currentNM()->mkNode(OR, t_leq_tplane.negate(), b_geq_bv_or_a_geq_av);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << ub_reverse2 << std::endl;
 		lemmas.push_back(ub_reverse2);
@@ -3392,11 +3392,11 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
 		Node t_geq_tplane = NodeManager::currentNM()->mkNode(GEQ, t, tplane);
 		Node a_leq_av_or_b_geq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_geq_bv);
 		Node a_geq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_geq_av, b_leq_bv);
-		Node lb_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_leq_av_or_b_geq_bv);
+		Node lb_reverse1 = NodeManager::currentNM()->mkNode(OR, t_geq_tplane.negate(), a_leq_av_or_b_geq_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << lb_reverse1 << std::endl;
 		lemmas.push_back(lb_reverse1);
-		Node lb_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_geq_av_or_b_leq_bv);
+		Node lb_reverse2 = NodeManager::currentNM()->mkNode(OR, t_geq_tplane.negate(), a_geq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << lb_reverse2 << std::endl;
 		lemmas.push_back(lb_reverse2);

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3361,42 +3361,45 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                   lemmas.push_back(tlem);
                 }
 
-		// tangent plane reverse implication
-
-		// t <= tplane -> ( (a <= a_v ^ b >= b_v) v (a >= a_v ^ b <= b_v) )
+		// tangent plane reverse implication (strict version).
+		// the strict version can also be used for the above lemmas
+		// but doing so will result in less instantiation of the above lemmas
+		// because the precondition on the variables values
+		
+		// t < tplane -> ( (a < a_v ^ b > b_v) v (a > a_v ^ b < b_v) )
 		// in clause form, the above becomes
-		// t <= tplane -> a <= a_v v b <= b_v
-		// t <= tplane -> b >= b_v v a >= a_v
-		Node a_leq_av = NodeManager::currentNM()->mkNode(LEQ, a, a_v);
-		Node b_leq_bv = NodeManager::currentNM()->mkNode(LEQ, b, b_v);
-		Node a_geq_av = NodeManager::currentNM()->mkNode(GEQ, a, a_v);
-		Node b_geq_bv = NodeManager::currentNM()->mkNode(GEQ, b, b_v);
+		// t < tplane -> a < a_v v b < b_v
+		// t < tplane -> b > b_v v a > a_v
+		Node a_l_av = NodeManager::currentNM()->mkNode(LT, a, a_v);
+		Node b_l_bv = NodeManager::currentNM()->mkNode(LT, b, b_v);
+		Node a_g_av = NodeManager::currentNM()->mkNode(GT, a, a_v);
+		Node b_g_bv = NodeManager::currentNM()->mkNode(GT, b, b_v);
 
-		Node t_leq_tplane = NodeManager::currentNM()->mkNode(LEQ, t, tplane);
-		Node a_leq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_leq_bv);
-		Node b_geq_bv_or_a_geq_av = NodeManager::currentNM()->mkNode(OR, b_geq_bv, a_geq_av);
-		Node ub_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, a_leq_av_or_b_leq_bv);
+		Node t_l_tplane = NodeManager::currentNM()->mkNode(LT, t, tplane);
+		Node a_l_av_or_b_l_bv = NodeManager::currentNM()->mkNode(OR, a_l_av, b_l_bv);
+		Node b_g_bv_or_a_g_av = NodeManager::currentNM()->mkNode(OR, b_g_bv, a_g_av);
+		Node ub_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_l_tplane, a_l_av_or_b_l_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << ub_reverse1 << std::endl;
  		lemmas.push_back(ub_reverse1);
-		Node ub_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, b_geq_bv_or_a_geq_av);
+		Node ub_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_l_tplane, b_g_bv_or_a_g_av);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << ub_reverse2 << std::endl;
 		lemmas.push_back(ub_reverse2);
 
 		
-		// t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >= b_v) )
+		// t > tplane -> ( (a < a_v ^ b < b_v) v (a > a_v ^ b > b_v) )
 		// in clause form, the above becomes
-		// t >= tplane -> a <= a_v v b >= b_v
-		// t >= tplane -> b >= b_v v a <= a_v
-		Node t_geq_tplane = NodeManager::currentNM()->mkNode(GEQ, t, tplane);
-		Node a_leq_av_or_b_geq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_geq_bv);
-		Node a_geq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_geq_av, b_leq_bv);
-		Node lb_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_leq_av_or_b_geq_bv);
+		// t > tplane -> a < a_v v b > b_v
+		// t > tplane -> b > b_v v a < a_v
+		Node t_g_tplane = NodeManager::currentNM()->mkNode(GT, t, tplane);
+		Node a_l_av_or_b_g_bv = NodeManager::currentNM()->mkNode(OR, a_l_av, b_g_bv);
+		Node a_g_av_or_b_l_bv = NodeManager::currentNM()->mkNode(OR, a_g_av, b_l_bv);
+		Node lb_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_g_tplane, a_l_av_or_b_g_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << lb_reverse1 << std::endl;
 		lemmas.push_back(lb_reverse1);
-		Node lb_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_geq_av_or_b_leq_bv);
+		Node lb_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_g_tplane, a_g_av_or_b_l_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << lb_reverse2 << std::endl;
 		lemmas.push_back(lb_reverse2);

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3363,9 +3363,11 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
 
                 // tangent plane reverse implication
 
-                // t <= tplane -> ( (a <= a_v ^ b >= b_v) v (a >= a_v ^ b <=
-                // b_v) ) in clause form, the above becomes t <= tplane -> a <=
-                // a_v v b <= b_v t <= tplane -> b >= b_v v a >= a_v
+                // t <= tplane -> ( (a <= a_v ^ b >= b_v) v
+                // (a >= a_v ^ b <= b_v) ).
+                // in clause form, the above becomes
+                // t <= tplane -> a <= a_v v b <= b_v.
+                // t <= tplane -> b >= b_v v a >= a_v.
                 Node a_leq_av = NodeManager::currentNM()->mkNode(LEQ, a, a_v);
                 Node b_leq_bv = NodeManager::currentNM()->mkNode(LEQ, b, b_v);
                 Node a_geq_av = NodeManager::currentNM()->mkNode(GEQ, a, a_v);
@@ -3380,12 +3382,14 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                 Node ub_reverse1 = NodeManager::currentNM()->mkNode(
                     OR, t_leq_tplane.negate(), a_leq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
-                    << "Tangent plane lemma : " << ub_reverse1 << std::endl;
+                    << "Tangent plane lemma (reverse) : " << ub_reverse1
+                    << std::endl;
                 lemmas.push_back(ub_reverse1);
                 Node ub_reverse2 = NodeManager::currentNM()->mkNode(
                     OR, t_leq_tplane.negate(), b_geq_bv_or_a_geq_av);
                 Trace("nl-ext-tplanes")
-                    << "Tangent plane lemma : " << ub_reverse2 << std::endl;
+                    << "Tangent plane lemma (reverse) : " << ub_reverse2
+                    << std::endl;
                 lemmas.push_back(ub_reverse2);
 
                 // t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >=
@@ -3400,12 +3404,14 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                 Node lb_reverse1 = NodeManager::currentNM()->mkNode(
                     OR, t_geq_tplane.negate(), a_leq_av_or_b_geq_bv);
                 Trace("nl-ext-tplanes")
-                    << "Tangent plane lemma : " << lb_reverse1 << std::endl;
+                    << "Tangent plane lemma (reverse) : " << lb_reverse1
+                    << std::endl;
                 lemmas.push_back(lb_reverse1);
                 Node lb_reverse2 = NodeManager::currentNM()->mkNode(
                     OR, t_geq_tplane.negate(), a_geq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
-                    << "Tangent plane lemma : " << lb_reverse2 << std::endl;
+                    << "Tangent plane lemma (reverse) : " << lb_reverse2
+                    << std::endl;
                 lemmas.push_back(lb_reverse2);
               }
             }

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3360,6 +3360,45 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                       << "Tangent plane lemma : " << tlem << std::endl;
                   lemmas.push_back(tlem);
                 }
+
+		// tangent plane reverse implication
+
+		// t <= tplane -> ( (a <= a_v ^ b >= b_v) v (a >= a_v ^ b <= b_v) )
+		// in clause form, the above becomes
+		// t <= tplane -> a <= a_v v b <= b_v
+		// t <= tplane -> b >= b_v v a >= a_v
+		Node a_leq_av = NodeManager::currentNM()->mkNode(LEQ, a, a_v);
+		Node b_leq_bv = NodeManager::currentNM()->mkNode(LEQ, b, b_v);
+		Node a_geq_av = NodeManager::currentNM()->mkNode(GEQ, a, a_v);
+		Node b_geq_bv = NodeManager::currentNM()->mkNode(GEQ, b, b_v);
+
+		Node t_leq_tplane = NodeManager::currentNM()->mkNode(LEQ, t, tplane);
+		Node a_leq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_leq_bv);
+		Node b_geq_bv_or_a_geq_av = NodeManager::currentNM()->mkNode(OR, b_geq_bv, a_geq_av);
+		Node ub_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, a_leq_av_or_b_leq_bv);
+                Trace("nl-ext-tplanes")
+                      << "Tangent plane lemma : " << ub_reverse1 << std::endl;
+ 		lemmas.push_back(ub_reverse1);
+		Node ub_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, b_geq_bv_or_a_geq_av);
+                Trace("nl-ext-tplanes")
+                      << "Tangent plane lemma : " << ub_reverse2 << std::endl;
+		lemmas.push_back(ub_reverse2);
+		
+		// t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >= b_v) )
+		// in clause form, the above becomes
+		// t >= tplane -> a <= a_v v b >= b_v
+		// t >= tplane -> b >= b_v v a <= a_v
+		Node t_geq_tplane = NodeManager::currentNM()->mkNode(GEQ, t, tplane);
+		Node a_leq_av_or_b_geq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_geq_bv);
+		Node a_geq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_geq_av, b_leq_bv);
+		Node lb_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_leq_av_or_b_geq_bv);
+                Trace("nl-ext-tplanes")
+                      << "Tangent plane lemma : " << lb_reverse1 << std::endl;
+		lemmas.push_back(lb_reverse1);
+		Node lb_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_geq_av_or_b_leq_bv);
+                Trace("nl-ext-tplanes")
+                      << "Tangent plane lemma : " << lb_reverse2 << std::endl;
+		lemmas.push_back(lb_reverse2);
               }
             }
           }

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3361,45 +3361,42 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                   lemmas.push_back(tlem);
                 }
 
-		// tangent plane reverse implication (strict version).
-		// the strict version can also be used for the above lemmas
-		// but doing so will result in less instantiation of the above lemmas
-		// because the precondition on the variables values
-		
-		// t < tplane -> ( (a < a_v ^ b > b_v) v (a > a_v ^ b < b_v) )
-		// in clause form, the above becomes
-		// t < tplane -> a < a_v v b < b_v
-		// t < tplane -> b > b_v v a > a_v
-		Node a_l_av = NodeManager::currentNM()->mkNode(LT, a, a_v);
-		Node b_l_bv = NodeManager::currentNM()->mkNode(LT, b, b_v);
-		Node a_g_av = NodeManager::currentNM()->mkNode(GT, a, a_v);
-		Node b_g_bv = NodeManager::currentNM()->mkNode(GT, b, b_v);
+		// tangent plane reverse implication
 
-		Node t_l_tplane = NodeManager::currentNM()->mkNode(LT, t, tplane);
-		Node a_l_av_or_b_l_bv = NodeManager::currentNM()->mkNode(OR, a_l_av, b_l_bv);
-		Node b_g_bv_or_a_g_av = NodeManager::currentNM()->mkNode(OR, b_g_bv, a_g_av);
-		Node ub_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_l_tplane, a_l_av_or_b_l_bv);
+		// t <= tplane -> ( (a <= a_v ^ b >= b_v) v (a >= a_v ^ b <= b_v) )
+		// in clause form, the above becomes
+		// t <= tplane -> a <= a_v v b <= b_v
+		// t <= tplane -> b >= b_v v a >= a_v
+		Node a_leq_av = NodeManager::currentNM()->mkNode(LEQ, a, a_v);
+		Node b_leq_bv = NodeManager::currentNM()->mkNode(LEQ, b, b_v);
+		Node a_geq_av = NodeManager::currentNM()->mkNode(GEQ, a, a_v);
+		Node b_geq_bv = NodeManager::currentNM()->mkNode(GEQ, b, b_v);
+
+		Node t_leq_tplane = NodeManager::currentNM()->mkNode(LEQ, t, tplane);
+		Node a_leq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_leq_bv);
+		Node b_geq_bv_or_a_geq_av = NodeManager::currentNM()->mkNode(OR, b_geq_bv, a_geq_av);
+		Node ub_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, a_leq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << ub_reverse1 << std::endl;
  		lemmas.push_back(ub_reverse1);
-		Node ub_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_l_tplane, b_g_bv_or_a_g_av);
+		Node ub_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_leq_tplane, b_geq_bv_or_a_geq_av);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << ub_reverse2 << std::endl;
 		lemmas.push_back(ub_reverse2);
 
 		
-		// t > tplane -> ( (a < a_v ^ b < b_v) v (a > a_v ^ b > b_v) )
+		// t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >= b_v) )
 		// in clause form, the above becomes
-		// t > tplane -> a < a_v v b > b_v
-		// t > tplane -> b > b_v v a < a_v
-		Node t_g_tplane = NodeManager::currentNM()->mkNode(GT, t, tplane);
-		Node a_l_av_or_b_g_bv = NodeManager::currentNM()->mkNode(OR, a_l_av, b_g_bv);
-		Node a_g_av_or_b_l_bv = NodeManager::currentNM()->mkNode(OR, a_g_av, b_l_bv);
-		Node lb_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_g_tplane, a_l_av_or_b_g_bv);
+		// t >= tplane -> a <= a_v v b >= b_v
+		// t >= tplane -> b >= b_v v a <= a_v
+		Node t_geq_tplane = NodeManager::currentNM()->mkNode(GEQ, t, tplane);
+		Node a_leq_av_or_b_geq_bv = NodeManager::currentNM()->mkNode(OR, a_leq_av, b_geq_bv);
+		Node a_geq_av_or_b_leq_bv = NodeManager::currentNM()->mkNode(OR, a_geq_av, b_leq_bv);
+		Node lb_reverse1 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_leq_av_or_b_geq_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << lb_reverse1 << std::endl;
 		lemmas.push_back(lb_reverse1);
-		Node lb_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_g_tplane, a_g_av_or_b_l_bv);
+		Node lb_reverse2 = NodeManager::currentNM()->mkNode(IMPLIES, t_geq_tplane, a_geq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << lb_reverse2 << std::endl;
 		lemmas.push_back(lb_reverse2);

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3392,9 +3392,11 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                     << std::endl;
                 lemmas.push_back(ub_reverse2);
 
-                // t >= tplane -> ( (a <= a_v ^ b <= b_v) v (a >= a_v ^ b >=
-                // b_v) ) in clause form, the above becomes t >= tplane -> a <=
-                // a_v v b >= b_v t >= tplane -> b >= b_v v a <= a_v
+                // t >= tplane -> ( (a <= a_v ^ b <= b_v) v
+                // (a >= a_v ^ b >= b_v) ).
+                // in clause form, the above becomes
+                // t >= tplane -> a <= a_v v b >= b_v.
+                // t >= tplane -> b >= b_v v a <= a_v
                 Node t_geq_tplane =
                     NodeManager::currentNM()->mkNode(GEQ, t, tplane);
                 Node a_leq_av_or_b_geq_bv =

--- a/src/theory/arith/nonlinear_extension.cpp
+++ b/src/theory/arith/nonlinear_extension.cpp
@@ -3282,6 +3282,7 @@ std::vector<Node> NonlinearExtension::checkMonomialMagnitude( unsigned c ) {
 std::vector<Node> NonlinearExtension::checkTangentPlanes() {
   std::vector< Node > lemmas;
   Trace("nl-ext") << "Get monomial tangent plane lemmas..." << std::endl;
+  NodeManager* nm = NodeManager::currentNM();
   unsigned kstart = d_ms_vars.size();
   for (unsigned k = kstart; k < d_mterms.size(); k++) {
     Node t = d_mterms[k];
@@ -3321,7 +3322,8 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                   Node pt_v = d_tangent_val_bound[p][a][b];
                   Assert( !pt_v.isNull() );
                   if( curr_v!=pt_v ){
-                    Node do_extend = NodeManager::currentNM()->mkNode( ( p==1 || p==3 ) ? GT : LT, curr_v, pt_v );
+                    Node do_extend =
+                        nm->mkNode((p == 1 || p == 3) ? GT : LT, curr_v, pt_v);
                     do_extend = Rewriter::rewrite( do_extend );
                     if( do_extend==d_true ){
                       for( unsigned q=0; q<2; q++ ){
@@ -3340,22 +3342,16 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                 Node b_v = pts[1][p];
               
                 // tangent plane
-                Node tplane = NodeManager::currentNM()->mkNode(
-                    MINUS,
-                    NodeManager::currentNM()->mkNode(
-                        PLUS,
-                        NodeManager::currentNM()->mkNode(MULT, b_v, a),
-                        NodeManager::currentNM()->mkNode(MULT, a_v, b)),
-                    NodeManager::currentNM()->mkNode(MULT, a_v, b_v));
+                Node tplane = nm->mkNode(MINUS,
+                                         nm->mkNode(PLUS,
+                                                    nm->mkNode(MULT, b_v, a),
+                                                    nm->mkNode(MULT, a_v, b)),
+                                         nm->mkNode(MULT, a_v, b_v));
                 for (unsigned d = 0; d < 4; d++) {
-                  Node aa = NodeManager::currentNM()->mkNode(
-                      d == 0 || d == 3 ? GEQ : LEQ, a, a_v);
-                  Node ab = NodeManager::currentNM()->mkNode(
-                      d == 1 || d == 3 ? GEQ : LEQ, b, b_v);
-                  Node conc = NodeManager::currentNM()->mkNode(
-                      d <= 1 ? LEQ : GEQ, t, tplane);
-                  Node tlem = NodeManager::currentNM()->mkNode(
-                      OR, aa.negate(), ab.negate(), conc);
+                  Node aa = nm->mkNode(d == 0 || d == 3 ? GEQ : LEQ, a, a_v);
+                  Node ab = nm->mkNode(d == 1 || d == 3 ? GEQ : LEQ, b, b_v);
+                  Node conc = nm->mkNode(d <= 1 ? LEQ : GEQ, t, tplane);
+                  Node tlem = nm->mkNode(OR, aa.negate(), ab.negate(), conc);
                   Trace("nl-ext-tplanes")
                       << "Tangent plane lemma : " << tlem << std::endl;
                   lemmas.push_back(tlem);
@@ -3368,25 +3364,22 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                 // in clause form, the above becomes
                 // t <= tplane -> a <= a_v v b <= b_v.
                 // t <= tplane -> b >= b_v v a >= a_v.
-                Node a_leq_av = NodeManager::currentNM()->mkNode(LEQ, a, a_v);
-                Node b_leq_bv = NodeManager::currentNM()->mkNode(LEQ, b, b_v);
-                Node a_geq_av = NodeManager::currentNM()->mkNode(GEQ, a, a_v);
-                Node b_geq_bv = NodeManager::currentNM()->mkNode(GEQ, b, b_v);
+                Node a_leq_av = nm->mkNode(LEQ, a, a_v);
+                Node b_leq_bv = nm->mkNode(LEQ, b, b_v);
+                Node a_geq_av = nm->mkNode(GEQ, a, a_v);
+                Node b_geq_bv = nm->mkNode(GEQ, b, b_v);
 
-                Node t_leq_tplane =
-                    NodeManager::currentNM()->mkNode(LEQ, t, tplane);
-                Node a_leq_av_or_b_leq_bv =
-                    NodeManager::currentNM()->mkNode(OR, a_leq_av, b_leq_bv);
-                Node b_geq_bv_or_a_geq_av =
-                    NodeManager::currentNM()->mkNode(OR, b_geq_bv, a_geq_av);
-                Node ub_reverse1 = NodeManager::currentNM()->mkNode(
-                    OR, t_leq_tplane.negate(), a_leq_av_or_b_leq_bv);
+                Node t_leq_tplane = nm->mkNode(LEQ, t, tplane);
+                Node a_leq_av_or_b_leq_bv = nm->mkNode(OR, a_leq_av, b_leq_bv);
+                Node b_geq_bv_or_a_geq_av = nm->mkNode(OR, b_geq_bv, a_geq_av);
+                Node ub_reverse1 =
+                    nm->mkNode(OR, t_leq_tplane.negate(), a_leq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
                     << "Tangent plane lemma (reverse) : " << ub_reverse1
                     << std::endl;
                 lemmas.push_back(ub_reverse1);
-                Node ub_reverse2 = NodeManager::currentNM()->mkNode(
-                    OR, t_leq_tplane.negate(), b_geq_bv_or_a_geq_av);
+                Node ub_reverse2 =
+                    nm->mkNode(OR, t_leq_tplane.negate(), b_geq_bv_or_a_geq_av);
                 Trace("nl-ext-tplanes")
                     << "Tangent plane lemma (reverse) : " << ub_reverse2
                     << std::endl;
@@ -3397,20 +3390,17 @@ std::vector<Node> NonlinearExtension::checkTangentPlanes() {
                 // in clause form, the above becomes
                 // t >= tplane -> a <= a_v v b >= b_v.
                 // t >= tplane -> b >= b_v v a <= a_v
-                Node t_geq_tplane =
-                    NodeManager::currentNM()->mkNode(GEQ, t, tplane);
-                Node a_leq_av_or_b_geq_bv =
-                    NodeManager::currentNM()->mkNode(OR, a_leq_av, b_geq_bv);
-                Node a_geq_av_or_b_leq_bv =
-                    NodeManager::currentNM()->mkNode(OR, a_geq_av, b_leq_bv);
-                Node lb_reverse1 = NodeManager::currentNM()->mkNode(
-                    OR, t_geq_tplane.negate(), a_leq_av_or_b_geq_bv);
+                Node t_geq_tplane = nm->mkNode(GEQ, t, tplane);
+                Node a_leq_av_or_b_geq_bv = nm->mkNode(OR, a_leq_av, b_geq_bv);
+                Node a_geq_av_or_b_leq_bv = nm->mkNode(OR, a_geq_av, b_leq_bv);
+                Node lb_reverse1 =
+                    nm->mkNode(OR, t_geq_tplane.negate(), a_leq_av_or_b_geq_bv);
                 Trace("nl-ext-tplanes")
                     << "Tangent plane lemma (reverse) : " << lb_reverse1
                     << std::endl;
                 lemmas.push_back(lb_reverse1);
-                Node lb_reverse2 = NodeManager::currentNM()->mkNode(
-                    OR, t_geq_tplane.negate(), a_geq_av_or_b_leq_bv);
+                Node lb_reverse2 =
+                    nm->mkNode(OR, t_geq_tplane.negate(), a_geq_av_or_b_leq_bv);
                 Trace("nl-ext-tplanes")
                     << "Tangent plane lemma (reverse) : " << lb_reverse2
                     << std::endl;


### PR DESCRIPTION
This PR adds additional tangent plane lemmas (reverse implication: FROM the comparison between a tangent plane and a multiplication TO bounds on the multiplicands).

We have run a small test on QF_NIA benchmarks with 60sec timeout. (Thanks to @yoni206 )
These additional lemmas helped to solve about 250 more benchmarks. 

![image](https://user-images.githubusercontent.com/43099566/59226762-97cb3180-8b88-11e9-82bf-80e559db2767.png)
