### PR TITLE
Add run script for next SMT-COMP

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp-current
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+cvc4=./cvc4
+bench="$1"
+
+logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+
+# use: trywith [params..]
+# to attempt a run.  Only thing printed on stdout is "sat" or "unsat", in which
+# case this run script terminates immediately.  Otherwise, this function
+# returns normally and prints the output of the solver to stderr.
+function trywith {
+  limit=$1; shift;
+  result="$(ulimit -S -t "$limit";$cvc4 -L smt2.6 --no-incremental --no-checking --no-interactive "$@" $bench)"
+  case "$result" in
+    sat|unsat) echo "$result"; exit 0;;
+    *)         echo "$result" >&2;;
+  esac
+}
+
+# use: finishwith [params..]
+# to run cvc4 and let it output whatever it will to stdout.
+function finishwith {
+  $cvc4 -L smt2.6 --no-incremental --no-checking --no-interactive "$@" $bench
+}
+
+case "$logic" in
+
+QF_LRA)
+  trywith 400 --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi
+  finishwith --no-restrict-pivots --use-soi --new-prop --unconstrained-simp
+  ;;
+QF_LIA)
+  # same as QF_LRA but add --pb-rewrites
+  finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --unconstrained-simp --use-soi --pb-rewrites
+  ;;
+QF_NIA)
+  trywith 600 --nl-ext-tplanes --decision=internal
+  trywith 60 --nl-ext-tplanes --decision=justification
+  trywith 60 --no-nl-ext-tplanes --decision=internal
+  # this totals up to more than 40 minutes, although notice that smaller bit-widths may quickly fail
+  trywith 600 --solve-int-as-bv=2 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=4 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=8 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=16 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 1200 --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  finishwith --nl-ext-tplanes --decision=internal
+  ;;
+QF_NRA)
+  trywith 600 --nl-ext-tplanes --decision=internal
+  trywith 600 --nl-ext-tplanes --decision=justification --no-nl-ext-factor
+  trywith 60 --nl-ext-tplanes --decision=internal --solve-real-as-int
+  finishwith --nl-ext-tplanes --decision=justification
+  ;;
+# all logics with UF + quantifiers should either fall under this or special cases below
+ALIA|AUFLIA|AUFLIRA|AUFNIRA|UF|UFIDL|UFLIA|UFLRA|UFNIA|UFDT|UFDTLIA|AUFDTLIA|AUFBVDTLIA|AUFNIA)
+  # the following is designed for a run time of 20 min.
+  # initial runs 2min
+  trywith 60 --simplification=none --full-saturate-quant
+  trywith 60 --no-e-matching --full-saturate-quant
+  # trigger selections 6min
+  trywith 60 --relevant-triggers --full-saturate-quant
+  trywith 60 --trigger-sel=max --full-saturate-quant
+  trywith 60 --multi-trigger-when-single --full-saturate-quant
+  trywith 60 --multi-trigger-when-single --multi-trigger-priority --full-saturate-quant
+  trywith 60 --multi-trigger-cache --full-saturate-quant
+  trywith 60 --no-multi-trigger-linear --full-saturate-quant
+  # other 8min
+  trywith 60 --pre-skolem-quant --full-saturate-quant
+  trywith 60 --inst-when=full --full-saturate-quant
+  trywith 60 --no-e-matching --no-quant-cf --full-saturate-quant
+  trywith 60 --full-saturate-quant --quant-ind
+  trywith 60 --decision=internal --simplification=none --no-inst-no-entail --no-quant-cf --full-saturate-quant
+  trywith 60 --decision=internal --full-saturate-quant
+  trywith 60 --term-db-mode=relevant --full-saturate-quant
+  trywith 60 --fs-interleave --full-saturate-quant
+  # finite model find 6min
+  trywith 60 --finite-model-find --mbqi=none
+  trywith 60 --finite-model-find --decision=internal
+  trywith 60 --finite-model-find --macros-quant --macros-quant-mode=all
+  trywith 60 --finite-model-find --uf-ss=no-minimal
+  trywith 120 --finite-model-find --fmf-inst-engine
+  # long runs 8min
+  trywith 480 --finite-model-find --decision=internal
+  finishwith --full-saturate-quant
+  ;;
+ABVFP|BVFP|FP)
+  finishwith --full-saturate-quant --fp-exp
+  ;;
+UFBV)
+  # most problems in UFBV are essentially BV
+  trywith 600 --full-saturate-quant --decision=internal
+  trywith 600 --full-saturate-quant --cbqi-nested-qe --decision=internal
+  trywith 60 --full-saturate-quant --no-cbqi-innermost --global-negate
+  finishwith --finite-model-find
+  ;;
+BV)
+  trywith 240 --full-saturate-quant
+  trywith 240 --full-saturate-quant --no-cbqi-innermost
+  trywith 600 --full-saturate-quant --cbqi-nested-qe --decision=internal
+  trywith 60 --full-saturate-quant --no-cbqi-bv
+  trywith 60 --full-saturate-quant --cbqi-bv-ineq=eq-slack
+  # finish 10min
+  finishwith --full-saturate-quant --no-cbqi-innermost --global-negate
+  ;;
+LIA|LRA|NIA|NRA)
+  trywith 60 --full-saturate-quant --nl-ext-tplanes
+  trywith 600 --full-saturate-quant --no-cbqi-innermost
+  trywith 600 --full-saturate-quant --cbqi-nested-qe
+  finishwith --full-saturate-quant --cbqi-nested-qe --decision=internal
+  ;;
+QF_AUFBV)
+  trywith 1200
+  finishwith --decision=justification-stoponly
+  ;;
+QF_ABV)
+  trywith 100 --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
+  trywith 1000 --arrays-weak-equiv
+  finishwith --ite-simp --simp-with-care --repeat-simp --arrays-weak-equiv
+  ;;
+QF_UFBV)
+  # Benchmarks with uninterpreted sorts cannot be solved with eager
+  # bit-blasting currently
+  trywith 2400 --bitblast=eager --bv-sat-solver=cadical
+  finishwith
+  ;;
+QF_BV)
+  finishwith --bv-div-zero-const --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  ;;
+QF_AUFLIA)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification
+  ;;
+QF_AX)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=internal
+  ;;
+QF_AUFNIA)
+  finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_ALIA)
+  trywith 140 --decision=justification --arrays-weak-equiv
+  finishwith --decision=justification-stoponly --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_S|QF_SLIA)
+  trywith 300 --strings-exp --rewrite-divk --lang=smt2.6.1 --strings-fmf
+  finishwith --strings-exp --rewrite-divk --lang=smt2.6.1
+  ;;
+QF_ABVFP)
+  finishwith --fp-exp
+  ;;
+QF_BVFP)
+  finishwith --fp-exp
+  ;;
+QF_FP)
+  finishwith --fp-exp
+  ;;
+*)
+  # just run the default
+  finishwith
+  ;;
+
+esac
+

--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-incremental
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-incremental
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+cvc4=./cvc4
+
+line=""
+while [[ -z "$line" ]]; do
+  read line
+done
+if [ "$line" != '(set-option :print-success true)' ]; then
+  echo 'ERROR: first line supposed to be set-option :print-success, but got: "'"$line"'"' >&2
+  exit 1
+fi
+echo success
+line=""
+while [[ -z "$line" ]]; do
+  read line
+done
+logic=$(expr "$line" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+if [ -z "$logic" ]; then
+  echo 'ERROR: second line supposed to be set-logic, but got: "'"$line"'"' >&2
+  exit 1
+fi
+echo success
+
+function runcvc4 {
+  # we run in this way for line-buffered input, otherwise memory's a
+  # concern (plus it mimics what we'll end up getting from an
+  # application-track trace runner?)
+  $cvc4 --force-logic="$logic" -L smt2.6 --print-success --no-checking --no-interactive "$@" <&0-
+}
+
+case "$logic" in
+
+ALIA|QF_ALIA|QF_LRA|QF_UFLIA|QF_UFLRA|UFLRA)
+  runcvc4 --incremental
+  ;;
+ANIA|QF_ANIA|QF_NIA|QF_UFNIA|QF_NRA)
+  runcvc4 --tear-down-incremental=1
+  ;;
+LIA|LRA)
+  runcvc4 --incremental
+  ;;
+QF_AUFLIA)
+  runcvc4 --no-arrays-eager-index --arrays-eager-lemmas --incremental
+  ;;
+QF_BV)
+  runcvc4 --incremental --bitblast=eager --bv-sat-solver=cadical
+  ;;
+QF_LIA)
+  runcvc4 --tear-down-incremental=1 --unconstrained-simp
+  ;;
+QF_UFBV)
+  runcvc4 --incremental
+  ;;
+QF_UF)
+  runcvc4 --incremental
+  ;;
+QF_AUFBV)
+  runcvc4 --incremental
+  ;;
+QF_ABV)
+  runcvc4 --incremental
+  ;;
+ABVFP)
+  runcvc4 --incremental
+  ;;
+BVFP)
+  runcvc4 --incremental
+  ;;
+QF_ABVFP)
+  runcvc4 --incremental
+  ;;
+QF_BVFP)
+  runcvc4 --incremental
+  ;;
+QF_FP)
+  runcvc4 --incremental
+  ;;
+*)
+  # just run the default
+  runcvc4 --incremental
+  ;;
+
+esac

--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-model-validation
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-model-validation
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cvc4=./cvc4
+bench="$1"
+
+logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+
+# use: finishwith [params..]
+# to run cvc4 and let it output whatever it will to stdout.
+function finishwith {
+  $cvc4 -L smt2.6 --no-incremental --no-checking --no-interactive "$@" $bench
+}
+
+case "$logic" in
+
+QF_BV)
+  finishwith --bv-div-zero-const --bitblast=eager --bv-sat-solver=cadical --no-bv-abstraction
+  ;;
+*)
+  # just run the default
+  finishwith
+  ;;
+
+esac
+

--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-unsat-cores
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+cvc4=./cvc4
+bench="$1"
+
+logic=$(expr "$(grep -m1 '^[^;]*set-logic' "$bench")" : ' *(set-logic  *\([A-Z_]*\) *) *$')
+
+# use: finishwith [params..]
+# to run cvc4 and let it output whatever it will to stdout.
+function finishwith {
+  $cvc4 -L smt2.6 --no-incremental --no-checking --no-interactive "$@" $bench
+}
+
+case "$logic" in
+
+QF_LRA)
+  finishwith --no-restrict-pivots --use-soi --new-prop
+  ;;
+QF_LIA)
+  finishwith --miplib-trick --miplib-trick-subs=4 --use-approx --lemmas-on-replay-failure --replay-early-close-depth=4 --replay-lemma-reject-cut=128 --replay-reject-cut=512 --use-soi
+  ;;
+QF_NIA)
+  finishwith --solve-int-as-bv=32 --bitblast=eager --bv-sat-solver=cryptominisat
+  ;;
+QF_NRA)
+  finishwith --nl-ext --nl-ext-tplanes
+  ;;
+# all logics with UF + quantifiers should either fall under this or special cases below
+ALIA|AUFLIA|AUFLIRA|AUFNIRA|UF|UFIDL|UFLIA|UFLRA|UFNIA|UFDT|UFDTLIA|AUFDTLIA|AUFBVDTLIA|AUFNIA|ABVFP|BVFP|FP)
+  finishwith --full-saturate-quant --fp-exp
+  ;;
+UFBV)
+  finishwith --finite-model-find
+  ;;
+BV)
+  finishwith --full-saturate-quant --decision=internal
+  ;;
+LIA|LRA)
+  finishwith --full-saturate-quant --cbqi-nested-qe --decision=internal
+  ;;
+NIA|NRA)
+  finishwith --full-saturate-quant --cbqi-nested-qe --decision=internal
+  ;;
+QF_AUFBV)
+  finishwith --decision=justification-stoponly
+  ;;
+QF_ABV)
+  finishwith --ite-simp --simp-with-care --arrays-weak-equiv
+  ;;
+QF_UFBV)
+  finishwith
+  ;;
+QF_BV)
+  finishwith --bv-div-zero-const --bv-eq-slicer=auto --no-bv-abstraction
+  ;;
+QF_AUFLIA)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=justification
+  ;;
+QF_AX)
+  finishwith --no-arrays-eager-index --arrays-eager-lemmas --decision=internal
+  ;;
+QF_AUFNIA)
+  finishwith --decision=justification --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_ALIA)
+  finishwith --decision=justification-stoponly --no-arrays-eager-index --arrays-eager-lemmas
+  ;;
+QF_S|QF_SLIA)
+  finishwith --strings-exp --rewrite-divk --lang=smt2.6.1
+  ;;
+QF_ABVFP)
+  finishwith --fp-exp
+  ;;
+QF_BVFP)
+  finishwith --fp-exp
+  ;;
+QF_FP)
+  finishwith --fp-exp
+  ;;
+*)
+  # just run the default
+  finishwith
+  ;;
+
+esac
+


### PR DESCRIPTION
This commit adds the run scripts for next SMT-COMP. They are just copies
of the 2019 files for now. Note that the new files do not mention a
year.  Instead, the idea is to keep working on these new files and then
just copy them after every year's competition. Like this, we have all
the changes over the years in one file instead of spread across multiple
files.