### PR TITLE
 Fix null node when using no-strings-lazy-pp

### DIFF
--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -609,7 +609,8 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
   }
   else
   {
-    Trace("strings-preprocess-debug") << "Return " << retNode << " unchanged" << std::endl;
+    Trace("strings-preprocess-debug")
+        << "Return " << retNode << " unchanged" << std::endl;
   }
   return retNode;
 }

--- a/src/theory/strings/theory_strings_preprocess.cpp
+++ b/src/theory/strings/theory_strings_preprocess.cpp
@@ -607,6 +607,10 @@ Node StringsPreprocess::simplify( Node t, std::vector< Node > &new_nodes ) {
       }
     }
   }
+  else
+  {
+    Trace("strings-preprocess-debug") << "Return " << retNode << " unchanged" << std::endl;
+  }
   return retNode;
 }
 
@@ -615,7 +619,7 @@ Node StringsPreprocess::simplifyRec( Node t, std::vector< Node > & new_nodes, st
   if( it!=visited.end() ){
     return it->second;
   }else{
-    Node retNode;
+    Node retNode = t;
     if( t.getNumChildren()==0 ){
       retNode = simplify( t, new_nodes );
     }else if( t.getKind()!=kind::FORALL ){

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1566,6 +1566,7 @@ set(regress_1_tests
   regress1/strings/loop008.smt2
   regress1/strings/loop009.smt2
   regress1/strings/nf-ff-contains-abs.smt2
+  regress1/strings/no-lazy-pp-quant.smt2
   regress1/strings/non_termination_regular_expression4.smt2
   regress1/strings/norn-13.smt2
   regress1/strings/norn-360.smt2

--- a/test/regress/regress1/strings/no-lazy-pp-quant.smt2
+++ b/test/regress/regress1/strings/no-lazy-pp-quant.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --strings-exp --no-strings-lazy-pp
+; EXPECT: sat
+(set-info :smt-lib-version 2.5)
+(set-logic ALL)
+(set-info :status sat)
+(declare-fun result () Int)
+(declare-fun s () String)
+(assert (! (not (= (str.to.int s) result)) :named a0))
+(check-sat)


### PR DESCRIPTION
This fixes a null node with using quantifiers + `--no-strings-lazy-pp`.