### PR TITLE
Fix clang-format file for brace wrapping with case labels.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,7 @@ BinPackArguments: false
 BinPackParameters: false
 BreakBeforeBinaryOperators: NonAssignment
 BraceWrapping:
+  AfterCaseLabel: true
   AfterClass: true
   AfterControlStatement: true
   AfterEnum: true


### PR DESCRIPTION
More recent clang version introduce an extra flag `AfterCaseLabel` for brace wrapping after case labels. Default is false, with the effect opening braces after case labels will be aligned on the same line as the label. Our style requires it to be set to true.