### PR TITLE
Remove a few deprecated functions from Datatype

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -1530,14 +1530,7 @@ DatatypeConstructorDecl::DatatypeConstructorDecl(const std::string& name)
 void DatatypeConstructorDecl::addSelector(const DatatypeSelectorDecl& stor)
 {
   CVC4::Type t = *stor.d_sort.d_type;
-  if (t.isNull())
-  {
-    d_ctor->addArg(stor.d_name, DatatypeSelfType());
-  }
-  else
-  {
-    d_ctor->addArg(stor.d_name, t);
-  }
+  d_ctor->addArg(stor.d_name, t);
 }
 
 std::string DatatypeConstructorDecl::toString() const

--- a/src/bindings/java/CMakeLists.txt
+++ b/src/bindings/java/CMakeLists.txt
@@ -72,7 +72,6 @@ set(gen_java_files
   ${CMAKE_CURRENT_BINARY_DIR}/DatatypeIndexConstant.java
   ${CMAKE_CURRENT_BINARY_DIR}/DatatypeIndexConstantHashFunction.java
   ${CMAKE_CURRENT_BINARY_DIR}/DatatypeResolutionException.java
-  ${CMAKE_CURRENT_BINARY_DIR}/DatatypeSelfType.java
   ${CMAKE_CURRENT_BINARY_DIR}/DatatypeType.java
   ${CMAKE_CURRENT_BINARY_DIR}/DeclarationCheck.java
   ${CMAKE_CURRENT_BINARY_DIR}/DeclarationDefinitionCommand.java

--- a/src/bindings/java/CMakeLists.txt
+++ b/src/bindings/java/CMakeLists.txt
@@ -74,7 +74,6 @@ set(gen_java_files
   ${CMAKE_CURRENT_BINARY_DIR}/DatatypeResolutionException.java
   ${CMAKE_CURRENT_BINARY_DIR}/DatatypeSelfType.java
   ${CMAKE_CURRENT_BINARY_DIR}/DatatypeType.java
-  ${CMAKE_CURRENT_BINARY_DIR}/DatatypeUnresolvedType.java
   ${CMAKE_CURRENT_BINARY_DIR}/DeclarationCheck.java
   ${CMAKE_CURRENT_BINARY_DIR}/DeclarationDefinitionCommand.java
   ${CMAKE_CURRENT_BINARY_DIR}/DeclarationSequence.java

--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -894,16 +894,6 @@ void DatatypeConstructor::addArg(std::string selectorName, Type selectorType) {
   d_args.push_back(DatatypeConstructorArg(selectorName, type));
 }
 
-void DatatypeConstructor::addArg(std::string selectorName, DatatypeUnresolvedType selectorType) {
-  // We don't want to introduce a new data member, because eventually
-  // we're going to be a constant stuffed inside a node.  So we stow
-  // the selector type away after a NUL in the name string until
-  // resolution (when we can create the proper selector type)
-  PrettyCheckArgument(!isResolved(), this, "cannot modify a finalized Datatype constructor");
-  PrettyCheckArgument(selectorType.getName() != "", selectorType, "cannot add a null selector type");
-  d_args.push_back(DatatypeConstructorArg(selectorName + '\0' + selectorType.getName(), Expr()));
-}
-
 void DatatypeConstructor::addArg(std::string selectorName, DatatypeSelfType) {
   // We don't want to introduce a new data member, because eventually
   // we're going to be a constant stuffed inside a node.  So we mark

--- a/src/expr/datatype.cpp
+++ b/src/expr/datatype.cpp
@@ -894,16 +894,6 @@ void DatatypeConstructor::addArg(std::string selectorName, Type selectorType) {
   d_args.push_back(DatatypeConstructorArg(selectorName, type));
 }
 
-void DatatypeConstructor::addArg(std::string selectorName, DatatypeSelfType) {
-  // We don't want to introduce a new data member, because eventually
-  // we're going to be a constant stuffed inside a node.  So we mark
-  // the name string with a NUL to indicate that we have a
-  // self-selecting selector until resolution (when we can create the
-  // proper selector type)
-  PrettyCheckArgument(!isResolved(), this, "cannot modify a finalized Datatype constructor");
-  d_args.push_back(DatatypeConstructorArg(selectorName + '\0', Expr()));
-}
-
 std::string DatatypeConstructor::getName() const
 {
   return d_name.substr(0, d_name.find('\0'));

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -102,21 +102,6 @@ class CVC4_PUBLIC DatatypeSelfType {
 };/* class DatatypeSelfType */
 
 /**
- * An unresolved type (used in calls to
- * DatatypeConstructor::addArg()) to allow a Datatype to refer to
- * itself or to other mutually-recursive Datatypes.  Unresolved-type
- * fields of Datatypes will be properly typed when a Type is created
- * for the Datatype by the ExprManager (which calls
- * Datatype::resolve()).
- */
-class CVC4_PUBLIC DatatypeUnresolvedType {
-  std::string d_name;
-public:
-  inline DatatypeUnresolvedType(std::string name);
-  inline std::string getName() const;
-};/* class DatatypeUnresolvedType */
-
-/**
  * A Datatype constructor argument (i.e., a Datatype field).
  */
 class CVC4_PUBLIC DatatypeConstructorArg {
@@ -239,14 +224,6 @@ class CVC4_PUBLIC DatatypeConstructor {
    * they are for convenience and pretty-printing only.
    */
   void addArg(std::string selectorName, Type selectorType);
-
-  /**
-   * Add an argument (i.e., a data field) of the given name to this
-   * Datatype constructor that refers to an as-yet-unresolved
-   * Datatype (which may be mutually-recursive).  Selector names need
-   * not be unique; they are for convenience and pretty-printing only.
-   */
-  void addArg(std::string selectorName, DatatypeUnresolvedType selectorType);
 
   /**
    * Add a self-referential (i.e., a data field) of the given name
@@ -1178,11 +1155,6 @@ inline DatatypeResolutionException::DatatypeResolutionException(std::string msg)
   Exception(msg) {
 }
 
-inline DatatypeUnresolvedType::DatatypeUnresolvedType(std::string name) :
-  d_name(name) {
-}
-
-inline std::string DatatypeUnresolvedType::getName() const { return d_name; }
 inline Datatype::Datatype(std::string name, bool isCo)
     : d_name(name),
       d_params(),

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -989,8 +989,7 @@ public:
    * addConstructor() will fail after a call to resolve().
    *
    * The basic goal of resolution is to assign constructors, selectors,
-   * and testers.  To do this, any UnresolvedType/SelfType references
-   * must be cleared up.  This is the purpose of the "resolutions" map;
+   * and testers.  To do this, we use the "resolutions" map;
    * it includes any mutually-recursive datatypes that are currently
    * under resolution.  The four vectors come in two pairs (so, really
    * they are two maps).  placeholders->replacements give type variables

--- a/src/expr/datatype.h
+++ b/src/expr/datatype.h
@@ -93,15 +93,6 @@ class CVC4_PUBLIC DatatypeResolutionException : public Exception {
 };/* class DatatypeResolutionException */
 
 /**
- * A holder type (used in calls to DatatypeConstructor::addArg())
- * to allow a Datatype to refer to itself.  Self-typed fields of
- * Datatypes will be properly typed when a Type is created for the
- * Datatype by the ExprManager (which calls Datatype::resolve()).
- */
-class CVC4_PUBLIC DatatypeSelfType {
-};/* class DatatypeSelfType */
-
-/**
  * A Datatype constructor argument (i.e., a Datatype field).
  */
 class CVC4_PUBLIC DatatypeConstructorArg {
@@ -224,21 +215,6 @@ class CVC4_PUBLIC DatatypeConstructor {
    * they are for convenience and pretty-printing only.
    */
   void addArg(std::string selectorName, Type selectorType);
-
-  /**
-   * Add a self-referential (i.e., a data field) of the given name
-   * to this Datatype constructor that refers to the enclosing
-   * Datatype.  For example, using the familiar "nat" Datatype, to
-   * create the "pred" field for "succ" constructor, one uses
-   * succ::addArg("pred", DatatypeSelfType())---the actual Type
-   * cannot be passed because the Datatype is still under
-   * construction.  Selector names need not be unique; they are for
-   * convenience and pretty-printing only.
-   *
-   * This is a special case of
-   * DatatypeConstructor::addArg(std::string, DatatypeUnresolvedType).
-   */
-  void addArg(std::string selectorName, DatatypeSelfType);
 
   /** Get the name of this Datatype constructor. */
   std::string getName() const;

--- a/src/expr/datatype.i
+++ b/src/expr/datatype.i
@@ -72,7 +72,6 @@
 %ignore CVC4::DatatypeConstructorIterator;
 %ignore CVC4::DatatypeConstructorArgIterator;
 
-%feature("valuewrapper") CVC4::DatatypeUnresolvedType;
 %feature("valuewrapper") CVC4::DatatypeConstructor;
 
 


### PR DESCRIPTION
There are several functions that are deprecated artifacts of very early design decisions on datatypes. This removes two of them.