### PR TITLE
cmake: Fix include of CVC4JavaTargets.cmake.

### DIFF
--- a/cmake/CVC4Config.cmake.in
+++ b/cmake/CVC4Config.cmake.in
@@ -1,10 +1,12 @@
 @PACKAGE_INIT@
 
+set(CVC4_BINDINGS_JAVA @BUILD_BINDINGS_JAVA@)
+
 if(NOT TARGET CVC4::cvc4)
   include(${CMAKE_CURRENT_LIST_DIR}/CVC4Targets.cmake)
 endif()
 
-if(NOT TARGET CVC4::cvc4jar)
+if(CVC4_BINDINGS_JAVA AND NOT TARGET CVC4::cvc4jar)
   set_and_check(CVC4_JNI_PATH "@PACKAGE_LIBRARY_INSTALL_DIR@")
   include(${CMAKE_CURRENT_LIST_DIR}/CVC4JavaTargets.cmake)
 endif()


### PR DESCRIPTION
Only include Java targets if Java bindings are enabled.