### PR TITLE
Fix subtyping for instantiations where internal representatives are chosen

### DIFF
--- a/src/theory/quantifiers/equality_query.cpp
+++ b/src/theory/quantifiers/equality_query.cpp
@@ -167,7 +167,9 @@ Node EqualityQueryQuantifiersEngine::getInternalRepresentative(Node a,
       if( d_rep_score.find( r_best )==d_rep_score.end() ){
         d_rep_score[ r_best ] = d_reset_count;
       }
-      Trace("internal-rep-select") << "...Choose " << r_best << " with score " << r_best_score << " and type " << r_best.getType() << std::endl;
+      Trace("internal-rep-select")
+          << "...Choose " << r_best << " with score " << r_best_score
+          << " and type " << r_best.getType() << std::endl;
       Assert(r_best.getType().isSubtypeOf(v_tn));
       v_int_rep[r] = r_best;
       if( r_best!=a ){

--- a/src/theory/quantifiers/equality_query.cpp
+++ b/src/theory/quantifiers/equality_query.cpp
@@ -167,7 +167,7 @@ Node EqualityQueryQuantifiersEngine::getInternalRepresentative(Node a,
       if( d_rep_score.find( r_best )==d_rep_score.end() ){
         d_rep_score[ r_best ] = d_reset_count;
       }
-      Trace("internal-rep-select") << "...Choose " << r_best << " with score " << r_best_score << std::endl;
+      Trace("internal-rep-select") << "...Choose " << r_best << " with score " << r_best_score << " and type " << r_best.getType() << std::endl;
       Assert(r_best.getType().isSubtypeOf(v_tn));
       v_int_rep[r] = r_best;
       if( r_best!=a ){

--- a/src/theory/quantifiers/instantiate.cpp
+++ b/src/theory/quantifiers/instantiate.cpp
@@ -126,16 +126,15 @@ bool Instantiate::addInstantiation(
     {
       terms[i] = getTermForType(tn);
     }
+    // Ensure the type is correct, this for instance ensures that real terms
+    // are cast to integers for { x -> t } where x has type Int and t has
+    // type Real.
+    terms[i] = quantifiers::TermUtil::ensureType(terms[i], tn);
     if (mkRep)
     {
       // pick the best possible representative for instantiation, based on past
       // use and simplicity of term
       terms[i] = d_qe->getInternalRepresentative(terms[i], q, i);
-    }
-    else
-    {
-      // ensure the type is correct
-      terms[i] = quantifiers::TermUtil::ensureType(terms[i], tn);
     }
     Trace("inst-add-debug") << " -> " << terms[i] << std::endl;
     if (terms[i].isNull())

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1225,6 +1225,7 @@ set(regress_1_tests
   regress1/fmf/german73.smt2
   regress1/fmf/issue2034-preinit.smt2
   regress1/fmf/issue3587.smt2
+  regress1/fmf/issue3626.smt2
   regress1/fmf/issue916-fmf-or.smt2
   regress1/fmf/jasmin-cdt-crash.smt2
   regress1/fmf/ko-bound-set.cvc

--- a/test/regress/regress1/fmf/issue3626.smt2
+++ b/test/regress/regress1/fmf/issue3626.smt2
@@ -1,2 +1,5 @@
+; COMMAND-LINE: --fmf-bound
+; EXPECT: sat
+(set-logic ALL)
 (assert (forall ((a Int)) (or (distinct (/ 0 0) a) (= (/ 0 a) 0))))
 (check-sat)

--- a/test/regress/regress1/fmf/issue3626.smt2
+++ b/test/regress/regress1/fmf/issue3626.smt2
@@ -1,0 +1,2 @@
+(assert (forall ((a Int)) (or (distinct (/ 0 0) a) (= (/ 0 a) 0))))
+(check-sat)


### PR DESCRIPTION
Fixes #3626. 

This updates quantifier instantiation to ensure types are correct before choosing representatives (which was leading to an assertion failure).