### PR TITLE
Do not debug check model for models with approximations

### DIFF
--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -1157,13 +1157,17 @@ void TheoryEngineModelBuilder::debugCheckModel(TheoryModel* tm)
       static int repCheckInstance = 0;
       ++repCheckInstance;
 
-      Debug("check-model::rep-checking") << "( " << repCheckInstance << ") "
-                                          << "n: " << n << endl
-                                          << "getValue(n): " << tm->getValue(n)
-                                          << endl
-                                          << "rep: " << rep << endl;
-      Assert(tm->getValue(*eqc_i) == rep)
-          << "run with -d check-model::rep-checking for details";
+      // non-linear mult is not necessarily accurate wrt getValue
+      if (n.getKind() != kind::NONLINEAR_MULT)
+      {
+        Debug("check-model::rep-checking") << "( " << repCheckInstance << ") "
+                                           << "n: " << n << endl
+                                           << "getValue(n): " << tm->getValue(n)
+                                           << endl
+                                           << "rep: " << rep << endl;
+        Assert(tm->getValue(*eqc_i) == rep)
+            << "run with -d check-model::rep-checking for details";
+      }
     }
   }
 #endif /* CVC4_ASSERTIONS */

--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -1127,6 +1127,11 @@ void TheoryEngineModelBuilder::debugCheckModel(TheoryModel* tm)
 {
 #ifdef CVC4_ASSERTIONS
   Assert(tm->isBuilt());
+  if (tm->hasApproximations())
+  {
+    // models with approximations may fail the assertions below
+    return;
+  }
   eq::EqClassesIterator eqcs_i = eq::EqClassesIterator(tm->d_equalityEngine);
   std::map<Node, Node>::iterator itMap;
   // Check that every term evaluates to its representative in the model
@@ -1152,17 +1157,13 @@ void TheoryEngineModelBuilder::debugCheckModel(TheoryModel* tm)
       static int repCheckInstance = 0;
       ++repCheckInstance;
 
-      // non-linear mult is not necessarily accurate wrt getValue
-      if (n.getKind() != kind::NONLINEAR_MULT)
-      {
-        Debug("check-model::rep-checking") << "( " << repCheckInstance << ") "
-                                           << "n: " << n << endl
-                                           << "getValue(n): " << tm->getValue(n)
-                                           << endl
-                                           << "rep: " << rep << endl;
-        Assert(tm->getValue(*eqc_i) == rep)
-            << "run with -d check-model::rep-checking for details";
-      }
+      Debug("check-model::rep-checking") << "( " << repCheckInstance << ") "
+                                          << "n: " << n << endl
+                                          << "getValue(n): " << tm->getValue(n)
+                                          << endl
+                                          << "rep: " << rep << endl;
+      Assert(tm->getValue(*eqc_i) == rep)
+          << "run with -d check-model::rep-checking for details";
     }
   }
 #endif /* CVC4_ASSERTIONS */

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -549,6 +549,7 @@ set(regress_0_tests
   regress0/nl/issue3407.smt2
   regress0/nl/issue3411.smt2
   regress0/nl/issue3475.smt2
+  regress0/nl/issue3652.smt2
   regress0/nl/magnitude-wrong-1020-m.smt2
   regress0/nl/mult-po.smt2
   regress0/nl/nia-wrong-tl.smt2

--- a/test/regress/regress0/nl/issue3652.smt2
+++ b/test/regress/regress0/nl/issue3652.smt2
@@ -1,0 +1,7 @@
+;COMMAND-LINE: --check-models
+;EXIT: 1
+;EXPECT: (error "Cannot run check-model on a model with approximate values.")
+(set-logic QF_NRA)
+(declare-fun a () Real)
+(assert (= (* a a) 2))
+(check-sat)


### PR DESCRIPTION
We don't run check-model for models with approximate values, however we were still running the internal debugCheckModel method, which leads to assertion failures.  This disables this check.

Fixes #3652.