### PR TITLE
Fix handling of bvxnor operator with arity > 2.

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2120,8 +2120,7 @@ termNonVariable[CVC4::Expr& expr, CVC4::Expr& expr2]
         if (args.size() > 2)
         {
           if (kind == CVC4::kind::INTS_DIVISION || kind == CVC4::kind::XOR
-              || kind == CVC4::kind::MINUS || kind == CVC4::kind::DIVISION
-              || (kind == CVC4::kind::BITVECTOR_XNOR && PARSER_STATE->v2_6()))
+              || kind == CVC4::kind::MINUS || kind == CVC4::kind::DIVISION)
           {
             // Builtin operators that are not tokenized, are left associative,
             // but not internally variadic must set this.

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -404,6 +404,7 @@ class Smt2 : public Parser
       case kind::BITVECTOR_OR:
       case kind::BITVECTOR_PLUS:
       case kind::BITVECTOR_XOR:
+      case kind::BITVECTOR_XNOR:
         if (numArgs != 2 && !v2_6())
         {
           parseError(

--- a/src/theory/bv/bitblast/bitblast_strategies_template.h
+++ b/src/theory/bv/bitblast/bitblast_strategies_template.h
@@ -309,22 +309,12 @@ void DefaultXorBB (TNode node, std::vector<T>& bits, TBitblaster<T>* bb) {
 }
 
 template <class T>
-void DefaultXnorBB (TNode node, std::vector<T>& bits, TBitblaster<T>* bb) {
-  Debug("bitvector-bb") << "theory::bv::DefaultXnorBB bitblasting " << node << "\n";
-
-  Assert(node.getNumChildren() == 2 &&
-         node.getKind() == kind::BITVECTOR_XNOR &&
-         bits.size() == 0);
-  std::vector<T> lhs, rhs;
-  bb->bbTerm(node[0], lhs);
-  bb->bbTerm(node[1], rhs);
-  Assert(lhs.size() == rhs.size()); 
-  
-  for (unsigned i = 0; i < lhs.size(); ++i) {
-    bits.push_back(mkIff(lhs[i], rhs[i])); 
-  }
+void DefaultXnorBB(TNode node, std::vector<T>& bits, TBitblaster<T>* bb)
+{
+  Debug("bitvector-bb") << "theory::bv::DefaultXnorBB bitblasting " << node
+                        << "\n";
+  Unimplemented();
 }
-
 
 template <class T>
 void DefaultNandBB (TNode node, std::vector<T>& bits, TBitblaster<T>* bb) {

--- a/src/theory/bv/kinds
+++ b/src/theory/bv/kinds
@@ -49,7 +49,7 @@ operator BITVECTOR_XOR 2: "bitwise xor of two or more bit-vectors"
 operator BITVECTOR_NOT 1 "bitwise not of a bit-vector"
 operator BITVECTOR_NAND 2 "bitwise nand of two bit-vectors"
 operator BITVECTOR_NOR 2 "bitwise nor of two bit-vectors"
-operator BITVECTOR_XNOR 2 "bitwise xnor of two bit-vectors"
+operator BITVECTOR_XNOR 2: "bitwise xnor of two or more bit-vectors"
 
 ## arithmetic kinds
 operator BITVECTOR_MULT 2: "multiplication of two or more bit-vectors"

--- a/src/theory/bv/theory_bv_rewrite_rules_operator_elimination.h
+++ b/src/theory/bv/theory_bv_rewrite_rules_operator_elimination.h
@@ -366,8 +366,7 @@ inline Node RewriteRule<NorEliminate>::apply(TNode node)
 template <>
 inline bool RewriteRule<XnorEliminate>::applies(TNode node)
 {
-  return (node.getKind() == kind::BITVECTOR_XNOR &&
-          node.getNumChildren() == 2);
+  return node.getKind() == kind::BITVECTOR_XNOR;
 }
 
 template <>
@@ -376,9 +375,8 @@ inline Node RewriteRule<XnorEliminate>::apply(TNode node)
   Debug("bv-rewrite") << "RewriteRule<XnorEliminate>(" << node << ")"
                       << std::endl;
   NodeManager *nm = NodeManager::currentNM();
-  TNode a = node[0];
-  TNode b = node[1];
-  Node xorNode = nm->mkNode(kind::BITVECTOR_XOR, a, b);
+  std::vector<TNode> children(node.begin(), node.end());
+  Node xorNode = nm->mkNode(kind::BITVECTOR_XOR, children);
   Node result = nm->mkNode(kind::BITVECTOR_NOT, xorNode);
   return result;
 }


### PR DESCRIPTION
Previously, (bvxnor a b c) was translated to (bvxnor a (bvxnor b c))
instead of creating a node (bvxnor a b c). Since (bvxnor a b) == (bvnot
(bvxor a b)) the above translation was not correct for arity > 2.

For example, (bvxnor #b0 #b0 #b0) = #b1, however, with above (wrong)
translation it yields (bvxnor #b0 (bvxnor #b0 #b0)) = #b0