### PR TITLE
Fix trivial solve method for single invocation

### DIFF
--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -676,7 +676,7 @@ bool CegSingleInv::solveTrivial(Node q)
     }
   }
   // if we solved all arguments
-  if (args.empty())
+  if (args.empty() && body.isConst() && !body.getConst<bool>())
   {
     Trace("cegqi-si-trivial-solve")
         << q << " is trivially solvable by substitution " << vars << " -> "

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1786,6 +1786,7 @@ set(regress_1_tests
   regress1/sygus/issue3580.sy
   regress1/sygus/issue3634.smt2
   regress1/sygus/issue3635.smt2
+  regress1/sygus/issue3654.sy
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/regress1/sygus/issue3654.sy
+++ b/test/regress/regress1/sygus/issue3654.sy
@@ -1,0 +1,24 @@
+; EXPECT: unknown
+; COMMAND-LINE: --sygus-out=status
+(set-logic ALL)
+(synth-fun inv-fn ((i Int) (x (Array Int Int)) (c Int)) Bool)
+
+(define-fun init-fn ((i Int) (x (Array Int Int)) (c Int)) Bool 
+	(and (= i 0)
+	(= (select x 10) c)))
+
+(define-fun post-fn ((i Int) (x (Array Int Int))(c Int)) Bool 
+	(exists ((index Int)) (and (= (select x index) c)
+	(forall ((index2 Int)) (=> (< index2 index) (not (= (select x index) c))))
+	)))
+
+(declare-var x (Array Int Int))
+(declare-var x! (Array Int Int))
+(declare-var i Int)
+(declare-var i! Int)
+(declare-var c Int)
+
+	
+(constraint (=> (init-fn i x c) (inv-fn i x c)))
+(constraint (=> (inv-fn i x c) (post-fn i x c)))
+(check-synth)


### PR DESCRIPTION
This fixes the trivial solve method for single invocation so that we only report a trivial solution when indeed the negated conjecture after substitution is false.  Previously, we would report incorrect solutions for some infeasible conjectures.  Fixes #3649.