### PR TITLE
Use the evaluator utility in the function definition evaluator

### DIFF
--- a/src/theory/evaluator.cpp
+++ b/src/theory/evaluator.cpp
@@ -116,7 +116,7 @@ Node EvalResult::toNode() const
 
 Node Evaluator::eval(TNode n,
                      const std::vector<Node>& args,
-                     const std::vector<Node>& vals)
+                     const std::vector<Node>& vals) const
 {
   Trace("evaluator") << "Evaluating " << n << " under substitution " << args
                      << " " << vals << std::endl;
@@ -128,7 +128,7 @@ EvalResult Evaluator::evalInternal(
     TNode n,
     const std::vector<Node>& args,
     const std::vector<Node>& vals,
-    std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode)
+    std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode) const
 {
   std::unordered_map<TNode, EvalResult, TNodeHashFunction> results;
   std::vector<TNode> queue;

--- a/src/theory/evaluator.h
+++ b/src/theory/evaluator.h
@@ -94,7 +94,7 @@ class Evaluator
    */
   Node eval(TNode n,
             const std::vector<Node>& args,
-            const std::vector<Node>& vals);
+            const std::vector<Node>& vals) const;
 
  private:
   /**
@@ -117,7 +117,7 @@ class Evaluator
       TNode n,
       const std::vector<Node>& args,
       const std::vector<Node>& vals,
-      std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode);
+      std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode) const;
 };
 
 }  // namespace theory

--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -181,23 +181,9 @@ Node FunDefEvaluator::evaluate(Node n) const
           const std::vector<Node>& args = itf->second.d_args;
           if (!args.empty())
           {
-            /*
-            Trace("ajr-temp") << "Check " << sbody << " under substitution:" << std::endl;
-            for (unsigned j=0; j<args.size(); j++)
-            {
-              Trace("ajr-temp") << "  " << args[j] << " -> " << children[j] << std::endl;
-            }
-            // invoke it on arguments
-            Node sbodyr = sbody.substitute(
-                args.begin(), args.end(), children.begin(), children.end());
-            // rewrite it
-            sbodyr = Rewriter::rewrite(sbodyr);
-            Trace("ajr-temp") << "Rewrite : " << sbodyr << std::endl;
-            */
-            // invoke it on arguments
+            // invoke it on arguments using the evaluator
             sbody = d_eval.eval(sbody,args,children);
             Trace("ajr-temp") << "Evaluate : " << sbody << std::endl;
-            //AlwaysAssert(sbodyr==sbody);
             if (Trace.isOn("fd-eval-debug2"))
             {
               Trace("fd-eval-debug2")

--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -183,7 +183,6 @@ Node FunDefEvaluator::evaluate(Node n) const
           {
             // invoke it on arguments using the evaluator
             sbody = d_eval.eval(sbody, args, children);
-            Trace("ajr-temp") << "Evaluate : " << sbody << std::endl;
             if (Trace.isOn("fd-eval-debug2"))
             {
               Trace("fd-eval-debug2")

--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -181,11 +181,23 @@ Node FunDefEvaluator::evaluate(Node n) const
           const std::vector<Node>& args = itf->second.d_args;
           if (!args.empty())
           {
+            /*
+            Trace("ajr-temp") << "Check " << sbody << " under substitution:" << std::endl;
+            for (unsigned j=0; j<args.size(); j++)
+            {
+              Trace("ajr-temp") << "  " << args[j] << " -> " << children[j] << std::endl;
+            }
             // invoke it on arguments
-            sbody = sbody.substitute(
+            Node sbodyr = sbody.substitute(
                 args.begin(), args.end(), children.begin(), children.end());
             // rewrite it
-            sbody = Rewriter::rewrite(sbody);
+            sbodyr = Rewriter::rewrite(sbodyr);
+            Trace("ajr-temp") << "Rewrite : " << sbodyr << std::endl;
+            */
+            // invoke it on arguments
+            sbody = d_eval.eval(sbody,args,children);
+            Trace("ajr-temp") << "Evaluate : " << sbody << std::endl;
+            //AlwaysAssert(sbodyr==sbody);
             if (Trace.isOn("fd-eval-debug2"))
             {
               Trace("fd-eval-debug2")
@@ -197,6 +209,7 @@ Node FunDefEvaluator::evaluate(Node n) const
               Trace("fd-eval-debug2")
                   << "FunDefEvaluator: results in " << sbody << "\n";
             }
+            Assert(!sbody.isNull());
           }
           // our result is the result of the body
           visited[cur] = sbody;

--- a/src/theory/quantifiers/fun_def_evaluator.cpp
+++ b/src/theory/quantifiers/fun_def_evaluator.cpp
@@ -182,7 +182,7 @@ Node FunDefEvaluator::evaluate(Node n) const
           if (!args.empty())
           {
             // invoke it on arguments using the evaluator
-            sbody = d_eval.eval(sbody,args,children);
+            sbody = d_eval.eval(sbody, args, children);
             Trace("ajr-temp") << "Evaluate : " << sbody << std::endl;
             if (Trace.isOn("fd-eval-debug2"))
             {

--- a/src/theory/quantifiers/fun_def_evaluator.h
+++ b/src/theory/quantifiers/fun_def_evaluator.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <vector>
 #include "expr/node.h"
+#include "theory/evaluator.h"
 
 namespace CVC4 {
 namespace theory {
@@ -63,6 +64,8 @@ class FunDefEvaluator
   };
   /** maps functions to the above information */
   std::map<Node, FunDefInfo> d_funDefMap;
+  /** evaluator utility */
+  Evaluator d_eval;
 };
 
 }  // namespace quantifiers


### PR DESCRIPTION
Improves performance on ground conjectures with recursive functions.  We use the evalutator to (partially) evaluate bodies of recursive functions, instead of relying on substitution+rewriting.