### PR TITLE
Cleaning-up the declaration of wrapped functions/methods, which have no definitions

### DIFF
--- a/src/expr/symbol_table.cpp
+++ b/src/expr/symbol_table.cpp
@@ -360,8 +360,6 @@ class SymbolTable::Implementation {
   void bindType(const string& name, const vector<Type>& params, Type t,
                 bool levelZero = false);
   bool isBound(const string& name) const;
-  bool isBoundDefinedFunction(const string& name) const;
-  bool isBoundDefinedFunction(Expr func) const;
   bool isBoundType(const string& name) const;
   Expr lookup(const string& name) const;
   Type lookupType(const string& name) const;

--- a/src/expr/symbol_table.h
+++ b/src/expr/symbol_table.h
@@ -109,12 +109,6 @@ class CVC4_PUBLIC SymbolTable {
   bool isBound(const std::string& name) const;
 
   /**
-   * Check whether an Expr was bound to a function (i.e., was the
-   * second arg to bindDefinedFunction()).
-   */
-  bool isBoundDefinedFunction(Expr func) const;
-
-  /**
    * Check whether a name is bound to a type (or type constructor).
    *
    * @param name the identifier to check.

--- a/src/options/options.h
+++ b/src/options/options.h
@@ -227,7 +227,6 @@ public:
   bool getVersion() const;
   bool getWaitToJoin() const;
   const std::string& getForceLogicString() const;
-  const std::vector<std::string>& getThreadArgv() const;
   int getVerbosity() const;
   std::istream* getIn() const;
   std::ostream* getErr();


### PR DESCRIPTION
When testing the most recent version of the CVC4 Python API (with Python3), I very quickly observed that `_CVC4.so` was "unloadable" (i.e., causes SIGSEGV) because of a number of unresolved symbols. This issue is very similar to https://github.com/CVC4/CVC4/pull/3086.

There were two main issues:

* In d1f3225e26b9d64f065048885053392b10994e71, the definitions of `isBoundDefinedFunction` were removed, but not the prototypes.

* In 1c09572e0e2031519a103caa2a4af0d9bd34a9c5, the definition of `getThreadArgv` was removed, but not the prototype.

The crux of this issue is that these methods are wrapped by SWIG, which then needs the complete definitions to exist for the resulting `.so` to be valid. Removing these prototypes means that SWIG does not wrap them, and therefore there are no unresolved symbols.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>