### PR TITLE
Fix ho extensionality in collect model info

### DIFF
--- a/src/theory/uf/ho_extension.h
+++ b/src/theory/uf/ho_extension.h
@@ -127,8 +127,12 @@ class HoExtension
    *
    * Given disequality deq f != g, this returns the disequality:
    *   (f k) != (g k) for fresh constant(s) k.
+   * 
+   * If isCached is true, then this returns the same k for all calls to this
+   * method with the same deq. If it is false, it creates fresh k and does not
+   * cache the result.
    */
-  Node getExtensionalityDeq(TNode deq);
+  Node getExtensionalityDeq(TNode deq, bool isCached=true);
 
   /**
    * Check whether extensionality should be applied for any pair of terms in the

--- a/src/theory/uf/ho_extension.h
+++ b/src/theory/uf/ho_extension.h
@@ -127,12 +127,12 @@ class HoExtension
    *
    * Given disequality deq f != g, this returns the disequality:
    *   (f k) != (g k) for fresh constant(s) k.
-   * 
+   *
    * If isCached is true, then this returns the same k for all calls to this
    * method with the same deq. If it is false, it creates fresh k and does not
    * cache the result.
    */
-  Node getExtensionalityDeq(TNode deq, bool isCached=true);
+  Node getExtensionalityDeq(TNode deq, bool isCached = true);
 
   /**
    * Check whether extensionality should be applied for any pair of terms in the


### PR DESCRIPTION
This corrects a bug in the model construction for higher-order in which the witness to extensionality was using constants that were not fresh. This can lead to model inconsistencies when combing theories.

Fixes #3422.  The benchmark in that issue now times out.