### PR TITLE
Fix single invocation partition for non-function non-atomic types

### DIFF
--- a/src/theory/quantifiers/single_inv_partition.cpp
+++ b/src/theory/quantifiers/single_inv_partition.cpp
@@ -513,8 +513,8 @@ bool SingleInvocationPartition::isAntiSkolemizableType(Node f)
   {
     TypeNode tn = f.getType();
     bool ret = false;
-    if (tn.getNumChildren() == d_arg_types.size() + 1
-        || (d_arg_types.empty() && tn.getNumChildren() == 0))
+    if (tn.isFunction() && (tn.getNumChildren() == d_arg_types.size() + 1
+        || (d_arg_types.empty() && tn.getNumChildren() == 0)))
     {
       ret = true;
       std::vector<Node> children;

--- a/src/theory/quantifiers/single_inv_partition.cpp
+++ b/src/theory/quantifiers/single_inv_partition.cpp
@@ -513,7 +513,7 @@ bool SingleInvocationPartition::isAntiSkolemizableType(Node f)
   {
     TypeNode tn = f.getType();
     bool ret = false;
-    if (tn.isFunction() && (tn.getNumChildren() == d_arg_types.size() + 1
+    if ( ((tn.isFunction() &&tn.getNumChildren() == d_arg_types.size() + 1)
         || (d_arg_types.empty() && tn.getNumChildren() == 0)))
     {
       ret = true;

--- a/src/theory/quantifiers/single_inv_partition.cpp
+++ b/src/theory/quantifiers/single_inv_partition.cpp
@@ -513,8 +513,8 @@ bool SingleInvocationPartition::isAntiSkolemizableType(Node f)
   {
     TypeNode tn = f.getType();
     bool ret = false;
-    if ( ((tn.isFunction() &&tn.getNumChildren() == d_arg_types.size() + 1)
-        || (d_arg_types.empty() && tn.getNumChildren() == 0)))
+    if (((tn.isFunction() && tn.getNumChildren() == d_arg_types.size() + 1)
+         || (d_arg_types.empty() && tn.getNumChildren() == 0)))
     {
       ret = true;
       std::vector<Node> children;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1783,6 +1783,7 @@ set(regress_1_tests
   regress1/sygus/issue3514.smt2
   regress1/sygus/issue3507.smt2
   regress1/sygus/issue3580.sy
+  regress1/sygus/issue3635.smt2
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/regress1/sygus/issue3635.smt2
+++ b/test/regress/regress1/sygus/issue3635.smt2
@@ -1,0 +1,4 @@
+(declare-fun a () (Array Int Int))
+(declare-fun b () (Array Int Int))
+(assert (= a b))
+(check-sat)

--- a/test/regress/regress1/sygus/issue3635.smt2
+++ b/test/regress/regress1/sygus/issue3635.smt2
@@ -1,5 +1,6 @@
 ; EXPECT: sat
 ; COMMAND-LINE: --sygus-inference
+(set-logic ALL)
 (declare-fun a () (Array Int Int))
 (declare-fun b () (Array Int Int))
 (assert (= a b))

--- a/test/regress/regress1/sygus/issue3635.smt2
+++ b/test/regress/regress1/sygus/issue3635.smt2
@@ -1,3 +1,5 @@
+; EXPECT: sat
+; COMMAND-LINE: --sygus-inference
 (declare-fun a () (Array Int Int))
 (declare-fun b () (Array Int Int))
 (assert (= a b))


### PR DESCRIPTION
A condition in the single invocation inference utility assumed that functions-to-synthesize had either function or atomic types.

This is problematic for functions-to-synthesize that have e.g. array return type with no arguments.

Fixes #3635.