### PR TITLE
Fix issue related to enum in cegqi

### DIFF
--- a/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
@@ -184,7 +184,10 @@ bool ArithInstantiator::processAssertion(CegInstantiator* ci,
         uires = mkNegateCTT(ires);
         if (d_type.isInteger())
         {
-          uval = nm->mkNode(PLUS, val, nm->mkConst(Rational(isUpperBoundCTT(uires) ? 1 : -1)));
+          uval = nm->mkNode(
+              PLUS,
+              val,
+              nm->mkConst(Rational(isUpperBoundCTT(uires) ? 1 : -1)));
           uval = Rewriter::rewrite(uval);
         }
         else
@@ -249,7 +252,8 @@ bool ArithInstantiator::processAssertion(CegInstantiator* ci,
       if (d_type.isInteger())
       {
         uires = is_upper ? CEG_TT_LOWER : CEG_TT_UPPER;
-        uval = nm->mkNode(PLUS, val, nm->mkConst(Rational(isUpperBoundCTT(uires) ? 1 : -1)));
+        uval = nm->mkNode(
+            PLUS, val, nm->mkConst(Rational(isUpperBoundCTT(uires) ? 1 : -1)));
         uval = Rewriter::rewrite(uval);
       }
       else

--- a/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
@@ -184,7 +184,7 @@ bool ArithInstantiator::processAssertion(CegInstantiator* ci,
         uires = mkNegateCTT(ires);
         if (d_type.isInteger())
         {
-          uval = nm->mkNode(PLUS, val, nm->mkConst(Rational(uires)));
+          uval = nm->mkNode(PLUS, val, nm->mkConst(Rational(isUpperBoundCTT(uires) ? 1 : -1)));
           uval = Rewriter::rewrite(uval);
         }
         else
@@ -249,7 +249,7 @@ bool ArithInstantiator::processAssertion(CegInstantiator* ci,
       if (d_type.isInteger())
       {
         uires = is_upper ? CEG_TT_LOWER : CEG_TT_UPPER;
-        uval = nm->mkNode(PLUS, val, nm->mkConst(Rational(uires)));
+        uval = nm->mkNode(PLUS, val, nm->mkConst(Rational(isUpperBoundCTT(uires) ? 1 : -1)));
         uval = Rewriter::rewrite(uval);
       }
       else


### PR DESCRIPTION
Corrects 2 cases where the enum was being used as its original value (1/-1) to indicate a required offset in a upper/lower bound.

This fixes the nightlies.