### PR TITLE
Return choice functions for approximate values in get-value

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -875,9 +875,13 @@ void Smt2Printer::toStream(std::ostream& out,
           out << ":fun-def";
         }
       }
-      else
+      else if (nc.getKind()== kind::INST_PATTERN)
       {
         out << ":pattern " << nc;
+      }
+      else if (nc.getKind() == kind::INST_NO_PATTERN )
+      {
+        out << ":no-pattern " << nc;
       }
     }
     return;

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -541,9 +541,7 @@ void Smt2Printer::toStream(std::ostream& out,
     return;
 
   case kind::LAMBDA:
-  case kind::CHOICE:
-    out << smtKindString(k, d_variant) << " ";
-    break;
+  case kind::CHOICE: out << smtKindString(k, d_variant) << " "; break;
 
   // arith theory
   case kind::PLUS:
@@ -875,11 +873,11 @@ void Smt2Printer::toStream(std::ostream& out,
           out << ":fun-def";
         }
       }
-      else if (nc.getKind()== kind::INST_PATTERN)
+      else if (nc.getKind() == kind::INST_PATTERN)
       {
         out << ":pattern " << nc;
       }
-      else if (nc.getKind() == kind::INST_NO_PATTERN )
+      else if (nc.getKind() == kind::INST_NO_PATTERN)
       {
         out << ":no-pattern " << nc;
       }
@@ -1031,8 +1029,7 @@ static string smtKindString(Kind k, Variant v)
 
   case kind::LAMBDA:
     return "lambda";
-  case kind::CHOICE:
-    return "choice";
+  case kind::CHOICE: return "choice";
 
   // arith theory
   case kind::PLUS: return "+";

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -541,6 +541,7 @@ void Smt2Printer::toStream(std::ostream& out,
     return;
 
   case kind::LAMBDA:
+  case kind::CHOICE:
     out << smtKindString(k, d_variant) << " ";
     break;
 
@@ -1026,6 +1027,8 @@ static string smtKindString(Kind k, Variant v)
 
   case kind::LAMBDA:
     return "lambda";
+  case kind::CHOICE:
+    return "choice";
 
   // arith theory
   case kind::PLUS: return "+";

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -861,8 +861,7 @@ void Smt2Printer::toStream(std::ostream& out,
     out << ')';
     return;
   }
-  case kind::INST_PATTERN:
-  case kind::INST_NO_PATTERN: break;
+  case kind::INST_PATTERN: break;
   case kind::INST_PATTERN_LIST:
   {
     for (const Node& nc : n)
@@ -874,13 +873,9 @@ void Smt2Printer::toStream(std::ostream& out,
           out << ":fun-def";
         }
       }
-      else if (nc.getKind() == kind::INST_PATTERN)
+      else
       {
         out << ":pattern " << nc;
-      }
-      else if (nc.getKind() == kind::INST_NO_PATTERN)
-      {
-        out << ":no-pattern " << nc;
       }
     }
     return;

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -861,7 +861,8 @@ void Smt2Printer::toStream(std::ostream& out,
     out << ')';
     return;
   }
-  case kind::INST_PATTERN: break;
+  case kind::INST_PATTERN:
+  case kind::INST_NO_PATTERN: break;
   case kind::INST_PATTERN_LIST:
   {
     for (const Node& nc : n)

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1345,15 +1345,8 @@ void Smt2Printer::toStream(std::ostream& out, const Model& m) const
   }
   //print the model
   out << "(model" << endl;
-  // print approximations
-  if (m.hasApproximations())
-  {
-    std::vector<std::pair<Expr, Expr> > approx = m.getApproximations();
-    for (unsigned i = 0, size = approx.size(); i < size; i++)
-    {
-      out << "(approximation " << approx[i].second << ")" << std::endl;
-    }
-  }
+  // don't need to print approximations since they are built into choice
+  // functions in the values of variables.
   this->Printer::toStream(out, m);
   out << ")" << endl;
   //print the heap model, if it exists

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4212,8 +4212,9 @@ Expr SmtEngine::getValue(const Expr& ex) const
              || resultNode.getType().isSubtypeOf(expectedType),
          "Run with -t smt for details.");
 
-  // ensure it's a constant
-  Assert(resultNode.getKind() == kind::LAMBDA || resultNode.isConst());
+  // Ensure it's a constant, or a lambda (for uninterpreted functions), or
+  // a choice (for approximate values).
+  Assert(resultNode.getKind() == kind::LAMBDA || resultNode.getKind() == kind::CHOICE || resultNode.isConst());
 
   if(options::abstractValues() && resultNode.getType().isArray()) {
     resultNode = d_private->mkAbstractValue(resultNode);

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4214,7 +4214,8 @@ Expr SmtEngine::getValue(const Expr& ex) const
 
   // Ensure it's a constant, or a lambda (for uninterpreted functions), or
   // a choice (for approximate values).
-  Assert(resultNode.getKind() == kind::LAMBDA || resultNode.getKind() == kind::CHOICE || resultNode.isConst());
+  Assert(resultNode.getKind() == kind::LAMBDA
+         || resultNode.getKind() == kind::CHOICE || resultNode.isConst());
 
   if(options::abstractValues() && resultNode.getType().isArray()) {
     resultNode = d_private->mkAbstractValue(resultNode);

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -257,14 +257,14 @@ Node TheoryModel::getModelValue(TNode n, bool hasBoundVars) const
     return ret;
   }
   // it might be approximate
-  std::map< Node, Node >::const_iterator ita = d_approximations.find(n);
-  if (ita!=d_approximations.end())
+  std::map<Node, Node>::const_iterator ita = d_approximations.find(n);
+  if (ita != d_approximations.end())
   {
     // If the value of n is approximate based on predicate P(n), we return
     // choice z. P(z).
     Node v = nm->mkBoundVar(n.getType());
-    Node bvl = nm->mkNode(BOUND_VAR_LIST,v);
-    Node ret = nm->mkNode(CHOICE,bvl,ita->second.substitute(n,v));
+    Node bvl = nm->mkNode(BOUND_VAR_LIST, v);
+    Node ret = nm->mkNode(CHOICE, bvl, ita->second.substitute(n, v));
     d_modelCache[n] = ret;
     return ret;
   }

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -256,6 +256,18 @@ Node TheoryModel::getModelValue(TNode n, bool hasBoundVars) const
     d_modelCache[n] = ret;
     return ret;
   }
+  // it might be approximate
+  std::map< Node, Node >::const_iterator ita = d_approximations.find(n);
+  if (ita!=d_approximations.end())
+  {
+    // If the value of n is approximate based on predicate P(n), we return
+    // choice z. P(z).
+    Node v = nm->mkBoundVar(n.getType());
+    Node bvl = nm->mkNode(BOUND_VAR_LIST,v);
+    Node ret = nm->mkNode(CHOICE,bvl,ita->second.substitute(n,v));
+    d_modelCache[n] = ret;
+    return ret;
+  }
   // must rewrite the term at this point
   ret = Rewriter::rewrite(n);
   // return the representative of the term in the equality engine, if it exists

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -540,6 +540,7 @@ set(regress_0_tests
   regress0/nl/nta/tan-rewrite.smt2
   regress0/nl/real-as-int.smt2
   regress0/nl/real-div-ufnra.smt2
+  regress0/nl/sqrt2-value.smt2
   regress0/nl/subs0-unsat-confirm.smt2
   regress0/nl/very-easy-sat.smt2
   regress0/nl/very-simple-unsat.smt2

--- a/test/regress/regress0/nl/sqrt2-value.smt2
+++ b/test/regress/regress0/nl/sqrt2-value.smt2
@@ -1,0 +1,9 @@
+; SCRUBBER: sed -e 's/choice.*/choice/'
+; EXPECT: sat
+; EXPECT: ((x (choice
+(set-option :produce-models true)
+(set-logic ALL)
+(declare-fun x () Real)
+(assert (= (* x x) 2))
+(check-sat)
+(get-value (x))


### PR DESCRIPTION
This returns choice functions in response to `get-value` if the value was approximate.  See discussion on #3300.

This partially addresses #3300. What remains is to provide approximate witnesses for choice functions.