### PR TITLE
Avoid printing success for `--force-logic`

### DIFF
--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -810,14 +810,9 @@ Command* Smt2::setLogic(std::string name, bool fromCommand)
     addTheory(THEORY_SEP);
   }
 
-  if (sygus())
-  {
-    return new SetBenchmarkLogicCommand(d_logic.getLogicString());
-  }
-  else
-  {
-    return new SetBenchmarkLogicCommand(name);
-  }
+  Command* cmd = new SetBenchmarkLogicCommand(sygus() ? d_logic.getLogicString() : name);
+  cmd->setMuted(!fromCommand);
+  return cmd;
 } /* Smt2::setLogic() */
 
 bool Smt2::sygus() const

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -553,6 +553,7 @@ set(regress_0_tests
   regress0/parser/constraint.smt2
   regress0/parser/declarefun-emptyset-uf.smt2
   regress0/parser/force_logic_set_logic.smt2
+  regress0/parser/force_logic_success.smt2
   regress0/parser/shadow_fun_symbol_all.smt2
   regress0/parser/shadow_fun_symbol_nirat.smt2
   regress0/parser/strings20.smt2

--- a/test/regress/regress0/parser/force_logic_success.smt2
+++ b/test/regress/regress0/parser/force_logic_success.smt2
@@ -1,0 +1,5 @@
+; COMMAND-LINE: --force-logic QF_BV --print-success
+; EXPECT: success
+; EXPECT: sat
+(assert true)
+(check-sat)


### PR DESCRIPTION
CVC4 was printing success when `--force-logic` was used because
internally, `--force-logic` generates a `SetBenchmarkLogicCommand`. This
commit fixes the behavior by muting the command if it was not issued by
the user.

The issue was likely introduced with #3062.