### PR TITLE
Remove option --continued-execution.

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -89,9 +89,10 @@ bool CommandExecutor::doCommand(Command* cmd)
     // assume no error
     bool status = true;
 
-    for(CommandSequence::iterator subcmd = seq->begin();
-        (status || d_options.getContinuedExecution()) && subcmd != seq->end();
-        ++subcmd) {
+    for (CommandSequence::iterator subcmd = seq->begin();
+         status && subcmd != seq->end();
+         ++subcmd)
+    {
       status = doCommand(*subcmd);
     }
 
@@ -183,7 +184,8 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
       }
       for (const auto& getterCommand : getterCommands) {
         status = doCommandSingleton(getterCommand.get());
-        if (!status && !d_options.getContinuedExecution()) {
+        if (!status)
+        {
           break;
         }
       }

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -362,7 +362,8 @@ int runCvc4(int argc, char* argv[], Options& opts) {
       int needReset = 0;
       // true if one of the commands was interrupted
       bool interrupted = false;
-      while (status || opts.getContinuedExecution()) {
+      while (status)
+      {
         if (interrupted) {
           (*opts.getOut()) << CommandInterrupted();
           break;
@@ -515,7 +516,8 @@ int runCvc4(int argc, char* argv[], Options& opts) {
         replayParser->useDeclarationsFrom(parser.get());
       }
       bool interrupted = false;
-      while(status || opts.getContinuedExecution()) {
+      while (status)
+      {
         if (interrupted) {
           (*opts.getOut()) << CommandInterrupted();
           pExecutor->reset();

--- a/src/options/didyoumean_test.cpp
+++ b/src/options/didyoumean_test.cpp
@@ -734,7 +734,6 @@ set<string> getOptionStrings() {
       "incremental-parallel",
       "no-incremental-parallel",
       "no-interactive-prompt",
-      "continued-execution",
       "immediate-exit",
       "segv-spin",
       "no-segv-spin",

--- a/src/options/main_options.toml
+++ b/src/options/main_options.toml
@@ -163,16 +163,6 @@ header = "options/main_options.h"
   help       = "interactive prompting while in interactive mode"
 
 [[option]]
-  name       = "continuedExecution"
-  category   = "regular"
-  long       = "continued-execution"
-  type       = "bool"
-  default    = "false"
-  links      = ["--interactive", "--no-interactive-prompt"]
-  read_only  = true
-  help       = "continue executing commands, even on error"
-
-[[option]]
   name       = "segvSpin"
   category   = "regular"
   long       = "segv-spin"

--- a/src/options/options.h
+++ b/src/options/options.h
@@ -198,7 +198,6 @@ public:
   InstFormatMode getInstFormatMode() const;
   OutputLanguage getOutputLanguage() const;
   bool getCheckProofs() const;
-  bool getContinuedExecution() const;
   bool getDumpInstantiations() const;
   bool getDumpModels() const;
   bool getDumpProofs() const;

--- a/src/options/options_public_functions.cpp
+++ b/src/options/options_public_functions.cpp
@@ -54,10 +54,6 @@ bool Options::getCheckProofs() const{
   return (*this)[options::checkProofs];
 }
 
-bool Options::getContinuedExecution() const{
-  return (*this)[options::continuedExecution];
-}
-
 bool Options::getDumpInstantiations() const{
   return (*this)[options::dumpInstantiations];
 }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2438,12 +2438,7 @@ CVC4::SExpr SmtEngine::getInfo(const std::string& key) const {
     }
     return SExpr(stats);
   } else if(key == "error-behavior") {
-    // immediate-exit | continued-execution
-    if( options::continuedExecution() || options::interactive() ) {
-      return SExpr(SExpr::Keyword("continued-execution"));
-    } else {
-      return SExpr(SExpr::Keyword("immediate-exit"));
-    }
+    return SExpr(SExpr::Keyword("immediate-exit"));
   } else if(key == "name") {
     return SExpr(Configuration::getName());
   } else if(key == "version") {


### PR DESCRIPTION
For now we will treat all errors as non-recoverable. With the new API we
will gradually specify recoverable errors that will be handled
differently.

Fixes #792.