### PR TITLE
Bi-directional unrolling of R* regular expressions

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -858,6 +858,7 @@ set(regress_0_tests
   regress0/smtlib/reset-force-logic.smt2
   regress0/smtlib/reset-set-logic.smt2
   regress0/smtlib/set-info-status.smt2
+  regress0/strings/bidir_star.smt2
   regress0/strings/bug001.smt2
   regress0/strings/bug002.smt2
   regress0/strings/bug612.smt2

--- a/test/regress/regress0/strings/bidir_star.smt2
+++ b/test/regress/regress0/strings/bidir_star.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --strings-exp
+(set-logic SLIA)
+(declare-fun a () String)
+(assert (>= (str.len a) 2))
+(assert (str.in.re a (re.+ (re.range "0" "1"))))
+(assert (<= 3 (str.to.int (str.substr a (+ (- 2) (str.len a)) 1))))
+(set-info :status unsat)
+(check-sat)


### PR DESCRIPTION
This commit changes the unfolding of `x in R*`. Previously, for the case
where `x` matches two or more `R`s, we were unfolding it to `x = x1 ++
x2 ^ x1 != "" ^ x2 != "" ^ x1 in R ^ x2 in R*`. This made it difficult
to find conflicts with the end of `x`. The new unfolding, unfolds both
the beginning and the end: `x = x1 ++ x2 ++ x3 ^ x1 != "" ^ x3 != "" ^
x1 in R ^ x2 in R* ^ x3 in R)` (note that we do not require `x2` to be
non-empty). This allows us to reason about both the beginning and the
end of `x` simultaneously.