### PR TITLE
Flip the polarity of the argument of get-abduct

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5078,7 +5078,9 @@ bool SmtEngine::getAbduct(const Expr& conj, const Type& grammarType, Expr& abd)
     axioms.push_back(Node::fromExpr(easserts[i]));
   }
   std::vector<Node> asserts(axioms.begin(), axioms.end());
-  asserts.push_back(Node::fromExpr(conj));
+  // negate the conjecture
+  Node conjn = Node::fromExpr(conj).negate();
+  asserts.push_back(conjn);
   d_sssfVarlist.clear();
   d_sssfSyms.clear();
   std::string name("A");

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -949,7 +949,7 @@ class CVC4_PUBLIC SmtEngine {
    * This method asks this SMT engine to find an abduct with respect to the
    * current assertion stack (call it A) and the conjecture (call it B).
    * If this method returns true, then abd is set to a formula C such that
-   * A ^ C is satisfiable, and A ^ B ^ C is unsatisfiable.
+   * A ^ C is satisfiable, and A ^ ~B ^ C is unsatisfiable.
    *
    * The argument grammarType is a sygus datatype type that encodes the syntax
    * restrictions on the shape of possible solutions.

--- a/test/regress/regress1/sygus-abduct-ex1-grammar.smt2
+++ b/test/regress/regress1/sygus-abduct-ex1-grammar.smt2
@@ -19,7 +19,7 @@
 ; since it is spurious: (>= j 0) is a stronger solution and will be enumerated
 ; first.
 (get-abduct A 
-  (not (<= n m))
+  (<= n m)
   ((GA Bool) (GI Int))
   (
   (GA Bool ((>= GI GI)))

--- a/test/regress/regress1/sygus-abduct-test-user.smt2
+++ b/test/regress/regress1/sygus-abduct-test-user.smt2
@@ -14,9 +14,9 @@
 
 ; Generate a predicate A that is consistent with the above axioms (i.e.
 ; their conjunction is SAT), and is such that the conjunction of the above
-; axioms, A and the conjecture below are UNSAT.
+; axioms, A and the negation of the conjecture below are UNSAT.
 ; The signature of A is below grammar.
-(get-abduct A (< x y)
+(get-abduct A (not (< x y))
 
 ; the grammar for the abduct-to-synthesize
 ((Start Bool) (StartInt Int))

--- a/test/regress/regress1/sygus-abduct-test.smt2
+++ b/test/regress/regress1/sygus-abduct-test.smt2
@@ -13,4 +13,4 @@
 (assert (and (<= n x)(<= x (+ n 5))))
 (assert (and (<= 1 y)(<= y m)))
 
-(get-abduct A (< x y))
+(get-abduct A (not (< x y)))


### PR DESCRIPTION
After discussion with Cesare, it is more straightforward to give the (non-negated) goal as an argument to `get-abduct`.

FYI @yoni206 