### PR TITLE
Use standard interface for sygus default grammar construction

### DIFF
--- a/src/expr/sygus_datatype.cpp
+++ b/src/expr/sygus_datatype.cpp
@@ -53,10 +53,7 @@ void SygusDatatype::addAnyConstantConstructor(TypeNode tn)
       av, cname, builtinArg, printer::SygusEmptyPrintCallback::getEmptyPC(), 0);
 }
 
-size_t SygusDatatype::getNumConstructors() const
-{
-  return d_ops.size();
-}
+size_t SygusDatatype::getNumConstructors() const { return d_ops.size(); }
 
 void SygusDatatype::initializeDatatype(TypeNode sygusType,
                                        Node sygusVars,
@@ -83,10 +80,11 @@ void SygusDatatype::initializeDatatype(TypeNode sygusType,
   Trace("sygus-type-cons") << "...built datatype " << d_dt << " ";
 }
 
-const Datatype& SygusDatatype::getDatatype() const { 
+const Datatype& SygusDatatype::getDatatype() const
+{
   // should have initialized by this point
   Assert(d_dt.isSygus());
-  return d_dt; 
+  return d_dt;
 }
 
 }  // namespace CVC4

--- a/src/expr/sygus_datatype.cpp
+++ b/src/expr/sygus_datatype.cpp
@@ -52,6 +52,14 @@ void SygusDatatype::addAnyConstantConstructor(TypeNode tn)
   addConstructor(
       av, cname, builtinArg, printer::SygusEmptyPrintCallback::getEmptyPC(), 0);
 }
+void SygusDatatype::addConstructor(Kind k,
+                      const std::vector<TypeNode>& consTypes,
+                      std::shared_ptr<SygusPrintCallback> spc,
+                      int weight)
+{
+  NodeManager * nm = NodeManager::currentNM();
+  addConstructor(nm->operatorOf(k), kindToString(k), consTypes, spc, weight);
+}
 
 size_t SygusDatatype::getNumConstructors() const { return d_ops.size(); }
 

--- a/src/expr/sygus_datatype.cpp
+++ b/src/expr/sygus_datatype.cpp
@@ -26,9 +26,9 @@ std::string SygusDatatype::getName() const { return d_dt.getName(); }
 
 void SygusDatatype::addConstructor(Node op,
                                    const std::string& name,
+                                   const std::vector<TypeNode>& consTypes,
                                    std::shared_ptr<SygusPrintCallback> spc,
-                                   int weight,
-                                   const std::vector<TypeNode>& consTypes)
+                                   int weight)
 {
   d_ops.push_back(op);
   d_cons_names.push_back(std::string(name));
@@ -50,7 +50,12 @@ void SygusDatatype::addAnyConstantConstructor(TypeNode tn)
   std::vector<TypeNode> builtinArg;
   builtinArg.push_back(tn);
   addConstructor(
-      av, cname, printer::SygusEmptyPrintCallback::getEmptyPC(), 0, builtinArg);
+      av, cname, builtinArg, printer::SygusEmptyPrintCallback::getEmptyPC(), 0);
+}
+
+size_t SygusDatatype::getNumConstructors() const
+{
+  return d_ops.size();
 }
 
 void SygusDatatype::initializeDatatype(TypeNode sygusType,
@@ -58,6 +63,8 @@ void SygusDatatype::initializeDatatype(TypeNode sygusType,
                                        bool allowConst,
                                        bool allowAll)
 {
+  // should not have initialized (set sygus) yet
+  Assert(!d_dt.isSygus());
   /* Use the sygus type to not lose reference to the original types (Bool,
    * Int, etc) */
   d_dt.setSygus(sygusType.toType(), sygusVars.toExpr(), allowConst, allowAll);
@@ -76,6 +83,10 @@ void SygusDatatype::initializeDatatype(TypeNode sygusType,
   Trace("sygus-type-cons") << "...built datatype " << d_dt << " ";
 }
 
-const Datatype& SygusDatatype::getDatatype() const { return d_dt; }
+const Datatype& SygusDatatype::getDatatype() const { 
+  // should have initialized by this point
+  Assert(d_dt.isSygus());
+  return d_dt; 
+}
 
 }  // namespace CVC4

--- a/src/expr/sygus_datatype.cpp
+++ b/src/expr/sygus_datatype.cpp
@@ -53,11 +53,11 @@ void SygusDatatype::addAnyConstantConstructor(TypeNode tn)
       av, cname, builtinArg, printer::SygusEmptyPrintCallback::getEmptyPC(), 0);
 }
 void SygusDatatype::addConstructor(Kind k,
-                      const std::vector<TypeNode>& consTypes,
-                      std::shared_ptr<SygusPrintCallback> spc,
-                      int weight)
+                                   const std::vector<TypeNode>& consTypes,
+                                   std::shared_ptr<SygusPrintCallback> spc,
+                                   int weight)
 {
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   addConstructor(nm->operatorOf(k), kindToString(k), consTypes, spc, weight);
 }
 

--- a/src/expr/sygus_datatype.h
+++ b/src/expr/sygus_datatype.h
@@ -72,7 +72,7 @@ class SygusDatatype
    * for the given (builtin) type tn.
    */
   void addAnyConstantConstructor(TypeNode tn);
-  
+
   /** Get the number of constructors added to this class so far */
   size_t getNumConstructors() const;
 

--- a/src/expr/sygus_datatype.h
+++ b/src/expr/sygus_datatype.h
@@ -64,14 +64,17 @@ class SygusDatatype
    */
   void addConstructor(Node op,
                       const std::string& name,
-                      std::shared_ptr<SygusPrintCallback> spc,
-                      int weight,
-                      const std::vector<TypeNode>& consTypes);
+                      const std::vector<TypeNode>& consTypes,
+                      std::shared_ptr<SygusPrintCallback> spc = nullptr,
+                      int weight = -1);
   /**
    * This adds a constructor that corresponds to the any constant constructor
    * for the given (builtin) type tn.
    */
   void addAnyConstantConstructor(TypeNode tn);
+  
+  /** Get the number of constructors added to this class so far */
+  size_t getNumConstructors() const;
 
   /** builds a datatype with the information in the type object
    *

--- a/src/expr/sygus_datatype.h
+++ b/src/expr/sygus_datatype.h
@@ -61,9 +61,23 @@ class SygusDatatype
    * weight: the weight of this constructor,
    * consTypes: the argument types of the constructor (typically other sygus
    * datatype types).
+   *
+   * It should be the case that consTypes are sygus datatype types (possibly
+   * unresolved) that encode the arguments of the builtin operator. That is,
+   * if op is the builtin PLUS operator, then consTypes could contain 2+
+   * sygus datatype types that encode integer.
    */
   void addConstructor(Node op,
                       const std::string& name,
+                      const std::vector<TypeNode>& consTypes,
+                      std::shared_ptr<SygusPrintCallback> spc = nullptr,
+                      int weight = -1);
+  /**
+   * Add constructor that encodes an application of builtin kind k. Like above,
+   * the arguments consTypes should correspond to sygus datatypes that encode
+   * the types of the arguments of the kind.
+   */
+  void addConstructor(Kind k,
                       const std::vector<TypeNode>& consTypes,
                       std::shared_ptr<SygusPrintCallback> spc = nullptr,
                       int weight = -1);

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -699,8 +699,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       std::vector<TypeNode> cargsBinary;
       cargsBinary.push_back(unres_t);
       cargsBinary.push_back(unres_t);
-      sdts[i].addConstructor(STRING_CONCAT,
-                             cargsBinary);
+      sdts[i].addConstructor(STRING_CONCAT, cargsBinary);
       // length
       TypeNode intType = nm->integerType();
       Assert(std::find(types.begin(), types.end(), intType) != types.end());

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -480,8 +480,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     TypeNode range,
     Node bvl,
     const std::string& fun,
-    std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>&
-        extra_cons,
+    std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>& extra_cons,
     std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>&
         exclude_cons,
     const std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>&
@@ -533,7 +532,8 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
   // create placeholders for collected types
   std::vector<TypeNode> unres_types;
   std::map<TypeNode, TypeNode> type_to_unres;
-  std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>::const_iterator itc;
+  std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>::const_iterator
+      itc;
   for (unsigned i = 0, size = types.size(); i < size; ++i)
   {
     std::stringstream ss;
@@ -541,12 +541,12 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     std::string dname = ss.str();
     sdts.push_back(SygusDatatypeGenerator(dname));
     itc = exclude_cons.find(types[i]);
-    if (itc!=exclude_cons.end())
+    if (itc != exclude_cons.end())
     {
       sdts.back().d_exclude_cons = itc->second;
     }
     itc = include_cons.find(types[i]);
-    if (itc!=include_cons.end())
+    if (itc != include_cons.end())
     {
       sdts.back().d_include_cons = itc->second;
     }
@@ -1061,32 +1061,35 @@ Node CegGrammarConstructor::getSygusVarList(Node f)
   return sfvl;
 }
 
-CegGrammarConstructor::SygusDatatypeGenerator::SygusDatatypeGenerator(const std::string& name) : d_sdt(name)
+CegGrammarConstructor::SygusDatatypeGenerator::SygusDatatypeGenerator(
+    const std::string& name)
+    : d_sdt(name)
 {
-  
 }
-void CegGrammarConstructor::SygusDatatypeGenerator::addConstructor(Node op,
-                    const std::string& name,
-                    const std::vector<TypeNode>& consTypes,
-                    std::shared_ptr<SygusPrintCallback> spc,
-                    int weight)
+void CegGrammarConstructor::SygusDatatypeGenerator::addConstructor(
+    Node op,
+    const std::string& name,
+    const std::vector<TypeNode>& consTypes,
+    std::shared_ptr<SygusPrintCallback> spc,
+    int weight)
 {
   if (shouldInclude(op))
   {
     d_sdt.addConstructor(op, name, consTypes, spc, weight);
   }
 }
-void CegGrammarConstructor::SygusDatatypeGenerator::addConstructor(Kind k,
-                    const std::vector<TypeNode>& consTypes,
-                    std::shared_ptr<SygusPrintCallback> spc,
-                    int weight)
+void CegGrammarConstructor::SygusDatatypeGenerator::addConstructor(
+    Kind k,
+    const std::vector<TypeNode>& consTypes,
+    std::shared_ptr<SygusPrintCallback> spc,
+    int weight)
 {
   NodeManager* nm = NodeManager::currentNM();
   addConstructor(nm->operatorOf(k), kindToString(k), consTypes, spc, weight);
 }
 bool CegGrammarConstructor::SygusDatatypeGenerator::shouldInclude(Node op) const
 {
-  if (d_exclude_cons.find(op)!=d_exclude_cons.end())
+  if (d_exclude_cons.find(op) != d_exclude_cons.end())
   {
     return false;
   }
@@ -1095,7 +1098,7 @@ bool CegGrammarConstructor::SygusDatatypeGenerator::shouldInclude(Node op) const
     // special case, variables and terms of certain types are always included
     if (!op.isVar() && op.getType().getKind() == TYPE_CONSTANT)
     {
-      if (d_include_cons.find(op)==d_include_cons.end())
+      if (d_include_cons.find(op) == d_include_cons.end())
       {
         return false;
       }

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -610,7 +610,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     cargsIte.push_back(unres_bt);
     cargsIte.push_back(unres_t);
     cargsIte.push_back(unres_t);
-    sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsIte);
+    sdts[i].addConstructor(k, cargsIte);
 
     if (types[i].isReal())
     {
@@ -622,7 +622,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
         std::vector<TypeNode> cargsOp;
         cargsOp.push_back(unres_t);
         cargsOp.push_back(unres_t);
-        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsOp);
+        sdts[i].addConstructor(k, cargsOp);
       }
       if (!types[i].isInteger())
       {
@@ -646,8 +646,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
         std::vector<TypeNode> cargsPlus;
         cargsPlus.push_back(unres_pos_int_t);
         cargsPlus.push_back(unres_pos_int_t);
-        sdts.back().addConstructor(
-            nm->operatorOf(k), kindToString(k), cargsPlus);
+        sdts.back().addConstructor(k, cargsPlus);
         sdts.back().initializeDatatype(types[i], bvl, true, true);
         Trace("sygus-grammar-def")
             << "  ...built datatype " << sdts.back().getDatatype() << " ";
@@ -657,7 +656,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
         std::vector<TypeNode> cargsDiv;
         cargsDiv.push_back(unres_t);
         cargsDiv.push_back(unres_pos_int_t);
-        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsDiv);
+        sdts[i].addConstructor(k, cargsDiv);
       }
     }
     else if (types[i].isBitVector())
@@ -669,7 +668,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       for (const Kind k : un_kinds)
       {
         Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsUnary);
+        sdts[i].addConstructor(k, cargsUnary);
       }
       // binary apps
       std::vector<Kind> bin_kinds = {BITVECTOR_AND,
@@ -691,7 +690,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       for (const Kind k : bin_kinds)
       {
         Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsBinary);
+        sdts[i].addConstructor(k, cargsBinary);
       }
     }
     else if (types[i].isString())
@@ -700,8 +699,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       std::vector<TypeNode> cargsBinary;
       cargsBinary.push_back(unres_t);
       cargsBinary.push_back(unres_t);
-      sdts[i].addConstructor(nm->operatorOf(STRING_CONCAT),
-                             kindToString(STRING_CONCAT),
+      sdts[i].addConstructor(STRING_CONCAT,
                              cargsBinary);
       // length
       TypeNode intType = nm->integerType();
@@ -713,8 +711,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
                     intType));
       std::vector<TypeNode> cargsLen;
       cargsLen.push_back(unres_t);
-      sdts[i_intType].addConstructor(
-          nm->operatorOf(STRING_LENGTH), kindToString(STRING_LENGTH), cargsLen);
+      sdts[i_intType].addConstructor(STRING_LENGTH, cargsLen);
     }
     else if (types[i].isArray())
     {
@@ -744,16 +741,14 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       cargsStore.push_back(unres_t);
       cargsStore.push_back(unres_indexType);
       cargsStore.push_back(unres_constituentType);
-      sdts[i].addConstructor(
-          nm->operatorOf(STORE), kindToString(STORE), cargsStore);
+      sdts[i].addConstructor(STORE, cargsStore);
       // add to constituent type : (select ArrayType IndexType)
       Trace("sygus-grammar-def") << "...add select for constituent type"
                                  << unres_constituentType << "\n";
       std::vector<TypeNode> cargsSelect;
       cargsSelect.push_back(unres_t);
       cargsSelect.push_back(unres_indexType);
-      sdts[i_constituentType].addConstructor(
-          nm->operatorOf(SELECT), kindToString(SELECT), cargsSelect);
+      sdts[i_constituentType].addConstructor(SELECT, cargsSelect);
     }
     else if (types[i].isDatatype())
     {
@@ -902,13 +897,13 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     {
       Kind k = LEQ;
       Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-      sdtBool.addConstructor(nm->operatorOf(k), kindToString(k), cargsBinary);
+      sdtBool.addConstructor(k, cargsBinary);
     }
     else if (types[i].isBitVector())
     {
       Kind k = BITVECTOR_ULT;
       Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-      sdtBool.addConstructor(nm->operatorOf(k), kindToString(k), cargsBinary);
+      sdtBool.addConstructor(k, cargsBinary);
     }
     else if (types[i].isDatatype())
     {
@@ -950,7 +945,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
           cargs.push_back(unres_bt);
         }
       }
-      sdtBool.addConstructor(nm->operatorOf(k), kindToString(k), cargs);
+      sdtBool.addConstructor(k, cargs);
     }
   }
   if( range==btype ){

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -48,8 +48,7 @@ bool CegGrammarConstructor::hasSyntaxRestrictions(Node q)
     if (!gv.isNull())
     {
       TypeNode tn = gv.getType();
-      if (tn.isDatatype()
-          && tn.getDatatype().isSygus())
+      if (tn.isDatatype() && tn.getDatatype().isSygus())
       {
         return true;
       }
@@ -434,8 +433,7 @@ void CegGrammarConstructor::collectSygusGrammarTypesFor(
                ++j)
           {
             TypeNode tn = TypeNode::fromType(dt[i][j].getRangeType());
-            collectSygusGrammarTypesFor(tn,
-                types);
+            collectSygusGrammarTypesFor(tn, types);
           }
         }
       }
@@ -513,7 +511,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
   }
   // index of top datatype, i.e. the datatype for the range type
   int startIndex = -1;
-  std::map< TypeNode, TypeNode > sygus_to_builtin;
+  std::map<TypeNode, TypeNode> sygus_to_builtin;
 
   std::vector<TypeNode> types;
   // collect connected types for each of the variables
@@ -531,8 +529,8 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
   TypeNode unres_bt = mkUnresolvedType(ssb.str(), unres);
 
   // create placeholders for collected types
-  std::vector< TypeNode > unres_types;
-  std::map< TypeNode, TypeNode > type_to_unres;
+  std::vector<TypeNode> unres_types;
+  std::map<TypeNode, TypeNode> type_to_unres;
   for (unsigned i = 0, size = types.size(); i < size; ++i)
   {
     std::stringstream ss;
@@ -560,7 +558,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
         Trace("sygus-grammar-def")
             << "...add for variable " << ss.str() << std::endl;
         std::vector<TypeNode> cargsEmpty;
-        sdts[i].addConstructor(sv,ss.str(),cargsEmpty);
+        sdts[i].addConstructor(sv, ss.str(), cargsEmpty);
       }
       else if (svt.isFunction() && svt.getRangeType() == types[i])
       {
@@ -577,7 +575,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
         }
         std::stringstream ss;
         ss << "apply_" << sv;
-        sdts[i].addConstructor(sv,ss.str(),stypes);
+        sdts[i].addConstructor(sv, ss.str(), stypes);
       }
     }
     //add constants
@@ -603,7 +601,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       ss << consts[j];
       Trace("sygus-grammar-def") << "...add for constant " << ss.str() << std::endl;
       std::vector<TypeNode> cargsEmpty;
-      sdts[i].addConstructor(consts[j],ss.str(),cargsEmpty);
+      sdts[i].addConstructor(consts[j], ss.str(), cargsEmpty);
     }
     // ITE
     Kind k = ITE;
@@ -612,7 +610,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     cargsIte.push_back(unres_bt);
     cargsIte.push_back(unres_t);
     cargsIte.push_back(unres_t);
-    sdts[i].addConstructor(nm->operatorOf(k),kindToString(k),cargsIte);
+    sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsIte);
 
     if (types[i].isReal())
     {
@@ -624,7 +622,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
         std::vector<TypeNode> cargsOp;
         cargsOp.push_back(unres_t);
         cargsOp.push_back(unres_t);
-        sdts[i].addConstructor(nm->operatorOf(k),kindToString(k),cargsOp);
+        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsOp);
       }
       if (!types[i].isInteger())
       {
@@ -640,25 +638,26 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
         sdts.push_back(SygusDatatype(pos_int_name));
         /* Add operator 1 */
         Trace("sygus-grammar-def") << "\t...add for 1 to Pos_Int\n";
-        std::vector<TypeNode > cargsEmpty;
-        sdts.back().addConstructor(nm->mkConst(Rational(1)),"1",cargsEmpty);
+        std::vector<TypeNode> cargsEmpty;
+        sdts.back().addConstructor(nm->mkConst(Rational(1)), "1", cargsEmpty);
         /* Add operator PLUS */
         Kind k = PLUS;
         Trace("sygus-grammar-def") << "\t...add for PLUS to Pos_Int\n";
-        std::vector<TypeNode > cargsPlus;
+        std::vector<TypeNode> cargsPlus;
         cargsPlus.push_back(unres_pos_int_t);
         cargsPlus.push_back(unres_pos_int_t);
-        sdts.back().addConstructor(nm->operatorOf(k),kindToString(k),cargsPlus);
+        sdts.back().addConstructor(
+            nm->operatorOf(k), kindToString(k), cargsPlus);
         sdts.back().initializeDatatype(types[i], bvl, true, true);
         Trace("sygus-grammar-def")
             << "  ...built datatype " << sdts.back().getDatatype() << " ";
         /* Adding division at root */
         k = DIVISION;
         Trace("sygus-grammar-def") << "\t...add for " << k << std::endl;
-        std::vector< TypeNode > cargsDiv;
+        std::vector<TypeNode> cargsDiv;
         cargsDiv.push_back(unres_t);
         cargsDiv.push_back(unres_pos_int_t);
-        sdts[i].addConstructor(nm->operatorOf(k),kindToString(k),cargsDiv);
+        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsDiv);
       }
     }
     else if (types[i].isBitVector())
@@ -670,7 +669,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       for (const Kind k : un_kinds)
       {
         Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-        sdts[i].addConstructor(nm->operatorOf(k),kindToString(k),cargsUnary);
+        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsUnary);
       }
       // binary apps
       std::vector<Kind> bin_kinds = {BITVECTOR_AND,
@@ -692,7 +691,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       for (const Kind k : bin_kinds)
       {
         Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-        sdts[i].addConstructor(nm->operatorOf(k),kindToString(k),cargsBinary);
+        sdts[i].addConstructor(nm->operatorOf(k), kindToString(k), cargsBinary);
       }
     }
     else if (types[i].isString())
@@ -701,7 +700,9 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       std::vector<TypeNode> cargsBinary;
       cargsBinary.push_back(unres_t);
       cargsBinary.push_back(unres_t);
-      sdts[i].addConstructor(nm->operatorOf(STRING_CONCAT),kindToString(STRING_CONCAT),cargsBinary);
+      sdts[i].addConstructor(nm->operatorOf(STRING_CONCAT),
+                             kindToString(STRING_CONCAT),
+                             cargsBinary);
       // length
       TypeNode intType = nm->integerType();
       Assert(std::find(types.begin(), types.end(), intType) != types.end());
@@ -712,51 +713,47 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
                     intType));
       std::vector<TypeNode> cargsLen;
       cargsLen.push_back(unres_t);
-      sdts[i_intType].addConstructor(nm->operatorOf(STRING_LENGTH),kindToString(STRING_LENGTH),cargsLen);
+      sdts[i_intType].addConstructor(
+          nm->operatorOf(STRING_LENGTH), kindToString(STRING_LENGTH), cargsLen);
     }
     else if (types[i].isArray())
     {
       Trace("sygus-grammar-def")
           << "...building for array type " << types[i] << "\n";
-      Trace("sygus-grammar-def")
-          << "......finding unres type for index type "
-          << types[i].getArrayIndexType() << "\n";
+      Trace("sygus-grammar-def") << "......finding unres type for index type "
+                                 << types[i].getArrayIndexType() << "\n";
       // retrieve index and constituent unresolved types
-      Assert(std::find(types.begin(),
-                       types.end(),
-                       types[i].getArrayIndexType() )
+      Assert(std::find(types.begin(), types.end(), types[i].getArrayIndexType())
              != types.end());
       unsigned i_indexType = std::distance(
           types.begin(),
-          std::find(types.begin(),
-                    types.end(),
-                    types[i].getArrayIndexType()));
+          std::find(types.begin(), types.end(), types[i].getArrayIndexType()));
       TypeNode unres_indexType = unres_types[i_indexType];
-      Assert(std::find(types.begin(),
-                       types.end(),
-                       types[i].getArrayConstituentType())
+      Assert(std::find(
+                 types.begin(), types.end(), types[i].getArrayConstituentType())
              != types.end());
       unsigned i_constituentType = std::distance(
           types.begin(),
-          std::find(types.begin(),
-                    types.end(),
-                    types[i].getArrayConstituentType()));
+          std::find(
+              types.begin(), types.end(), types[i].getArrayConstituentType()));
       TypeNode unres_constituentType = unres_types[i_constituentType];
       // add (store ArrayType IndexType ConstituentType)
       Trace("sygus-grammar-def") << "...add for STORE\n";
-      
+
       std::vector<TypeNode> cargsStore;
       cargsStore.push_back(unres_t);
       cargsStore.push_back(unres_indexType);
       cargsStore.push_back(unres_constituentType);
-      sdts[i].addConstructor(nm->operatorOf(STORE),kindToString(STORE),cargsStore);
+      sdts[i].addConstructor(
+          nm->operatorOf(STORE), kindToString(STORE), cargsStore);
       // add to constituent type : (select ArrayType IndexType)
       Trace("sygus-grammar-def") << "...add select for constituent type"
                                  << unres_constituentType << "\n";
       std::vector<TypeNode> cargsSelect;
       cargsSelect.push_back(unres_t);
       cargsSelect.push_back(unres_indexType);
-      sdts[i_constituentType].addConstructor(nm->operatorOf(SELECT),kindToString(SELECT),cargsSelect);
+      sdts[i_constituentType].addConstructor(
+          nm->operatorOf(SELECT), kindToString(SELECT), cargsSelect);
     }
     else if (types[i].isDatatype())
     {
@@ -792,9 +789,9 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
           std::vector<TypeNode> cargsSel;
           cargsSel.push_back(type_to_unres[arg_type]);
           Node sel = Node::fromExpr(dt[k][j].getSelector());
-          sdts[i_selType].addConstructor(sel,dt[k][j].getName(),cargsSel);
+          sdts[i_selType].addConstructor(sel, dt[k][j].getName(), cargsSel);
         }
-        sdts[i].addConstructor(cop,dt[k].getName(),cargsCons);
+        sdts[i].addConstructor(cop, dt[k].getName(), cargsCons);
       }
     }
     else if (types[i].isSort() || types[i].isFunction())
@@ -811,7 +808,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
   // make datatypes
   for (unsigned i = 0, size = types.size(); i < size; ++i)
   {
-    sdts[i].initializeDatatype( types[i], bvl, true, true );
+    sdts[i].initializeDatatype(types[i], bvl, true, true);
     /*
     //FIXME
     std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>::iterator
@@ -846,7 +843,8 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       }
     }
     */
-    Trace("sygus-grammar-def") << "...built datatype " << sdts[i].getDatatype() << " ";
+    Trace("sygus-grammar-def")
+        << "...built datatype " << sdts[i].getDatatype() << " ";
     //set start index if applicable
     if( types[i]==range ){
       startIndex = i;
@@ -867,7 +865,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       Trace("sygus-grammar-def") << "...add for variable " << ss.str() << std::endl;
       std::vector<TypeNode> cargsEmpty;
       // make boolean variables weight as non-nullary constructors
-      sdtBool.addConstructor(sygus_vars[i],ss.str(),cargsEmpty,nullptr,1);
+      sdtBool.addConstructor(sygus_vars[i], ss.str(), cargsEmpty, nullptr, 1);
     }
   }
   // add constants
@@ -880,7 +878,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     Trace("sygus-grammar-def") << "...add for constant " << ss.str()
                                << std::endl;
     std::vector<TypeNode> cargsEmpty;
-    sdtBool.addConstructor(consts[i],ss.str(),cargsEmpty);
+    sdtBool.addConstructor(consts[i], ss.str(), cargsEmpty);
   }
   // add predicates for types
   for (unsigned i = 0, size = types.size(); i < size; ++i)
@@ -898,19 +896,19 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     std::vector<TypeNode> cargsBinary;
     cargsBinary.push_back(unres_types[i]);
     cargsBinary.push_back(unres_types[i]);
-    sdtBool.addConstructor(nm->operatorOf(k),ss.str(),cargsBinary);
+    sdtBool.addConstructor(nm->operatorOf(k), ss.str(), cargsBinary);
     // type specific predicates
     if (types[i].isReal())
     {
       Kind k = LEQ;
       Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-      sdtBool.addConstructor(nm->operatorOf(k),kindToString(k),cargsBinary);
+      sdtBool.addConstructor(nm->operatorOf(k), kindToString(k), cargsBinary);
     }
     else if (types[i].isBitVector())
     {
       Kind k = BITVECTOR_ULT;
       Trace("sygus-grammar-def") << "...add for " << k << std::endl;
-      sdtBool.addConstructor(nm->operatorOf(k),kindToString(k),cargsBinary);
+      sdtBool.addConstructor(nm->operatorOf(k), kindToString(k), cargsBinary);
     }
     else if (types[i].isDatatype())
     {
@@ -922,7 +920,8 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
       for (unsigned k = 0, size_k = dt.getNumConstructors(); k < size_k; ++k)
       {
         Trace("sygus-grammar-def") << "...for " << dt[k].getTesterName() << std::endl;
-        sdtBool.addConstructor(dt[k].getTester(),dt[k].getTesterName(),cargsTester);
+        sdtBool.addConstructor(
+            dt[k].getTester(), dt[k].getTesterName(), cargsTester);
       }
     }
   }
@@ -951,14 +950,15 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
           cargs.push_back(unres_bt);
         }
       }
-      sdtBool.addConstructor(nm->operatorOf(k),kindToString(k),cargs);
+      sdtBool.addConstructor(nm->operatorOf(k), kindToString(k), cargs);
     }
   }
   if( range==btype ){
-    startIndex = sdts.size()-1;
+    startIndex = sdts.size() - 1;
   }
-  sdtBool.initializeDatatype( btype, bvl, true, true );
-  Trace("sygus-grammar-def") << "...built datatype for Bool " << sdtBool.getDatatype() << " ";
+  sdtBool.initializeDatatype(btype, bvl, true, true);
+  Trace("sygus-grammar-def")
+      << "...built datatype for Bool " << sdtBool.getDatatype() << " ";
   Trace("sygus-grammar-def") << "...finished make default grammar for " << fun << " " << range << std::endl;
   // make first datatype be the top level datatype
   if( startIndex>0 ){
@@ -988,7 +988,7 @@ TypeNode CegGrammarConstructor::mkSygusDefaultType(
     Trace("sygus-grammar-def") << "    ...using " << it->second.size() << " extra constants for " << it->first << std::endl;
   }
   std::set<Type> unres;
-  std::vector< SygusDatatype > sdts;
+  std::vector<SygusDatatype> sdts;
   mkSygusDefaultGrammar(range,
                         bvl,
                         fun,
@@ -1000,7 +1000,7 @@ TypeNode CegGrammarConstructor::mkSygusDefaultType(
                         unres);
   // extract the datatypes from the sygus datatype objects
   std::vector<Datatype> datatypes;
-  for (unsigned i=0, ndts=sdts.size(); i<ndts; i++)
+  for (unsigned i = 0, ndts = sdts.size(); i < ndts; i++)
   {
     datatypes.push_back(sdts[i].getDatatype());
   }
@@ -1022,13 +1022,13 @@ TypeNode CegGrammarConstructor::mkSygusTemplateTypeRec( Node templ, Node templ_a
   }else{
     tcount++;
     std::set<Type> unres;
-    std::vector< SygusDatatype > sdts;
+    std::vector<SygusDatatype> sdts;
     std::stringstream ssd;
     ssd << fun << "_templ_" << tcount;
     std::string dbname = ssd.str();
     sdts.push_back(SygusDatatype(dbname));
     Node op;
-    std::vector< TypeNode > argTypes;
+    std::vector<TypeNode> argTypes;
     if( templ.getNumChildren()==0 ){
       // TODO : can short circuit to this case when !TermUtil::containsTerm( templ, templ_arg )
       op = templ;
@@ -1039,17 +1039,17 @@ TypeNode CegGrammarConstructor::mkSygusTemplateTypeRec( Node templ, Node templ_a
       for( unsigned i=0; i<templ.getNumChildren(); i++ ){
         //recursion depth bound by the depth of SyGuS template expressions (low)
         TypeNode tnc = mkSygusTemplateTypeRec( templ[i], templ_arg, templ_arg_sygus_type, bvl, fun, tcount );
-        argTypes.push_back( tnc );
+        argTypes.push_back(tnc);
       }
     }
     std::stringstream ssdc;
     ssdc << fun << "_templ_cons_" << tcount;
     // we have a single sygus constructor that encodes the template
-    sdts.back().addConstructor( op, ssdc.str(), argTypes );
-    sdts.back().initializeDatatype( templ.getType(), bvl, true, true );
+    sdts.back().addConstructor(op, ssdc.str(), argTypes);
+    sdts.back().initializeDatatype(templ.getType(), bvl, true, true);
     // extract the datatypes from the sygus datatype objects
     std::vector<Datatype> datatypes;
-    for (unsigned i=0, ndts=sdts.size(); i<ndts; i++)
+    for (unsigned i = 0, ndts = sdts.size(); i < ndts; i++)
     {
       datatypes.push_back(sdts[i].getDatatype());
     }

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.h
@@ -193,13 +193,19 @@ public:
    public:
     SygusDatatypeGenerator(const std::string& name);
     ~SygusDatatypeGenerator() {}
-    /** Possibly add a constructor to d_sdt, based on the above criteria. */
+    /**
+     * Possibly add a constructor to d_sdt, based on the criteria mentioned
+     * in this class below. For details see expr/sygus_datatype.h.
+     */
     void addConstructor(Node op,
                         const std::string& name,
                         const std::vector<TypeNode>& consTypes,
                         std::shared_ptr<SygusPrintCallback> spc = nullptr,
                         int weight = -1);
-    /** Possibly add a constructor to d_sdt, based on the above criteria. */
+    /**
+     * Possibly add a constructor to d_sdt, based on the criteria mentioned
+     * in this class below.
+     */
     void addConstructor(Kind k,
                         const std::vector<TypeNode>& consTypes,
                         std::shared_ptr<SygusPrintCallback> spc = nullptr,

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.h
@@ -190,9 +190,9 @@ public:
   /** A class for generating sygus datatypes */
   class SygusDatatypeGenerator
   {
-  public:
+   public:
     SygusDatatypeGenerator(const std::string& name);
-    ~SygusDatatypeGenerator(){}
+    ~SygusDatatypeGenerator() {}
     /** Possibly add a constructor to d_sdt, based on the above criteria. */
     void addConstructor(Node op,
                         const std::string& name,
@@ -208,15 +208,15 @@ public:
     bool shouldInclude(Node op) const;
     /** The constructors that should be excluded. */
     std::unordered_set<Node, NodeHashFunction> d_exclude_cons;
-    /** 
+    /**
      * If this set is non-empty, then only include variables and constructors
-     * from it. 
+     * from it.
      */
     std::unordered_set<Node, NodeHashFunction> d_include_cons;
     /** The sygus datatype we are generating. */
     SygusDatatype d_sdt;
   };
-  
+
   // helper for mkSygusDefaultGrammar (makes unresolved type for mutually recursive datatype construction)
   static TypeNode mkUnresolvedType(const std::string& name, std::set<Type>& unres);
   // collect the list of types that depend on type range
@@ -240,7 +240,7 @@ public:
       std::unordered_set<Node, NodeHashFunction>& term_irrelevant,
       std::vector<SygusDatatypeGenerator>& sdts,
       std::set<Type>& unres);
-  
+
   // helper function for mkSygusTemplateType
   static TypeNode mkSygusTemplateTypeRec( Node templ, Node templ_arg, TypeNode templ_arg_sygus_type, Node bvl, 
                                           const std::string& fun, unsigned& tcount );

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.h
@@ -23,6 +23,7 @@
 
 #include "expr/attribute.h"
 #include "expr/node.h"
+#include "expr/sygus_datatype.h"
 
 namespace CVC4 {
 namespace theory {
@@ -207,7 +208,7 @@ public:
       const std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>&
           include_cons,
       std::unordered_set<Node, NodeHashFunction>& term_irrelevant,
-      std::vector<CVC4::Datatype>& datatypes,
+      std::vector<SygusDatatype>& datatypes,
       std::set<Type>& unres);
 
   // helper function for mkSygusTemplateType

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.h
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.h
@@ -187,6 +187,36 @@ public:
       Node n,
       std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>& consts);
   //---------------- grammar construction
+  /** A class for generating sygus datatypes */
+  class SygusDatatypeGenerator
+  {
+  public:
+    SygusDatatypeGenerator(const std::string& name);
+    ~SygusDatatypeGenerator(){}
+    /** Possibly add a constructor to d_sdt, based on the above criteria. */
+    void addConstructor(Node op,
+                        const std::string& name,
+                        const std::vector<TypeNode>& consTypes,
+                        std::shared_ptr<SygusPrintCallback> spc = nullptr,
+                        int weight = -1);
+    /** Possibly add a constructor to d_sdt, based on the above criteria. */
+    void addConstructor(Kind k,
+                        const std::vector<TypeNode>& consTypes,
+                        std::shared_ptr<SygusPrintCallback> spc = nullptr,
+                        int weight = -1);
+    /** Should we include constructor with operator op? */
+    bool shouldInclude(Node op) const;
+    /** The constructors that should be excluded. */
+    std::unordered_set<Node, NodeHashFunction> d_exclude_cons;
+    /** 
+     * If this set is non-empty, then only include variables and constructors
+     * from it. 
+     */
+    std::unordered_set<Node, NodeHashFunction> d_include_cons;
+    /** The sygus datatype we are generating. */
+    SygusDatatype d_sdt;
+  };
+  
   // helper for mkSygusDefaultGrammar (makes unresolved type for mutually recursive datatype construction)
   static TypeNode mkUnresolvedType(const std::string& name, std::set<Type>& unres);
   // collect the list of types that depend on type range
@@ -208,9 +238,9 @@ public:
       const std::map<TypeNode, std::unordered_set<Node, NodeHashFunction>>&
           include_cons,
       std::unordered_set<Node, NodeHashFunction>& term_irrelevant,
-      std::vector<SygusDatatype>& datatypes,
+      std::vector<SygusDatatypeGenerator>& sdts,
       std::set<Type>& unres);
-
+  
   // helper function for mkSygusTemplateType
   static TypeNode mkSygusTemplateTypeRec( Node templ, Node templ_arg, TypeNode templ_arg_sygus_type, Node bvl, 
                                           const std::string& fun, unsigned& tcount );

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -222,9 +222,9 @@ void SygusGrammarNorm::TypeObject::addConsInfo(SygusGrammarNorm* sygus_norm,
                                 << "\n\tExpanded one: " << exp_sop_n << "\n\n";
   d_sdt.addConstructor(exp_sop_n,
                        cons.getName(),
+                       consTypes,
                        cons.getSygusPrintCallback(),
-                       cons.getWeight(),
-                       consTypes);
+                       cons.getWeight());
 }
 
 void SygusGrammarNorm::TypeObject::initializeDatatype(
@@ -342,9 +342,9 @@ void SygusGrammarNorm::TransfChain::buildType(SygusGrammarNorm* sygus_norm,
     ctypes.push_back(t);
     to.d_sdt.addConstructor(iden_op,
                             "id",
+                            ctypes,
                             printer::SygusEmptyPrintCallback::getEmptyPC(),
-                            0,
-                            ctypes);
+                            0);
     Trace("sygus-grammar-normalize-chain")
         << "\tAdding  " << t << " to " << to.d_unres_tn << "\n";
     /* adds to Root: "type + Root" */
@@ -352,7 +352,7 @@ void SygusGrammarNorm::TransfChain::buildType(SygusGrammarNorm* sygus_norm,
     ctypesp.push_back(t);
     ctypesp.push_back(to.d_unres_tn);
     to.d_sdt.addConstructor(
-        nm->operatorOf(PLUS), kindToString(PLUS), nullptr, -1, ctypesp);
+        nm->operatorOf(PLUS), kindToString(PLUS), ctypesp);
     Trace("sygus-grammar-normalize-chain")
         << "\tAdding PLUS to " << to.d_unres_tn << " with arg types "
         << to.d_unres_tn << " and " << t << "\n";
@@ -385,9 +385,9 @@ void SygusGrammarNorm::TransfChain::buildType(SygusGrammarNorm* sygus_norm,
   ctypes.push_back(sygus_norm->normalizeSygusRec(to.d_tn, dt, d_elem_pos));
   to.d_sdt.addConstructor(iden_op,
                           "id_next",
+                          ctypes,
                           printer::SygusEmptyPrintCallback::getEmptyPC(),
-                          0,
-                          ctypes);
+                          0);
 }
 
 std::map<TypeNode, Node> SygusGrammarNorm::d_tn_to_id = {};

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -351,8 +351,7 @@ void SygusGrammarNorm::TransfChain::buildType(SygusGrammarNorm* sygus_norm,
     std::vector<TypeNode> ctypesp;
     ctypesp.push_back(t);
     ctypesp.push_back(to.d_unres_tn);
-    to.d_sdt.addConstructor(
-        nm->operatorOf(PLUS), kindToString(PLUS), ctypesp);
+    to.d_sdt.addConstructor(nm->operatorOf(PLUS), kindToString(PLUS), ctypesp);
     Trace("sygus-grammar-normalize-chain")
         << "\tAdding PLUS to " << to.d_unres_tn << " with arg types "
         << to.d_unres_tn << " and " << t << "\n";


### PR DESCRIPTION
Also eliminates essentially all use of Expr/Type in sygus_grammar_cons.

This is work towards eliminating the Expr layer and the SyGuS API.