### PR TITLE
Fix mkConst<RoundingMode>() for Python bindings

### DIFF
--- a/src/expr/expr_manager.i
+++ b/src/expr/expr_manager.i
@@ -52,7 +52,6 @@
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::BitVectorRotateRight>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::IntToBitVector>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::FloatingPoint>;
-%template(mkConst) CVC4::ExprManager::mkConst<CVC4::RoundingMode>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::FloatingPointSize>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::FloatingPointToFPIEEEBitVector>;
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::FloatingPointToFPFloatingPoint>;
@@ -77,12 +76,14 @@
  * case into mkBoolConst.
 */
 %template(mkBoolConst) CVC4::ExprManager::mkConst<bool>;
+%template(mkRoundingMode) CVC4::ExprManager::mkConst<RoundingMode>;
 
 // These cases have trouble too.  Remove them for now.
 //%template(mkConst) CVC4::ExprManager::mkConst<CVC4::TypeConstant>;
 #else
 %template(mkConst) CVC4::ExprManager::mkConst<CVC4::TypeConstant>;
 %template(mkConst) CVC4::ExprManager::mkConst<bool>;
+%template(mkConst) CVC4::ExprManager::mkConst<CVC4::RoundingMode>;
 #endif
 
 %include "expr/expr_manager.h"


### PR DESCRIPTION
Fixes #3089. In the Python bindings, we cannot differentiate between
basic types such as enum, int, and bool. Thus, `mkConst()` was not
working correctly when a rounding mode was passed. This commit fixes the
issue by introducing `mkRoundingMode` for the Python bindings, which
accepts a rounding mode as an argument.