### PR TITLE
Fix match trie for polymorphic operators

### DIFF
--- a/src/theory/quantifiers/candidate_rewrite_filter.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_filter.cpp
@@ -135,6 +135,10 @@ bool MatchTrie::getMatches(Node n, NotifyMatch* ntm)
               recurse = false;
             }
           }
+          else if (!var.getType().isSubtypeOf(cn.getType()))
+          {
+            recurse = false;
+          }
           else
           {
             vars.push_back(var);


### PR DESCRIPTION
This fixes a bug in the MatchTrie where type constraints were not considered.  This means that e.g. `(= x y)` with `x:Int y:Int` could be matched to `(= t s)` with `t:String s:String`.

This utility is currently used for filtering rewrite rules with `--sygus-rr` where such spurious matches likely did not affect much. (However, in the context of the proof infrastructure https://github.com/ajreynol/CVC4/tree/proofDb, this bug needs to be fixed).