### PR TITLE
Fix memory leak in unit test

### DIFF
--- a/test/unit/parser/parser_black.h
+++ b/test/unit/parser/parser_black.h
@@ -141,7 +141,8 @@ class ParserBlack
       if (d_lang == LANG_SMTLIB_V2)
       {
         // Use QF_LIA to make multiplication ("*") available
-        static_cast<Smt2*>(parser)->setLogic("QF_LIA");
+        std::unique_ptr<Command> cmd(
+            static_cast<Smt2*>(parser)->setLogic("QF_LIA"));
       }
 
       TS_ASSERT(!parser->done());


### PR DESCRIPTION
PR #3062 changed `Smt2::setLogic()` to return a heap-allocated command,
which didn't get cleaned up by our `parser_black` unit test. This commit
fixes the memory leak.

This should fix the nightlies.