### PR TITLE
Fix regression

### DIFF
--- a/test/regress/regress0/sygus/no-logic.sy
+++ b/test/regress/regress0/sygus/no-logic.sy
@@ -1,4 +1,4 @@
-; REQUIRE: no-competition
+; REQUIRES: no-competition
 ; COMMAND-LINE: --sygus-out=status --lang=sygus2
 ; EXPECT-ERROR: no-logic.sy:8.10: No set-logic command was given before this point.
 ; EXPECT-ERROR: no-logic.sy:8.10: CVC4 will make all theories available.


### PR DESCRIPTION
PR #3388 didn't disable the regression correctly (due to using `REQUIRE`
instead of `REQUIRES`). This commit fixes the issue.