### PR TITLE
[Regressions] Remove leading whitespace in output

### DIFF
--- a/test/regress/run_regression.py
+++ b/test/regress/run_regression.py
@@ -342,6 +342,8 @@ def run_regression(unsat_cores, proofs, dump, use_skip_return_code, wrapper,
         output, error, exit_status = run_benchmark(
             dump, wrapper, scrubber, error_scrubber, cvc4_binary,
             command_line_args, benchmark_dir, benchmark_basename, timeout)
+        output = re.sub(r'^[ \t]*', '', output, flags=re.MULTILINE)
+        error = re.sub(r'^[ \t]*', '', error, flags=re.MULTILINE)
         if output != expected_output:
             exit_code = EXIT_FAILURE
             print(


### PR DESCRIPTION
With #3436, we are stripping whitespace off the expected (error) output
but we did not do the same for leading whitespace in the actual input,
leading to failing regressions. This change removes leading whitespace
in the (error) output of CVC4.