### PR TITLE
Allow (set-logic ...) after (reset)

### DIFF
--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -610,6 +610,7 @@ void Smt2::pushDefineFunRecScope(
 
 void Smt2::reset() {
   d_logicSet = false;
+  d_seenSetLogic = false;
   d_logic = LogicInfo();
   operatorKindMap.clear();
   d_lastNamedTerm = std::pair<Expr, std::string>();

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -851,6 +851,8 @@ set(regress_0_tests
   regress0/smtlib/get-unsat-assumptions.smt2
   regress0/smtlib/global-decls.smt2
   regress0/smtlib/reason-unknown.smt2
+  regress0/smtlib/reset-force-logic.smt2
+  regress0/smtlib/reset-set-logic.smt2
   regress0/smtlib/set-info-status.smt2
   regress0/strings/bug001.smt2
   regress0/strings/bug002.smt2

--- a/test/regress/regress0/smtlib/reset-force-logic.smt2
+++ b/test/regress/regress0/smtlib/reset-force-logic.smt2
@@ -1,0 +1,17 @@
+; COMMAND-LINE: --force-logic QF_LIRA
+; EXPECT: sat
+; EXPECT: sat
+
+; Intentionally set the wrong logic
+(set-logic QF_BV)
+(declare-const x Real)
+(assert (= x (- 2.5)))
+(check-sat)
+
+(reset)
+
+; Intentionally set the wrong logic
+(set-logic QF_BV)
+(declare-const x Int)
+(assert (= x 2))
+(check-sat)

--- a/test/regress/regress0/smtlib/reset-set-logic.smt2
+++ b/test/regress/regress0/smtlib/reset-set-logic.smt2
@@ -1,0 +1,13 @@
+; EXPECT: sat
+; EXPECT: sat
+(set-logic QF_LRA)
+(declare-const x Real)
+(assert (= x (- 2.5)))
+(check-sat)
+
+(reset)
+
+(set-logic QF_LIA)
+(declare-const x Int)
+(assert (= x 2))
+(check-sat)


### PR DESCRIPTION
Fixes #3353. #3062 introduced a flag that tracks whether we have seen a
`(set-logic ...)` command to improve the handling of `--force-logic`.
However, the flag was not set to `false` when `(reset)` was called. This
commit fixes the issue.