### PR TITLE
External cache argument for evaluator

### DIFF
--- a/src/theory/evaluator.h
+++ b/src/theory/evaluator.h
@@ -95,6 +95,14 @@ class Evaluator
   Node eval(TNode n,
             const std::vector<Node>& args,
             const std::vector<Node>& vals) const;
+  /**
+   * Same as above, but with a precomputed visited map.
+   */
+  Node eval(
+      TNode n,
+      const std::vector<Node>& args,
+      const std::vector<Node>& vals,
+      const std::unordered_map<Node, Node, NodeHashFunction>& visited) const;
 
  private:
   /**
@@ -117,7 +125,8 @@ class Evaluator
       TNode n,
       const std::vector<Node>& args,
       const std::vector<Node>& vals,
-      std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode) const;
+      std::unordered_map<TNode, Node, NodeHashFunction>& evalAsNode,
+      std::unordered_map<TNode, EvalResult, TNodeHashFunction>& results) const;
   /** reconstruct
    *
    * This function reconstructs the result of evaluating n using a combination


### PR DESCRIPTION
This updates the evaluator so that it accepts a cache of precomputed results.

It also fixes an issue with parametric builtin operators (such as bit-vector extract).  Previously, we failed to evaluate bit-vector extract since the code expected a substitution for it.  This updates the code to handle this properly.

This is work towards optimizing our performance on "examples" conjectures (from this branch: https://github.com/ajreynol/CVC4/tree/optExamplesSygus).