### PR TITLE
Disable check-synth-sol in regression with recursive functions

### DIFF
--- a/test/regress/regress1/sygus/node-discrete.sy
+++ b/test/regress/regress1/sygus/node-discrete.sy
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-out=status --lang=sygus2
+; COMMAND-LINE: --sygus-out=status --lang=sygus2 --no-check-synth-sol
 (set-logic ALL)
 
 (declare-datatype Packet ((P1) (P2)))


### PR DESCRIPTION
Currently we cannot (efficiently) reverify this solution external via E-matching and recursive functions.

This fixes an issue in regress1 where a benchmark takes 45 seconds in production.