### PR TITLE
Fix check for subtypes in sygus PBE

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_pbe.cpp
+++ b/src/theory/quantifiers/sygus/sygus_pbe.cpp
@@ -420,7 +420,7 @@ Node SygusPbe::addSearchVal(TypeNode tn, Node e, Node bvr)
         d_sygus_unif[ee].clearExampleCache(e, bvr);
       }
     }
-    Assert(ret.getType() == bvr.getType());
+    Assert(ret.getType().isComparableTo(bvr.getType()));
     return ret;
   }
   return Node::null();

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1784,6 +1784,7 @@ set(regress_1_tests
   regress1/sygus/issue3514.smt2
   regress1/sygus/issue3507.smt2
   regress1/sygus/issue3580.sy
+  regress1/sygus/issue3634.smt2
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/regress1/sygus/issue3634.smt2
+++ b/test/regress/regress1/sygus/issue3634.smt2
@@ -1,0 +1,4 @@
+(declare-fun a () Int)
+(declare-fun b () Real)
+(assert (= (/ 1 (to_real a)) b))
+(check-sat)

--- a/test/regress/regress1/sygus/issue3634.smt2
+++ b/test/regress/regress1/sygus/issue3634.smt2
@@ -1,3 +1,6 @@
+; EXPECT: sat
+; COMMAND-LINE: --sygus-inference
+(set-logic ALL)
 (declare-fun a () Int)
 (declare-fun b () Real)
 (assert (= (/ 1 (to_real a)) b))


### PR DESCRIPTION
Assertion did not account for subtypes, this fixes #3634.