### PR TITLE
Add methods to `CVC4::api::Term` for retrieving an operator

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -1030,7 +1030,10 @@ bool Term::isNull() const { return d_expr->isNull(); }
 
 bool Term::hasOperator() const { return d_expr->hasOperator(); }
 
-bool Term::hasBuiltinOperator() const { return d_expr->getOperator().getKind() == CVC4::kind::BUILTIN; }
+bool Term::hasBuiltinOperator() const
+{
+  return d_expr->getOperator().getKind() == CVC4::kind::BUILTIN;
+}
 
 bool Term::hasOpTermOperator() const
 {
@@ -1042,13 +1045,15 @@ bool Term::hasUFOperator() const { return d_expr->getOperator().isVariable(); }
 
 OpTerm Term::getOpTerm() const
 {
-  CVC4_API_CHECK(hasOperator() && hasOpTermOperator()) << "Does not have an OpTerm operator.";
+  CVC4_API_CHECK(hasOperator() && hasOpTermOperator())
+      << "Does not have an OpTerm operator.";
   return OpTerm(d_expr->getOperator());
 }
 
 Term Term::getUF() const
 {
-  CVC4_API_CHECK(hasOperator() && hasUFOperator()) << "Does not have an UF operator.";
+  CVC4_API_CHECK(hasOperator() && hasUFOperator())
+      << "Does not have an UF operator.";
   return Term(d_expr->getOperator());
 }
 

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -1042,11 +1042,13 @@ bool Term::hasUFOperator() const { return d_expr->getOperator().isVariable(); }
 
 OpTerm Term::getOpTerm() const
 {
+  CVC4_API_CHECK(hasOperator() && hasOpTermOperator()) << "Does not have an OpTerm operator.";
   return OpTerm(d_expr->getOperator());
 }
 
 Term Term::getUF() const
 {
+  CVC4_API_CHECK(hasOperator() && hasUFOperator()) << "Does not have an UF operator.";
   return Term(d_expr->getOperator());
 }
 

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -1028,6 +1028,28 @@ Sort Term::getSort() const
 
 bool Term::isNull() const { return d_expr->isNull(); }
 
+bool Term::hasOperator() const { return d_expr->hasOperator(); }
+
+bool Term::hasBuiltinOperator() const { return d_expr->getOperator().getKind() == CVC4::kind::BUILTIN; }
+
+bool Term::hasOpTermOperator() const
+{
+  CVC4::Expr op = d_expr->getOperator();
+  return (op.getKind() != CVC4::kind::BUILTIN) && (op.isConst());
+}
+
+bool Term::hasUFOperator() const { return d_expr->getOperator().isVariable(); }
+
+OpTerm Term::getOpTerm() const
+{
+  return OpTerm(d_expr->getOperator());
+}
+
+Term Term::getUF() const
+{
+  return Term(d_expr->getOperator());
+}
+
 Term Term::notTerm() const
 {
   try

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -1030,29 +1030,29 @@ bool Term::isNull() const { return d_expr->isNull(); }
 
 bool Term::hasOperator() const { return d_expr->hasOperator(); }
 
-bool Term::hasBuiltinOperator() const
+bool Term::hasOperatorBuiltin() const
 {
   return d_expr->getOperator().getKind() == CVC4::kind::BUILTIN;
 }
 
-bool Term::hasOpTermOperator() const
+bool Term::hasOperatorOpTerm() const
 {
   CVC4::Expr op = d_expr->getOperator();
   return (op.getKind() != CVC4::kind::BUILTIN) && (op.isConst());
 }
 
-bool Term::hasUFOperator() const { return d_expr->getOperator().isVariable(); }
+bool Term::hasOperatorUF() const { return d_expr->getOperator().isVariable(); }
 
-OpTerm Term::getOpTerm() const
+OpTerm Term::getOperatorOpTerm() const
 {
-  CVC4_API_CHECK(hasOperator() && hasOpTermOperator())
+  CVC4_API_CHECK(hasOperator() && hasOperatorOpTerm())
       << "Does not have an OpTerm operator.";
   return OpTerm(d_expr->getOperator());
 }
 
-Term Term::getUF() const
+Term Term::getOperatorUF() const
 {
-  CVC4_API_CHECK(hasOperator() && hasUFOperator())
+  CVC4_API_CHECK(hasOperator() && hasOperatorUF())
       << "Does not have an UF operator.";
   return Term(d_expr->getOperator());
 }

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -591,6 +591,43 @@ class CVC4_PUBLIC Term
   bool isNull() const;
 
   /**
+   * @return true iff this Term has an operator
+   */
+  bool hasOperator() const;
+
+  /**
+   * @return true iff this Term has a builtin operator
+   *
+   * in this case, getKind() will return the operator
+   */
+  bool hasBuilltinOperator() const;
+
+  /**
+   * @return true iff this Term has an indexed operator
+   */
+  bool hasOpTermOperator() const;
+
+  /**
+   * @return true iff this Term is the result of
+   *         applying an uninterpreted function
+   */
+  bool hasUFOperator() const;
+
+  /**
+   * @return the OpTerm used to create this time
+   *
+   * valid to call when hasOpTermOperator() returns true
+   */
+  OpTerm getOpTerm() const;
+
+  /**
+   * @return the OpTerm used to create this time
+   *
+   * valid to call when hasUFOperator() returns true
+   */
+  Term getUF() const;
+
+  /**
    * Boolean negation.
    * @return the Boolean negation of this term
    */

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -718,7 +718,8 @@ class CVC4_PUBLIC Term
   bool hasOpTermOperator() const;
 
   /**
-   * Returns true if this Term was created with an uninterpreted function application.
+   * Returns true if this Term was created with an
+   * uninterpreted function application.
    * If true, getUFOperator() returns the operator UF.
    * @return true iff this Term is the result of
    *         applying an uninterpreted function

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -524,6 +524,114 @@ struct CVC4_PUBLIC SortHashFunction
 };
 
 /* -------------------------------------------------------------------------- */
+/* OpTerm                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A CVC4 operator term.
+ * An operator term is a term that represents certain operators, instantiated
+ * with its required parameters, e.g., a term of kind BITVECTOR_EXTRACT.
+ */
+class CVC4_PUBLIC OpTerm
+{
+  friend class Solver;
+  friend struct OpTermHashFunction;
+
+ public:
+  /**
+   * Constructor.
+   */
+  OpTerm();
+
+  // !!! This constructor is only temporarily public until the parser is fully
+  // migrated to the new API. !!!
+  /**
+   * Constructor.
+   * @param e the internal expression that is to be wrapped by this term
+   * @return the Term
+   */
+  OpTerm(const CVC4::Expr& e);
+
+  /**
+   * Destructor.
+   */
+  ~OpTerm();
+
+  /**
+   * Syntactic equality operator.
+   * Return true if both operator terms are syntactically identical.
+   * Both operator terms must belong to the same solver object.
+   * @param t the operator term to compare to for equality
+   * @return true if the operator terms are equal
+   */
+  bool operator==(const OpTerm& t) const;
+
+  /**
+   * Syntactic disequality operator.
+   * Return true if both operator terms differ syntactically.
+   * Both terms must belong to the same solver object.
+   * @param t the operator term to compare to for disequality
+   * @return true if operator terms are disequal
+   */
+  bool operator!=(const OpTerm& t) const;
+
+  /**
+   * @return the kind of this operator term
+   */
+  Kind getKind() const;
+
+  /**
+   * @return the sort of this operator term
+   */
+  Sort getSort() const;
+
+  /**
+   * @return true if this operator term is a null term
+   */
+  bool isNull() const;
+
+  /**
+   * @return the indices used to create this OpTerm
+   */
+  template <typename T>
+  T getIndices() const;
+
+  /**
+   * @return a string representation of this operator term
+   */
+  std::string toString() const;
+
+  // !!! This is only temporarily available until the parser is fully migrated
+  // to the new API. !!!
+  CVC4::Expr getExpr(void) const;
+
+ private:
+  /**
+   * The internal expression wrapped by this operator term.
+   * This is a shared_ptr rather than a unique_ptr to avoid overhead due to
+   * memory allocation (CVC4::Expr is already ref counted, so this could be
+   * a unique_ptr instead).
+   */
+  std::shared_ptr<CVC4::Expr> d_expr;
+};
+
+/**
+ * Serialize an operator term to given stream.
+ * @param out the output stream
+ * @param t the operator term to be serialized to the given output stream
+ * @return the output stream
+ */
+std::ostream& operator<<(std::ostream& out, const OpTerm& t) CVC4_PUBLIC;
+
+/**
+ * Hash function for OpTerms.
+ */
+struct CVC4_PUBLIC OpTermHashFunction
+{
+  size_t operator()(const OpTerm& t) const;
+};
+
+/* -------------------------------------------------------------------------- */
 /* Term                                                                       */
 /* -------------------------------------------------------------------------- */
 
@@ -600,7 +708,7 @@ class CVC4_PUBLIC Term
    *
    * in this case, getKind() will return the operator
    */
-  bool hasBuilltinOperator() const;
+  bool hasBuiltinOperator() const;
 
   /**
    * @return true iff this Term has an indexed operator
@@ -841,108 +949,6 @@ template <typename V>
 std::ostream& operator<<(std::ostream& out,
                          const std::unordered_map<Term, V, TermHashFunction>&
                              unordered_map) CVC4_PUBLIC;
-
-/* -------------------------------------------------------------------------- */
-/* OpTerm                                                                     */
-/* -------------------------------------------------------------------------- */
-
-/**
- * A CVC4 operator term.
- * An operator term is a term that represents certain operators, instantiated
- * with its required parameters, e.g., a term of kind BITVECTOR_EXTRACT.
- */
-class CVC4_PUBLIC OpTerm
-{
-  friend class Solver;
-  friend struct OpTermHashFunction;
-
- public:
-  /**
-   * Constructor.
-   */
-  OpTerm();
-
-  // !!! This constructor is only temporarily public until the parser is fully
-  // migrated to the new API. !!!
-  /**
-   * Constructor.
-   * @param e the internal expression that is to be wrapped by this term
-   * @return the Term
-   */
-  OpTerm(const CVC4::Expr& e);
-
-  /**
-   * Destructor.
-   */
-  ~OpTerm();
-
-  /**
-   * Syntactic equality operator.
-   * Return true if both operator terms are syntactically identical.
-   * Both operator terms must belong to the same solver object.
-   * @param t the operator term to compare to for equality
-   * @return true if the operator terms are equal
-   */
-  bool operator==(const OpTerm& t) const;
-
-  /**
-   * Syntactic disequality operator.
-   * Return true if both operator terms differ syntactically.
-   * Both terms must belong to the same solver object.
-   * @param t the operator term to compare to for disequality
-   * @return true if operator terms are disequal
-   */
-  bool operator!=(const OpTerm& t) const;
-
-  /**
-   * @return the kind of this operator term
-   */
-  Kind getKind() const;
-
-  /**
-   * @return the sort of this operator term
-   */
-  Sort getSort() const;
-
-  /**
-   * @return true if this operator term is a null term
-   */
-  bool isNull() const;
-
-  /**
-   * @return a string representation of this operator term
-   */
-  std::string toString() const;
-
-  // !!! This is only temporarily available until the parser is fully migrated
-  // to the new API. !!!
-  CVC4::Expr getExpr(void) const;
-
- private:
-  /**
-   * The internal expression wrapped by this operator term.
-   * This is a shared_ptr rather than a unique_ptr to avoid overhead due to
-   * memory allocation (CVC4::Expr is already ref counted, so this could be
-   * a unique_ptr instead).
-   */
-  std::shared_ptr<CVC4::Expr> d_expr;
-};
-
-/**
- * Serialize an operator term to given stream.
- * @param out the output stream
- * @param t the operator term to be serialized to the given output stream
- * @return the output stream
- */
-std::ostream& operator<<(std::ostream& out, const OpTerm& t) CVC4_PUBLIC;
-
-/**
- * Hash function for OpTerms.
- */
-struct CVC4_PUBLIC OpTermHashFunction
-{
-  size_t operator()(const OpTerm& t) const;
-};
 
 /* -------------------------------------------------------------------------- */
 /* Datatypes                                                                  */

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -708,14 +708,14 @@ class CVC4_PUBLIC Term
    * If true, getKind() will return the operator kind.
    * @return true iff this Term has a builtin operator
    */
-  bool hasBuiltinOperator() const;
+  bool hasOperatorBuiltin() const;
 
   /**
    * Returns true if this Term was created using an OpTerm.
    * If true, getOpTerm() will return the operator OpTerm.
    * @return true iff this Term has an indexed operator
    */
-  bool hasOpTermOperator() const;
+  bool hasOperatorOpTerm() const;
 
   /**
    * Returns true if this Term was created with an
@@ -724,21 +724,21 @@ class CVC4_PUBLIC Term
    * @return true iff this Term is the result of
    *         applying an uninterpreted function
    */
-  bool hasUFOperator() const;
+  bool hasOperatorUF() const;
 
   /**
    * Returns the OpTerm used to create this term.
-   * Valid to call when hasOpTermOperator() returns true.
+   * Valid to call when hasOperatorOpTerm() returns true.
    * @return the OpTerm used to create this term
    */
-  OpTerm getOpTerm() const;
+  OpTerm getOperatorOpTerm() const;
 
   /**
    * Returns the UF term used to create this term.
-   * Valid to call when hasUFOperator() returns true.
+   * Valid to call when hasOperatorUF() returns true.
    * @return the UF term used to create this term
    */
-  Term getUF() const;
+  Term getOperatorUF() const;
 
   /**
    * Boolean negation.

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -704,34 +704,38 @@ class CVC4_PUBLIC Term
   bool hasOperator() const;
 
   /**
+   * Returns true if this Term was created with a builtin operator.
+   * If true, getKind() will return the operator kind.
    * @return true iff this Term has a builtin operator
-   *
-   * in this case, getKind() will return the operator
    */
   bool hasBuiltinOperator() const;
 
   /**
+   * Returns true if this Term was created using an OpTerm.
+   * If true, getOpTerm() will return the operator OpTerm.
    * @return true iff this Term has an indexed operator
    */
   bool hasOpTermOperator() const;
 
   /**
+   * Returns true if this Term was created with an uninterpreted function application.
+   * If true, getUFOperator() returns the operator UF.
    * @return true iff this Term is the result of
    *         applying an uninterpreted function
    */
   bool hasUFOperator() const;
 
   /**
-   * @return the OpTerm used to create this time
-   *
-   * valid to call when hasOpTermOperator() returns true
+   * Returns the OpTerm used to create this term.
+   * Valid to call when hasOpTermOperator() returns true.
+   * @return the OpTerm used to create this term
    */
   OpTerm getOpTerm() const;
 
   /**
-   * @return the OpTerm used to create this time
-   *
-   * valid to call when hasUFOperator() returns true
+   * Returns the UF term used to create this term.
+   * Valid to call when hasUFOperator() returns true.
+   * @return the UF term used to create this term
    */
   Term getUF() const;
 

--- a/test/unit/api/term_black.h
+++ b/test/unit/api/term_black.h
@@ -38,6 +38,10 @@ class TermBlack : public CxxTest::TestSuite
 
   void testTermAssignment();
 
+  void testBuiltinOperator();
+  void testOpTermOperator();
+  void testUFOperator();
+
  private:
   Solver d_solver;
 };
@@ -541,3 +545,49 @@ void TermBlack::testTermAssignment()
   t2 = d_solver.mkReal(2);
   TS_ASSERT_EQUALS(t1, d_solver.mkReal(1));
 }
+
+void TermBlack::testBuiltinOperator()
+{
+  Sort bv8 = d_solver.mkBitVectorSort(8);
+  Term x = d_solver.mkConst(bv8, "x");
+  Term y = d_solver.mkConst(bv8, "y");
+  Term xpy = d_solver.mkTerm(BITVECTOR_PLUS, x, y);
+
+  TS_ASSERT(xpy.hasOperator());
+  TS_ASSERT(xpy.hasBuiltinOperator());
+  TS_ASSERT(!xpy.hasUFOperator());
+  TS_ASSERT_EQUALS(xpy.getKind(), BITVECTOR_PLUS);
+}
+
+void TermBlack::testOpTermOperator()
+{
+  Sort bv8 = d_solver.mkBitVectorSort(8);
+  Term x = d_solver.mkConst(bv8, "x");
+  Term y = d_solver.mkConst(bv8, "y");
+
+  OpTerm ext40 = d_solver.mkOpTerm(BITVECTOR_EXTRACT_OP, 4, 0);
+  Term ext40x = d_solver.mkTerm(BITVECTOR_EXTRACT, ext40, x);
+
+  TS_ASSERT(!x.hasOperator());
+  TS_ASSERT(ext40x.hasOperator());
+  TS_ASSERT(ext40x.hasOpTermOperator());
+  TS_ASSERT(!ext40x.hasBuiltinOperator());
+  OpTerm op = ext40x.getOpTerm();
+  TS_ASSERT_EQUALS(op, ext40);
+}
+
+void TermBlack::testUFOperator()
+{
+  Sort bv8 = d_solver.mkBitVectorSort(8);
+  Term x = d_solver.mkConst(bv8, "x");
+  Term y = d_solver.mkConst(bv8, "y");
+
+  Term f = d_solver.declareFun("f", std::vector<Sort>{bv8}, bv8);
+  Term fx = d_solver.mkTerm(APPLY_UF, f, x);
+
+  TS_ASSERT(fx.hasOperator());
+  TS_ASSERT(fx.hasUFOperator());
+  TS_ASSERT(!fx.hasOpTermOperator());
+  TS_ASSERT_EQUALS(fx.getUF(), f);
+}
+

--- a/test/unit/api/term_black.h
+++ b/test/unit/api/term_black.h
@@ -590,4 +590,3 @@ void TermBlack::testUFOperator()
   TS_ASSERT(!fx.hasOpTermOperator());
   TS_ASSERT_EQUALS(fx.getUF(), f);
 }
-

--- a/test/unit/api/term_black.h
+++ b/test/unit/api/term_black.h
@@ -38,9 +38,9 @@ class TermBlack : public CxxTest::TestSuite
 
   void testTermAssignment();
 
-  void testBuiltinOperator();
-  void testOpTermOperator();
-  void testUFOperator();
+  void testOperatorBuiltin();
+  void testOperatorOpTerm();
+  void testOperatorUF();
 
  private:
   Solver d_solver;
@@ -546,7 +546,7 @@ void TermBlack::testTermAssignment()
   TS_ASSERT_EQUALS(t1, d_solver.mkReal(1));
 }
 
-void TermBlack::testBuiltinOperator()
+void TermBlack::testOperatorBuiltin()
 {
   Sort bv8 = d_solver.mkBitVectorSort(8);
   Term x = d_solver.mkConst(bv8, "x");
@@ -554,12 +554,12 @@ void TermBlack::testBuiltinOperator()
   Term xpy = d_solver.mkTerm(BITVECTOR_PLUS, x, y);
 
   TS_ASSERT(xpy.hasOperator());
-  TS_ASSERT(xpy.hasBuiltinOperator());
-  TS_ASSERT(!xpy.hasUFOperator());
+  TS_ASSERT(xpy.hasOperatorBuiltin());
+  TS_ASSERT(!xpy.hasOperatorUF());
   TS_ASSERT_EQUALS(xpy.getKind(), BITVECTOR_PLUS);
 }
 
-void TermBlack::testOpTermOperator()
+void TermBlack::testOperatorOpTerm()
 {
   Sort bv8 = d_solver.mkBitVectorSort(8);
   Term x = d_solver.mkConst(bv8, "x");
@@ -570,13 +570,13 @@ void TermBlack::testOpTermOperator()
 
   TS_ASSERT(!x.hasOperator());
   TS_ASSERT(ext40x.hasOperator());
-  TS_ASSERT(ext40x.hasOpTermOperator());
-  TS_ASSERT(!ext40x.hasBuiltinOperator());
-  OpTerm op = ext40x.getOpTerm();
+  TS_ASSERT(ext40x.hasOperatorOpTerm());
+  TS_ASSERT(!ext40x.hasOperatorBuiltin());
+  OpTerm op = ext40x.getOperatorOpTerm();
   TS_ASSERT_EQUALS(op, ext40);
 }
 
-void TermBlack::testUFOperator()
+void TermBlack::testOperatorUF()
 {
   Sort bv8 = d_solver.mkBitVectorSort(8);
   Term x = d_solver.mkConst(bv8, "x");
@@ -586,7 +586,7 @@ void TermBlack::testUFOperator()
   Term fx = d_solver.mkTerm(APPLY_UF, f, x);
 
   TS_ASSERT(fx.hasOperator());
-  TS_ASSERT(fx.hasUFOperator());
-  TS_ASSERT(!fx.hasOpTermOperator());
-  TS_ASSERT_EQUALS(fx.getUF(), f);
+  TS_ASSERT(fx.hasOperatorUF());
+  TS_ASSERT(!fx.hasOperatorOpTerm());
+  TS_ASSERT_EQUALS(fx.getOperatorUF(), f);
 }


### PR DESCRIPTION
This pull request implements several `has` queries and getters for obtaining the operator of a term. There are three cases:

* `BUILTIN` operator
  * Check with `hasBuiltinOperator()`
  * Get it with `getKind()`
* OpTerm operator, e.g. indexed operator
  * Check with `hasOpTermOperator()`
  * Get it with `getOpTerm()`
* Uninterpreted function operator (operator is a Term)
  * Check with `hasUFOperator()`
  * Get it with `getUF()`

Each getter is guarded with a `CVC4_API_CHECK`, and there's also a `hasOperator()` that returns true iff the term has an operator (of any type).