### PR TITLE
cmake: Use ExactVersion instead of SameMinorVersion.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,7 @@ configure_package_config_file(
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/CVC4ConfigVersion.cmake
   VERSION ${CVC4_RELEASE_STRING}
-  COMPATIBILITY SameMinorVersion
+  COMPATIBILITY ExactVersion
 )
 
 install(FILES


### PR DESCRIPTION
SameMinorVersion was introduced in version 3.11, however, we don't want
to require version 3.11 or higher, so we use ExactVersion for now.