### PR TITLE
Fix finiteness check for bounded fmf

### DIFF
--- a/src/theory/quantifiers/fmf/bounded_integers.cpp
+++ b/src/theory/quantifiers/fmf/bounded_integers.cpp
@@ -409,7 +409,7 @@ void BoundedIntegers::checkOwnership(Node f)
       for( unsigned i=0; i<f[0].getNumChildren(); i++) {
         if( d_bound_type[f].find( f[0][i] )==d_bound_type[f].end() ){
           TypeNode tn = f[0][i].getType();
-          if (tn.isSort()
+          if ((tn.isSort() && tn.isInterpretedFinite())
               || d_quantEngine->getTermEnumeration()->mayComplete(tn))
           {
             success = true;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1222,6 +1222,7 @@ set(regress_1_tests
   regress1/fmf/german169.smt2
   regress1/fmf/german73.smt2
   regress1/fmf/issue2034-preinit.smt2
+  regress1/fmf/issue3587.smt2
   regress1/fmf/issue916-fmf-or.smt2
   regress1/fmf/jasmin-cdt-crash.smt2
   regress1/fmf/ko-bound-set.cvc

--- a/test/regress/regress1/fmf/issue3587.smt2
+++ b/test/regress/regress1/fmf/issue3587.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --fmf-bound
+; EXPECT: unsat
+(declare-sort a 0) 
+(declare-datatypes ((prod 0)) (((Pair (gx a) (gy a))))) 
+(declare-fun p () prod) 
+(assert (forall ((x a) (y a)) (not (= p (Pair x y))))) 
+(check-sat)  

--- a/test/regress/regress1/fmf/issue3587.smt2
+++ b/test/regress/regress1/fmf/issue3587.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --fmf-bound
-; EXPECT: unsat
+; EXPECT: unknown
+(set-logic ALL)
 (declare-sort a 0) 
 (declare-datatypes ((prod 0)) (((Pair (gx a) (gy a))))) 
 (declare-fun p () prod) 

--- a/test/regress/regress1/fmf/issue3587.smt2
+++ b/test/regress/regress1/fmf/issue3587.smt2
@@ -5,4 +5,5 @@
 (declare-datatypes ((prod 0)) (((Pair (gx a) (gy a))))) 
 (declare-fun p () prod) 
 (assert (forall ((x a) (y a)) (not (= p (Pair x y))))) 
+; problem is unsat, currently unknown with fmf-bound
 (check-sat)  

--- a/test/regress/regress1/quantifiers/issue3537.smt2
+++ b/test/regress/regress1/quantifiers/issue3537.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --strings-exp --no-check-models
+; COMMAND-LINE: --strings-exp --no-check-models --finite-model-find
 ; EXPECT: sat
 (set-logic ALL)
 (declare-datatypes ((UNIT 0)) (((Unit))


### PR DESCRIPTION
Recently, finite model finding via uninterpreted sorts was decoupled from finite bound inference techniques (the BoundedIntegers module in theory/quantifiers/fmf/).  This module assumed that finite model finding was enabled in one place.  This fixes the issue by adding an additional check.  This fixes a model unsoundness issue where bounds on an uninterpreted sort were not being enforced.

This fixes #3587.