### PR TITLE
Fix printing of instantiation patterns

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -862,7 +862,8 @@ void Smt2Printer::toStream(std::ostream& out,
     out << ')';
     return;
   }
-  case kind::INST_PATTERN: break;
+  case kind::INST_PATTERN:
+  case kind::INST_NO_PATTERN: break;
   case kind::INST_PATTERN_LIST:
   {
     for (const Node& nc : n)
@@ -874,9 +875,13 @@ void Smt2Printer::toStream(std::ostream& out,
           out << ":fun-def";
         }
       }
-      else
+      else if (nc.getKind() == kind::INST_PATTERN)
       {
         out << ":pattern " << nc;
+      }
+      else if (nc.getKind() == kind::INST_NO_PATTERN)
+      {
+        out << ":no-pattern " << nc;
       }
     }
     return;

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -881,7 +881,7 @@ void Smt2Printer::toStream(std::ostream& out,
       }
       else if (nc.getKind() == kind::INST_NO_PATTERN)
       {
-        out << ":no-pattern " << nc;
+        out << ":no-pattern " << nc[0];
       }
     }
     return;


### PR DESCRIPTION
Previously we were assuming all children of INST_PATTERN_LIST were of kind INST_ATTRIBUTE or INST_PATTERN, which is not the case.