### PR TITLE
Fix evaluator for non-evaluatable nodes

### DIFF
--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -125,30 +125,15 @@ Node Evaluator::eval(TNode n,
   // if we failed to evaluate
   if (ret.isNull())
   {
-    Trace("ajr-temp") << "Could not evaluate " << n << std::endl;
     // maybe it was stored in the evaluation-as-node map
     std::unordered_map<TNode, Node, NodeHashFunction>::iterator itn =
         evalAsNode.find(n);
-    if (itn != evalAsNode.end())
-    {
-      Node sn = n.substitute(args.begin(),args.end(),vals.begin(),vals.end());
-      sn = Rewriter::rewrite(sn);
-      if (sn!=itn->second)
-      {
-        Trace("ajr-temp") << "From : " << n << std::endl;
-        for (unsigned i=0, nargs=args.size(); i<nargs; i++)
-        {
-          Trace("ajr-temp") << "  " << args[i] << " -> " << vals[i] << std::endl;
-        }
-        Trace("ajr-temp") << "Not equal : " << sn << " " << itn->second << std::endl;
-      }
-      AlwaysAssert(sn==itn->second);
-      // should be the same as substitution + rewriting
-      Assert(itn->second
-            == Rewriter::rewrite(n.substitute(
-                args.begin(), args.end(), vals.begin(), vals.end())));
-      return itn->second;
-    }
+    Assert(itn != evalAsNode.end());
+    // should be the same as substitution + rewriting
+    Assert(itn->second
+          == Rewriter::rewrite(n.substitute(
+              args.begin(), args.end(), vals.begin(), vals.end())));
+    return itn->second;
   }
   return ret;
 }

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -794,12 +794,12 @@ Node Evaluator::reconstruct(TNode n,
   {
     TNode op = n.getOperator();
     itr = eresults.find(op);
-    AlwaysAssert (itr!=eresults.end());
+    Assert (itr!=eresults.end());
     if (itr->second.d_tag == EvalResult::INVALID)
     {
       // could not evaluate this child, look in the node cache
       itn = evalAsNode.find(op);
-      AlwaysAssert(itn != evalAsNode.end());
+      Assert(itn != evalAsNode.end());
       echildren.push_back(itn->second);
     }
     else
@@ -811,12 +811,12 @@ Node Evaluator::reconstruct(TNode n,
   for (const auto& currNodeChild : n)
   {
     itr = eresults.find(currNodeChild);
-    AlwaysAssert (itr!=eresults.end());
+    Assert (itr!=eresults.end());
     if (itr->second.d_tag == EvalResult::INVALID)
     {
       // could not evaluate this child, look in the node cache
       itn = evalAsNode.find(currNodeChild);
-      AlwaysAssert(itn != evalAsNode.end());
+      Assert(itn != evalAsNode.end());
       echildren.push_back(itn->second);
     }
     else

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -131,8 +131,8 @@ Node Evaluator::eval(TNode n,
     Assert(itn != evalAsNode.end());
     // should be the same as substitution + rewriting
     Assert(itn->second
-          == Rewriter::rewrite(n.substitute(
-              args.begin(), args.end(), vals.begin(), vals.end())));
+           == Rewriter::rewrite(n.substitute(
+               args.begin(), args.end(), vals.begin(), vals.end())));
     return itn->second;
   }
   return ret;
@@ -251,10 +251,10 @@ EvalResult Evaluator::evalInternal(
       {
         Trace("evaluator") << "Evaluate " << currNode << std::endl;
         TNode op = currNode.getOperator();
-        Assert (evalAsNode.find(op)!=evalAsNode.end());
+        Assert(evalAsNode.find(op) != evalAsNode.end());
         op = evalAsNode[op];
         Trace("evaluator") << "Operator evaluated to " << op << std::endl;
-        if (op.getKind()!=kind::LAMBDA)
+        if (op.getKind() != kind::LAMBDA)
         {
           // operator is not evaluatable
           results[currNode] = EvalResult();
@@ -286,12 +286,14 @@ EvalResult Evaluator::evalInternal(
         std::unordered_map<TNode, Node, NodeHashFunction> evalAsNodeC;
         results[currNode] =
             evalInternal(op[1], lambdaArgs, lambdaVals, evalAsNodeC);
-        Trace("evaluator") << "Evaluated via arguments to " << results[currNode].d_tag << std::endl;
+        Trace("evaluator") << "Evaluated via arguments to "
+                           << results[currNode].d_tag << std::endl;
         if (results[currNode].d_tag == EvalResult::INVALID)
         {
           // evaluation was invalid, we take the node of op[1] as the result
           evalAsNode[currNode] = evalAsNodeC[op[1]];
-        Trace("evaluator") << "Take node evaluation: " << evalAsNodeC[op[1]] << std::endl;
+          Trace("evaluator")
+              << "Take node evaluation: " << evalAsNodeC[op[1]] << std::endl;
         }
         continue;
       }
@@ -684,7 +686,9 @@ EvalResult Evaluator::evalInternal(
           else
           {
             results[currNode] = EvalResult();
-            evalAsNode[currNode] = needsReconstruct ? reconstruct(currNode, results, evalAsNode) : currNodeVal;
+            evalAsNode[currNode] =
+                needsReconstruct ? reconstruct(currNode, results, evalAsNode)
+                                 : currNodeVal;
           }
           break;
         }
@@ -701,7 +705,9 @@ EvalResult Evaluator::evalInternal(
           else
           {
             results[currNode] = EvalResult();
-            evalAsNode[currNode] = needsReconstruct ? reconstruct(currNode, results, evalAsNode) : currNodeVal;
+            evalAsNode[currNode] =
+                needsReconstruct ? reconstruct(currNode, results, evalAsNode)
+                                 : currNodeVal;
           }
           break;
         }
@@ -742,7 +748,9 @@ EvalResult Evaluator::evalInternal(
               Trace("evaluator") << "Theory " << Theory::theoryOf(currNode[0])
                                  << " not supported" << std::endl;
               results[currNode] = EvalResult();
-              evalAsNode[currNode] = needsReconstruct ? reconstruct(currNode, results, evalAsNode) : currNodeVal;
+              evalAsNode[currNode] =
+                  needsReconstruct ? reconstruct(currNode, results, evalAsNode)
+                                   : currNodeVal;
               break;
             }
           }
@@ -768,7 +776,9 @@ EvalResult Evaluator::evalInternal(
           Trace("evaluator") << "Kind " << currNodeVal.getKind()
                              << " not supported" << std::endl;
           results[currNode] = EvalResult();
-          evalAsNode[currNode] = needsReconstruct ? reconstruct(currNode, results, evalAsNode) : currNodeVal;
+          evalAsNode[currNode] =
+              needsReconstruct ? reconstruct(currNode, results, evalAsNode)
+                               : currNodeVal;
         }
       }
     }
@@ -777,11 +787,12 @@ EvalResult Evaluator::evalInternal(
   return results[n];
 }
 
-Node Evaluator::reconstruct(TNode n,
-      std::unordered_map<TNode, EvalResult, TNodeHashFunction>& eresults,
-      std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode)
+Node Evaluator::reconstruct(
+    TNode n,
+    std::unordered_map<TNode, EvalResult, TNodeHashFunction>& eresults,
+    std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode)
 {
-  if (n.getNumChildren()==0)
+  if (n.getNumChildren() == 0)
   {
     return n;
   }
@@ -794,7 +805,7 @@ Node Evaluator::reconstruct(TNode n,
   {
     TNode op = n.getOperator();
     itr = eresults.find(op);
-    Assert (itr!=eresults.end());
+    Assert(itr != eresults.end());
     if (itr->second.d_tag == EvalResult::INVALID)
     {
       // could not evaluate this child, look in the node cache
@@ -811,7 +822,7 @@ Node Evaluator::reconstruct(TNode n,
   for (const auto& currNodeChild : n)
   {
     itr = eresults.find(currNodeChild);
-    Assert (itr!=eresults.end());
+    Assert(itr != eresults.end());
     if (itr->second.d_tag == EvalResult::INVALID)
     {
       // could not evaluate this child, look in the node cache
@@ -828,8 +839,7 @@ Node Evaluator::reconstruct(TNode n,
   // The value is the result of our (partially) successful evaluation
   // of the children.
   Node nn = nm->mkNode(n.getKind(), echildren);
-  Trace("evaluator") << "Evaluator: reconstructed " << nn
-                      << std::endl;
+  Trace("evaluator") << "Evaluator: reconstructed " << nn << std::endl;
   // Use rewriting. Notice we do not need to substitute here since
   // all substitutions should already have been applied recursively.
   return Rewriter::rewrite(nn);

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -252,11 +252,12 @@ EvalResult Evaluator::evalInternal(
         Trace("evaluator") << "Evaluate " << currNode << std::endl;
         TNode op = currNode.getOperator();
         Assert(evalAsNode.find(op) != evalAsNode.end());
+        // no function can be a valid EvalResult
         op = evalAsNode[op];
         Trace("evaluator") << "Operator evaluated to " << op << std::endl;
         if (op.getKind() != kind::LAMBDA)
         {
-          // operator is not evaluatable, must add to evalAsNode
+          // this node is not evaluatable due to operator, must add to evalAsNode
           results[currNode] = EvalResult();
           evalAsNode[currNode] = reconstruct(currNode, results, evalAsNode);
           continue;

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -125,7 +125,7 @@ Node Evaluator::eval(TNode n,
   // if we failed to evaluate
   if (ret.isNull())
   {
-    // maybe it was stored in the evaluation-as-node map
+    // should be stored in the evaluation-as-node map
     std::unordered_map<TNode, Node, NodeHashFunction>::iterator itn =
         evalAsNode.find(n);
     Assert(itn != evalAsNode.end());
@@ -245,6 +245,7 @@ EvalResult Evaluator::evalInternal(
         currNodeVal = vals[pos];
         // Don't need to reconstruct since range of substitution should already
         // be normalized.
+        Assert (vals[pos] == Rewriter::rewrite(vals[pos]));
         needsReconstruct = false;
       }
       else if (currNode.getKind() == kind::APPLY_UF)

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -245,7 +245,7 @@ EvalResult Evaluator::evalInternal(
         currNodeVal = vals[pos];
         // Don't need to reconstruct since range of substitution should already
         // be normalized.
-        Assert (vals[pos] == Rewriter::rewrite(vals[pos]));
+        Assert(vals[pos] == Rewriter::rewrite(vals[pos]));
         needsReconstruct = false;
       }
       else if (currNode.getKind() == kind::APPLY_UF)

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -257,7 +257,8 @@ EvalResult Evaluator::evalInternal(
         Trace("evaluator") << "Operator evaluated to " << op << std::endl;
         if (op.getKind() != kind::LAMBDA)
         {
-          // this node is not evaluatable due to operator, must add to evalAsNode
+          // this node is not evaluatable due to operator, must add to
+          // evalAsNode
           results[currNode] = EvalResult();
           evalAsNode[currNode] = reconstruct(currNode, results, evalAsNode);
           continue;

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -133,8 +133,8 @@ Node Evaluator::eval(TNode n,
   }
   // should be the same as substitution + rewriting
   Assert(ret
-          == Rewriter::rewrite(n.substitute(
-              args.begin(), args.end(), vals.begin(), vals.end())));
+         == Rewriter::rewrite(
+             n.substitute(args.begin(), args.end(), vals.begin(), vals.end())));
   return ret;
 }
 

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -810,14 +810,14 @@ Node Evaluator::reconstruct(
     Assert(itr != eresults.end());
     if (itr->second.d_tag == EvalResult::INVALID)
     {
-      // could not evaluate this child, look in the node cache
+      // could not evaluate the operator, look in the node cache
       itn = evalAsNode.find(op);
       Assert(itn != evalAsNode.end());
       echildren.push_back(itn->second);
     }
     else
     {
-      // otherwise, use the evaluation
+      // otherwise, use the evaluation of the operator
       echildren.push_back(itr->second.toNode());
     }
   }

--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -129,12 +129,12 @@ Node Evaluator::eval(TNode n,
     std::unordered_map<TNode, Node, NodeHashFunction>::iterator itn =
         evalAsNode.find(n);
     Assert(itn != evalAsNode.end());
-    // should be the same as substitution + rewriting
-    Assert(itn->second
-           == Rewriter::rewrite(n.substitute(
-               args.begin(), args.end(), vals.begin(), vals.end())));
-    return itn->second;
+    ret = itn->second;
   }
+  // should be the same as substitution + rewriting
+  Assert(ret
+          == Rewriter::rewrite(n.substitute(
+              args.begin(), args.end(), vals.begin(), vals.end())));
   return ret;
 }
 
@@ -256,7 +256,7 @@ EvalResult Evaluator::evalInternal(
         Trace("evaluator") << "Operator evaluated to " << op << std::endl;
         if (op.getKind() != kind::LAMBDA)
         {
-          // operator is not evaluatable
+          // operator is not evaluatable, must add to evalAsNode
           results[currNode] = EvalResult();
           evalAsNode[currNode] = reconstruct(currNode, results, evalAsNode);
           continue;

--- a/src/theory/evaluator.h
+++ b/src/theory/evaluator.h
@@ -119,15 +119,16 @@ class Evaluator
       const std::vector<Node>& vals,
       std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode);
   /** reconstruct
-   * 
+   *
    * This function reconstructs the result of evaluating n using a combination
    * of evaluation results (eresults) and substitution+rewriting (evalAsNode).
-   * 
+   *
    * Arguments eresults and evalAsNode are built within the context of the
    * above method for some args and vals. This method ensures that the return
    * value is equivalent to the rewritten form of n * { args -> vals }.
    */
-  Node reconstruct(TNode n,
+  Node reconstruct(
+      TNode n,
       std::unordered_map<TNode, EvalResult, TNodeHashFunction>& eresults,
       std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode);
 };

--- a/src/theory/evaluator.h
+++ b/src/theory/evaluator.h
@@ -118,6 +118,18 @@ class Evaluator
       const std::vector<Node>& args,
       const std::vector<Node>& vals,
       std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode);
+  /** reconstruct
+   * 
+   * This function reconstructs the result of evaluating n using a combination
+   * of evaluation results (eresults) and substitution+rewriting (evalAsNode).
+   * 
+   * Arguments eresults and evalAsNode are built within the context of the
+   * above method for some args and vals. This method ensures that the return
+   * value is equivalent to the rewritten form of n * { args -> vals }.
+   */
+  Node reconstruct(TNode n,
+      std::unordered_map<TNode, EvalResult, TNodeHashFunction>& eresults,
+      std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode);
 };
 
 }  // namespace theory

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -984,7 +984,8 @@ Node TermDbSygus::evaluateBuiltin(TypeNode tn,
   if (res.isNull())
   {
     // must do substitution
-    res = bn.substitute(varlist.begin(), varlist.end(), args.begin(), args.end());
+    res =
+        bn.substitute(varlist.begin(), varlist.end(), args.begin(), args.end());
   }
   // Call the rewrite node function, which may involve recursive function
   // evaluation.

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -981,14 +981,11 @@ Node TermDbSygus::evaluateBuiltin(TypeNode tn,
     // supported by the evaluator
     res = d_eval->eval(bn, varlist, args);
   }
-  if (!res.isNull())
+  if (res.isNull())
   {
-    Assert(res
-           == Rewriter::rewrite(bn.substitute(
-               varlist.begin(), varlist.end(), args.begin(), args.end())));
-    return res;
+    // must do substitution
+    res = bn.substitute(varlist.begin(), varlist.end(), args.begin(), args.end());
   }
-  res = bn.substitute(varlist.begin(), varlist.end(), args.begin(), args.end());
   // Call the rewrite node function, which may involve recursive function
   // evaluation.
   return rewriteNode(res);


### PR DESCRIPTION
This ensures that the Evaluator always returns the result of substitution + rewriting for constant substitutions.

This requires a few further extensions to the code, namely:
(1) Applying substutitions to operators,
(2) Reconstructing all nodes that fail to evaluate by taking into account evaluation of their children.