### PR TITLE
 Fix for when to apply single invocation techniques

### DIFF
--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -329,7 +329,7 @@ void CegSingleInv::finishInit(bool syntaxRestricted)
   }
   // If we succeeded, mark the quantified formula with the quantifier
   // elimination attribute to ensure its structure is preserved
-  if (!d_single_inv.isNull() && d_single_inv.getKind()==FORALL)
+  if (!d_single_inv.isNull() && d_single_inv.getKind() == FORALL)
   {
     Node n_attr =
         nm->mkSkolem("qe_si",


### PR DESCRIPTION
This corrects an issue which caused us to apply single invocation techniques for quantified formulas where an appropriate quantifier instantiation technique is not available (e.g. strings).

This was caused by merging #3148 independently of #3151.

The fix is to mark the single invocation quantified formula with the quantifier elimination attribute after its status checked against the CEGQI module.

This fixes a timeout in regress1/sygus/strings-no-syntax.sy.