### PR TITLE
 FP converter: convert: Use std::vector as instead of std::stack.

### DIFF
--- a/src/theory/fp/fp_converter.cpp
+++ b/src/theory/fp/fp_converter.cpp
@@ -17,6 +17,7 @@
 // theory.h Only needed for the leaf test
 
 #include <stack>
+#include <vector>
 
 #ifdef CVC4_USE_SYMFPU
 #include "symfpu/core/add.h"
@@ -846,7 +847,7 @@ FpConverter::uf FpConverter::buildComponents(TNode current)
 Node FpConverter::convert(TNode node)
 {
 #ifdef CVC4_USE_SYMFPU
-  std::stack<TNode> workStack;
+  std::stack<TNode, std::vector<TNode>> workStack;
   TNode result = node;
 
   workStack.push(node);

--- a/src/theory/fp/fp_converter.cpp
+++ b/src/theory/fp/fp_converter.cpp
@@ -847,17 +847,17 @@ FpConverter::uf FpConverter::buildComponents(TNode current)
 Node FpConverter::convert(TNode node)
 {
 #ifdef CVC4_USE_SYMFPU
-  std::stack<TNode, std::vector<TNode>> workStack;
+  std::vector<TNode> workStack;
   TNode result = node;
 
-  workStack.push(node);
+  workStack.push_back(node);
 
   NodeManager *nm = NodeManager::currentNM();
 
   while (!workStack.empty())
   {
-    TNode current = workStack.top();
-    workStack.pop();
+    TNode current = workStack.back();
+    workStack.pop_back();
     result = current;
 
     TypeNode t(current.getType());
@@ -942,8 +942,8 @@ Node FpConverter::convert(TNode node)
 
               if (arg1 == f.end())
               {
-                workStack.push(current);
-                workStack.push(current[0]);
+                workStack.push_back(current);
+                workStack.push_back(current[0]);
                 continue;  // i.e. recurse!
               }
 
@@ -975,14 +975,14 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (mode == r.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg1 == f.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1018,14 +1018,14 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (arg1 == f.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg2 == f.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1048,14 +1048,14 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (arg1 == f.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg2 == f.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1099,18 +1099,18 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (mode == r.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg1 == f.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 if (arg2 == f.end())
                 {
-                  workStack.push(current[2]);
+                  workStack.push_back(current[2]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1179,22 +1179,22 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (mode == r.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg1 == f.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 if (arg2 == f.end())
                 {
-                  workStack.push(current[2]);
+                  workStack.push_back(current[2]);
                 }
                 if (arg3 == f.end())
                 {
-                  workStack.push(current[3]);
+                  workStack.push_back(current[3]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1217,14 +1217,14 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (mode == r.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg1 == f.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1261,10 +1261,10 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (mode == r.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1336,14 +1336,14 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (arg1 == f.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg2 == f.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1360,14 +1360,14 @@ Node FpConverter::convert(TNode node)
 
               if (recurseNeeded)
               {
-                workStack.push(current);
+                workStack.push_back(current);
                 if (arg1 == r.end())
                 {
-                  workStack.push(current[0]);
+                  workStack.push_back(current[0]);
                 }
                 if (arg2 == r.end())
                 {
-                  workStack.push(current[1]);
+                  workStack.push_back(current[1]);
                 }
                 continue;  // i.e. recurse!
               }
@@ -1393,14 +1393,14 @@ Node FpConverter::convert(TNode node)
 
             if (recurseNeeded)
             {
-              workStack.push(current);
+              workStack.push_back(current);
               if (arg1 == f.end())
               {
-                workStack.push(current[0]);
+                workStack.push_back(current[0]);
               }
               if (arg2 == f.end())
               {
-                workStack.push(current[1]);
+                workStack.push_back(current[1]);
               }
               continue;  // i.e. recurse!
             }
@@ -1439,8 +1439,8 @@ Node FpConverter::convert(TNode node)
 
             if (arg1 == f.end())
             {
-              workStack.push(current);
-              workStack.push(current[0]);
+              workStack.push_back(current);
+              workStack.push_back(current[0]);
               continue;  // i.e. recurse!
             }
 
@@ -1537,14 +1537,14 @@ Node FpConverter::convert(TNode node)
 
             if (recurseNeeded)
             {
-              workStack.push(current);
+              workStack.push_back(current);
               if (mode == r.end())
               {
-                workStack.push(current[0]);
+                workStack.push_back(current[0]);
               }
               if (arg1 == f.end())
               {
-                workStack.push(current[1]);
+                workStack.push_back(current[1]);
               }
               continue;  // i.e. recurse!
             }
@@ -1578,14 +1578,14 @@ Node FpConverter::convert(TNode node)
 
             if (recurseNeeded)
             {
-              workStack.push(current);
+              workStack.push_back(current);
               if (mode == r.end())
               {
-                workStack.push(current[0]);
+                workStack.push_back(current[0]);
               }
               if (arg1 == f.end())
               {
-                workStack.push(current[1]);
+                workStack.push_back(current[1]);
               }
               continue;  // i.e. recurse!
             }
@@ -1644,8 +1644,8 @@ Node FpConverter::convert(TNode node)
 
           if (arg1 == f.end())
           {
-            workStack.push(current);
-            workStack.push(current[0]);
+            workStack.push_back(current);
+            workStack.push_back(current[0]);
             continue;  // i.e. recurse!
           }
 

--- a/src/theory/fp/fp_converter.cpp
+++ b/src/theory/fp/fp_converter.cpp
@@ -16,7 +16,6 @@
 #include "theory/theory.h"
 // theory.h Only needed for the leaf test
 
-#include <stack>
 #include <vector>
 
 #ifdef CVC4_USE_SYMFPU


### PR DESCRIPTION
The word-blasting function `FpConverter::convert` used a `std::stack` with `deque` as an underlying data structure (default) for node traversal. Previous experiments suggested that using `std::stack<T, std::deque<T>>` performs worse than using `std::vector<T>`, and we decided, as a guideline, to always use `std::vector` for stacks: https://github.com/CVC4/CVC4/wiki/Code-Style-Guidelines#stack.

This PR refactors `FpConverter::convert` to use `std::vector`. Runs on all incremental and non-incremental FP logics in SMT-LIB showed a slight improvement over the previous (`std::stack<T, std::deque<T>>`) implementation, and an even greater (albeit still slight) improvement over using `std::stack<T, std::vector<T>>`.