### PR TITLE
New C++ API: Add Term::getId().

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -1044,16 +1044,16 @@ bool Term::operator==(const Term& t) const { return *d_expr == *t.d_expr; }
 
 bool Term::operator!=(const Term& t) const { return *d_expr != *t.d_expr; }
 
+uint64_t Term::getId() const
+{
+  CVC4_API_CHECK_NOT_NULL;
+  return d_expr->getId();
+}
+
 Kind Term::getKind() const
 {
   CVC4_API_CHECK_NOT_NULL;
   return intToExtKind(d_expr->getKind());
-}
-
-bool Term::isParameterized() const
-{
-  CVC4_API_CHECK_NOT_NULL;
-  return d_expr->isParameterized();
 }
 
 Sort Term::getSort() const
@@ -1063,6 +1063,12 @@ Sort Term::getSort() const
 }
 
 bool Term::isNull() const { return d_expr->isNull(); }
+
+bool Term::isParameterized() const
+{
+  CVC4_API_CHECK_NOT_NULL;
+  return d_expr->isParameterized();
+}
 
 Term Term::notTerm() const
 {

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -576,10 +576,25 @@ class CVC4_PUBLIC Term
   bool operator!=(const Term& t) const;
 
   /**
+   * @return the id of this term
+   */
+  uint64_t getId() const;
+
+  /**
    * @return the kind of this term
    */
   Kind getKind() const;
-  
+
+  /**
+   * @return the sort of this term
+   */
+  Sort getSort() const;
+
+  /**
+   * @return true if this Term is a null term
+   */
+  bool isNull() const;
+
   /**
    * @return true if this expression is parameterized.
    *
@@ -596,16 +611,6 @@ class CVC4_PUBLIC Term
    *   mkTerm(t.getKind(), b1, ..., bn )
    */
   bool isParameterized() const;
-  
-  /**
-   * @return the sort of this term
-   */
-  Sort getSort() const;
-
-  /**
-   * @return true if this Term is a null term
-   */
-  bool isNull() const;
 
   /**
    * Boolean negation.

--- a/src/expr/expr_template.cpp
+++ b/src/expr/expr_template.cpp
@@ -371,7 +371,8 @@ bool Expr::operator>(const Expr& e) const {
   return *d_node > *e.d_node;
 }
 
-unsigned long Expr::getId() const {
+uint64_t Expr::getId() const
+{
   ExprManagerScope ems(*this);
   Assert(d_node != NULL, "Unexpected NULL expression pointer!");
   return d_node->getId();

--- a/src/expr/expr_template.h
+++ b/src/expr/expr_template.h
@@ -326,7 +326,7 @@ public:
    * @return an identifier uniquely identifying the value this
    * expression holds.
    */
-  unsigned long getId() const;
+  uint64_t getId() const;
 
   /**
    * Returns the kind of the expression (AND, PLUS ...).

--- a/src/expr/metakind_template.h
+++ b/src/expr/metakind_template.h
@@ -124,7 +124,7 @@ namespace metakind {
 #define CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN 26
 
 static const uint32_t MAX_CHILDREN =
-    (1u << CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN) - 1;
+    (((uint32_t) 1) << CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN) - 1;
 
 }/* CVC4::kind::metakind namespace */
 }/* CVC4::kind namespace */

--- a/src/expr/metakind_template.h
+++ b/src/expr/metakind_template.h
@@ -123,8 +123,8 @@ namespace metakind {
 #define CVC4__EXPR__NODE_VALUE__NBITS__ID 40
 #define CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN 26
 
-static const unsigned MAX_CHILDREN =
-  (1u << CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN) - 1;
+static const uint32_t MAX_CHILDREN =
+    (1u << CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN) - 1;
 
 }/* CVC4::kind::metakind namespace */
 }/* CVC4::kind namespace */

--- a/src/expr/metakind_template.h
+++ b/src/expr/metakind_template.h
@@ -124,7 +124,7 @@ namespace metakind {
 #define CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN 26
 
 static const uint32_t MAX_CHILDREN =
-    (((uint32_t) 1) << CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN) - 1;
+    (((uint32_t)1) << CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN) - 1;
 
 }/* CVC4::kind::metakind namespace */
 }/* CVC4::kind namespace */

--- a/src/expr/node.h
+++ b/src/expr/node.h
@@ -476,7 +476,8 @@ public:
    * Returns the unique id of this node
    * @return the ud
    */
-  unsigned long getId() const {
+  uint64_t getId() const
+  {
     assertTNodeNotExpired();
     return d_nv->getId();
   }

--- a/src/expr/node_value.h
+++ b/src/expr/node_value.h
@@ -79,10 +79,10 @@ class NodeValue {
 
   /** Maximum reference count possible.  Used for sticky
    *  reference-counting.  Should be (1 << num_bits(d_rc)) - 1 */
-  static const uint32_t MAX_RC = (1u << NBITS_REFCOUNT) - 1;
+  static const uint32_t MAX_RC = (((uint32_t) 1) << NBITS_REFCOUNT) - 1;
 
   /** A mask for d_kind */
-  static const uint32_t kindMask = (1u << NBITS_KIND) - 1;
+  static const uint32_t kindMask = (((uint32_t) 1) << NBITS_KIND) - 1;
 
   // This header fits into 96 bits
 

--- a/src/expr/node_value.h
+++ b/src/expr/node_value.h
@@ -70,18 +70,19 @@ namespace expr {
  * This is a NodeValue.
  */
 class NodeValue {
-
-  static const unsigned NBITS_REFCOUNT = CVC4__EXPR__NODE_VALUE__NBITS__REFCOUNT;
-  static const unsigned NBITS_KIND = CVC4__EXPR__NODE_VALUE__NBITS__KIND;
-  static const unsigned NBITS_ID = CVC4__EXPR__NODE_VALUE__NBITS__ID;
-  static const unsigned NBITS_NCHILDREN = CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN;
+  static const uint32_t NBITS_REFCOUNT =
+      CVC4__EXPR__NODE_VALUE__NBITS__REFCOUNT;
+  static const uint32_t NBITS_KIND = CVC4__EXPR__NODE_VALUE__NBITS__KIND;
+  static const uint32_t NBITS_ID = CVC4__EXPR__NODE_VALUE__NBITS__ID;
+  static const uint32_t NBITS_NCHILDREN =
+      CVC4__EXPR__NODE_VALUE__NBITS__NCHILDREN;
 
   /** Maximum reference count possible.  Used for sticky
    *  reference-counting.  Should be (1 << num_bits(d_rc)) - 1 */
-  static const unsigned MAX_RC = (1u << NBITS_REFCOUNT) - 1;
+  static const uint32_t MAX_RC = (1u << NBITS_REFCOUNT) - 1;
 
   /** A mask for d_kind */
-  static const unsigned kindMask = (1u << NBITS_KIND) - 1;
+  static const uint32_t kindMask = (1u << NBITS_KIND) - 1;
 
   // This header fits into 96 bits
 
@@ -89,13 +90,13 @@ class NodeValue {
   uint64_t d_id        : NBITS_ID;
 
   /** The expression's reference count.  @see cvc4::Node. */
-  uint64_t d_rc        : NBITS_REFCOUNT;
+  uint32_t d_rc : NBITS_REFCOUNT;
 
   /** Kind of the expression */
-  uint64_t d_kind      : NBITS_KIND;
+  uint32_t d_kind : NBITS_KIND;
 
   /** Number of children */
-  uint64_t d_nchildren : NBITS_NCHILDREN;
+  uint32_t d_nchildren : NBITS_NCHILDREN;
 
   /** Variable number of child nodes */
   NodeValue* d_children[0];
@@ -252,13 +253,16 @@ public:
     return hash;
   }
 
-  unsigned long getId() const { return d_id; }
+  uint64_t getId() const { return d_id; }
+
   Kind getKind() const { return dKindToKind(d_kind); }
+
   kind::MetaKind getMetaKind() const { return kind::metaKindOf(getKind()); }
-  unsigned getNumChildren() const {
-    return (getMetaKind() == kind::metakind::PARAMETERIZED)
-      ? d_nchildren - 1
-      : d_nchildren;
+
+  uint32_t getNumChildren() const
+  {
+    return (getMetaKind() == kind::metakind::PARAMETERIZED) ? d_nchildren - 1
+                                                            : d_nchildren;
   }
 
   unsigned getRefCount() const { return d_rc; }
@@ -267,11 +271,13 @@ public:
   void toStream(std::ostream& out, int toDepth = -1, bool types = false, size_t dag = 1,
                 OutputLanguage = language::output::LANG_AUTO) const;
 
-  static inline unsigned kindToDKind(Kind k) {
-    return ((unsigned) k) & kindMask;
+  static inline uint32_t kindToDKind(Kind k)
+  {
+    return ((uint32_t)k) & kindMask;
   }
 
-  static inline Kind dKindToKind(unsigned d) {
+  static inline Kind dKindToKind(uint32_t d)
+  {
     return (d == kindMask) ? kind::UNDEFINED_KIND : Kind(d);
   }
 

--- a/src/expr/node_value.h
+++ b/src/expr/node_value.h
@@ -79,10 +79,10 @@ class NodeValue {
 
   /** Maximum reference count possible.  Used for sticky
    *  reference-counting.  Should be (1 << num_bits(d_rc)) - 1 */
-  static const uint32_t MAX_RC = (((uint32_t) 1) << NBITS_REFCOUNT) - 1;
+  static const uint32_t MAX_RC = (((uint32_t)1) << NBITS_REFCOUNT) - 1;
 
   /** A mask for d_kind */
-  static const uint32_t kindMask = (((uint32_t) 1) << NBITS_KIND) - 1;
+  static const uint32_t kindMask = (((uint32_t)1) << NBITS_KIND) - 1;
 
   // This header fits into 96 bits
 

--- a/test/unit/api/term_black.h
+++ b/test/unit/api/term_black.h
@@ -25,9 +25,11 @@ class TermBlack : public CxxTest::TestSuite
   void tearDown() override {}
 
   void testEq();
+  void testGetId();
   void testGetKind();
   void testGetSort();
   void testIsNull();
+  void testIsParameterized();
   void testNotTerm();
   void testAndTerm();
   void testOrTerm();
@@ -55,6 +57,14 @@ void TermBlack::testEq()
   TS_ASSERT(x != y);
   TS_ASSERT(!(x == z));
   TS_ASSERT(x != z);
+}
+
+void TermBlack::testGetId()
+{
+  Term n;
+  TS_ASSERT_THROWS(n.getId(), CVC4ApiException&);
+  Term x = d_solver.mkVar(d_solver.getIntegerSort(), "x");
+  TS_ASSERT_THROWS_NOTHING(x.getId());
 }
 
 void TermBlack::testGetKind()
@@ -171,6 +181,14 @@ void TermBlack::testNotTerm()
   TS_ASSERT_THROWS_NOTHING(p_0.notTerm());
   Term p_f_x = d_solver.mkTerm(APPLY_UF, p, f_x);
   TS_ASSERT_THROWS_NOTHING(p_f_x.notTerm());
+}
+
+void TermBlack::testIsParameterized()
+{
+  Term n;
+  TS_ASSERT_THROWS(n.isParameterized(), CVC4ApiException&);
+  Term x = d_solver.mkVar(d_solver.getIntegerSort(), "x");
+  TS_ASSERT_THROWS_NOTHING(x.isParameterized());
 }
 
 void TermBlack::testAndTerm()

--- a/test/unit/api/term_black.h
+++ b/test/unit/api/term_black.h
@@ -65,6 +65,11 @@ void TermBlack::testGetId()
   TS_ASSERT_THROWS(n.getId(), CVC4ApiException&);
   Term x = d_solver.mkVar(d_solver.getIntegerSort(), "x");
   TS_ASSERT_THROWS_NOTHING(x.getId());
+Term y = x;
+TS_ASSERT_EQUALS(x.getId(), y.getId());
+
+Term z = d_solver.mkVar(d_solver.getIntegerSort(), "z");
+TS_ASSERT_DIFFERS(x.getId(), z.getId());
 }
 
 void TermBlack::testGetKind()

--- a/test/unit/api/term_black.h
+++ b/test/unit/api/term_black.h
@@ -65,11 +65,11 @@ void TermBlack::testGetId()
   TS_ASSERT_THROWS(n.getId(), CVC4ApiException&);
   Term x = d_solver.mkVar(d_solver.getIntegerSort(), "x");
   TS_ASSERT_THROWS_NOTHING(x.getId());
-Term y = x;
-TS_ASSERT_EQUALS(x.getId(), y.getId());
+  Term y = x;
+  TS_ASSERT_EQUALS(x.getId(), y.getId());
 
-Term z = d_solver.mkVar(d_solver.getIntegerSort(), "z");
-TS_ASSERT_DIFFERS(x.getId(), z.getId());
+  Term z = d_solver.mkVar(d_solver.getIntegerSort(), "z");
+  TS_ASSERT_DIFFERS(x.getId(), z.getId());
 }
 
 void TermBlack::testGetKind()


### PR DESCRIPTION
Plus:
+ use explicit types in NodeValue
+ add unit test for Term::isParameterized()

Note: I moved `Term::isParameterized()` down, below `isNull()`, for consistency. Nothing else changed in this function.

Labelling 'major' since I need it for the MBT.