### PR TITLE
Fix substitution in nl solver

### DIFF
--- a/src/theory/arith/nl_model.cpp
+++ b/src/theory/arith/nl_model.cpp
@@ -905,8 +905,7 @@ bool NlModel::simpleCheckModelLit(Node lit)
   if (!qvars.empty())
   {
     Assert(qvars.size() == qsubs.size());
-    Node slit =
-        lit.substitute(qvars.begin(), qvars.end(), qsubs.begin(), qsubs.end());
+    Node slit = arithSubstitute(lit, qvars, qsubs);
     slit = Rewriter::rewrite(slit);
     return simpleCheckModelLit(slit);
   }

--- a/test/regress/regress1/nl/issue3614.smt2
+++ b/test/regress/regress1/nl/issue3614.smt2
@@ -1,0 +1,3 @@
+(declare-fun x () Real)
+(assert (distinct x (sin 4.0)))
+(check-sat)

--- a/test/regress/regress1/nl/issue3614.smt2
+++ b/test/regress/regress1/nl/issue3614.smt2
@@ -1,3 +1,0 @@
-(declare-fun x () Real)
-(assert (distinct x (sin 4.0)))
-(check-sat)


### PR DESCRIPTION
There was a place that was not using the updated arithmetic substitution utility function, this fixes #3614 (that benchmark now times out).