### PR TITLE
Fix unary minus parse check

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -538,7 +538,6 @@ void Parser::checkDeclaration(const std::string& varName,
   if (!d_checksEnabled) {
     return;
   }
-  std::cout << check << " Check with notes: {" << notes << "} size " << notes.size() << std::endl;
 
   switch (check) {
     case CHECK_DECLARED:

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -538,6 +538,7 @@ void Parser::checkDeclaration(const std::string& varName,
   if (!d_checksEnabled) {
     return;
   }
+  std::cout << check << " Check with notes: {" << notes << "} size " << notes.size() << std::endl;
 
   switch (check) {
     case CHECK_DECLARED:

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -465,7 +465,6 @@ class Smt2 : public Parser
       return;
     }
     this->Parser::checkDeclaration(name, check, type, notes);
-    return;
   }
 
   void checkOperator(Kind kind, unsigned numArgs)

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -448,14 +448,13 @@ class Smt2 : public Parser
                         SymbolType type = SYM_VARIABLE,
                         std::string notes = "")
   {
-    std::cout << "{" << name << "} " << name[0] << " " << name.find_first_not_of("0123456789", 1) << " " << std::string::npos << " " << name.length() << std::endl;
     // if the symbol is something like "-1", we'll give the user a helpful
     // syntax hint.  (-1 is a valid identifier in SMT-LIB, NOT unary minus.)
     if (name.length()>1 && name[0]=='-' && name.find_first_not_of("0123456789", 1) == std::string::npos )
     {
-      std::cout << " I am here " << std::endl;
       if (sygus_v1())
       {
+        // "-1" is allowed in SyGuS version 1.0
         return;
       }
       std::stringstream ss;

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -448,28 +448,26 @@ class Smt2 : public Parser
                         SymbolType type = SYM_VARIABLE,
                         std::string notes = "")
   {
+    std::cout << "{" << name << "} " << name[0] << " " << name.find_first_not_of("0123456789", 1) << " " << std::string::npos << " " << name.length() << std::endl;
     // if the symbol is something like "-1", we'll give the user a helpful
     // syntax hint.  (-1 is a valid identifier in SMT-LIB, NOT unary minus.)
-    if( check != CHECK_DECLARED ||
-        name[0] != '-' ||
-        name.find_first_not_of("0123456789", 1) != std::string::npos ) {
-      this->Parser::checkDeclaration(name, check, type, notes);
-      return;
-    }else{
-      //it is allowable in sygus
-      if (sygus_v1() && name[0] == '-')
+    if (name.length()>1 && name[0]=='-' && name.find_first_not_of("0123456789", 1) == std::string::npos )
+    {
+      std::cout << " I am here " << std::endl;
+      if (sygus_v1())
       {
-        //do not check anything
         return;
       }
+      std::stringstream ss;
+      ss << notes
+        << "You may have intended to apply unary minus: `(- "
+        << name.substr(1)
+        << ")'\n";
+      this->Parser::checkDeclaration(name, check, type, ss.str());
+      return;
     }
-
-    std::stringstream ss;
-    ss << notes
-       << "You may have intended to apply unary minus: `(- "
-       << name.substr(1)
-       << ")'\n";
-    this->Parser::checkDeclaration(name, check, type, ss.str());
+    this->Parser::checkDeclaration(name, check, type, notes);
+    return;
   }
 
   void checkOperator(Kind kind, unsigned numArgs)

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -450,7 +450,8 @@ class Smt2 : public Parser
   {
     // if the symbol is something like "-1", we'll give the user a helpful
     // syntax hint.  (-1 is a valid identifier in SMT-LIB, NOT unary minus.)
-    if (name.length()>1 && name[0]=='-' && name.find_first_not_of("0123456789", 1) == std::string::npos )
+    if (name.length() > 1 && name[0] == '-'
+        && name.find_first_not_of("0123456789", 1) == std::string::npos)
     {
       if (sygus_v1())
       {
@@ -458,10 +459,8 @@ class Smt2 : public Parser
         return;
       }
       std::stringstream ss;
-      ss << notes
-        << "You may have intended to apply unary minus: `(- "
-        << name.substr(1)
-        << ")'\n";
+      ss << notes << "You may have intended to apply unary minus: `(- "
+         << name.substr(1) << ")'\n";
       this->Parser::checkDeclaration(name, check, type, ss.str());
       return;
     }


### PR DESCRIPTION
We were throwing a misleading parse error about unary minus when the symbol `-` was not declared.  This makes it so that error message is thrown only for `-N` for non-empty N.

This fixes #3590.