### PR TITLE
Optimize DRAT optimization: clause matching

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,6 +219,7 @@ libcvc4_add_sources(
   prop/sat_solver_factory.cpp
   prop/sat_solver_factory.h
   prop/bv_sat_solver_notify.h
+  prop/sat_solver_types.cpp
   prop/sat_solver_types.h
   prop/theory_proxy.cpp
   prop/theory_proxy.h

--- a/src/proof/clausal_bitvector_proof.cpp
+++ b/src/proof/clausal_bitvector_proof.cpp
@@ -135,7 +135,7 @@ void ClausalBitVectorProof::optimizeDratProof()
           == theory::bv::BvOptimizeSatProof::BITVECTOR_OPTIMIZE_SAT_PROOF_PROOF
       || options::bvOptimizeSatProof()
              == theory::bv::BvOptimizeSatProof::
-                 BITVECTOR_OPTIMIZE_SAT_PROOF_FORMULA)
+                    BITVECTOR_OPTIMIZE_SAT_PROOF_FORMULA)
   {
     Debug("bv::clausal") << "Optimizing DRAT" << std::endl;
     std::string formulaFilename("cvc4-dimacs-XXXXXX");
@@ -379,13 +379,13 @@ void LfscLratBitVectorProof::printEmptyClauseProof(std::ostream& os,
   os << "(@ lratProof ";
   paren << ")";
   d_dratTranslationStatistics.d_totalTime.start();
-  std::pair<lrat::LratProof, TimerStat> pfAndToolTimer =
-      lrat::LratProof::fromDratProof(
-          d_clauses, d_coreClauseIndices, d_binaryDratProof.str());
+  lrat::LratProof pf =
+      lrat::LratProof::fromDratProof(d_clauses,
+                                     d_coreClauseIndices,
+                                     d_binaryDratProof.str(),
+                                     d_dratTranslationStatistics.d_toolTime);
   d_dratTranslationStatistics.d_totalTime.stop();
-  d_dratTranslationStatistics.d_toolTime.setData(
-      pfAndToolTimer.second.getData());
-  pfAndToolTimer.first.outputAsLfsc(os);
+  pf.outputAsLfsc(os);
   os << "\n";
 
   os << "\n;; Verification of DRAT Proof\n";
@@ -401,14 +401,14 @@ void LfscErBitVectorProof::printEmptyClauseProof(std::ostream& os,
          "bitblasting mode");
 
   d_dratTranslationStatistics.d_totalTime.start();
-  std::pair<er::ErProof, TimerStat> pfAndToolTimer =
-      er::ErProof::fromBinaryDratProof(
-          d_clauses, d_coreClauseIndices, d_binaryDratProof.str());
+  er::ErProof pf =
+      er::ErProof::fromBinaryDratProof(d_clauses,
+                                       d_coreClauseIndices,
+                                       d_binaryDratProof.str(),
+                                       d_dratTranslationStatistics.d_toolTime);
   d_dratTranslationStatistics.d_totalTime.stop();
-  d_dratTranslationStatistics.d_toolTime.setData(
-      pfAndToolTimer.second.getData());
 
-  pfAndToolTimer.first.outputAsLfsc(os);
+  pf.outputAsLfsc(os);
 }
 
 }  // namespace proof

--- a/src/proof/clausal_bitvector_proof.h
+++ b/src/proof/clausal_bitvector_proof.h
@@ -101,7 +101,8 @@ class ClausalBitVectorProof : public BitVectorProof
     TimerStat d_totalTime;
     // Time that drat-trim actually spent optimizing the DRAT proof/formula
     TimerStat d_toolTime;
-    // Time that drat-trim actually spent optimizing the DRAT proof/formula
+    // Time that was spent matching clauses in drat-trim's output to clauses in
+    // its input
     TimerStat d_clauseMatchingTime;
     // Bytes in binary DRAT proof before optimization
     IntStat d_initialDratSize;

--- a/src/proof/clausal_bitvector_proof.h
+++ b/src/proof/clausal_bitvector_proof.h
@@ -87,6 +87,10 @@ class ClausalBitVectorProof : public BitVectorProof
   // of clause actually needed to check that proof (a smaller UNSAT core)
   void optimizeDratProof();
 
+  // Given reference to a SAT clause encoded as a vector of literals, puts the
+  // literals into a canonical order
+  static void canonicalizeClause(prop::SatClause& clause);
+
   struct DratOptimizationStatistics
   {
     DratOptimizationStatistics();

--- a/src/proof/clausal_bitvector_proof.h
+++ b/src/proof/clausal_bitvector_proof.h
@@ -33,6 +33,7 @@
 #include "prop/cnf_stream.h"
 #include "prop/sat_solver_types.h"
 #include "theory/bv/theory_bv.h"
+#include "util/statistics_registry.h"
 
 namespace CVC4 {
 
@@ -67,10 +68,48 @@ class ClausalBitVectorProof : public BitVectorProof
   std::ostringstream d_binaryDratProof{};
   std::vector<ClauseId> d_coreClauseIndices{};
 
+  struct DratTranslationStatistics
+  {
+    DratTranslationStatistics();
+    ~DratTranslationStatistics();
+
+    // Total time spent doing translation (optimized binary DRAT -> in memory
+    // target format) (including IO, postprocessing, etc.)
+    TimerStat d_totalTime;
+    // Time that the external tool actually spent
+    TimerStat d_toolTime;
+  };
+
+  DratTranslationStatistics d_dratTranslationStatistics;
+
  private:
   // Optimizes the DRAT proof stored in `d_binaryDratProof` and returns a list
   // of clause actually needed to check that proof (a smaller UNSAT core)
   void optimizeDratProof();
+
+  struct DratOptimizationStatistics
+  {
+    DratOptimizationStatistics();
+    ~DratOptimizationStatistics();
+
+    // Total time spent using drat-trim to optimize the DRAT proof/formula
+    // (including IO, etc.)
+    TimerStat d_totalTime;
+    // Time that drat-trim actually spent optimizing the DRAT proof/formula
+    TimerStat d_toolTime;
+    // Time that drat-trim actually spent optimizing the DRAT proof/formula
+    TimerStat d_clauseMatchingTime;
+    // Bytes in binary DRAT proof before optimization
+    IntStat d_initialDratSize;
+    // Bytes in binary DRAT proof after optimization
+    IntStat d_optimizedDratSize;
+    // Bytes in textual DIMACS bitblasted formula before optimization
+    IntStat d_initialFormulaSize;
+    // Bytes in textual DIMACS bitblasted formula after optimization
+    IntStat d_optimizedFormulaSize;
+  };
+
+  DratOptimizationStatistics d_dratOptimizationStatistics;
 };
 
 /**

--- a/src/proof/clausal_bitvector_proof.h
+++ b/src/proof/clausal_bitvector_proof.h
@@ -74,7 +74,7 @@ class ClausalBitVectorProof : public BitVectorProof
     ~DratTranslationStatistics();
 
     // Total time spent doing translation (optimized binary DRAT -> in memory
-    // target format) (including IO, postprocessing, etc.)
+    // target format including IO, postprocessing, etc.)
     TimerStat d_totalTime;
     // Time that the external tool actually spent
     TimerStat d_toolTime;

--- a/src/proof/er/er_proof.h
+++ b/src/proof/er/er_proof.h
@@ -32,6 +32,7 @@
 
 #include "proof/clause_id.h"
 #include "prop/sat_solver_types.h"
+#include "util/statistics_registry.h"
 
 namespace CVC4 {
 namespace proof {
@@ -118,8 +119,10 @@ class ErProof
    * @param clauses A store of clauses that might be in our formula
    * @param usedIds the ids of clauses that are actually in our formula
    * @param dratBinary  The DRAT proof from the SAT solver, as a binary stream
+   *
+   * @return the Er proof and a timer of the execution of drat2er
    */
-  static ErProof fromBinaryDratProof(
+  static std::pair<ErProof, TimerStat> fromBinaryDratProof(
       const std::unordered_map<ClauseId, prop::SatClause>& clauses,
       const std::vector<ClauseId>& usedIds,
       const std::string& dratBinary);

--- a/src/proof/er/er_proof.h
+++ b/src/proof/er/er_proof.h
@@ -122,10 +122,12 @@ class ErProof
    *
    * @return the Er proof and a timer of the execution of drat2er
    */
-  static std::pair<ErProof, TimerStat> fromBinaryDratProof(
+  static ErProof fromBinaryDratProof(
       const std::unordered_map<ClauseId, prop::SatClause>& clauses,
       const std::vector<ClauseId>& usedIds,
-      const std::string& dratBinary);
+      const std::string& dratBinary,
+      TimerStat& toolTimer
+      );
 
   /**
    * Construct an ER proof from a TRACECHECK ER proof

--- a/src/proof/lrat/lrat_proof.h
+++ b/src/proof/lrat/lrat_proof.h
@@ -137,10 +137,11 @@ class LratProof
    *
    * @return an LRAT proof an a timer for how long it took to run drat-trim
    */
-  static std::pair<LratProof, TimerStat> fromDratProof(
+  static LratProof fromDratProof(
       const std::unordered_map<ClauseId, prop::SatClause>& clauses,
       const std::vector<ClauseId> usedIds,
-      const std::string& dratBinary);
+      const std::string& dratBinary,
+      TimerStat& toolTimer);
   /**
    * @brief Construct an LRAT proof from its textual representation
    *

--- a/src/proof/lrat/lrat_proof.h
+++ b/src/proof/lrat/lrat_proof.h
@@ -29,11 +29,13 @@
 #include <iosfwd>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "proof/clause_id.h"
 // Included because we need operator<< for the SAT types
 #include "prop/sat_solver.h"
+#include "util/statistics_registry.h"
 
 namespace CVC4 {
 namespace proof {
@@ -132,8 +134,10 @@ class LratProof
    * @param clauses A store of clauses that might be in our formula
    * @param usedIds the ids of clauses that are actually in our formula
    * @param dratBinary  The DRAT proof from the SAT solver, as a binary stream.
+   *
+   * @return an LRAT proof an a timer for how long it took to run drat-trim
    */
-  static LratProof fromDratProof(
+  static std::pair<LratProof, TimerStat> fromDratProof(
       const std::unordered_map<ClauseId, prop::SatClause>& clauses,
       const std::vector<ClauseId> usedIds,
       const std::string& dratBinary);

--- a/src/proof/proof_manager.cpp
+++ b/src/proof/proof_manager.cpp
@@ -562,198 +562,249 @@ void LFSCProof::toStream(std::ostream& out) const
 {
   TimerStat::CodeTimer proofProductionTimer(
       ProofManager::currentPM()->getStats().d_proofProductionTime);
-  ProofManager::currentPM()->getStats().d_skeletonProofTraceTime.start();
-  Assert(!d_satProof->proofConstructed());
-  d_satProof->constructProof();
 
-  // collecting leaf clauses in resolution proof
   IdToSatClause used_lemmas;
   IdToSatClause used_inputs;
-  d_satProof->collectClausesUsed(used_inputs,
-                                 used_lemmas);
+  std::set<Node> atoms;
+  NodePairSet rewrites;
+  NodeSet used_assertions;
 
-  IdToSatClause::iterator it2;
-  Debug("pf::pm") << std::endl << "Used inputs: " << std::endl;
-  for (it2 = used_inputs.begin(); it2 != used_inputs.end(); ++it2) {
-    Debug("pf::pm") << "\t input = " << *(it2->second) << std::endl;
-  }
-  Debug("pf::pm") << std::endl;
+  {
+    CodeTimer skeletonProofTimer{
+        ProofManager::currentPM()->getStats().d_skeletonProofTraceTime};
+    Assert(!d_satProof->proofConstructed());
+    d_satProof->constructProof();
 
-  // Debug("pf::pm") << std::endl << "Used lemmas: " << std::endl;
-  // for (it2 = used_lemmas.begin(); it2 != used_lemmas.end(); ++it2) {
-  //   Debug("pf::pm") << "\t lemma = " << *(it2->second) << std::endl;
-  // }
-  // Debug("pf::pm") << std::endl;
-  Debug("pf::pm") << std::endl << "Used lemmas: " << std::endl;
-  for (it2 = used_lemmas.begin(); it2 != used_lemmas.end(); ++it2) {
+    // collecting leaf clauses in resolution proof
+    d_satProof->collectClausesUsed(used_inputs, used_lemmas);
 
-    std::vector<Expr> clause_expr;
-    for(unsigned i = 0; i < it2->second->size(); ++i) {
-      prop::SatLiteral lit = (*(it2->second))[i];
-      Expr atom = d_cnfProof->getAtom(lit.getSatVariable()).toExpr();
-      if (atom.isConst()) {
-        Assert (atom == utils::mkTrue());
-        continue;
-      }
-      Expr expr_lit = lit.isNegated() ? atom.notExpr(): atom;
-      clause_expr.push_back(expr_lit);
-    }
-
-    Debug("pf::pm") << "\t lemma " << it2->first << " = " << *(it2->second) << std::endl;
-    Debug("pf::pm") << "\t";
-    for (unsigned i = 0; i < clause_expr.size(); ++i) {
-      Debug("pf::pm") << clause_expr[i] << " ";
+    IdToSatClause::iterator it2;
+    Debug("pf::pm") << std::endl << "Used inputs: " << std::endl;
+    for (it2 = used_inputs.begin(); it2 != used_inputs.end(); ++it2)
+    {
+      Debug("pf::pm") << "\t input = " << *(it2->second) << std::endl;
     }
     Debug("pf::pm") << std::endl;
-  }
-  Debug("pf::pm") << std::endl;
 
-  // collecting assertions that lead to the clauses being asserted
-  NodeSet used_assertions;
-  d_cnfProof->collectAssertionsForClauses(used_inputs, used_assertions);
+    // Debug("pf::pm") << std::endl << "Used lemmas: " << std::endl;
+    // for (it2 = used_lemmas.begin(); it2 != used_lemmas.end(); ++it2) {
+    //   Debug("pf::pm") << "\t lemma = " << *(it2->second) << std::endl;
+    // }
+    // Debug("pf::pm") << std::endl;
+    Debug("pf::pm") << std::endl << "Used lemmas: " << std::endl;
+    for (it2 = used_lemmas.begin(); it2 != used_lemmas.end(); ++it2)
+    {
+      std::vector<Expr> clause_expr;
+      for (unsigned i = 0; i < it2->second->size(); ++i)
+      {
+        prop::SatLiteral lit = (*(it2->second))[i];
+        Expr atom = d_cnfProof->getAtom(lit.getSatVariable()).toExpr();
+        if (atom.isConst())
+        {
+          Assert(atom == utils::mkTrue());
+          continue;
+        }
+        Expr expr_lit = lit.isNegated() ? atom.notExpr() : atom;
+        clause_expr.push_back(expr_lit);
+      }
 
-  NodeSet::iterator it3;
-  Debug("pf::pm") << std::endl << "Used assertions: " << std::endl;
-  for (it3 = used_assertions.begin(); it3 != used_assertions.end(); ++it3)
-    Debug("pf::pm") << "\t assertion = " << *it3 << std::endl;
-
-  std::set<Node> atoms;
-
-  NodePairSet rewrites;
-  // collects the atoms in the clauses
-  d_cnfProof->collectAtomsAndRewritesForLemmas(used_lemmas, atoms, rewrites);
-
-  if (!rewrites.empty()) {
-    Debug("pf::pm") << std::endl << "Rewrites used in lemmas: " << std::endl;
-    NodePairSet::const_iterator rewriteIt;
-    for (rewriteIt = rewrites.begin(); rewriteIt != rewrites.end(); ++rewriteIt) {
-      Debug("pf::pm") << "\t" << rewriteIt->first << " --> " << rewriteIt->second << std::endl;
+      Debug("pf::pm") << "\t lemma " << it2->first << " = " << *(it2->second)
+                      << std::endl;
+      Debug("pf::pm") << "\t";
+      for (unsigned i = 0; i < clause_expr.size(); ++i)
+      {
+        Debug("pf::pm") << clause_expr[i] << " ";
+      }
+      Debug("pf::pm") << std::endl;
     }
-    Debug("pf::pm") << std::endl << "Rewrite printing done" << std::endl;
-  } else {
-    Debug("pf::pm") << "No rewrites in lemmas found" << std::endl;
-  }
+    Debug("pf::pm") << std::endl;
 
-  // The derived/unrewritten atoms may not have CNF literals required later on.
-  // If they don't, add them.
-  std::set<Node>::const_iterator it;
-  for (it = atoms.begin(); it != atoms.end(); ++it) {
-    Debug("pf::pm") << "Ensure literal for atom: " << *it << std::endl;
-    if (!d_cnfProof->hasLiteral(*it)) {
-      // For arithmetic: these literals are not normalized, causing an error in Arith.
-      if (theory::Theory::theoryOf(*it) == theory::THEORY_ARITH) {
-        d_cnfProof->ensureLiteral(*it, true); // This disables preregistration with the theory solver.
-      } else {
-        d_cnfProof->ensureLiteral(*it); // Normal method, with theory solver preregisteration.
+    // collecting assertions that lead to the clauses being asserted
+    d_cnfProof->collectAssertionsForClauses(used_inputs, used_assertions);
+
+    NodeSet::iterator it3;
+    Debug("pf::pm") << std::endl << "Used assertions: " << std::endl;
+    for (it3 = used_assertions.begin(); it3 != used_assertions.end(); ++it3)
+      Debug("pf::pm") << "\t assertion = " << *it3 << std::endl;
+
+    // collects the atoms in the clauses
+    d_cnfProof->collectAtomsAndRewritesForLemmas(used_lemmas, atoms, rewrites);
+
+    if (!rewrites.empty())
+    {
+      Debug("pf::pm") << std::endl << "Rewrites used in lemmas: " << std::endl;
+      NodePairSet::const_iterator rewriteIt;
+      for (rewriteIt = rewrites.begin(); rewriteIt != rewrites.end();
+           ++rewriteIt)
+      {
+        Debug("pf::pm") << "\t" << rewriteIt->first << " --> "
+                        << rewriteIt->second << std::endl;
+      }
+      Debug("pf::pm") << std::endl << "Rewrite printing done" << std::endl;
+    }
+    else
+    {
+      Debug("pf::pm") << "No rewrites in lemmas found" << std::endl;
+    }
+
+    // The derived/unrewritten atoms may not have CNF literals required later
+    // on. If they don't, add them.
+    std::set<Node>::const_iterator it;
+    for (it = atoms.begin(); it != atoms.end(); ++it)
+    {
+      Debug("pf::pm") << "Ensure literal for atom: " << *it << std::endl;
+      if (!d_cnfProof->hasLiteral(*it))
+      {
+        // For arithmetic: these literals are not normalized, causing an error
+        // in Arith.
+        if (theory::Theory::theoryOf(*it) == theory::THEORY_ARITH)
+        {
+          d_cnfProof->ensureLiteral(
+              *it,
+              true);  // This disables preregistration with the theory solver.
+        }
+        else
+        {
+          d_cnfProof->ensureLiteral(
+              *it);  // Normal method, with theory solver preregisteration.
+        }
       }
     }
+
+    d_cnfProof->collectAtomsForClauses(used_inputs, atoms);
+    d_cnfProof->collectAtomsForClauses(used_lemmas, atoms);
+
+    // collects the atoms in the assertions
+    for (NodeSet::const_iterator it = used_assertions.begin();
+         it != used_assertions.end();
+         ++it)
+    {
+      utils::collectAtoms(*it, atoms);
+      // utils::collectAtoms(*it, newAtoms);
+    }
+
+    std::set<Node>::iterator atomIt;
+    Debug("pf::pm") << std::endl
+                    << "Dumping atoms from lemmas, inputs and assertions: "
+                    << std::endl
+                    << std::endl;
+    for (atomIt = atoms.begin(); atomIt != atoms.end(); ++atomIt)
+    {
+      Debug("pf::pm") << "\tAtom: " << *atomIt << std::endl;
+    }
   }
-
-  d_cnfProof->collectAtomsForClauses(used_inputs, atoms);
-  d_cnfProof->collectAtomsForClauses(used_lemmas, atoms);
-
-  // collects the atoms in the assertions
-  for (NodeSet::const_iterator it = used_assertions.begin();
-       it != used_assertions.end(); ++it) {
-    utils::collectAtoms(*it, atoms);
-    // utils::collectAtoms(*it, newAtoms);
-  }
-
-  std::set<Node>::iterator atomIt;
-  Debug("pf::pm") << std::endl << "Dumping atoms from lemmas, inputs and assertions: "
-                  << std::endl << std::endl;
-  for (atomIt = atoms.begin(); atomIt != atoms.end(); ++atomIt) {
-    Debug("pf::pm") << "\tAtom: " << *atomIt << std::endl;
-  }
-
-  ProofManager::currentPM()->getStats().d_skeletonProofTraceTime.stop();
-  ProofManager::currentPM()->getStats().d_proofDeclarationsTime.start();
 
   smt::SmtScope scope(d_smtEngine);
-  std::ostringstream paren;
-  out << "(check\n";
-  paren << ")";
-  out << " ;; Declarations\n";
-
-  // declare the theory atoms
-  Debug("pf::pm") << "LFSCProof::toStream: registering terms:" << std::endl;
-  for(it = atoms.begin(); it != atoms.end(); ++it) {
-    Debug("pf::pm") << "\tTerm: " << (*it).toExpr() << std::endl;
-    d_theoryProof->registerTerm((*it).toExpr());
-  }
-
-  Debug("pf::pm") << std::endl << "Term registration done!" << std::endl << std::endl;
-
-  Debug("pf::pm") << std::endl << "LFSCProof::toStream: starting to print assertions" << std::endl;
-
-  // print out all the original assertions
-  d_theoryProof->registerTermsFromAssertions();
-  d_theoryProof->printSortDeclarations(out, paren);
-  d_theoryProof->printTermDeclarations(out, paren);
-  d_theoryProof->printAssertions(out, paren);
-
-  Debug("pf::pm") << std::endl << "LFSCProof::toStream: print assertions DONE" << std::endl;
-
-  out << "(: (holds cln)\n\n";
-  paren << ")";
-
-  // Have the theory proofs print deferred declarations, e.g. for skolem variables.
-  out << " ;; Printing deferred declarations \n\n";
-  d_theoryProof->printDeferredDeclarations(out, paren);
-
-  out << "\n ;; Printing the global let map";
-  d_theoryProof->finalizeBvConflicts(used_lemmas, out);
-  ProofManager::getBitVectorProof()->calculateAtomsInBitblastingProof();
   ProofLetMap globalLetMap;
-  if (options::lfscLetification()) {
-    ProofManager::currentPM()->printGlobalLetMap(atoms, globalLetMap, out, paren);
+  std::ostringstream paren;
+  {
+    CodeTimer declTimer{
+        ProofManager::currentPM()->getStats().d_proofDeclarationsTime};
+    out << "(check\n";
+    paren << ")";
+    out << " ;; Declarations\n";
+
+    // declare the theory atoms
+    Debug("pf::pm") << "LFSCProof::toStream: registering terms:" << std::endl;
+    for (std::set<Node>::const_iterator it = atoms.begin(); it != atoms.end(); ++it)
+    {
+      Debug("pf::pm") << "\tTerm: " << (*it).toExpr() << std::endl;
+      d_theoryProof->registerTerm((*it).toExpr());
+    }
+
+    Debug("pf::pm") << std::endl
+                    << "Term registration done!" << std::endl
+                    << std::endl;
+
+    Debug("pf::pm") << std::endl
+                    << "LFSCProof::toStream: starting to print assertions"
+                    << std::endl;
+
+    // print out all the original assertions
+    d_theoryProof->registerTermsFromAssertions();
+    d_theoryProof->printSortDeclarations(out, paren);
+    d_theoryProof->printTermDeclarations(out, paren);
+    d_theoryProof->printAssertions(out, paren);
+
+    Debug("pf::pm") << std::endl
+                    << "LFSCProof::toStream: print assertions DONE"
+                    << std::endl;
+
+    out << "(: (holds cln)\n\n";
+    paren << ")";
+
+    // Have the theory proofs print deferred declarations, e.g. for skolem
+    // variables.
+    out << " ;; Printing deferred declarations \n\n";
+    d_theoryProof->printDeferredDeclarations(out, paren);
+
+    out << "\n ;; Printing the global let map";
+    d_theoryProof->finalizeBvConflicts(used_lemmas, out);
+    ProofManager::getBitVectorProof()->calculateAtomsInBitblastingProof();
+    if (options::lfscLetification())
+    {
+      ProofManager::currentPM()->printGlobalLetMap(
+          atoms, globalLetMap, out, paren);
+    }
+
+    out << " ;; Printing aliasing declarations \n\n";
+    d_theoryProof->printAliasingDeclarations(out, paren, globalLetMap);
+
+    out << " ;; Rewrites for Lemmas \n";
+    d_theoryProof->printLemmaRewrites(rewrites, out, paren);
+
+    // print trust that input assertions are their preprocessed form
+    printPreprocessedAssertions(used_assertions, out, paren, globalLetMap);
   }
 
-  out << " ;; Printing aliasing declarations \n\n";
-  d_theoryProof->printAliasingDeclarations(out, paren, globalLetMap);
+  {
+    CodeTimer cnfProofTimer{
+        ProofManager::currentPM()->getStats().d_cnfProofTime};
+    // print mapping between theory atoms and internal SAT variables
+    out << ";; Printing mapping from preprocessed assertions into atoms \n";
+    d_cnfProof->printAtomMapping(atoms, out, paren, globalLetMap);
 
-  out << " ;; Rewrites for Lemmas \n";
-  d_theoryProof->printLemmaRewrites(rewrites, out, paren);
+    Debug("pf::pm") << std::endl
+                    << "Printing cnf proof for clauses" << std::endl;
 
-  // print trust that input assertions are their preprocessed form
-  printPreprocessedAssertions(used_assertions, out, paren, globalLetMap);
-
-  ProofManager::currentPM()->getStats().d_proofDeclarationsTime.stop();
-  ProofManager::currentPM()->getStats().d_cnfProofTime.start();
-
-  // print mapping between theory atoms and internal SAT variables
-  out << ";; Printing mapping from preprocessed assertions into atoms \n";
-  d_cnfProof->printAtomMapping(atoms, out, paren, globalLetMap);
-
-  Debug("pf::pm") << std::endl << "Printing cnf proof for clauses" << std::endl;
-
-  IdToSatClause::const_iterator cl_it = used_inputs.begin();
-  // print CNF conversion proof for each clause
-  for (; cl_it != used_inputs.end(); ++cl_it) {
-    d_cnfProof->printCnfProofForClause(cl_it->first, cl_it->second, out, paren);
+    IdToSatClause::const_iterator cl_it = used_inputs.begin();
+    // print CNF conversion proof for each clause
+    for (; cl_it != used_inputs.end(); ++cl_it)
+    {
+      d_cnfProof->printCnfProofForClause(
+          cl_it->first, cl_it->second, out, paren);
+    }
   }
 
-  ProofManager::currentPM()->getStats().d_cnfProofTime.stop();
-  ProofManager::currentPM()->getStats().d_theoryLemmaTime.start();
+  {
+    CodeTimer theoryLemmaTimer{
+        ProofManager::currentPM()->getStats().d_theoryLemmaTime};
+    Debug("pf::pm") << std::endl
+                    << "Printing cnf proof for clauses DONE" << std::endl;
 
-  Debug("pf::pm") << std::endl << "Printing cnf proof for clauses DONE" << std::endl;
-
-  Debug("pf::pm") << "Proof manager: printing theory lemmas" << std::endl;
-  d_theoryProof->printTheoryLemmas(used_lemmas, out, paren, globalLetMap);
-  Debug("pf::pm") << "Proof manager: printing theory lemmas DONE!" << std::endl;
-
-  ProofManager::currentPM()->getStats().d_theoryLemmaTime.stop();
-  ProofManager::currentPM()->getStats().d_finalProofTime.start();
-
-  out << ";; Printing final unsat proof \n";
-  if (options::bitblastMode() == theory::bv::BITBLAST_MODE_EAGER && ProofManager::getBitVectorProof()) {
-    ProofManager::getBitVectorProof()->printEmptyClauseProof(out, paren);
-  } else {
-    // print actual resolution proof
-    proof::LFSCProofPrinter::printResolutions(d_satProof, out, paren);
-    proof::LFSCProofPrinter::printResolutionEmptyClause(d_satProof, out, paren);
+    Debug("pf::pm") << "Proof manager: printing theory lemmas" << std::endl;
+    d_theoryProof->printTheoryLemmas(used_lemmas, out, paren, globalLetMap);
+    Debug("pf::pm") << "Proof manager: printing theory lemmas DONE!"
+                    << std::endl;
   }
-  ProofManager::currentPM()->getStats().d_finalProofTime.stop();
+
+  {
+    CodeTimer finalProofTimer{
+        ProofManager::currentPM()->getStats().d_finalProofTime};
+    out << ";; Printing final unsat proof \n";
+    if (options::bitblastMode() == theory::bv::BITBLAST_MODE_EAGER
+        && ProofManager::getBitVectorProof())
+    {
+      ProofManager::getBitVectorProof()->printEmptyClauseProof(out, paren);
+    }
+    else
+    {
+      // print actual resolution proof
+      proof::LFSCProofPrinter::printResolutions(d_satProof, out, paren);
+      proof::LFSCProofPrinter::printResolutionEmptyClause(
+          d_satProof, out, paren);
+    }
+  }
 
   out << paren.str();
   out << "\n;;\n";

--- a/src/proof/proof_manager.cpp
+++ b/src/proof/proof_manager.cpp
@@ -586,11 +586,6 @@ void LFSCProof::toStream(std::ostream& out) const
     }
     Debug("pf::pm") << std::endl;
 
-    // Debug("pf::pm") << std::endl << "Used lemmas: " << std::endl;
-    // for (it2 = used_lemmas.begin(); it2 != used_lemmas.end(); ++it2) {
-    //   Debug("pf::pm") << "\t lemma = " << *(it2->second) << std::endl;
-    // }
-    // Debug("pf::pm") << std::endl;
     Debug("pf::pm") << std::endl << "Used lemmas: " << std::endl;
     for (it2 = used_lemmas.begin(); it2 != used_lemmas.end(); ++it2)
     {
@@ -680,7 +675,6 @@ void LFSCProof::toStream(std::ostream& out) const
          ++it)
     {
       utils::collectAtoms(*it, atoms);
-      // utils::collectAtoms(*it, newAtoms);
     }
 
     std::set<Node>::iterator atomIt;

--- a/src/proof/proof_manager.h
+++ b/src/proof/proof_manager.h
@@ -298,12 +298,6 @@ public:
                          std::ostream& out,
                          std::ostringstream& paren);
 
-  TimerStat* getProofProductionTime() { return &d_stats.d_proofProductionTime; }
-
- private:
-  void constructSatProof();
-  std::set<Node> satClauseToNodeSet(prop::SatClause* clause);
-
   struct ProofManagerStatistics
   {
     ProofManagerStatistics();
@@ -314,7 +308,40 @@ public:
      * information)
      */
     TimerStat d_proofProductionTime;
+
+    /**
+     * Time spent printing proofs of theory lemmas
+     */
+    TimerStat d_theoryLemmaTime;
+
+    /**
+     * Time spent tracing the proof of the boolean skeleton
+     * (e.g. figuring out which assertions are needed, etc.)
+     */
+    TimerStat d_skeletonProofTraceTime;
+
+    /**
+     * Time spent processing and printing declarations in the proof
+     */
+    TimerStat d_proofDeclarationsTime;
+
+    /**
+     * Time spent printing the CNF proof
+     */
+    TimerStat d_cnfProofTime;
+
+    /**
+     * Time spent printing the final proof of UNSAT
+     */
+    TimerStat d_finalProofTime;
+
   }; /* struct ProofManagerStatistics */
+
+  ProofManagerStatistics& getStats() { return d_stats; }
+
+ private:
+  void constructSatProof();
+  std::set<Node> satClauseToNodeSet(prop::SatClause* clause);
 
   ProofManagerStatistics d_stats;
 

--- a/src/prop/sat_solver_types.cpp
+++ b/src/prop/sat_solver_types.cpp
@@ -1,0 +1,28 @@
+/*********************                                                        */
+/*! \file sat_solver_types.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Alex Ozdemir
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Implementations of SAT solver type operations which require large
+ ** std headers.
+ **
+ **/
+
+#include "prop/sat_solver_types.h"
+
+#include <algorithm>
+
+namespace CVC4 {
+namespace prop {
+bool SatClauseLessThan::operator()(const SatClause& l, const SatClause& r) const
+{
+  return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
+}
+}  // namespace prop
+}  // namespace CVC4

--- a/src/prop/sat_solver_types.h
+++ b/src/prop/sat_solver_types.h
@@ -122,6 +122,16 @@ public:
   }
 
   /**
+   * Compare two literals
+   */
+  bool operator<(const SatLiteral& other) const
+  {
+    return getSatVariable() == other.getSatVariable()
+               ? isNegated() < other.isNegated()
+               : getSatVariable() < other.getSatVariable();
+  }
+
+  /**
    * Returns a string representation of the literal.
    */
   std::string toString() const {
@@ -183,6 +193,11 @@ struct SatClauseSetHashFunction
   }
 };
 
+struct SatClauseLessThan
+{
+  bool operator()(const SatClause& l, const SatClause& r) const;
+};
+
 /**
  * Each object in the SAT solver, such as as variables and clauses, can be assigned a life span,
  * so that the SAT solver can (or should) remove them when the lifespan is over.
@@ -221,5 +236,3 @@ enum SatSolverLifespan
 
 }
 }
-
-


### PR DESCRIPTION
tldr: I made a bad data-structure/algorithm choice when implementing
part of DRAT/CNF-optimization, which consumed **a lot** of time on some
bechmarks. This commit fixes that choice.

Long Version:

Set-Keyed Maps Considered Harmful
=================================

Algorithmic Problem
-------------------

The DRAT optimization process spits out a unsatifiable core of the CNF.
The clauses in the core are all from the original formula, but their
literals may have been reordered and deduplicated.  We must match the
old clauses with new ones, so we know which old clauses are in the core.

Old (BAD) Solution
------------------

Before I didn't really think about this process very much. I built a
solution in which clauses were canonically represented by hash sets of
literals, and made a hash map from canonical clauses to clause indices
into the original CNF.

Problem With Old Solution
-------------------------

In hindsight this was a bad idea. First, it required a new hash set to
be heap-allocated for every clause in the CNF. Second, the map lookups
required set-hashes (reasonable -- linear time, once) and hash-set
equality (not reasonable -- quadratic time, multiple times) on every
lookup.

New Solution
------------

The ideal solution is probably to have the map from clauses to clause
ids be something like a trie. STL doesn't have a trie, but representing
clauses as sorted, deduped vectors of literal in a tree based on
lexicographical comparison is pretty closed to this. On randomly chosen
examples it seems to be a huge improvement over the old
map-keyed-by-sets solution, and I'm in the process of running a full set
of bechmarks.

Also, we store pointers to the clauses already stored elsewhere in the
proof, instead of allocating new memory for them.

Measuring the Improvment
-----------------

Using the statistics also included in this PR, I measured how the amount
of time spent doing core-input clause matching changed. `set-keyed hashmap` 
is the old system. `vector-keyed treemap` is the new. Notice that for some
instances, the old system spent a lot of the proof production time matching
clauses (how embarrassing :frowning_face:). Now it spends significantly less
time. 

### Clause Matching Time as a Fraction of DRAT Optimization Time

![clause-match-v-opt-time](https://user-images.githubusercontent.com/5809398/60317583-976ebc80-9924-11e9-9b54-09c5f910bd7b.png)

### Clause Matching Time as a Fraction of Proof Production Time
![clause-match-v-production-time](https://user-images.githubusercontent.com/5809398/60317588-9a69ad00-9924-11e9-9ae2-e0a7e6160dea.png)

### Time Spent on Different Tasks
![task-time-dist](https://user-images.githubusercontent.com/5809398/60317638-c4bb6a80-9924-11e9-80d9-8f66c93d5f2e.png)

### Solved Instances
```
DIRECTORY |    Tot |   Slvd |  Sat |  Unsat |  Unk |    To |   Mo |  Err |     Cpu[s] |      Mem[MB] |
run-er    |  21127 |  13822 |    2 |  13820 |    0 |  6791 |   99 |  415 |  4493334.7 |  128195543.1 |
run-er    |  21127 |  13857 |    2 |  13855 |    0 |  6623 |  102 |  545 |  4354398.9 |  128616361.1 |
```

We check 35 more proofs! We also error more. I haven't verified why, but I
assume it is because we attempt to check more proofs and have LFSC fail us :cry:. 


Future Work
-----------

It may also be reasonable to do a hash map of sorted, deduped, vector
clauses, or actually do a trie. I haven't tried this, yet (there's a TODO in the code).
