### PR TITLE
Use Ubuntu 16.04 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
   - libcln-dev
   - libgmp-dev
   - libhamcrest-java
-  - openjdk-7-jdk
+  - openjdk-8-jdk
   - swig3.0
 before_install:
  - eval "${MATRIX_EVAL}"
@@ -37,7 +37,7 @@ before_install:
      sudo ln -s $(which ccache) /usr/lib/ccache/clang++
    fi
 before_script:
-  export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+  export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 script:
  - ccache -M 1G
  - ccache -z

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
-# Fix Travis write errors on Clang builds. These write errors occurred after
-# a Travis update to new Trusty images on Dec. 12th 2017. The reason for these
-# write errors is unknown. Using the deprecated builds did not fix the problem.
-# Setting 'filter_secrets: false' as suggested here
-# https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-321777557
-# fixes the problem.
-filter_secrets: false
-
 language: cpp
 cache:
  - apt
  - ccache
 
 sudo: false
-dist: trusty
 
 env:
  global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
  - ccache
 
 sudo: false
+dist: xenial
 
 env:
  global:


### PR DESCRIPTION
Travis has started to switch to Ubuntu 16.04 [0]. We were explicitly
specifying 14.04 as the `dist` in our `.travis.yml`. This commit changes
that specification to 16.04, updates the Java version, and removes
a workaround for an old Travis issue.

[0] https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476