### PR TITLE
 Track sygus variable to term relationship via attribute

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5149,10 +5149,7 @@ bool SmtEngine::getAbduct(const Expr& conj, const Type& grammarType, Expr& abd)
   asserts.push_back(conjn);
   std::string name("A");
   Node aconj = theory::quantifiers::SygusAbduct::mkAbductionConjecture(
-      name,
-      asserts,
-      axioms,
-      TypeNode::fromType(grammarType));
+      name, asserts, axioms, TypeNode::fromType(grammarType));
   // should be a quantified conjecture with one function-to-synthesize
   Assert(aconj.getKind() == kind::FORALL && aconj[0].getNumChildren() == 1);
   // remember the abduct-to-synthesize
@@ -5206,29 +5203,27 @@ bool SmtEngine::getAbductInternal(Expr& abd)
       // get the grammar type for the abduct
       Node af = Node::fromExpr(d_sssf);
       Node agt = af.getAttribute(theory::SygusSynthGrammarAttribute());
-      Assert( !agt.isNull() );
-      Assert( agt.getType().isDatatype() );
+      Assert(!agt.isNull());
+      Assert(agt.getType().isDatatype());
       const Datatype& agdt = agt.getType().getDatatype();
-      Assert( agdt.isSygus() );
+      Assert(agdt.isSygus());
       // get the formal argument list of the abduct
-      Node agdtbv = Node::fromExpr( agdt.getSygusVarList() );
-      Assert( !agdtbv.isNull() );
-      Assert( agdtbv.getKind()==kind::BOUND_VAR_LIST );
+      Node agdtbv = Node::fromExpr(agdt.getSygusVarList());
+      Assert(!agdtbv.isNull());
+      Assert(agdtbv.getKind() == kind::BOUND_VAR_LIST);
       // convert back to original
       // must replace formal arguments of abd with the free variables in the
       // input problem that they correspond to.
-      std::vector< Node > vars;
-      std::vector< Node > syms;
+      std::vector<Node> vars;
+      std::vector<Node> syms;
       SygusVarToTermAttribute sta;
-      for( const Node& bv : agdtbv )
+      for (const Node& bv : agdtbv)
       {
         vars.push_back(bv);
         syms.push_back(bv.hasAttribute(sta) ? bv.getAttribute(sta) : bv);
       }
-      abdn = abdn.substitute(vars.begin(),
-                             vars.end(),
-                             syms.begin(),
-                             syms.end());
+      abdn =
+          abdn.substitute(vars.begin(), vars.end(), syms.begin(), syms.end());
 
       // convert to expression
       abd = abdn.toExpr();

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5202,13 +5202,7 @@ bool SmtEngine::getAbductInternal(Expr& abd)
       }
       // get the grammar type for the abduct
       Node af = Node::fromExpr(d_sssf);
-      Node agt = af.getAttribute(theory::SygusSynthGrammarAttribute());
-      Assert(!agt.isNull());
-      Assert(agt.getType().isDatatype());
-      const Datatype& agdt = agt.getType().getDatatype();
-      Assert(agdt.isSygus());
-      // get the formal argument list of the abduct
-      Node agdtbv = Node::fromExpr(agdt.getSygusVarList());
+      Node agdtbv = af.getAttribute(theory::SygusSynthFunVarListAttribute());
       Assert(!agdtbv.isNull());
       Assert(agdtbv.getKind() == kind::BOUND_VAR_LIST);
       // convert back to original

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -5147,16 +5147,12 @@ bool SmtEngine::getAbduct(const Expr& conj, const Type& grammarType, Expr& abd)
   Node conjn = Node::fromExpr(conj).negate();
   d_abdConj = conjn.toExpr();
   asserts.push_back(conjn);
-  d_sssfVarlist.clear();
-  d_sssfSyms.clear();
   std::string name("A");
   Node aconj = theory::quantifiers::SygusAbduct::mkAbductionConjecture(
       name,
       asserts,
       axioms,
-      TypeNode::fromType(grammarType),
-      d_sssfVarlist,
-      d_sssfSyms);
+      TypeNode::fromType(grammarType));
   // should be a quantified conjecture with one function-to-synthesize
   Assert(aconj.getKind() == kind::FORALL && aconj[0].getNumChildren() == 1);
   // remember the abduct-to-synthesize
@@ -5207,14 +5203,32 @@ bool SmtEngine::getAbductInternal(Expr& abd)
       {
         abdn = abdn[1];
       }
-      Assert(d_sssfVarlist.size() == d_sssfSyms.size());
+      // get the grammar type for the abduct
+      Node af = Node::fromExpr(d_sssf);
+      Node agt = af.getAttribute(theory::SygusSynthGrammarAttribute());
+      Assert( !agt.isNull() );
+      Assert( agt.getType().isDatatype() );
+      const Datatype& agdt = agt.getType().getDatatype();
+      Assert( agdt.isSygus() );
+      // get the formal argument list of the abduct
+      Node agdtbv = Node::fromExpr( agdt.getSygusVarList() );
+      Assert( !agdtbv.isNull() );
+      Assert( agdtbv.getKind()==kind::BOUND_VAR_LIST );
       // convert back to original
       // must replace formal arguments of abd with the free variables in the
       // input problem that they correspond to.
-      abdn = abdn.substitute(d_sssfVarlist.begin(),
-                             d_sssfVarlist.end(),
-                             d_sssfSyms.begin(),
-                             d_sssfSyms.end());
+      std::vector< Node > vars;
+      std::vector< Node > syms;
+      SygusVarToTermAttribute sta;
+      for( const Node& bv : agdtbv )
+      {
+        vars.push_back(bv);
+        syms.push_back(bv.hasAttribute(sta) ? bv.getAttribute(sta) : bv);
+      }
+      abdn = abdn.substitute(vars.begin(),
+                             vars.end(),
+                             syms.begin(),
+                             syms.end());
 
       // convert to expression
       abd = abdn.toExpr();

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -170,12 +170,6 @@ class CVC4_PUBLIC SmtEngine {
    */
   Expr d_sssf;
   /**
-   * The substitution to apply to the solutions from the subsolver, used for
-   * the get-abduct command.
-   */
-  std::vector<Node> d_sssfVarlist;
-  std::vector<Node> d_sssfSyms;
-  /**
    * The conjecture of the current abduction problem. This expression is only
    * valid while we are in mode SMT_MODE_ABDUCT.
    */

--- a/src/theory/quantifiers/quantifiers_attributes.h
+++ b/src/theory/quantifiers/quantifiers_attributes.h
@@ -84,6 +84,18 @@ struct SygusSideConditionAttributeId
 typedef expr::Attribute<SygusSideConditionAttributeId, Node>
     SygusSideConditionAttribute;
 
+/** Attribute for indicating that a sygus variable encodes a term
+ *
+ * This is used, e.g., for abduction where the formal argument list of the
+ * abduct-to-synthesize corresponds to the free variables of the sygus
+ * problem.
+ */
+struct SygusVarToTermAttributeId
+{
+};
+typedef expr::Attribute<SygusVarToTermAttributeId, Node>
+    SygusVarToTermAttribute;
+
 namespace quantifiers {
 
 /** Attribute priority for rewrite rules */

--- a/src/theory/quantifiers/sygus/sygus_abduct.cpp
+++ b/src/theory/quantifiers/sygus/sygus_abduct.cpp
@@ -35,9 +35,7 @@ SygusAbduct::SygusAbduct() {}
 Node SygusAbduct::mkAbductionConjecture(const std::string& name,
                                         const std::vector<Node>& asserts,
                                         const std::vector<Node>& axioms,
-                                        TypeNode abdGType,
-                                        std::vector<Node>& varlist,
-                                        std::vector<Node>& syms)
+                                        TypeNode abdGType)
 {
   NodeManager* nm = NodeManager::currentNM();
   std::unordered_set<Node, NodeHashFunction> symset;
@@ -49,7 +47,9 @@ Node SygusAbduct::mkAbductionConjecture(const std::string& name,
       << "...finish, got " << symset.size() << " symbols." << std::endl;
 
   Trace("sygus-abduct-debug") << "Setup symbols..." << std::endl;
+  std::vector<Node> syms;
   std::vector<Node> vars;
+  std::vector<Node> varlist;
   std::vector<TypeNode> varlistTypes;
   for (const Node& s : symset)
   {
@@ -64,6 +64,9 @@ Node SygusAbduct::mkAbductionConjecture(const std::string& name,
       Node vlv = nm->mkBoundVar(ss.str(), tn);
       varlist.push_back(vlv);
       varlistTypes.push_back(tn);
+      // set that this variable encodes the term s
+      SygusVarToTermAttribute sta;
+      vlv.setAttribute(sta,s);
     }
   }
   // make the sygus variable list

--- a/src/theory/quantifiers/sygus/sygus_abduct.cpp
+++ b/src/theory/quantifiers/sygus/sygus_abduct.cpp
@@ -66,7 +66,7 @@ Node SygusAbduct::mkAbductionConjecture(const std::string& name,
       varlistTypes.push_back(tn);
       // set that this variable encodes the term s
       SygusVarToTermAttribute sta;
-      vlv.setAttribute(sta,s);
+      vlv.setAttribute(sta, s);
     }
   }
   // make the sygus variable list

--- a/src/theory/quantifiers/sygus/sygus_abduct.h
+++ b/src/theory/quantifiers/sygus/sygus_abduct.h
@@ -68,13 +68,13 @@ class SygusAbduct
    * The type abdGType (if non-null) is a sygus datatype type that encodes the
    * grammar that should be used for solutions of the abduction conjecture.
    *
-   * The relationship between the free variables of asserts and the formal 
-   * rgument list of the abduct-to-synthesize are tracked by the attribute 
+   * The relationship between the free variables of asserts and the formal
+   * rgument list of the abduct-to-synthesize are tracked by the attribute
    * SygusVarToTermAttribute.
-   * 
+   *
    * In particular, solutions to the synthesis conjecture will be in the form
    * of a closed term (lambda varlist. t). The intended solution, which is a
-   * term whose free variables are a subset of asserts, is the term 
+   * term whose free variables are a subset of asserts, is the term
    * t * { varlist -> SygusVarToTermAttribute(varlist) }.
    */
   static Node mkAbductionConjecture(const std::string& name,

--- a/src/theory/quantifiers/sygus/sygus_abduct.h
+++ b/src/theory/quantifiers/sygus/sygus_abduct.h
@@ -68,19 +68,19 @@ class SygusAbduct
    * The type abdGType (if non-null) is a sygus datatype type that encodes the
    * grammar that should be used for solutions of the abduction conjecture.
    *
-   * The arguments varlist and syms specify the relationship between the free
-   * variables of asserts and the formal argument list of the
-   * abduct-to-synthesize. In particular, solutions to the synthesis conjecture
-   * will be in the form of a closed term (lambda varlist. t). The intended
-   * solution, which is a term whose free variables are a subset of asserts,
-   * is the term t { varlist -> syms }.
+   * The relationship between the free variables of asserts and the formal 
+   * rgument list of the abduct-to-synthesize are tracked by the attribute 
+   * SygusVarToTermAttribute.
+   * 
+   * In particular, solutions to the synthesis conjecture will be in the form
+   * of a closed term (lambda varlist. t). The intended solution, which is a
+   * term whose free variables are a subset of asserts, is the term 
+   * t * { varlist -> SygusVarToTermAttribute(varlist) }.
    */
   static Node mkAbductionConjecture(const std::string& name,
                                     const std::vector<Node>& asserts,
                                     const std::vector<Node>& axioms,
-                                    TypeNode abdGType,
-                                    std::vector<Node>& varlist,
-                                    std::vector<Node>& syms);
+                                    TypeNode abdGType);
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -1017,7 +1017,7 @@ void SynthConjecture::printSynthSolution(std::ostream& out)
   {
     return;
   }
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   for (unsigned i = 0, size = d_embed_quant[0].getNumChildren(); i < size; i++)
   {
     Node sol = sols[i];
@@ -1087,17 +1087,17 @@ void SynthConjecture::printSynthSolution(std::ostream& out)
         // external terms. This ensures that --sygus-stream prints
         // solutions with no arguments on the predicate for responses to
         // the get-abduct command.
-        std::vector< Node > pvs;
+        std::vector<Node> pvs;
         Node vl = Node::fromExpr(dt.getSygusVarList());
-        if( !vl.isNull() )
+        if (!vl.isNull())
         {
-          Assert( vl.getKind()==BOUND_VAR_LIST );
+          Assert(vl.getKind() == BOUND_VAR_LIST);
           SygusVarToTermAttribute sta;
-          for( const Node& v : vl )
+          for (const Node& v : vl)
           {
-            if( !v.hasAttribute(sta) )
+            if (!v.hasAttribute(sta))
             {
-              pvs.push_back( v );
+              pvs.push_back(v);
             }
           }
         }
@@ -1107,7 +1107,7 @@ void SynthConjecture::printSynthSolution(std::ostream& out)
         }
         else
         {
-          vl = nm->mkNode(BOUND_VAR_LIST,pvs);
+          vl = nm->mkNode(BOUND_VAR_LIST, pvs);
           out << vl << " ";
         }
         out << dt.getSygusType() << " ";

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -1087,6 +1087,8 @@ void SynthConjecture::printSynthSolution(std::ostream& out)
         // external terms. This ensures that --sygus-stream prints
         // solutions with no arguments on the predicate for responses to
         // the get-abduct command.
+        // pvs stores the variables that will be printed in the argument list
+        // below.
         std::vector<Node> pvs;
         Node vl = Node::fromExpr(dt.getSygusVarList());
         if (!vl.isNull())


### PR DESCRIPTION
This generalizes support for sygus functions-to-synthesize whose formal argument lists encode free symbols. 

We now track an attribute on formal arguments to functions-to-synthesize to the term they encode (of the same name).  This allows us to print:

`(declare-fun A () (> x 0))`

instead of:

`(declare-fun A ((x Int)) (> x 0))`

when `x` is intended to refer to a free variable in the scope of, e.g. a `get-abduct` command.

This eliminates the need to track the substitution on solutions for get-abduct and makes our printing of abducts with `--sygus-stream` consistent with the non-streaming version.