### PR TITLE
Fix global-declarations support

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -308,12 +308,12 @@ void Parser::defineParameterizedType(const std::string& name,
 }
 
 SortType Parser::mkSort(const std::string& name, uint32_t flags) {
-  if (d_globalDeclarations) {
-    flags |= ExprManager::VAR_FLAG_GLOBAL;
-  }
   Debug("parser") << "newSort(" << name << ")" << std::endl;
   Type type = getExprManager()->mkSort(name, flags);
-  defineType(name, type, flags & ExprManager::VAR_FLAG_GLOBAL);
+  defineType(
+      name,
+      type,
+      d_globalDeclarations && !(flags & ExprManager::SORT_FLAG_PLACEHOLDER));
   return type;
 }
 
@@ -321,16 +321,15 @@ SortConstructorType Parser::mkSortConstructor(const std::string& name,
                                               size_t arity,
                                               uint32_t flags)
 {
-  if (d_globalDeclarations)
-  {
-    flags |= ExprManager::VAR_FLAG_GLOBAL;
-  }
   Debug("parser") << "newSortConstructor(" << name << ", " << arity << ")"
                   << std::endl;
   SortConstructorType type =
       getExprManager()->mkSortConstructor(name, arity, flags);
   defineType(
-      name, vector<Type>(arity), type, flags & ExprManager::VAR_FLAG_GLOBAL);
+      name,
+      vector<Type>(arity),
+      type,
+      d_globalDeclarations && !(flags & ExprManager::SORT_FLAG_PLACEHOLDER));
   return type;
 }
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -527,11 +527,15 @@ public:
                  bool levelZero = false, bool doOverload = false);
 
   /** Create a new type definition. */
-  void defineType(const std::string& name, const Type& type);
+  void defineType(const std::string& name,
+                  const Type& type,
+                  bool levelZero = false);
 
   /** Create a new (parameterized) type definition. */
   void defineType(const std::string& name,
-                  const std::vector<Type>& params, const Type& type);
+                  const std::vector<Type>& params,
+                  const Type& type,
+                  bool levelZero = false);
 
   /** Create a new type definition (e.g., from an SMT-LIBv2 define-sort). */
   void defineParameterizedType(const std::string& name,

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -526,12 +526,27 @@ public:
   void defineVar(const std::string& name, const Expr& val,
                  bool levelZero = false, bool doOverload = false);
 
-  /** Create a new type definition. */
+  /**
+   * Create a new type definition.
+   *
+   * @param name The name of the type
+   * @param type The type that should be associated with the name
+   * @param levelZero If true, the type definition is considered global and
+   *                  cannot be removed by poppoing the user context
+   */
   void defineType(const std::string& name,
                   const Type& type,
                   bool levelZero = false);
 
-  /** Create a new (parameterized) type definition. */
+  /**
+   * Create a new (parameterized) type definition.
+   *
+   * @param name The name of the type
+   * @param params The type parameters
+   * @param type The type that should be associated with the name
+   * @param levelZero If true, the type definition is considered global and
+   *                  cannot be removed by poppoing the user context
+   */
   void defineType(const std::string& name,
                   const std::vector<Type>& params,
                   const Type& type,

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -846,6 +846,7 @@ set(regress_0_tests
   regress0/smallcnf.cvc
   regress0/smt2output.smt2
   regress0/smtlib/get-unsat-assumptions.smt2
+  regress0/smtlib/global-decls.smt2
   regress0/smtlib/reason-unknown.smt2
   regress0/smtlib/set-info-status.smt2
   regress0/strings/bug001.smt2

--- a/test/regress/regress0/datatypes/bug597-rbt.smt2
+++ b/test/regress/regress0/datatypes/bug597-rbt.smt2
@@ -1,3 +1,4 @@
+(set-option :global-declarations true)
 (set-logic ALL_SUPPORTED)
 (set-info :status sat)
 

--- a/test/regress/regress0/smtlib/global-decls.smt2
+++ b/test/regress/regress0/smtlib/global-decls.smt2
@@ -1,0 +1,25 @@
+; COMMAND-LINE: --incremental
+(set-option :global-declarations true)
+(set-logic QF_UFDT)
+
+(push 1)
+(declare-datatype Struct1 (par (T0) ((mk-struct1 (struct1-proj0 T0)))))
+(declare-datatypes ((Unit 0)) (((u))))
+(declare-fun x () (Struct1 Bool))
+(declare-sort U1 0)
+(declare-sort U2 1)
+(pop 1)
+
+(assert (= x x))
+
+(define-fun y () (Struct1 Bool) (mk-struct1 true))
+(declare-const z Unit)
+(assert (= u u))
+(assert (is-mk-struct1 y))
+(assert (is-u z))
+
+(declare-const w1 U1)
+(declare-const w2 (U2 Bool))
+
+(set-info :status sat)
+(check-sat)

--- a/test/regress/regress0/smtlib/global-decls.smt2
+++ b/test/regress/regress0/smtlib/global-decls.smt2
@@ -1,10 +1,11 @@
 ; COMMAND-LINE: --incremental
 (set-option :global-declarations true)
-(set-logic QF_UFDT)
+(set-logic QF_UFDTLIA)
 
 (push 1)
 (declare-datatype Struct1 (par (T0) ((mk-struct1 (struct1-proj0 T0)))))
 (declare-datatypes ((Unit 0)) (((u))))
+(declare-datatypes ((Tree 0)) (((node (data Int) (color Bool) (left Tree) (right Tree)) (nil))))
 (declare-fun x () (Struct1 Bool))
 (declare-sort U1 0)
 (declare-sort U2 1)

--- a/test/regress/regress0/smtlib/global-decls.smt2
+++ b/test/regress/regress0/smtlib/global-decls.smt2
@@ -19,6 +19,9 @@
 (assert (is-mk-struct1 y))
 (assert (is-u z))
 
+(declare-fun size (Tree) Int)
+(assert (= (size nil) 0))
+
 (declare-const w1 U1)
 (declare-const w2 (U2 Bool))
 


### PR DESCRIPTION
Fixes #3402. Previously, we were removing datatype and uninterpreted
sort declarations when popping the user context even with
`global-declarations` set to true. However, the SMT-LIB standard says
that ":global-declarations [...] makes all definitions and declarations
global and not removable by pop operations". This commit fixes those
issues by making sure that the uninterpreted sorts as well as the
datatype sorts, constructors, and testers are inserted at level zero if
global declarations are enabled.