### PR TITLE
Fix drat signature wrt side condition return types

### DIFF
--- a/proofs/signatures/drat.plf
+++ b/proofs/signatures/drat.plf
@@ -325,7 +325,7 @@
 
 
 ; Do unit propagation on `f`, constructing a UP model for it.
-(program build_up_model ((f cnf)) clause
+(program build_up_model ((f cnf)) UPConstructionResult
          (match (unit_search f)
                 (USRBottom UPCRBottom)
                 (USRNoUnit (UPCRModel cln))
@@ -338,7 +338,7 @@
 
 ; Given some starting assignment (`up_model`), continue UP to construct a larger
 ; model.
-(program extend_up_model ((f cnf) (up_model clause)) clause
+(program extend_up_model ((f cnf) (up_model clause)) UPConstructionResult
          (do (clause_into_global up_model)
            (let result (build_up_model f)
              (do (clause_undo_into_global up_model)


### PR DESCRIPTION
LFSC was not properly checking return types for side conditions, which was fixed in https://github.com/CVC4/LFSC/commit/616c72671dff7f6a83db9c3dbe6c1353404ccf19.  

As a result, it was not reporting an error for a type mismatch in `drat.plf`.  This fixes the type mismatch.

This should fix the failing proof tests on CVC4 master.