### PR TITLE
[SMT-COMP] Remove --unconstrained-simp for incremental QF_LIA

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp-current-incremental
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current-incremental
@@ -47,7 +47,7 @@ QF_BV)
   runcvc4 --incremental --bitblast=eager --bv-sat-solver=cadical
   ;;
 QF_LIA)
-  runcvc4 --tear-down-incremental=1 --unconstrained-simp
+  runcvc4 --tear-down-incremental=1
   ;;
 QF_UFBV)
   runcvc4 --incremental


### PR DESCRIPTION
Fixes #3058. Commit a7c4cd3ecacb1e484a076edde0274c282bb43ffb changed
CVC4's behavior to emit an error when `--unconstrained-simp` is used
with `--incremental`. Before, we were silently disabling it. For some
reason, we had that option enabled for the incremental QF_LIA track of
SMT-COMP, so CVC4 failed on those benchmarks. This commit changes the
corresponding competition script to not use the option.