### PR TITLE
Add support for creating constant arrays to the new C++ API

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2558,6 +2558,7 @@ Term Solver::mkBitVector(uint32_t size, std::string& s, uint32_t base) const
 Term Solver::mkConstArray(Sort sort, Term val) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
+  CVC4_API_ARG_CHECK_NOT_NULL(val);
   CVC4_API_CHECK(sort.isArray())  << "Not an array sort.";
   CVC4_API_CHECK(sort.getArrayElementSort() == val.getSort())  << "Value does not match element sort.";
   Term res = mkValHelper<CVC4::ArrayStoreAll>(CVC4::ArrayStoreAll(*sort.d_type, *val.d_expr));

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2559,9 +2559,11 @@ Term Solver::mkConstArray(Sort sort, Term val) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
   CVC4_API_ARG_CHECK_NOT_NULL(val);
-  CVC4_API_CHECK(sort.isArray())  << "Not an array sort.";
-  CVC4_API_CHECK(sort.getArrayElementSort() == val.getSort())  << "Value does not match element sort.";
-  Term res = mkValHelper<CVC4::ArrayStoreAll>(CVC4::ArrayStoreAll(*sort.d_type, *val.d_expr));
+  CVC4_API_CHECK(sort.isArray()) << "Not an array sort.";
+  CVC4_API_CHECK(sort.getArrayElementSort() == val.getSort())
+      << "Value does not match element sort.";
+  Term res = mkValHelper<CVC4::ArrayStoreAll>(
+      CVC4::ArrayStoreAll(*sort.d_type, *val.d_expr));
   return res;
   CVC4_API_SOLVER_TRY_CATCH_END;
 }

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2555,6 +2555,16 @@ Term Solver::mkBitVector(uint32_t size, std::string& s, uint32_t base) const
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
 
+Term Solver::mkConstArray(Sort sort, Term val) const
+{
+  CVC4_API_SOLVER_TRY_CATCH_BEGIN;
+  CVC4_API_CHECK(sort.isArray())  << "Not an array sort.";
+  CVC4_API_CHECK(sort.getArrayElementSort() == val.getSort())  << "Value does not match element sort.";
+  Term res = mkValHelper<CVC4::ArrayStoreAll>(CVC4::ArrayStoreAll(*sort.d_type, *val.d_expr));
+  return res;
+  CVC4_API_SOLVER_TRY_CATCH_END;
+}
+
 Term Solver::mkPosInf(uint32_t exp, uint32_t sig) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -2097,7 +2097,8 @@ class CVC4_PUBLIC Solver
   Term mkBitVector(uint32_t size, std::string& s, uint32_t base) const;
 
   /**
-   * Create a constant array with the provided constant value stored at every index
+   * Create a constant array with the provided constant value stored at every
+   * index
    * @param sort the sort of the constant array (must be an array sort)
    * @param val the constant value to store (must match the sort's element sort)
    * @return the constant array term

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -2097,6 +2097,14 @@ class CVC4_PUBLIC Solver
   Term mkBitVector(uint32_t size, std::string& s, uint32_t base) const;
 
   /**
+   * Create a constant array with the provided constant value stored at every index
+   * @param sort the sort of the constant array (must be an array sort)
+   * @param val the constant value to store (must match the sort's element sort)
+   * @return the constant array term
+   */
+  Term mkConstArray(Sort sort, Term val) const;
+
+  /**
    * Create a positive infinity floating-point constant. Requires CVC4 to be
    * compiled with SymFPU support.
    * @param exp Number of bits in the exponent

--- a/test/unit/api/solver_black.h
+++ b/test/unit/api/solver_black.h
@@ -765,7 +765,8 @@ void SolverBlack::testMkConstArray()
 
   TS_ASSERT_THROWS_NOTHING(d_solver->mkConstArray(arrSort, zero));
   TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, Term()), CVC4ApiException&);
-  TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, d_solver->mkBitVector(1, 1)), CVC4ApiException&);
+  TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, d_solver->mkBitVector(1, 1)),
+                   CVC4ApiException&);
   TS_ASSERT_THROWS(d_solver->mkConstArray(intSort, zero), CVC4ApiException&);
 }
 

--- a/test/unit/api/solver_black.h
+++ b/test/unit/api/solver_black.h
@@ -764,8 +764,8 @@ void SolverBlack::testMkConstArray()
   Term constArr = d_solver->mkConstArray(arrSort, zero);
 
   TS_ASSERT_THROWS_NOTHING(d_solver->mkConstArray(arrSort, zero));
-  TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, d_solver->mkBitVector(1, 1)));
-  TS_ASSERT_THROWS(d_solver->mkConstArray(intSort, zero));
+  TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, d_solver->mkBitVector(1, 1)), CVC4ApiException&);
+  TS_ASSERT_THROWS(d_solver->mkConstArray(intSort, zero), CVC4ApiException&);
 }
 
 void SolverBlack::testDeclareDatatype()

--- a/test/unit/api/solver_black.h
+++ b/test/unit/api/solver_black.h
@@ -764,6 +764,7 @@ void SolverBlack::testMkConstArray()
   Term constArr = d_solver->mkConstArray(arrSort, zero);
 
   TS_ASSERT_THROWS_NOTHING(d_solver->mkConstArray(arrSort, zero));
+  TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, Term()), CVC4ApiException&);
   TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, d_solver->mkBitVector(1, 1)), CVC4ApiException&);
   TS_ASSERT_THROWS(d_solver->mkConstArray(intSort, zero), CVC4ApiException&);
 }

--- a/test/unit/api/solver_black.h
+++ b/test/unit/api/solver_black.h
@@ -53,6 +53,7 @@ class SolverBlack : public CxxTest::TestSuite
   void testMkBitVector();
   void testMkBoolean();
   void testMkConst();
+  void testMkConstArray();
   void testMkEmptySet();
   void testMkFalse();
   void testMkFloatingPoint();
@@ -753,6 +754,18 @@ void SolverBlack::testMkConst()
   TS_ASSERT_THROWS_NOTHING(d_solver->mkConst(funSort, ""));
   TS_ASSERT_THROWS(d_solver->mkConst(Sort()), CVC4ApiException&);
   TS_ASSERT_THROWS(d_solver->mkConst(Sort(), "a"), CVC4ApiException&);
+}
+
+void SolverBlack::testMkConstArray()
+{
+  Sort intSort = d_solver->getIntegerSort();
+  Sort arrSort = d_solver->mkArraySort(intSort, intSort);
+  Term zero = d_solver->mkReal(0);
+  Term constArr = d_solver->mkConstArray(arrSort, zero);
+
+  TS_ASSERT_THROWS_NOTHING(d_solver->mkConstArray(arrSort, zero));
+  TS_ASSERT_THROWS(d_solver->mkConstArray(arrSort, d_solver->mkBitVector(1, 1)));
+  TS_ASSERT_THROWS(d_solver->mkConstArray(intSort, zero));
 }
 
 void SolverBlack::testDeclareDatatype()


### PR DESCRIPTION
I believe it is currently not possible to create a constant array through the new C++ API. This pull request adds this support.