### PR TITLE
Enable sygus logic when produce-abducts is true

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1260,13 +1260,7 @@ void SmtEngine::setDefaults() {
   // sygus inference may require datatypes
   if (!d_isInternalSubsolver)
   {
-    if (options::produceAbducts())
-    {
-      // we may invoke a sygus conjecture, hence we need options related to
-      // sygus
-      is_sygus = true;
-    }
-    if (options::sygusInference() || options::sygusRewSynthInput())
+    if (options::produceAbducts() || options::sygusInference() || options::sygusRewSynthInput())
     {
       // since we are trying to recast as sygus, we assume the input is sygus
       is_sygus = true;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1260,7 +1260,8 @@ void SmtEngine::setDefaults() {
   // sygus inference may require datatypes
   if (!d_isInternalSubsolver)
   {
-    if (options::produceAbducts() || options::sygusInference() || options::sygusRewSynthInput())
+    if (options::produceAbducts() || options::sygusInference()
+        || options::sygusRewSynthInput())
     {
       // since we are trying to recast as sygus, we assume the input is sygus
       is_sygus = true;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -546,6 +546,7 @@ set(regress_0_tests
   regress0/nl/very-easy-sat.smt2
   regress0/nl/very-simple-unsat.smt2
   regress0/options/invalid_dump.smt2
+  regress0/opt-abd-no-use.smt2
   regress0/parallel-let.smt2
   regress0/parser/as.smt2
   regress0/parser/bv_arity_smt2.6.smt2

--- a/test/regress/regress0/opt-abd-no-use.smt2
+++ b/test/regress/regress0/opt-abd-no-use.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_LIA)
+(set-option :produce-abducts true)
+(declare-fun x () Int)
+(assert (> x 0))
+(check-sat)

--- a/test/regress/regress0/opt-abd-no-use.smt2
+++ b/test/regress/regress0/opt-abd-no-use.smt2
@@ -1,4 +1,5 @@
 (set-logic QF_LIA)
+(set-info :status sat)
 (set-option :produce-abducts true)
 (declare-fun x () Int)
 (assert (> x 0))


### PR DESCRIPTION
CVC4 would otherwise crash when a `check-sat` was issued when `produce-abduct` was true and the logic was quantifier-free.