### PR TITLE
Properly implement logic info for separation logic

### DIFF
--- a/src/theory/logic_info.cpp
+++ b/src/theory/logic_info.cpp
@@ -283,10 +283,11 @@ std::string LogicInfo::getLogicString() const {
       if(!isQuantified()) {
         ss << "QF_";
       }
-      if(d_theories[THEORY_SEP]) {
+      if (d_theories[THEORY_SEP])
+      {
         ss << "SEP_";
         ++seen;
-      }    
+      }
       if(d_theories[THEORY_ARRAYS]) {
         ss << (d_sharingTheories == 1 ? "AX" : "A");
         ++seen;
@@ -331,7 +332,7 @@ std::string LogicInfo::getLogicString() const {
       if(d_theories[THEORY_SETS]) {
         ss << "FS";
         ++seen;
-      } 
+      }
       if(seen != d_sharingTheories) {
         Unhandled("can't extract a logic string from LogicInfo; at least one "
                   "active theory is unknown to LogicInfo::getLogicString() !");
@@ -412,7 +413,8 @@ void LogicInfo::setLogicString(std::string logicString)
     } else {
       enableQuantifiers();
     }
-    if(!strncmp(p, "SEP_", 3)) {
+    if (!strncmp(p, "SEP_", 3))
+    {
       enableSeparationLogic();
       p += 4;
     }

--- a/src/theory/logic_info.cpp
+++ b/src/theory/logic_info.cpp
@@ -413,7 +413,7 @@ void LogicInfo::setLogicString(std::string logicString)
     } else {
       enableQuantifiers();
     }
-    if (!strncmp(p, "SEP_", 3))
+    if (!strncmp(p, "SEP_", 4))
     {
       enableSeparationLogic();
       p += 4;

--- a/src/theory/logic_info.cpp
+++ b/src/theory/logic_info.cpp
@@ -283,6 +283,10 @@ std::string LogicInfo::getLogicString() const {
       if(!isQuantified()) {
         ss << "QF_";
       }
+      if(d_theories[THEORY_SEP]) {
+        ss << "SEP_";
+        ++seen;
+      }    
       if(d_theories[THEORY_ARRAYS]) {
         ss << (d_sharingTheories == 1 ? "AX" : "A");
         ++seen;
@@ -327,11 +331,7 @@ std::string LogicInfo::getLogicString() const {
       if(d_theories[THEORY_SETS]) {
         ss << "FS";
         ++seen;
-      }
-      if(d_theories[THEORY_SEP]) {
-        ss << "SEP";
-        ++seen;
-      }     
+      } 
       if(seen != d_sharingTheories) {
         Unhandled("can't extract a logic string from LogicInfo; at least one "
                   "active theory is unknown to LogicInfo::getLogicString() !");
@@ -411,6 +411,10 @@ void LogicInfo::setLogicString(std::string logicString)
       p += 3;
     } else {
       enableQuantifiers();
+    }
+    if(!strncmp(p, "SEP_", 3)) {
+      enableSeparationLogic();
+      p += 4;
     }
     if(!strncmp(p, "AX", 2)) {
       enableTheory(THEORY_ARRAYS);
@@ -511,10 +515,6 @@ void LogicInfo::setLogicString(std::string logicString)
         enableTheory(THEORY_SETS);
         p += 2;
       }
-      if(!strncmp(p, "SEP", 3)) {
-        enableTheory(THEORY_SEP);
-        p += 3;
-      }
     }
   }
 
@@ -586,6 +586,13 @@ void LogicInfo::enableSygus()
   enableTheory(THEORY_DATATYPES);
   enableIntegers();
   enableHigherOrder();
+}
+
+void LogicInfo::enableSeparationLogic()
+{
+  enableTheory(THEORY_SEP);
+  enableTheory(THEORY_UF);
+  enableTheory(THEORY_SETS);
 }
 
 void LogicInfo::enableIntegers() {

--- a/src/theory/logic_info.h
+++ b/src/theory/logic_info.h
@@ -211,7 +211,7 @@ public:
    * the theories of separation logic, UF and sets.
    */
   void enableSeparationLogic();
-  
+
   // these are for arithmetic
 
   /** Enable the use of integers in this logic. */

--- a/src/theory/logic_info.h
+++ b/src/theory/logic_info.h
@@ -206,7 +206,12 @@ public:
    * This means enabling quantifiers, datatypes, UF, integers, and higher order.
    */
   void enableSygus();
-
+  /**
+   * Enable everything that is needed for separation logic. This means enabling
+   * the theories of separation logic, UF and sets.
+   */
+  void enableSeparationLogic();
+  
   // these are for arithmetic
 
   /** Enable the use of integers in this logic. */

--- a/test/regress/regress0/sep/nemp.smt2
+++ b/test/regress/regress0/sep/nemp.smt2
@@ -1,5 +1,5 @@
 ; COMMAND-LINE: --no-check-models
 ; EXPECT: sat
-(set-logic QF_ALL_SUPPORTED)
+(set-logic QF_SEP_LIA)
 (assert (not (_ emp Int Int)))
 (check-sat)

--- a/test/regress/regress1/sep/sep-find2.smt2
+++ b/test/regress/regress1/sep/sep-find2.smt2
@@ -1,4 +1,4 @@
-(set-logic QF_ALL_SUPPORTED)
+(set-logic QF_SEP_LIA)
 (set-info :status unsat)
 
 (declare-const x1 Int)

--- a/test/unit/theory/logic_info_white.h
+++ b/test/unit/theory/logic_info_white.h
@@ -541,13 +541,13 @@ public:
     info.arithOnlyLinear();
     info.disableIntegers();
     info.lock();
-    TS_ASSERT_EQUALS( info.getLogicString(), "AUFBVFPDTLRASEP" );
+    TS_ASSERT_EQUALS( info.getLogicString(), "SEP_AUFBVFPDTLRA" );
 
     info = info.getUnlockedCopy();
     TS_ASSERT( !info.isLocked() );
     info.disableQuantifiers();
     info.lock();
-    TS_ASSERT_EQUALS( info.getLogicString(), "QF_AUFBVFPDTLRASEP" );
+    TS_ASSERT_EQUALS( info.getLogicString(), "QF_SEP_AUFBVFPDTLRA" );
 
     info = info.getUnlockedCopy();
     TS_ASSERT( !info.isLocked() );
@@ -556,7 +556,7 @@ public:
     info.enableIntegers();
     info.disableReals();
     info.lock();
-    TS_ASSERT_EQUALS( info.getLogicString(), "QF_AUFFPLIASEP" );
+    TS_ASSERT_EQUALS( info.getLogicString(), "QF_SEP_AUFFPLIA" );
 
     info = info.getUnlockedCopy();
     TS_ASSERT( !info.isLocked() );

--- a/test/unit/theory/logic_info_white.h
+++ b/test/unit/theory/logic_info_white.h
@@ -541,13 +541,13 @@ public:
     info.arithOnlyLinear();
     info.disableIntegers();
     info.lock();
-    TS_ASSERT_EQUALS( info.getLogicString(), "SEP_AUFBVFPDTLRA" );
+    TS_ASSERT_EQUALS(info.getLogicString(), "SEP_AUFBVFPDTLRA");
 
     info = info.getUnlockedCopy();
     TS_ASSERT( !info.isLocked() );
     info.disableQuantifiers();
     info.lock();
-    TS_ASSERT_EQUALS( info.getLogicString(), "QF_SEP_AUFBVFPDTLRA" );
+    TS_ASSERT_EQUALS(info.getLogicString(), "QF_SEP_AUFBVFPDTLRA");
 
     info = info.getUnlockedCopy();
     TS_ASSERT( !info.isLocked() );
@@ -556,7 +556,7 @@ public:
     info.enableIntegers();
     info.disableReals();
     info.lock();
-    TS_ASSERT_EQUALS( info.getLogicString(), "QF_SEP_AUFFPLIA" );
+    TS_ASSERT_EQUALS(info.getLogicString(), "QF_SEP_AUFFPLIA");
 
     info = info.getUnlockedCopy();
     TS_ASSERT( !info.isLocked() );


### PR DESCRIPTION
Fixes #2230.  This changes logic strings that involve the separation logic theory (which was not properly implemented before) and enables it on a few regressions.