### PR TITLE
Ensure lemmas from sygus repair const are guarded

### DIFF
--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -247,11 +247,10 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
             enums[i], enum_values[i], exp);
       }
       Assert(!exp.empty());
-      NodeManager * nm = NodeManager::currentNM();
-      Node expn =
-          exp.size() == 1 ? exp[0] : nm->mkNode(AND, exp);
+      NodeManager* nm = NodeManager::currentNM();
+      Node expn = exp.size() == 1 ? exp[0] : nm->mkNode(AND, exp);
       // must guard it
-      expn = nm->mkNode(OR,d_parent->getGuard().negate(),expn.negate());
+      expn = nm->mkNode(OR, d_parent->getGuard().negate(), expn.negate());
       lems.push_back(expn);
       return false;
     }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -247,9 +247,12 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
             enums[i], enum_values[i], exp);
       }
       Assert(!exp.empty());
+      NodeManager * nm = NodeManager::currentNM();
       Node expn =
-          exp.size() == 1 ? exp[0] : NodeManager::currentNM()->mkNode(AND, exp);
-      lems.push_back(expn.negate());
+          exp.size() == 1 ? exp[0] : nm->mkNode(AND, exp);
+      // must guard it
+      expn = nm->mkNode(OR,d_parent->getGuard().negate(),expn.negate());
+      lems.push_back(expn);
       return false;
     }
   }
@@ -300,6 +303,7 @@ bool Cegis::processConstructCandidates(const std::vector<Node>& enums,
 
 void Cegis::addRefinementLemma(Node lem)
 {
+  Trace("cegis-rl") << "Cegis::addRefinementLemma: " << lem << std::endl;
   d_refinement_lemmas.push_back(lem);
   // apply existing substitution
   Node slem = lem;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1724,6 +1724,7 @@ set(regress_1_tests
   regress1/sygus/qe.sy
   regress1/sygus/qf_abv.smt2
   regress1/sygus/real-grammar.sy
+  regress1/sygus/repair-const-unk.sy
   regress1/sygus/simple-regexp.sy
   regress1/sygus/stopwatch-bt.sy
   regress1/sygus/strings-no-syntax.sy

--- a/test/regress/regress1/sygus/repair-const-unk.sy
+++ b/test/regress/regress1/sygus/repair-const-unk.sy
@@ -1,0 +1,17 @@
+; EXPECT: unknown
+; COMMAND-LINE: --sygus-out=status --sygus-repair-const --lang=sygus2 --no-sygus-pbe
+(set-logic LIA)
+(synth-fun f ((x Int) (y Int)) Int
+  ((Start Int) (CInt Int))
+  (
+    (Start Int ((+ (* CInt x) (* CInt y) CInt)))
+    (CInt Int ((Constant Int)))
+  )
+)
+(declare-var x Int)
+(declare-var y Int)
+(constraint (= (f 0 0) 100))
+(constraint (= (f 1 1) 110))
+(constraint (= (f 2 1) 117))
+(constraint (>= (- (* 3 (f x y)) (f (* 2 x) (+ y 1))) (+ (* 7 x) (* 6 y))))
+(check-synth)

--- a/test/regress/regress1/sygus/repair-const-unk.sy
+++ b/test/regress/regress1/sygus/repair-const-unk.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unknown
-; COMMAND-LINE: --sygus-out=status --sygus-repair-const --lang=sygus2 --no-sygus-pbe
+; COMMAND-LINE: --sygus-out=status --sygus-repair-const --lang=sygus2
 (set-logic LIA)
 (synth-fun f ((x Int) (y Int)) Int
   ((Start Int) (CInt Int))


### PR DESCRIPTION
Previously we could spuriously answer "unsat" due to excluding the entire range of values for a datatype.  This was caused by not guarding a refinement lemma from the repair constant module was guarded by the "feasible guard" of the sygus conjecture.