### PR TITLE
Do not insist on bound values being constant in arithmetic instantiation

### DIFF
--- a/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
@@ -468,8 +468,9 @@ bool ArithInstantiator::processAssertions(CegInstantiator* ci,
               cmp_bound = Rewriter::rewrite(cmp_bound);
               // Should be comparing two constant values which should rewrite
               // to a constant. If a step failed, we assume that this is not
-              // the new best bound.
-              Assert(cmp_bound.isConst());
+              // the new best bound. We might not be comparing constant
+              // values (for instance if transcendental functions are
+              // involved), in which case we do update the best bound value.
               if (!cmp_bound.isConst() || !cmp_bound.getConst<bool>())
               {
                 new_best = false;

--- a/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
+++ b/src/theory/quantifiers/cegqi/ceg_arith_instantiator.cpp
@@ -236,9 +236,11 @@ bool ArithInstantiator::processAssertion(CegInstantiator* ci,
           // since the quantifier-free arithmetic solver may pass full
           // effort with no lemmas even when we are not guaranteed to have a
           // model. By convention, we use GEQ to compare the values here.
+          // It also may be the case that cmp is non-constant, in the case
+          // where lhs or rhs contains a transcendental function. We consider
+          // the bound to be an upper bound in this case.
           Node cmp = nm->mkNode(GEQ, lhs_value, rhs_value);
           cmp = Rewriter::rewrite(cmp);
-          Assert(cmp.isConst());
           is_upper = !cmp.isConst() || !cmp.getConst<bool>();
         }
       }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1784,6 +1784,7 @@ set(regress_1_tests
   regress1/sygus/issue3514.smt2
   regress1/sygus/issue3507.smt2
   regress1/sygus/issue3580.sy
+  regress1/sygus/issue3633.smt2
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1785,6 +1785,7 @@ set(regress_1_tests
   regress1/sygus/issue3507.smt2
   regress1/sygus/issue3580.sy
   regress1/sygus/issue3633.smt2
+  regress1/sygus/issue3648.smt2
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/regress1/sygus/issue3633.smt2
+++ b/test/regress/regress1/sygus/issue3633.smt2
@@ -1,0 +1,6 @@
+; EXPECT: sat
+; COMMAND-LINE: --sygus-inference
+(set-logic ALL)
+(declare-fun a () Real)
+(assert (distinct a (sin 2)))
+(check-sat)

--- a/test/regress/regress1/sygus/issue3648.smt2
+++ b/test/regress/regress1/sygus/issue3648.smt2
@@ -1,0 +1,7 @@
+; EXPECT: sat
+; COMMAND-LINE: --sygus-inference --no-check-models
+(set-logic ALL)
+(declare-fun a () Real)
+(assert (> a 0.000001))
+(assert (< (- (sin 1) a) 0.000001))
+(check-sat)


### PR DESCRIPTION
There was an assertion that the bound values we are solving for must be constant in the model for CEGQI with arithmetic. This is not the case for transcendental function applications.  This PR removes this assertion.

Fixes #3633.