### PR TITLE
Apply sygus repair constant techniques restricted to refinement lemmas

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -510,8 +510,6 @@ class SmtEnginePrivate : public NodeManagerListener {
    * universally quantified in the constraints.
    */
   std::vector<Node> d_sygusVars;
-  /** types of sygus primed variables (for debugging) */
-  std::vector<Type> d_sygusPrimedVarTypes;
   /** sygus constraints */
   std::vector<Node> d_sygusConstraints;
   /** functions-to-synthesize */
@@ -3925,9 +3923,7 @@ void SmtEngine::declareSygusVar(const std::string& id, Expr var, Type type)
 
 void SmtEngine::declareSygusPrimedVar(const std::string& id, Type type)
 {
-#ifdef CVC4_ASSERTIONS
-  d_private->d_sygusPrimedVarTypes.push_back(type);
-#endif
+  // do nothing (the command is spurious)
   Trace("smt") << "SmtEngine::declareSygusPrimedVar: " << id << "\n";
   // don't need to set that the conjecture is stale
 }
@@ -4010,27 +4006,6 @@ void SmtEngine::assertSygusInvConstraint(const Expr& inv,
     ss << vars.back() << "'";
     primed_vars.push_back(d_nodeManager->mkBoundVar(ss.str(), tn));
     d_private->d_sygusVars.push_back(primed_vars.back());
-#ifdef CVC4_ASSERTIONS
-    bool find_new_declared_var = false;
-    for (const Type& t : d_private->d_sygusPrimedVarTypes)
-    {
-      if (t == ti)
-      {
-        d_private->d_sygusPrimedVarTypes.erase(
-            std::find(d_private->d_sygusPrimedVarTypes.begin(),
-                      d_private->d_sygusPrimedVarTypes.end(),
-                      t));
-        find_new_declared_var = true;
-        break;
-      }
-    }
-    if (!find_new_declared_var)
-    {
-      Warning()
-          << "warning: declared primed variables do not match invariant's "
-             "type\n";
-    }
-#endif
   }
 
   // make relevant terms; 0 -> Inv, 1 -> Pre, 2 -> Trans, 3 -> Post

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -215,13 +215,9 @@ Node Cegis::getRefinementLemmaFormula()
   {
     ret = nm->mkConst(true);
   }
-  else if (conj.size() == 1)
-  {
-    ret = conj[0];
-  }
   else
   {
-    ret = nm->mkNode(AND, conj);
+    ret = conj.size() == 1 ? conj[0] : nm->mkNode(AND, conj);
   }
   return ret;
 }
@@ -269,15 +265,11 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
         return true;
       }
       Node rl = getRefinementLemmaFormula();
-      bool ret = false;
       // try to solve for the refinement lemmas only
-      if (src->repairSolution(rl, candidates, fail_cvs, candidate_values))
-      {
-        // We will exclude the skeleton as well; this means that we have one
-        // chance to repair the solution.
-        ret = true;
-      }
-      // repair solution didn't work, exclude this solution
+      bool ret = src->repairSolution(rl, candidates, fail_cvs, candidate_values);
+      // Even if ret is true, we will exclude the skeleton as well; this means
+      // that we have one chance to repair each skeleton. It is possible however
+      // that we might want to repair the same skeleton multiple times.
       std::vector<Node> exp;
       for (unsigned i = 0, size = enums.size(); i < size; i++)
       {

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -269,10 +269,13 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
         return true;
       }
       Node rl = getRefinementLemmaFormula();
+      bool ret = false;
       // try to solve for the refinement lemmas only
       if (src->repairSolution(rl,candidates, fail_cvs, candidate_values))
       {
-        return true;
+        // We will exclude the skeleton as well; this means that we have one
+        // chance to repair the solution.
+        ret = true;
       }
       // repair solution didn't work, exclude this solution
       std::vector<Node> exp;
@@ -285,7 +288,7 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
       Node expn =
           exp.size() == 1 ? exp[0] : NodeManager::currentNM()->mkNode(AND, exp);
       lems.push_back(expn.negate());
-      return false;
+      return ret;
     }
   }
 

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -198,6 +198,30 @@ bool Cegis::addEvalLemmas(const std::vector<Node>& candidates,
   return addedEvalLemmas;
 }
 
+Node Cegis::getRefinementLemmaFormula()
+{
+  std::vector< Node > conj;
+  conj.insert(conj.end(),d_refinement_lemmas.begin(),d_refinement_lemmas.end());
+  // get the propagated values
+  
+  
+  NodeManager * nm = NodeManager::currentNM();
+  Node ret;  
+  if (conj.empty())
+  {
+    ret = nm->mkConst(true);
+  }
+  else if (conj.size()==1)
+  {
+    ret = conj[0];
+  }
+  else
+  {
+    ret = nm->mkNode(AND,conj);
+  }
+  return ret;
+}
+
 bool Cegis::constructCandidates(const std::vector<Node>& enums,
                                 const std::vector<Node>& enum_values,
                                 const std::vector<Node>& candidates,

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -263,7 +263,14 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
     {
       std::vector<Node> fail_cvs = enum_values;
       Assert(candidates.size() == fail_cvs.size());
+      // try to solve entire problem?
       if (src->repairSolution(candidates, fail_cvs, candidate_values))
+      {
+        return true;
+      }
+      Node rl = getRefinementLemmaFormula();
+      // try to solve for the refinement lemmas only
+      if (src->repairSolution(rl,candidates, fail_cvs, candidate_values))
       {
         return true;
       }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -204,7 +204,11 @@ Node Cegis::getRefinementLemmaFormula()
   conj.insert(
       conj.end(), d_refinement_lemmas.begin(), d_refinement_lemmas.end());
   // get the propagated values
-
+  for (unsigned i=0, nprops=d_rl_eval_hds.size(); i<nprops; i++)
+  {
+    conj.push_back(d_rl_eval_hds[i].eqNode(d_rl_vals[i]));
+  }
+  // make the formula
   NodeManager* nm = NodeManager::currentNM();
   Node ret;
   if (conj.empty())

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -204,7 +204,7 @@ Node Cegis::getRefinementLemmaFormula()
   conj.insert(
       conj.end(), d_refinement_lemmas.begin(), d_refinement_lemmas.end());
   // get the propagated values
-  for (unsigned i=0, nprops=d_rl_eval_hds.size(); i<nprops; i++)
+  for (unsigned i = 0, nprops = d_rl_eval_hds.size(); i < nprops; i++)
   {
     conj.push_back(d_rl_eval_hds[i].eqNode(d_rl_vals[i]));
   }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -271,7 +271,7 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
       Node rl = getRefinementLemmaFormula();
       bool ret = false;
       // try to solve for the refinement lemmas only
-      if (src->repairSolution(rl,candidates, fail_cvs, candidate_values))
+      if (src->repairSolution(rl, candidates, fail_cvs, candidate_values))
       {
         // We will exclude the skeleton as well; this means that we have one
         // chance to repair the solution.

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -200,24 +200,24 @@ bool Cegis::addEvalLemmas(const std::vector<Node>& candidates,
 
 Node Cegis::getRefinementLemmaFormula()
 {
-  std::vector< Node > conj;
-  conj.insert(conj.end(),d_refinement_lemmas.begin(),d_refinement_lemmas.end());
+  std::vector<Node> conj;
+  conj.insert(
+      conj.end(), d_refinement_lemmas.begin(), d_refinement_lemmas.end());
   // get the propagated values
-  
-  
-  NodeManager * nm = NodeManager::currentNM();
-  Node ret;  
+
+  NodeManager* nm = NodeManager::currentNM();
+  Node ret;
   if (conj.empty())
   {
     ret = nm->mkConst(true);
   }
-  else if (conj.size()==1)
+  else if (conj.size() == 1)
   {
     ret = conj[0];
   }
   else
   {
-    ret = nm->mkNode(AND,conj);
+    ret = nm->mkNode(AND, conj);
   }
   return ret;
 }

--- a/src/theory/quantifiers/sygus/cegis.cpp
+++ b/src/theory/quantifiers/sygus/cegis.cpp
@@ -266,7 +266,8 @@ bool Cegis::constructCandidates(const std::vector<Node>& enums,
       }
       Node rl = getRefinementLemmaFormula();
       // try to solve for the refinement lemmas only
-      bool ret = src->repairSolution(rl, candidates, fail_cvs, candidate_values);
+      bool ret =
+          src->repairSolution(rl, candidates, fail_cvs, candidate_values);
       // Even if ret is true, we will exclude the skeleton as well; this means
       // that we have one chance to repair each skeleton. It is possible however
       // that we might want to repair the same skeleton multiple times.

--- a/src/theory/quantifiers/sygus/cegis.h
+++ b/src/theory/quantifiers/sygus/cegis.h
@@ -168,6 +168,8 @@ class Cegis : public SygusModule
   bool addEvalLemmas(const std::vector<Node>& candidates,
                      const std::vector<Node>& candidate_values,
                      std::vector<Node>& lems);
+  /** Get the node corresponding to the conjunction of all refinement lemmas. */
+  Node getRefinementLemmaFormula();
   //-----------------------------------end refinement lemmas
 
   /** Get refinement evaluation lemmas

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -208,8 +208,9 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   }
 
   NodeManager* nm = NodeManager::currentNM();
+  Node sygusBody =d_base_inst;
   Trace("sygus-repair-const") << "Get first-order query..." << std::endl;
-  Node fo_body = getFoQuery(candidates, candidate_skeletons, sk_vars);
+  Node fo_body = getFoQuery(sygusBody, candidates, candidate_skeletons, sk_vars);
 
   Trace("sygus-repair-const-debug") << "...got : " << fo_body << std::endl;
 
@@ -225,7 +226,8 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   LogicInfo logic = smt::currentSmtEngine()->getLogicInfo();
   if (logic.isTheoryEnabled(THEORY_ARITH) && logic.isLinear())
   {
-    fo_body = fitToLogic(logic,
+    fo_body = fitToLogic(sygusBody,
+                         logic,
                          fo_body,
                          candidates,
                          candidate_skeletons,
@@ -460,12 +462,12 @@ Node SygusRepairConst::getSkeleton(Node n,
   return visited[n];
 }
 
-Node SygusRepairConst::getFoQuery(const std::vector<Node>& candidates,
+Node SygusRepairConst::getFoQuery(Node body,
+                                  const std::vector<Node>& candidates,
                                   const std::vector<Node>& candidate_skeletons,
                                   const std::vector<Node>& sk_vars)
 {
   NodeManager* nm = NodeManager::currentNM();
-  Node body = d_base_inst;
   Trace("sygus-repair-const") << "  Substitute skeletons..." << std::endl;
   body = body.substitute(candidates.begin(),
                          candidates.end(),
@@ -558,7 +560,8 @@ Node SygusRepairConst::getFoQuery(const std::vector<Node>& candidates,
   return fo_body;
 }
 
-Node SygusRepairConst::fitToLogic(LogicInfo& logic,
+Node SygusRepairConst::fitToLogic(Node body,
+                                  LogicInfo& logic,
                                   Node n,
                                   const std::vector<Node>& candidates,
                                   std::vector<Node>& candidate_skeletons,
@@ -590,7 +593,7 @@ Node SygusRepairConst::fitToLogic(LogicInfo& logic,
     Assert(it != sk_vars.end());
     sk_vars.erase(it);
     // reconstruct the query
-    n = getFoQuery(candidates, candidate_skeletons, sk_vars);
+    n = getFoQuery(body,candidates, candidate_skeletons, sk_vars);
     // reset the exclusion variable
     exc_var = Node::null();
   }

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -149,6 +149,15 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
                                       std::vector<Node>& repair_cv,
                                       bool useConstantsAsHoles)
 {
+  return repairSolution(d_base_inst,candidates,candidate_values,repair_cv,useConstantsAsHoles);
+}
+  
+bool SygusRepairConst::repairSolution(Node sygusBody,
+                                      const std::vector<Node>& candidates,
+                                      const std::vector<Node>& candidate_values,
+                                      std::vector<Node>& repair_cv,
+                                      bool useConstantsAsHoles)
+{
   Assert(candidates.size() == candidate_values.size());
 
   // if no grammar type allows constants, no repair is possible
@@ -208,7 +217,6 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   }
 
   NodeManager* nm = NodeManager::currentNM();
-  Node sygusBody = d_base_inst;
   Trace("sygus-repair-const") << "Get first-order query..." << std::endl;
   Node fo_body =
       getFoQuery(sygusBody, candidates, candidate_skeletons, sk_vars);

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -208,9 +208,10 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
   }
 
   NodeManager* nm = NodeManager::currentNM();
-  Node sygusBody =d_base_inst;
+  Node sygusBody = d_base_inst;
   Trace("sygus-repair-const") << "Get first-order query..." << std::endl;
-  Node fo_body = getFoQuery(sygusBody, candidates, candidate_skeletons, sk_vars);
+  Node fo_body =
+      getFoQuery(sygusBody, candidates, candidate_skeletons, sk_vars);
 
   Trace("sygus-repair-const-debug") << "...got : " << fo_body << std::endl;
 
@@ -593,7 +594,7 @@ Node SygusRepairConst::fitToLogic(Node body,
     Assert(it != sk_vars.end());
     sk_vars.erase(it);
     // reconstruct the query
-    n = getFoQuery(body,candidates, candidate_skeletons, sk_vars);
+    n = getFoQuery(body, candidates, candidate_skeletons, sk_vars);
     // reset the exclusion variable
     exc_var = Node::null();
   }

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -149,9 +149,13 @@ bool SygusRepairConst::repairSolution(const std::vector<Node>& candidates,
                                       std::vector<Node>& repair_cv,
                                       bool useConstantsAsHoles)
 {
-  return repairSolution(d_base_inst,candidates,candidate_values,repair_cv,useConstantsAsHoles);
+  return repairSolution(d_base_inst,
+                        candidates,
+                        candidate_values,
+                        repair_cv,
+                        useConstantsAsHoles);
 }
-  
+
 bool SygusRepairConst::repairSolution(Node sygusBody,
                                       const std::vector<Node>& candidates,
                                       const std::vector<Node>& candidate_values,

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -153,7 +153,8 @@ class SygusRepairConst
    * is a first-order (quantified) formula in the background logic, without UF,
    * of the form [***] above.
    */
-  Node getFoQuery(const std::vector<Node>& candidates,
+  Node getFoQuery(Node body,
+                  const std::vector<Node>& candidates,
                   const std::vector<Node>& candidate_skeletons,
                   const std::vector<Node>& sk_vars);
   /** fit to logic
@@ -174,7 +175,8 @@ class SygusRepairConst
    * It uses the function below to choose which variables to remove from
    * sk_vars.
    */
-  Node fitToLogic(LogicInfo& logic,
+  Node fitToLogic(Node body,
+                  LogicInfo& logic,
                   Node n,
                   const std::vector<Node>& candidates,
                   std::vector<Node>& candidate_skeletons,

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -53,9 +53,9 @@ class SygusRepairConst
   ~SygusRepairConst() {}
   /** initialize
    *
-   * Initialize this class with the base instantiation of the sygus conjecture
-   * (see CegConjecture::d_base_inst) and its candidate variables (see
-   * CegConjecture::d_candidates).
+   * Initialize this class with the base instantiation (body) of the sygus
+   * conjecture (see SynthConjecture::d_base_inst) and its candidate variables
+   * (see SynthConjecture::d_candidates).
    */
   void initialize(Node base_inst, const std::vector<Node>& candidates);
   /** repair solution
@@ -75,6 +75,17 @@ class SygusRepairConst
    * candidate_values to be repairable. In addition, if the flag
    * useConstantsAsHoles is true, we consider all constants whose (sygus) type
    * admit alls constants to be repairable.
+   * The repaired solution has the property that it satisfies the synthesis
+   * conjecture whose body is given by sygusBody.
+   */
+  bool repairSolution(Node sygusBody,
+                      const std::vector<Node>& candidates,
+                      const std::vector<Node>& candidate_values,
+                      std::vector<Node>& repair_cv,
+                      bool useConstantsAsHoles = false);
+  /** 
+   * Same as above, but where sygusBody is the body (base_inst) provided to the
+   * call to initialize of this class.
    */
   bool repairSolution(const std::vector<Node>& candidates,
                       const std::vector<Node>& candidate_values,
@@ -148,7 +159,8 @@ class SygusRepairConst
   /** get first-order query
    *
    * This function returns a formula that is equivalent to the negation of the
-   * synthesis conjecture, where candidates are replaced by candidate_skeletons,
+   * synthesis conjecture whose body is given in the first argument, where
+   * candidates are replaced by candidate_skeletons,
    * whose free variables are in the set sk_vars. The returned formula
    * is a first-order (quantified) formula in the background logic, without UF,
    * of the form [***] above.
@@ -164,6 +176,9 @@ class SygusRepairConst
    * variables may introduce e.g. non-linearity. If non-linear arithmetic is
    * not enabled, we must undo some of the variables we introduced when
    * inferring candidate skeletons.
+   * 
+   * body is the (sygus) form of the original synthesis conjecture we are
+   * considering in this call.
    *
    * This function may remove variables from sk_vars and the map
    * sk_vars_to_subs. The skeletons candidate_skeletons are obtained by

--- a/src/theory/quantifiers/sygus/sygus_repair_const.h
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.h
@@ -83,7 +83,7 @@ class SygusRepairConst
                       const std::vector<Node>& candidate_values,
                       std::vector<Node>& repair_cv,
                       bool useConstantsAsHoles = false);
-  /** 
+  /**
    * Same as above, but where sygusBody is the body (base_inst) provided to the
    * call to initialize of this class.
    */
@@ -176,7 +176,7 @@ class SygusRepairConst
    * variables may introduce e.g. non-linearity. If non-linear arithmetic is
    * not enabled, we must undo some of the variables we introduced when
    * inferring candidate skeletons.
-   * 
+   *
    * body is the (sygus) form of the original synthesis conjecture we are
    * considering in this call.
    *

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1724,6 +1724,7 @@ set(regress_1_tests
   regress1/sygus/qe.sy
   regress1/sygus/qf_abv.smt2
   regress1/sygus/real-grammar.sy
+  regress1/sygus/repair-const-rl.sy
   regress1/sygus/simple-regexp.sy
   regress1/sygus/stopwatch-bt.sy
   regress1/sygus/strings-no-syntax.sy

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1667,6 +1667,7 @@ set(regress_1_tests
   regress1/sygus/cegisunif-depth1.sy
   regress1/sygus/cggmp.sy
   regress1/sygus/clock-inc-tuple.sy
+  regress1/sygus/coeff-solve-inv.sy
   regress1/sygus/commutative-stream.sy
   regress1/sygus/commutative.sy
   regress1/sygus/concat_extract_example.sy

--- a/test/regress/regress1/sygus/coeff-solve-inv.sy
+++ b/test/regress/regress1/sygus/coeff-solve-inv.sy
@@ -1,0 +1,29 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status --sygus-repair-const --lang=sygus2
+(set-logic LIA)
+
+(synth-inv inv-f ((x Int) (y Int)) )
+
+
+(define-fun pre-f ((x Int) (y Int)) Bool
+  (and 
+    (= x 0)
+    (= y 100)
+  )
+)
+
+(define-fun trans-f ((x Int) (y Int) (x! Int) (y! Int)) Bool
+  (and
+    (< x 100)
+    (= x! (+ x 1))
+    (= y! (+ y 1))
+  )
+)
+
+(define-fun post-f ((x Int) (y Int)) Bool 
+  (=> (>= x 100) (>= y 200))
+)
+
+(inv-constraint inv-f pre-f trans-f post-f)
+
+(check-synth)

--- a/test/regress/regress1/sygus/repair-const-rl.sy
+++ b/test/regress/regress1/sygus/repair-const-rl.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-out=status --cegqi-si=none --sygus-repair-const
+; COMMAND-LINE: --sygus-out=status --cegqi-si=none --sygus-repair-const --lang=sygus2
 (set-logic LIA)
 
 (synth-fun f ((x Int) (y Int)) Int

--- a/test/regress/regress1/sygus/repair-const-rl.sy
+++ b/test/regress/regress1/sygus/repair-const-rl.sy
@@ -1,0 +1,24 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status --cegqi-si=none --sygus-repair-const
+(set-logic LIA)
+
+(synth-fun f ((x Int) (y Int)) Int
+  ((Start Int) (CInt Int))
+  (
+    (Start Int ((+ (* CInt x) (* CInt y) CInt)))
+    (CInt Int ((Constant Int)))
+  )
+)
+
+(declare-var x Int)
+(declare-var y Int)
+
+(constraint (= (f 0 0) 100))
+
+(constraint (= (f 1 1) 110))
+
+(constraint (= (f 2 1) 117))
+
+(constraint (>= (- (* 3 (f x y)) (f (* 2 x) (+ y 1))) (+ (* 7 x) (* 6 y))))
+
+(check-synth)


### PR DESCRIPTION
This supplements the techniques for repairing constants in sygus solutions via ensuring the constants supplied to the current skeleton are a *candidate* solution, that is, a solution for the current set of CEGIS refinement lemmas. Previously, we enforced that the repair constant module ensured the constants supplied to the current skeleton are a solution to the entire synthesis conjecture.

The current fairness scheme is naive (each skeleton is repaired exactly once). In the future, we could consider repairing skeletons multiple times.

This is work towards improving predicate generation for Unif+PI.