### PR TITLE
Check that logic is set when synth-fun command is encountered

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -607,6 +607,7 @@ sygusCommand returns [std::unique_ptr<CVC4::Command> cmd]
     ( SYNTH_FUN_TOK { isInv = false; }
       | SYNTH_INV_TOK { isInv = true; range = EXPR_MANAGER->booleanType(); }
     )
+    { PARSER_STATE->checkThatLogicIsSet(); }
     symbol[fun,CHECK_UNDECLARED,SYM_VARIABLE]
     LPAREN_TOK sortedVarList[sortedVarNames] RPAREN_TOK
     ( sortSymbol[range,CHECK_DECLARED] )?

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -585,6 +585,7 @@ sygusCommand returns [std::unique_ptr<CVC4::Command> cmd]
     ( SYNTH_FUN_V1_TOK { isInv = false; }
       | SYNTH_INV_V1_TOK { isInv = true; range = EXPR_MANAGER->booleanType(); }
     )
+    { PARSER_STATE->checkThatLogicIsSet(); }
     symbol[fun,CHECK_UNDECLARED,SYM_VARIABLE]
     LPAREN_TOK sortedVarList[sortedVarNames] RPAREN_TOK
     ( sortSymbol[range,CHECK_DECLARED] )?

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -662,7 +662,6 @@ Smt2::SynthFunFactory::SynthFunFactory(
     std::vector<std::pair<std::string, CVC4::Type>>& sortedVarNames)
     : d_smt2(smt2), d_fun(fun), d_isInv(isInv)
 {
-  smt2->checkThatLogicIsSet();
   if (range.isNull())
   {
     smt2->parseError("Must supply return type for synth-fun.");

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -909,6 +909,7 @@ set(regress_0_tests
   regress0/sygus/issue3356-syg-inf-usort.smt2
   regress0/sygus/let-ringer.sy
   regress0/sygus/let-simp.sy
+  regress0/sygus/no-logic.sy
   regress0/sygus/no-syntax-test-bool.sy
   regress0/sygus/no-syntax-test.sy
   regress0/sygus/parity-AIG-d0.sy

--- a/test/regress/regress0/sygus/no-logic.sy
+++ b/test/regress/regress0/sygus/no-logic.sy
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --sygus-out=status --lang=sygus2
+; EXPECT-ERROR: no-logic.sy:7.10: No set-logic command was given before this point.
+; EXPECT-ERROR: no-logic.sy:7.10: CVC4 will make all theories available.
+; EXPECT-ERROR: no-logic.sy:7.10: Consider setting a stricter logic for (likely) better performance.
+; EXPECT-ERROR: no-logic.sy:7.10: To suppress this warning in the future use (set-logic ALL).
+; EXPECT: unsat
+(synth-fun f ((x Int)) Int
+  ((Start Int))
+  (
+    (Start Int (x))
+  )
+)
+
+(check-synth)


### PR DESCRIPTION
This ensures we assume the default ALL logic when `synth-fun` is encountered before `set-logic` instead of aborting due to undefined symbols. This behavior was introduced in #3335; this PR adds back a line of code that was deleted in that PR. 