### PR TITLE
[Regressions] Require proof support for abduction

### DIFF
--- a/test/regress/regress1/sygus-abduct-test-ccore.smt2
+++ b/test/regress/regress1/sygus-abduct-test-ccore.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: proof
 ; COMMAND-LINE: --produce-abducts --sygus-core-connective
 ; SCRUBBER: grep -v -E '(\(define-fun)'
 ; EXIT: 0

--- a/test/regress/regress1/sygus/abd-simple-conj-4.smt2
+++ b/test/regress/regress1/sygus/abd-simple-conj-4.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: proof
 ; COMMAND-LINE: --produce-abducts --sygus-core-connective
 ; SCRUBBER: grep -v -E '(\(define-fun)'
 ; EXIT: 0


### PR DESCRIPTION
PR #3255 introduced a new feature for more scalable
abduction/interpolation that relies on unsat cores. The regressions
added in the PR were not marked as requiring proof support, however,
leading to failing builds if proof support was not enabled.