### PR TITLE
Travis: Reenable building and running of examples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ script:
      mkdir build
      cd build
      cmake .. -DCMAKE_PREFIX_PATH=$(pwd)/../../build/install/lib/cmake
+     make -j2
      ctest -j2 --output-on-failure || error "RUNNING EXAMPLES FAILED"
    }
    makeInstallCheck() {

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,41 +47,50 @@ script:
    echo "travis_fold:start:load_script"
    normal="$(echo -e '\033[0m')" red="$normal$(echo -e '\033[01;31m')" green="$normal$(echo -e '\033[01;32m')"
    configureCVC4() {
-     echo "CVC4 config - $TRAVIS_CVC4_CONFIG";
-     ./configure.sh --name=build --prefix=$(pwd)/build/install --unit-testing $TRAVIS_CVC4_CONFIG
+     (
+       echo "CVC4 config - $TRAVIS_CVC4_CONFIG";
+       ./configure.sh --name=build --prefix=$(pwd)/build/install --unit-testing $TRAVIS_CVC4_CONFIG
+     )
    }
    error() {
-     echo;
-     echo "${red}${1}${normal}";
-     echo;
-     exit 1;
+     (
+       echo;
+       echo "${red}${1}${normal}";
+       echo;
+       exit 1;
+     )
    }
    makeCheck() {
-     cd build
-     make -j2 check ARGS='-LE regress[1-4]' CVC4_REGRESSION_ARGS='--no-early-exit' || error "BUILD/UNIT/SYSTEM/REGRESSION TEST FAILED"
-     cd -
+     (
+       cd build
+       make -j2 check ARGS='-LE regress[1-4]' CVC4_REGRESSION_ARGS='--no-early-exit' || error "BUILD/UNIT/SYSTEM/REGRESSION TEST FAILED"
+     )
    }
    makeExamples() {
-     cd examples
-     mkdir build
-     cd build
-     cmake .. -DCMAKE_PREFIX_PATH=$(pwd)/../../build/install/lib/cmake
-     make -j2
-     ctest -j2 --output-on-failure || error "RUNNING EXAMPLES FAILED"
-     cd -
+     (
+       cd examples
+       mkdir build
+       cd build
+       cmake .. -DCMAKE_PREFIX_PATH=$(pwd)/../../build/install/lib/cmake
+       make -j2
+       ctest -j2 --output-on-failure || error "RUNNING EXAMPLES FAILED"
+     )
    }
    makeInstallCheck() {
-     cd build
-     make install -j2
-     echo -e "#include <cvc4/cvc4.h>\nint main() { CVC4::ExprManager em; return 0; }" > /tmp/test.cpp
-     $CXX -std=c++11 /tmp/test.cpp -I install/include -L install/lib -lcvc4 -lcln || exit 1
-     cd -
+     (
+       cd build
+       make install -j2
+       echo -e "#include <cvc4/cvc4.h>\nint main() { CVC4::ExprManager em; return 0; }" > /tmp/test.cpp
+       $CXX -std=c++11 /tmp/test.cpp -I install/include -L install/lib -lcvc4 -lcln || exit 1
+     )
    }
    run() {
-     echo "travis_fold:start:$1"
-     echo "Running $1"
-     $1 || exit 1
-     echo "travis_fold:end:$1"
+     (
+       echo "travis_fold:start:$1"
+       echo "Running $1"
+       $1 || exit 1
+       echo "travis_fold:end:$1"
+     )
    }
    [[ "$TRAVIS_CVC4_CONFIG" == *"symfpu"* ]] && CVC4_SYMFPU_BUILD="yes"
    [ -n "$CVC4_SYMFPU_BUILD" ] && run contrib/get-symfpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
    makeCheck() {
      cd build
      make -j2 check ARGS='-LE regress[1-4]' CVC4_REGRESSION_ARGS='--no-early-exit' || error "BUILD/UNIT/SYSTEM/REGRESSION TEST FAILED"
+     cd -
    }
    makeExamples() {
      cd examples
@@ -67,6 +68,7 @@ script:
      cmake .. -DCMAKE_PREFIX_PATH=$(pwd)/../../build/install/lib/cmake
      make -j2
      ctest -j2 --output-on-failure || error "RUNNING EXAMPLES FAILED"
+     cd -
    }
    makeInstallCheck() {
      cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,18 +47,14 @@ script:
    echo "travis_fold:start:load_script"
    normal="$(echo -e '\033[0m')" red="$normal$(echo -e '\033[01;31m')" green="$normal$(echo -e '\033[01;32m')"
    configureCVC4() {
-     (
-       echo "CVC4 config - $TRAVIS_CVC4_CONFIG";
-       ./configure.sh --name=build --prefix=$(pwd)/build/install --unit-testing $TRAVIS_CVC4_CONFIG
-     )
+     echo "CVC4 config - $TRAVIS_CVC4_CONFIG";
+     ./configure.sh --name=build --prefix=$(pwd)/build/install --unit-testing $TRAVIS_CVC4_CONFIG
    }
    error() {
-     (
-       echo;
-       echo "${red}${1}${normal}";
-       echo;
-       exit 1;
-     )
+     echo;
+     echo "${red}${1}${normal}";
+     echo;
+     exit 1;
    }
    makeCheck() {
      (
@@ -85,12 +81,10 @@ script:
      )
    }
    run() {
-     (
-       echo "travis_fold:start:$1"
-       echo "Running $1"
-       $1 || exit 1
-       echo "travis_fold:end:$1"
-     )
+     echo "travis_fold:start:$1"
+     echo "Running $1"
+     $1 || exit 1
+     echo "travis_fold:end:$1"
    }
    [[ "$TRAVIS_CVC4_CONFIG" == *"symfpu"* ]] && CVC4_SYMFPU_BUILD="yes"
    [ -n "$CVC4_SYMFPU_BUILD" ] && run contrib/get-symfpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ script:
      make install -j2
      echo -e "#include <cvc4/cvc4.h>\nint main() { CVC4::ExprManager em; return 0; }" > /tmp/test.cpp
      $CXX -std=c++11 /tmp/test.cpp -I install/include -L install/lib -lcvc4 -lcln || exit 1
+     cd -
    }
    run() {
      echo "travis_fold:start:$1"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.2)
 
 project(cvc4-examples)
 
+set(CMAKE_CXX_STANDARD 11)
+
 enable_testing()
 
 # Find CVC4 package. If CVC4 is not installed into the default system location


### PR DESCRIPTION
#3196 changed the build configuration of `src/examples` and broke running the examples on Travis.