### PR TITLE
Lazy evaluation via rec-funs of ITE expressions 

### DIFF
--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -117,7 +117,7 @@ Node FunDefEvaluator::evaluate(Node n) const
           Assert(!it->second.isNull());
           Assert(it->second.isConst());
           // pick child to evaluate depending on condition eval
-          unsigned childIdxToEval = it->second.getConst<bool>()? 1 : 2;
+          unsigned childIdxToEval = it->second.getConst<bool>() ? 1 : 2;
           Trace("fd-eval-debug2")
               << "FunDefEvaluator: result of ITE condition : "
               << it->second.getConst<bool>() << "\n";
@@ -143,7 +143,8 @@ Node FunDefEvaluator::evaluate(Node n) const
         {
           // need to evaluate it
           f = cur.getOperator();
-          Trace("fd-eval-debug2") << "FunDefEvaluator: need to eval " << f << "\n";
+          Trace("fd-eval-debug2")
+              << "FunDefEvaluator: need to eval " << f << "\n";
           itf = d_funDefMap.find(f);
           if (itf == d_funDefMap.end())
           {
@@ -153,7 +154,8 @@ Node FunDefEvaluator::evaluate(Node n) const
           }
           // get the function definition
           Node sbody = itf->second.d_body;
-          Trace("fd-eval-debug2") << "FunDefEvaluator: definition: " << sbody << "\n";
+          Trace("fd-eval-debug2")
+              << "FunDefEvaluator: definition: " << sbody << "\n";
           const std::vector<Node>& args = itf->second.d_args;
           if (!args.empty())
           {
@@ -164,7 +166,8 @@ Node FunDefEvaluator::evaluate(Node n) const
             sbody = Rewriter::rewrite(sbody);
             if (Trace.isOn("fd-eval-debug2"))
             {
-              Trace("fd-eval-debug2") << "FunDefEvaluator: evaluation with args:\n";
+              Trace("fd-eval-debug2")
+                  << "FunDefEvaluator: evaluation with args:\n";
               for (const Node& child : children)
               {
                 Trace("fd-eval-debug2") << "..." << child << "\n";

--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -208,7 +208,6 @@ Node FunDefEvaluator::evaluate(Node n) const
   Trace("fd-eval") << "FunDefEvaluator: return " << visited[n];
   Assert(visited.find(n) != visited.end());
   Assert(!visited.find(n)->second.isNull());
-  // Assert(visited.find(n)->second.isConst());
   if (!visited.find(n)->second.isConst())
   {
     visited[n] = Node::null();

--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -205,11 +205,19 @@ Node FunDefEvaluator::evaluate(Node n) const
       }
     }
   } while (!visit.empty());
+  Trace("fd-eval") << "FunDefEvaluator: return " << visited[n];
   Assert(visited.find(n) != visited.end());
   Assert(!visited.find(n)->second.isNull());
-  Assert(visited.find(n)->second.isConst());
-  Trace("fd-eval") << "FunDefEvaluator: return SUCCESS " << visited[n]
-                   << std::endl;
+  // Assert(visited.find(n)->second.isConst());
+  if (!visited.find(n)->second.isConst())
+  {
+    visited[n] = Node::null();
+    Trace("fd-eval") << "\n with NONCONST\n";
+  }
+  else
+  {
+    Trace("fd-eval") << "\n with SUCCESS\n";
+  }
   return visited[n];
 }
 

--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -75,6 +75,13 @@ Node FunDefEvaluator::evaluate(Node n) const
         Trace("fd-eval-debug") << "constant " << cur << std::endl;
         visited[cur] = cur;
       }
+      else if (cur.getKind() == ITE)
+      {
+        Trace("fd-eval-debug") << "ITE " << cur << std::endl;
+        visited[cur] = Node::null();
+        visit.push_back(cur);
+        visit.push_back(cur[0]);
+      }
       else
       {
         Trace("fd-eval-debug") << "recurse " << cur << std::endl;
@@ -102,6 +109,28 @@ Node FunDefEvaluator::evaluate(Node n) const
         {
           children.push_back(cur.getOperator());
         }
+        else if (ck == ITE)
+        {
+          // get evaluation of condition
+          it = visited.find(cur[0]);
+          Assert(it != visited.end());
+          Assert(!it->second.isNull());
+          Assert(it->second.isConst());
+          // pick child to evaluate depending on condition eval
+          unsigned childIdxToEval = it->second.getConst<bool>()? 1 : 2;
+          Trace("fd-eval-debug2")
+              << "FunDefEvaluator: result of ITE condition : "
+              << it->second.getConst<bool>() << "\n";
+          // the result will be the result of evaluation the child
+          visited[cur] = cur[childIdxToEval];
+          // push back self and child. The child will be evaluated first and
+          // result will be the result of evaluation child
+          visit.push_back(cur);
+          visit.push_back(cur[childIdxToEval]);
+          Trace("fd-eval-debug2") << "FunDefEvaluator: result will be from : "
+                                  << cur[childIdxToEval] << "\n";
+          continue;
+        }
         for (const Node& cn : cur)
         {
           it = visited.find(cn);
@@ -114,6 +143,7 @@ Node FunDefEvaluator::evaluate(Node n) const
         {
           // need to evaluate it
           f = cur.getOperator();
+          Trace("fd-eval-debug2") << "FunDefEvaluator: need to eval " << f << "\n";
           itf = d_funDefMap.find(f);
           if (itf == d_funDefMap.end())
           {
@@ -123,6 +153,7 @@ Node FunDefEvaluator::evaluate(Node n) const
           }
           // get the function definition
           Node sbody = itf->second.d_body;
+          Trace("fd-eval-debug2") << "FunDefEvaluator: definition: " << sbody << "\n";
           const std::vector<Node>& args = itf->second.d_args;
           if (!args.empty())
           {
@@ -131,6 +162,16 @@ Node FunDefEvaluator::evaluate(Node n) const
                 args.begin(), args.end(), children.begin(), children.end());
             // rewrite it
             sbody = Rewriter::rewrite(sbody);
+            if (Trace.isOn("fd-eval-debug2"))
+            {
+              Trace("fd-eval-debug2") << "FunDefEvaluator: evaluation with args:\n";
+              for (const Node& child : children)
+              {
+                Trace("fd-eval-debug2") << "..." << child << "\n";
+              }
+              Trace("fd-eval-debug2")
+                  << "FunDefEvaluator: results in " << sbody << "\n";
+            }
           }
           // our result is the result of the body
           visited[cur] = sbody;

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -591,7 +591,7 @@ bool SynthConjecture::doCheck(std::vector<Node>& lems)
         Trace("cegqi-debug") << "...squery : " << squery << std::endl;
         squery = Rewriter::rewrite(squery);
         Trace("cegqi-debug") << "...rewrites to : " << squery << std::endl;
-        Assert(squery.isConst() && squery.getConst<bool>());
+        Assert(options::sygusRecFun() || (squery.isConst() && squery.getConst<bool>()));
 #endif
         return false;
       }

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -591,7 +591,8 @@ bool SynthConjecture::doCheck(std::vector<Node>& lems)
         Trace("cegqi-debug") << "...squery : " << squery << std::endl;
         squery = Rewriter::rewrite(squery);
         Trace("cegqi-debug") << "...rewrites to : " << squery << std::endl;
-        Assert(options::sygusRecFun() || (squery.isConst() && squery.getConst<bool>()));
+        Assert(options::sygusRecFun()
+               || (squery.isConst() && squery.getConst<bool>()));
 #endif
         return false;
       }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1743,6 +1743,8 @@ set(regress_1_tests
   regress1/sygus/qf_abv.smt2
   regress1/sygus/real-grammar.sy
   regress1/sygus/rec-fun-sygus.sy
+  regress1/sygus/rec-fun-while-1.sy
+  regress1/sygus/rec-fun-while-2.sy
   regress1/sygus/re-concat.sy
   regress1/sygus/repair-const-rl.sy
   regress1/sygus/simple-regexp.sy

--- a/test/regress/regress1/sygus/rec-fun-while-1.sy
+++ b/test/regress/regress1/sygus/rec-fun-while-1.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-out=status --lang=sygus2 --sygus-rec-fun --no-e-matching
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --sygus-rec-fun --no-e-matching --no-check-synth-sol
 
 (set-logic ALL)
 

--- a/test/regress/regress1/sygus/rec-fun-while-1.sy
+++ b/test/regress/regress1/sygus/rec-fun-while-1.sy
@@ -70,10 +70,9 @@
 (define-fun-rec evalC ((env Env) (c Com)) Env
   (ite (is-Assign c)
     (envStore (lhs c) (evalA env (rhs c)) env)
-        ; (is-While c)
-          (ite (evalB env (wCond c)) (evalC (evalC env (wCom c)) c) env)
-        )
-      )
+    (ite (evalB env (wCond c)) (evalC (evalC env (wCom c)) c) env)
+    )
+  )
 
 (synth-fun prog () Com
   ((C1 Com) (C2 Com) (VX NVars) (A1 Aexp) (A2 Aexp) (B Bexp) (I Int))

--- a/test/regress/regress1/sygus/rec-fun-while-1.sy
+++ b/test/regress/regress1/sygus/rec-fun-while-1.sy
@@ -1,0 +1,93 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --sygus-rec-fun --no-e-matching
+
+(set-logic ALL)
+
+; The environment datatypes
+(declare-datatype NVars ((x)))
+
+(declare-datatype Pair ((build (first NVars) (second Int))))
+
+(declare-datatype Env ((cons (head Pair) (tail Env)) (nil)))
+
+(define-fun-rec envStore ((var NVars) (value Int) (env Env)) Env
+  (ite (is-nil env)
+    (cons (build var value) env)
+    (ite (= var (first (head env)))
+      (cons (build var value) (tail env))
+      (cons (head env) (envStore var value (tail env)))
+      )
+    )
+  )
+
+(define-fun-rec envSelect ((var NVars) (env Env)) Int
+  (ite (is-nil env)
+    0
+    (ite (= var (first (head env)))
+      (second (head env))
+      (envSelect var (tail env))
+      )
+    )
+  )
+
+; Syntax for arithmetic expressions
+(declare-datatype Aexp
+  (
+    (Val (val Int))
+    (Var (name NVars))
+    (Add (addL Aexp) (addR Aexp))
+    )
+  )
+
+; Function to evaluate arithmetic expressions
+(define-fun-rec evalA ((env Env) (a Aexp)) Int
+  (ite (is-Val a)
+    (val a)
+    (envSelect (name a) env)
+    ))
+
+; Syntax for boolean expressions
+(declare-datatype Bexp
+  (
+    (LT (ltL Aexp) (ltR Aexp))
+    )
+  )
+
+; Function to evaluate boolean expressions
+(define-fun-rec evalB ((env Env) (b Bexp)) Bool
+  (< (evalA env (ltL b)) (evalA env (ltR b)))
+  )
+
+; Syntax for commands
+(declare-datatype Com
+  (
+    (Assign (lhs NVars) (rhs Aexp))
+    (While (wCond Bexp) (wCom Com))
+    )
+  )
+
+; Function to evaluate statements
+(define-fun-rec evalC ((env Env) (c Com)) Env
+  (ite (is-Assign c)
+    (envStore (lhs c) (evalA env (rhs c)) env)
+        ; (is-While c)
+          (ite (evalB env (wCond c)) (evalC (evalC env (wCom c)) c) env)
+        )
+      )
+
+(synth-fun prog () Com
+  ((C1 Com) (C2 Com) (VX NVars) (A1 Aexp) (A2 Aexp) (B Bexp) (I Int))
+  (
+    (C1 Com ((While B C2)))
+    (C2 Com ((Assign VX A2)))
+    (VX NVars (x))
+    (A1 Aexp ((Var VX)))
+    (A2 Aexp ((Val I)))
+    (B Bexp ((LT A1 A2)))
+    (I Int (0 1 (+ I I)))
+    )
+)
+
+(constraint (= (evalC (cons (build x 0) nil) prog) (cons (build x 2) nil)))
+
+(check-synth)

--- a/test/regress/regress1/sygus/rec-fun-while-2.sy
+++ b/test/regress/regress1/sygus/rec-fun-while-2.sy
@@ -1,0 +1,127 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --sygus-rec-fun --no-e-matching
+
+(set-logic ALL)
+
+; The environment datatypes
+(declare-datatype NVars ((x) (y)))
+
+(declare-datatype Pair ((build (first NVars) (second Int))))
+
+(declare-datatype Env ((cons (head Pair) (tail Env)) (nil)))
+
+(define-fun-rec envStore ((var NVars) (value Int) (env Env)) Env
+  (ite (is-nil env)
+    (cons (build var value) env)
+    (ite (= var (first (head env)))
+      (cons (build var value) (tail env))
+      (cons (head env) (envStore var value (tail env)))
+      )
+    )
+  )
+
+(define-fun-rec envSelect ((var NVars) (env Env)) Int
+  (ite (is-nil env)
+    0
+    (ite (= var (first (head env)))
+      (second (head env))
+      (envSelect var (tail env))
+      )
+    )
+  )
+
+; Syntax for arithmetic expressions
+(declare-datatype Aexp
+  (
+    (Val (val Int))
+    (Var (name NVars))
+    (Add (addL Aexp) (addR Aexp))
+    (Sub (subL Aexp) (subR Aexp))
+    )
+  )
+
+; Function to evaluate arithmetic expressions
+(define-fun-rec evalA ((env Env) (a Aexp)) Int
+  (ite (is-Val a)
+    (val a)
+    ; (ite (is-Var a)
+      (envSelect (name a) env)
+      ; (ite (is-Add a)
+      ; (+ (evalA env (addL a)) (evalA env (addR a)))
+      ; (- (evalA env (subL a)) (evalA env (subR a)))
+    ))
+; ))
+
+; Syntax for boolean expressions
+(declare-datatype Bexp
+  (
+    ; (NEQ (eqL Aexp) (eqR Aexp))
+    (GTH (geqL Aexp) (geqR Aexp))
+    ; (AND (andL Bexp) (andR Bexp))
+    )
+  )
+
+; Function to evaluate boolean expressions
+(define-fun-rec evalB ((env Env) (b Bexp)) Bool
+  ; (ite (is-NEQ b)
+  ;   (not (= (evalA env (eqL b)) (evalA env (eqR b))))
+    ; (ite (is-GTH b)
+    (> (evalA env (geqL b)) (evalA env (geqR b)))
+    ; (and (evalB env (andL b)) (evalB env (andL b))))
+  )
+; )
+
+; Syntax for commands
+(declare-datatype Com
+  (
+    ; (Skip)
+    (Assign (lhs NVars) (rhs Aexp))
+    ; (CondS (tCond Bexp) (tCom Com) (eCom Com))
+    (While (wCond Bexp) (wCom Com))
+    ; (CSeq (cBef Com) (aAft Com))
+    )
+  )
+
+; Function to evaluate statements
+(define-fun-rec evalC ((env Env) (c Com)) Env
+  ; (ite (is-Skip c)
+  ;   env
+    (ite (is-Assign c)
+      (envStore (lhs c) (evalA env (rhs c)) env)
+      ; (ite (is-CondS c)
+        ; (ite (evalB env (tCond c)) (evalC env (tCom c)) (evalC env (eCom c)))
+        ; (ite (is-While c)
+          (ite (evalB env (wCond c)) (evalC (evalC env (wCom c)) c) env)
+          ; (evalC (evalC env (cBef c)) (aAft c))
+        )
+      )
+    ; )
+;   )
+; )
+
+(synth-fun prog () Com
+  ((C1 Com) (C2 Com) (C3 Com) (C4 Com) (VX NVars) (VY NVars) (A0 Aexp) (A1 Aexp) (A2 Aexp) (A3 Aexp) (A4 Aexp) (B Bexp) (I1 Int) (I2 Int))
+  (
+    (C1 Com ((While B C2)))
+    ; (C2 Com ((CSeq C3 C4)))
+    (C2 Com (C4))
+    (C3 Com ((Assign VX A3)))
+    (C4 Com ((Assign VY A4)))
+    (VX NVars (x))
+    (VY NVars (y))
+    (A0 Aexp ((Var VX)))
+    (A1 Aexp ((Var VY)))
+    (A2 Aexp ((Val I2)))
+    (A3 Aexp ((Add A0 A2)))
+    (A4 Aexp ((Val I1)))
+    (B Bexp ((GTH A2 A1)))
+    (I1 Int (2))
+    (I2 Int (2))
+    )
+)
+
+(constraint (= (evalC (cons (build y 0) nil) prog) (cons (build y 2) nil)))
+
+; (constraint (= (evalC (cons (build y 0) (cons (build x 0) nil)) prog) (cons (build y 2) (cons (build x 4) nil))))
+
+(check-synth)

--- a/test/regress/regress1/sygus/rec-fun-while-2.sy
+++ b/test/regress/regress1/sygus/rec-fun-while-2.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-out=status --lang=sygus2 --sygus-rec-fun --no-e-matching
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --sygus-rec-fun --no-e-matching --no-check-synth-sol
 
 (set-logic ALL)
 

--- a/test/regress/regress1/sygus/rec-fun-while-2.sy
+++ b/test/regress/regress1/sygus/rec-fun-while-2.sy
@@ -44,84 +44,50 @@
 (define-fun-rec evalA ((env Env) (a Aexp)) Int
   (ite (is-Val a)
     (val a)
-    ; (ite (is-Var a)
-      (envSelect (name a) env)
-      ; (ite (is-Add a)
-      ; (+ (evalA env (addL a)) (evalA env (addR a)))
-      ; (- (evalA env (subL a)) (evalA env (subR a)))
+    (envSelect (name a) env)
     ))
-; ))
 
 ; Syntax for boolean expressions
 (declare-datatype Bexp
   (
-    ; (NEQ (eqL Aexp) (eqR Aexp))
     (GTH (geqL Aexp) (geqR Aexp))
-    ; (AND (andL Bexp) (andR Bexp))
     )
   )
 
 ; Function to evaluate boolean expressions
 (define-fun-rec evalB ((env Env) (b Bexp)) Bool
-  ; (ite (is-NEQ b)
-  ;   (not (= (evalA env (eqL b)) (evalA env (eqR b))))
-    ; (ite (is-GTH b)
-    (> (evalA env (geqL b)) (evalA env (geqR b)))
-    ; (and (evalB env (andL b)) (evalB env (andL b))))
+  (> (evalA env (geqL b)) (evalA env (geqR b)))
   )
-; )
 
 ; Syntax for commands
 (declare-datatype Com
   (
-    ; (Skip)
     (Assign (lhs NVars) (rhs Aexp))
-    ; (CondS (tCond Bexp) (tCom Com) (eCom Com))
     (While (wCond Bexp) (wCom Com))
-    ; (CSeq (cBef Com) (aAft Com))
     )
   )
 
 ; Function to evaluate statements
 (define-fun-rec evalC ((env Env) (c Com)) Env
-  ; (ite (is-Skip c)
-  ;   env
     (ite (is-Assign c)
       (envStore (lhs c) (evalA env (rhs c)) env)
-      ; (ite (is-CondS c)
-        ; (ite (evalB env (tCond c)) (evalC env (tCom c)) (evalC env (eCom c)))
-        ; (ite (is-While c)
           (ite (evalB env (wCond c)) (evalC (evalC env (wCom c)) c) env)
-          ; (evalC (evalC env (cBef c)) (aAft c))
         )
       )
-    ; )
-;   )
-; )
 
 (synth-fun prog () Com
-  ((C1 Com) (C2 Com) (C3 Com) (C4 Com) (VX NVars) (VY NVars) (A0 Aexp) (A1 Aexp) (A2 Aexp) (A3 Aexp) (A4 Aexp) (B Bexp) (I1 Int) (I2 Int))
+  ((C1 Com) (C2 Com) (VX NVars) (A1 Aexp) (A2 Aexp) (B Bexp) (I Int))
   (
     (C1 Com ((While B C2)))
-    ; (C2 Com ((CSeq C3 C4)))
-    (C2 Com (C4))
-    (C3 Com ((Assign VX A3)))
-    (C4 Com ((Assign VY A4)))
+    (C2 Com ((Assign VX A2)))
     (VX NVars (x))
-    (VY NVars (y))
-    (A0 Aexp ((Var VX)))
-    (A1 Aexp ((Var VY)))
-    (A2 Aexp ((Val I2)))
-    (A3 Aexp ((Add A0 A2)))
-    (A4 Aexp ((Val I1)))
+    (A1 Aexp ((Var VX)))
+    (A2 Aexp ((Val I)))
     (B Bexp ((GTH A2 A1)))
-    (I1 Int (2))
-    (I2 Int (2))
+    (I Int (2))
     )
 )
 
-(constraint (= (evalC (cons (build y 0) nil) prog) (cons (build y 2) nil)))
-
-; (constraint (= (evalC (cons (build y 0) (cons (build x 0) nil)) prog) (cons (build y 2) (cons (build x 4) nil))))
+(constraint (= (evalC (cons (build x 0) nil) prog) (cons (build x 2) nil)))
 
 (check-synth)


### PR DESCRIPTION
Extends `FunDefEvaluator` to do lazy evaluation of ITE expressions. This allows us to for example handle evaluation of finite loops (as defined via datatypes and recursive functions).  