### PR TITLE
Mark symbols introduced by named attributes as defined.

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2367,7 +2367,6 @@ attribute[CVC4::Expr& expr, CVC4::Expr& retExpr, std::string& attr]
   : KEYWORD ( simpleSymbolicExprNoKeyword[sexpr] { hasValue = true; } )?
   {
     attr = AntlrInput::tokenText($KEYWORD);
-    // EXPR_MANAGER->setNamedAttribute( expr, attr );
     if(attr == ":rewrite-rule") {
       if(hasValue) {
         std::stringstream ss;
@@ -2463,13 +2462,7 @@ attribute[CVC4::Expr& expr, CVC4::Expr& retExpr, std::string& attr]
   | ATTRIBUTE_NAMED_TOK symbolicExpr[sexpr]
     {
       attr = std::string(":named");
-      Expr func = PARSER_STATE->setNamedAttribute(expr, sexpr);
-      std::string name = sexpr.getValue();
-      // bind name to expr with define-fun
-      Command* c =
-        new DefineNamedFunctionCommand(name, func, std::vector<Expr>(), expr);
-      c->setMuted(true);
-      PARSER_STATE->preemptCommand(c);
+      PARSER_STATE->setNamedAttribute(expr, sexpr);
     }
   ;
 

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2367,6 +2367,7 @@ attribute[CVC4::Expr& expr, CVC4::Expr& retExpr, std::string& attr]
   : KEYWORD ( simpleSymbolicExprNoKeyword[sexpr] { hasValue = true; } )?
   {
     attr = AntlrInput::tokenText($KEYWORD);
+    // EXPR_MANAGER->setNamedAttribute( expr, attr );
     if(attr == ":rewrite-rule") {
       if(hasValue) {
         std::stringstream ss;
@@ -2462,7 +2463,13 @@ attribute[CVC4::Expr& expr, CVC4::Expr& retExpr, std::string& attr]
   | ATTRIBUTE_NAMED_TOK symbolicExpr[sexpr]
     {
       attr = std::string(":named");
-      PARSER_STATE->setNamedAttribute(expr, sexpr);
+      Expr func = PARSER_STATE->setNamedAttribute(expr, sexpr);
+      std::string name = sexpr.getValue();
+      // bind name to expr with define-fun
+      Command* c =
+        new DefineNamedFunctionCommand(name, func, std::vector<Expr>(), expr);
+      c->setMuted(true);
+      PARSER_STATE->preemptCommand(c);
     }
   ;
 

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -1933,7 +1933,7 @@ Expr Smt2::setNamedAttribute(Expr& expr, const SExpr& sexpr)
   // check that sexpr is a fresh function symbol, and reserve it
   reserveSymbolAtAssertionLevel(name);
   // define it
-  Expr func = mkVar(name, expr.getType());
+  Expr func = mkVar(name, expr.getType(),ExprManager::VAR_FLAG_DEFINED);
   // remember the last term to have been given a :named attribute
   setLastNamedTerm(expr, name);
   return func;

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -1933,7 +1933,7 @@ Expr Smt2::setNamedAttribute(Expr& expr, const SExpr& sexpr)
   // check that sexpr is a fresh function symbol, and reserve it
   reserveSymbolAtAssertionLevel(name);
   // define it
-  Expr func = mkVar(name, expr.getType(),ExprManager::VAR_FLAG_DEFINED);
+  Expr func = mkVar(name, expr.getType(), ExprManager::VAR_FLAG_DEFINED);
   // remember the last term to have been given a :named attribute
   setLastNamedTerm(expr, name);
   return func;


### PR DESCRIPTION
This fixes #1864 and fixes #3188.

When we encounter a `:named` attribute, we currently introduce a symbol. This symbol was appearing in models as if it were a user-declared symbol, when it should have been marked as defined.

Btw, our behavior in introducing a `define-fun` that corresponds to the named subexpression is compatible with the semantics stated in Section 4.1.6 of http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf.  Although we don't reprint the benchmark in #1864 in its exact original form, it is printed in an equivalent form as indicated in that section.