### PR TITLE
Ensure quantifiers options are set with --no-strings-lazy-pp

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1251,10 +1251,12 @@ void SmtEngine::setDefaults() {
     }
   }
 
-  // set default options associated with strings-exp
-  if (options::stringExp())
+  // Set default options associated with strings-exp. We also set these options
+  // if we are using eager string preprocessing, which may introduce quantified
+  // formulas at preprocess time.
+  if (options::stringExp() || !options::stringLazyPreproc())
   {
-    // We require quantifiers since extended functions reduce using them
+    // We require quantifiers since extended functions reduce using them.
     if (!d_logic.isQuantified())
     {
       d_logic = d_logic.getUnlockedCopy();

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -871,6 +871,7 @@ set(regress_0_tests
   regress0/strings/indexof-sym-simp.smt2
   regress0/strings/issue1189.smt2
   regress0/strings/issue2958.smt2
+  regress0/strings/issue3440.smt2
   regress0/strings/issue3497.smt2
   regress0/strings/itos-entail.smt2
   regress0/strings/leadingzero001.smt2

--- a/test/regress/regress0/strings/issue3440.smt2
+++ b/test/regress/regress0/strings/issue3440.smt2
@@ -1,7 +1,7 @@
 ; COMMAND-LINE: --no-strings-lazy-pp
 ; EXPECT: sat
 (set-info :smt-lib-version 2.5)
-(set-logic QF_SL)
+(set-logic QF_S)
 (set-info :status sat)
 (declare-fun a () String)                                                       
 (declare-fun b () String)                                                       

--- a/test/regress/regress0/strings/issue3440.smt2
+++ b/test/regress/regress0/strings/issue3440.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --no-strings-lazy-pp
+; EXPECT: sat
+(set-info :smt-lib-version 2.5)
+(set-logic QF_SL)
+(set-info :status sat)
+(declare-fun a () String)                                                       
+(declare-fun b () String)                                                       
+(declare-fun c () String)                                                       
+(declare-fun d () String)                                                       
+(assert (= (str.replace a b "") (str.++ c d)))                                  
+(check-sat)   


### PR DESCRIPTION
Previously we would introduce quantified assertions in non-quantified logics if --no-strings-lazy-pp was used in isolation.

Fixes #3440.