### PR TITLE
Removing forward-declaration of undefined function 'registerForceLogicListener'

### DIFF
--- a/src/options/options.h
+++ b/src/options/options.h
@@ -348,19 +348,6 @@ public:
   ListenerCollection::Registration* registerBeforeSearchListener(
       Listener* listener);
 
-
-  /**
-   * Registers a listener for options::forceLogic being set.
-   *
-   * If notifyIfSet is true, this calls notify on the listener
-   * if the option was set by the user.
-   *
-   * The memory for the Registration is controlled by the user and must
-   * be destroyed before the Options object is.
-   */
-  ListenerCollection::Registration* registerForceLogicListener(
-      Listener* listener, bool notifyIfSet);
-
   /**
    * Registers a listener for options::tlimit being set.
    *


### PR DESCRIPTION
Commit [be33ac9](https://github.com/CVC4/CVC4/commit/be33ac9656bf7feafa3715d6623749f6afd962b5) removed the implementation of `registerForceLogicListener` in [`src/options/options_template.cpp`](https://github.com/CVC4/CVC4/blob/master/src/options/options_template.cpp), but did not remove the prototype in [`src/options/options.h`](https://github.com/CVC4/CVC4/blob/master/src/options/options.h#L361).

However, the existence of the declaration of `CVC4::Options::registerForceLogicListener(CVC4::Listener*, bool)` in `options.h` causes SWIG to wrap this, which then adds:

```
result = (ListenerCollection::Registration *)(arg1)->registerForceLogicListener(arg2,arg3);
```

into `cvc4PYTHON_wrap.cxx`.

Eventually, this leads to their being an unresolved symbol in `_CVC4.so`:

```
$ nm _CVC4.so | c++filt | grep registerForceLogicListener
000000000009d3f0 t _wrap_Options_registerForceLogicListener
                 U CVC4::Options::registerForceLogicListener(CVC4::Listener*, bool)

```

which leads to the following at runtime:

```
$ echo -e "import importlib\nimportlib.import_module('_CVC4')" | python
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 658, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 571, in module_from_spec
  File "<frozen importlib._bootstrap_external>", line 922, in create_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
ImportError: lib64/python3.6/site-packages/_CVC4.so: undefined symbol: _ZN4CVC47Options26registerForceLogicListenerEPNS_8ListenerEb
```

This PR removes the forward-declaration of `registerForceLogicListener`.

Regrettably, CVC4 has no automated tests for its Python API, so no test has been added to check this issue.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>