### PR TITLE
 Fix spurious assertion in get-value

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4201,7 +4201,9 @@ Expr SmtEngine::getValue(const Expr& ex) const
   Trace("smt") << "--- model-post expected " << expectedType << endl;
 
   // type-check the result we got
-  Assert(resultNode.isNull() || resultNode.getType().isSubtypeOf(expectedType),
+  // Notice that lambdas have function type, which does not respect the subtype
+  // relation, so we ignore them here.
+  Assert(resultNode.isNull() || resultNode.getKind() == kind::LAMBDA || resultNode.getType().isSubtypeOf(expectedType),
          "Run with -t smt for details.");
 
   // ensure it's a constant

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4203,7 +4203,8 @@ Expr SmtEngine::getValue(const Expr& ex) const
   // type-check the result we got
   // Notice that lambdas have function type, which does not respect the subtype
   // relation, so we ignore them here.
-  Assert(resultNode.isNull() || resultNode.getKind() == kind::LAMBDA || resultNode.getType().isSubtypeOf(expectedType),
+  Assert(resultNode.isNull() || resultNode.getKind() == kind::LAMBDA
+             || resultNode.getType().isSubtypeOf(expectedType),
          "Run with -t smt for details.");
 
   // ensure it's a constant


### PR DESCRIPTION
CVC4 was complaining that `lambda x : U. 0` was given as a model for a function of type U -> Real since U -> Int is not a subtype of U -> Real.  This is a spurious failure.