### PR TITLE
Fix helper function in cegqi for strict bounds

### DIFF
--- a/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_instantiator.cpp
@@ -77,7 +77,7 @@ CegTermType mkNegateCTT(CegTermType c)
 }
 bool isStrictCTT(CegTermType c)
 {
-  return c == CEG_TT_LOWER_STRICT && c == CEG_TT_UPPER_STRICT;
+  return c == CEG_TT_LOWER_STRICT || c == CEG_TT_UPPER_STRICT;
 }
 bool isLowerBoundCTT(CegTermType c)
 {


### PR DESCRIPTION
Might be causing the nightly failures (although I wasn't able to reproduce the failure).