### PR TITLE
Fix parameteric sorts involving Booleans in sygus default grammars

### DIFF
--- a/src/theory/booleans/theory_bool_type_rules.h
+++ b/src/theory/booleans/theory_bool_type_rules.h
@@ -33,9 +33,9 @@ public:
       TNode::iterator child_it_end = n.end();
       for(; child_it != child_it_end; ++child_it) {
         if(!(*child_it).getType(check).isBoolean()) {
-          Debug("pb") << "failed type checking: " << *child_it << std::endl;
-          Debug("pb") << "  integer: " << (*child_it).getType(check).isInteger() << std::endl;
-          Debug("pb") << "  real: " << (*child_it).getType(check).isReal() << std::endl;
+          Trace("pb") << "failed type checking: " << n << " " << *child_it << std::endl;
+          Trace("pb") << "  integer: " << (*child_it).getType(check).isInteger() << std::endl;
+          Trace("pb") << "  real: " << (*child_it).getType(check).isReal() << std::endl;
           throw TypeCheckingExceptionPrivate(n, "expecting a Boolean subexpression");
         }
       }

--- a/src/theory/booleans/theory_bool_type_rules.h
+++ b/src/theory/booleans/theory_bool_type_rules.h
@@ -33,12 +33,9 @@ public:
       TNode::iterator child_it_end = n.end();
       for(; child_it != child_it_end; ++child_it) {
         if(!(*child_it).getType(check).isBoolean()) {
-          Trace("pb") << "failed type checking: " << n << " " << *child_it
-                      << std::endl;
-          Trace("pb") << "  integer: " << (*child_it).getType(check).isInteger()
-                      << std::endl;
-          Trace("pb") << "  real: " << (*child_it).getType(check).isReal()
-                      << std::endl;
+          Debug("pb") << "failed type checking: " << *child_it << std::endl;
+          Debug("pb") << "  integer: " << (*child_it).getType(check).isInteger() << std::endl;
+          Debug("pb") << "  real: " << (*child_it).getType(check).isReal() << std::endl;
           throw TypeCheckingExceptionPrivate(n, "expecting a Boolean subexpression");
         }
       }

--- a/src/theory/booleans/theory_bool_type_rules.h
+++ b/src/theory/booleans/theory_bool_type_rules.h
@@ -33,9 +33,12 @@ public:
       TNode::iterator child_it_end = n.end();
       for(; child_it != child_it_end; ++child_it) {
         if(!(*child_it).getType(check).isBoolean()) {
-          Trace("pb") << "failed type checking: " << n << " " << *child_it << std::endl;
-          Trace("pb") << "  integer: " << (*child_it).getType(check).isInteger() << std::endl;
-          Trace("pb") << "  real: " << (*child_it).getType(check).isReal() << std::endl;
+          Trace("pb") << "failed type checking: " << n << " " << *child_it
+                      << std::endl;
+          Trace("pb") << "  integer: " << (*child_it).getType(check).isInteger()
+                      << std::endl;
+          Trace("pb") << "  real: " << (*child_it).getType(check).isReal()
+                      << std::endl;
           throw TypeCheckingExceptionPrivate(n, "expecting a Boolean subexpression");
         }
       }

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -568,7 +568,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
   unres_types.push_back(unres_bt);
   type_to_unres[btype] = unres_bt;
   sygus_to_builtin[unres_bt] = btype;
-  
+
   // We ensure an ordering on types such that parametric types are processed
   // before their consitituents. Since parametric types were added before their
   // arguments in collectSygusGrammarTypesFor above, we will construct the
@@ -876,7 +876,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
   }
   std::map<TypeNode, unsigned>::iterator itgat;
   // initialize the datatypes (except for the last one, reserved for Bool)
-  for (unsigned i = 0, size = types.size()-1; i < size; ++i)
+  for (unsigned i = 0, size = types.size() - 1; i < size; ++i)
   {
     sdts[i].d_sdt.initializeDatatype(types[i], bvl, true, true);
     Trace("sygus-grammar-def")
@@ -1144,7 +1144,7 @@ void CegGrammarConstructor::mkSygusDefaultGrammar(
     sdtBool.addConstructor(consts[i], ss.str(), cargsEmpty);
   }
   // add predicates for non-Boolean types
-  for (unsigned i = 0, size = types.size()-1; i < size; ++i)
+  for (unsigned i = 0, size = types.size() - 1; i < size; ++i)
   {
     if (!types[i].isFirstClass())
     {

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -935,6 +935,7 @@ set(regress_0_tests
   regress0/sygus/hd-05-d1-prog-nogrammar.sy
   regress0/sygus/inv-different-var-order.sy
   regress0/sygus/issue3356-syg-inf-usort.smt2
+  regress0/sygus/issue3624.sy
   regress0/sygus/let-ringer.sy
   regress0/sygus/let-simp.sy
   regress0/sygus/no-logic.sy

--- a/test/regress/regress0/sygus/issue3624.sy
+++ b/test/regress/regress0/sygus/issue3624.sy
@@ -1,0 +1,8 @@
+; EXPECT: unsat
+; COMMAND-LINE: --sygus-out=status
+(set-logic ALL)
+(declare-var A Bool)
+(declare-var B (Array Int Bool))
+(synth-fun secure-sync ((A Bool) (B (Array Int Bool))) Bool)
+(constraint (secure-sync A B))
+(check-synth)


### PR DESCRIPTION
Our default grammars for parametric sorts did not handle Booleans since it was not properly added as a placeholder at the beginning of the `mkSygusDefaultGrammar` function.

Fixes #3624. 