### PR TITLE
Fix printing issue related to nested quotes

### DIFF
--- a/src/expr/uninterpreted_constant.cpp
+++ b/src/expr/uninterpreted_constant.cpp
@@ -16,10 +16,10 @@
 
 #include "expr/uninterpreted_constant.h"
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <algorithm>
 
 #include "base/cvc4_assert.h"
 

--- a/src/expr/uninterpreted_constant.cpp
+++ b/src/expr/uninterpreted_constant.cpp
@@ -34,7 +34,13 @@ UninterpretedConstant::UninterpretedConstant(Type type, Integer index)
 }
 
 std::ostream& operator<<(std::ostream& out, const UninterpretedConstant& uc) {
-  return out << "uc_" << uc.getType() << '_' << uc.getIndex();
+  std::stringstream ss;
+  ss << uc.getType();
+  std::string st(ss.str());
+  // must remove delimiting quotes from the name of the type
+  // this prevents us from printing symbols like |@uc_|T|_n|
+  std::replace( st.begin(), st.end(), '|', '@');
+  return out << "uc_" << st.c_str() << "_" << uc.getIndex();
 }
 
 }/* CVC4 namespace */

--- a/src/expr/uninterpreted_constant.cpp
+++ b/src/expr/uninterpreted_constant.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <algorithm>
 
 #include "base/cvc4_assert.h"
 

--- a/src/expr/uninterpreted_constant.cpp
+++ b/src/expr/uninterpreted_constant.cpp
@@ -39,7 +39,12 @@ std::ostream& operator<<(std::ostream& out, const UninterpretedConstant& uc) {
   std::string st(ss.str());
   // must remove delimiting quotes from the name of the type
   // this prevents us from printing symbols like |@uc_|T|_n|
-  std::replace( st.begin(), st.end(), '|', '@');
+  std::string q("|");
+  size_t pos;
+  while( (pos=st.find(q)) != std::string::npos )
+  {
+    st.replace(pos,1,"");
+  }
   return out << "uc_" << st.c_str() << "_" << uc.getIndex();
 }
 

--- a/src/expr/uninterpreted_constant.cpp
+++ b/src/expr/uninterpreted_constant.cpp
@@ -41,9 +41,9 @@ std::ostream& operator<<(std::ostream& out, const UninterpretedConstant& uc) {
   // this prevents us from printing symbols like |@uc_|T|_n|
   std::string q("|");
   size_t pos;
-  while( (pos=st.find(q)) != std::string::npos )
+  while ((pos = st.find(q)) != std::string::npos)
   {
-    st.replace(pos,1,"");
+    st.replace(pos, 1, "");
   }
   return out << "uc_" << st.c_str() << "_" << uc.getIndex();
 }

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1732,7 +1732,7 @@ static void toStreamRational(std::ostream& out,
 
 static void toStream(std::ostream& out, const DeclareTypeCommand* c)
 {
-  out << "(declare-sort " << c->getSymbol() << " " << c->getArity() << ")";
+  out << "(declare-sort " << maybeQuoteSymbol(c->getSymbol()) << " " << c->getArity() << ")";
 }
 
 static void toStream(std::ostream& out, const DefineTypeCommand* c)

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1732,7 +1732,8 @@ static void toStreamRational(std::ostream& out,
 
 static void toStream(std::ostream& out, const DeclareTypeCommand* c)
 {
-  out << "(declare-sort " << maybeQuoteSymbol(c->getSymbol()) << " " << c->getArity() << ")";
+  out << "(declare-sort " << maybeQuoteSymbol(c->getSymbol()) << " "
+      << c->getArity() << ")";
 }
 
 static void toStream(std::ostream& out, const DefineTypeCommand* c)

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -1005,7 +1005,7 @@ void TheoryEngineModelBuilder::assignFunction(TheoryModel* m, Node f)
     ufmt.simplify();
   }
   std::stringstream ss;
-  ss << "_arg_" << f << "_";
+  ss << "_arg_";
   Node val = ufmt.getFunctionValue(ss.str().c_str(), condenseFuncValues);
   m->assignFunctionDefinition(f, val);
   // ufmt.debugPrint( std::cout, m );


### PR DESCRIPTION
This ensures we do choose names for certain identifiers we introduce (including bound variables and uninterpreted constants) that contain `|`.