### PR TITLE
 Fixes for sygus regressions

### DIFF
--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -353,7 +353,7 @@ CegHandledStatus CegInstantiator::isCbqiQuantPrefix(Node q,
 
 CegHandledStatus CegInstantiator::isCbqiQuant(Node q, QuantifiersEngine* qe)
 {
-  Assert(q.getKind()==FORALL);
+  Assert(q.getKind() == FORALL);
   // compute attributes
   QAttributes qa;
   QuantAttributes::computeQuantAttributes(q, qa);

--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -353,6 +353,7 @@ CegHandledStatus CegInstantiator::isCbqiQuantPrefix(Node q,
 
 CegHandledStatus CegInstantiator::isCbqiQuant(Node q, QuantifiersEngine* qe)
 {
+  Assert(q.getKind()==FORALL);
   // compute attributes
   QAttributes qa;
   QuantAttributes::computeQuantAttributes(q, qa);

--- a/src/theory/quantifiers/quant_split.cpp
+++ b/src/theory/quantifiers/quant_split.cpp
@@ -33,6 +33,14 @@ QuantifiersModule( qe ), d_added_split( qe->getUserContext() ){
 
 void QuantDSplit::checkOwnership(Node q)
 {
+  // If q is non-standard (marked as sygus, quantifier elimination, etc.), then
+  // do no split it.
+  QAttributes qa;
+  QuantAttributes::computeQuantAttributes(q, qa);
+  if (!qa.isStandard())
+  {
+    return;
+  }
   int max_index = -1;
   int max_score = -1;
   Trace("quant-dsplit-debug") << "Check split quantified formula : " << q << std::endl;

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -314,7 +314,11 @@ void CegSingleInv::finishInit(bool syntaxRestricted)
   Trace("cegqi-si") << "Single invocation formula is : " << d_single_inv
                     << std::endl;
   // check whether we can handle this quantified formula
-  CegHandledStatus status = CegInstantiator::isCbqiQuant(d_single_inv);
+  CegHandledStatus status = CEG_HANDLED;
+  if( d_single_inv.getKind()==FORALL )
+  {
+    status = CegInstantiator::isCbqiQuant(d_single_inv);
+  }
   Trace("cegqi-si") << "CegHandledStatus is " << status << std::endl;
   if (status < CEG_HANDLED)
   {

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -315,7 +315,7 @@ void CegSingleInv::finishInit(bool syntaxRestricted)
                     << std::endl;
   // check whether we can handle this quantified formula
   CegHandledStatus status = CEG_HANDLED;
-  if( d_single_inv.getKind()==FORALL )
+  if (d_single_inv.getKind() == FORALL)
   {
     status = CegInstantiator::isCbqiQuant(d_single_inv);
   }


### PR DESCRIPTION
Fixes two miscellaneous issues in regress1 related to combinations of recent commits.

The first ensures we do not do quantifiers splitting for non-standard quantified formulas.

The second ensures we handle trivial conjectures whose body does not involve functions-to-synthesize with single invocation.