### PR TITLE
Eliminate spurious postprocessing step for single invocation

### DIFF
--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -437,33 +437,6 @@ struct sortSiInstanceIndices {
   }
 };
 
-Node CegSingleInv::postProcessSolution(Node n)
-{
-  bool childChanged = false;
-  Kind k = n.getKind();
-  if( n.getKind()==INTS_DIVISION_TOTAL ){
-    k = INTS_DIVISION;
-    childChanged = true;
-  }else if( n.getKind()==INTS_MODULUS_TOTAL ){
-    k = INTS_MODULUS;
-    childChanged = true;
-  }
-  std::vector< Node > children;
-  for( unsigned i=0; i<n.getNumChildren(); i++ ){
-    Node nn = postProcessSolution( n[i] );
-    children.push_back( nn );
-    childChanged = childChanged || nn!=n[i];
-  }
-  if( childChanged ){
-    if( n.hasOperator() && k==n.getKind() ){
-      children.insert( children.begin(), n.getOperator() );
-    }
-    return NodeManager::currentNM()->mkNode( k, children );
-  }else{
-    return n;
-  }
-}
-
 Node CegSingleInv::getSolution(unsigned sol_index,
                                TypeNode stn,
                                int& reconstructed,
@@ -584,7 +557,6 @@ Node CegSingleInv::reconstructToSyntax(Node s,
           d_qe->getTermDatabaseSygus()->getExtRewriter()->extendedRewrite(
               d_solution);
     }
-    d_solution = postProcessSolution( d_solution );
     if( prev!=d_solution ){
       Trace("csi-sol") << "Solution (after post process) : " << d_solution << std::endl;
     }

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.h
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.h
@@ -49,7 +49,6 @@ class CegSingleInv
                                std::vector< Node >& terms,
                                std::map< Node, std::vector< Node > >& teq,
                                Node n, std::vector< Node >& conj );
-  Node postProcessSolution(Node n);
  private:
   /** pointer to the quantifiers engine */
   QuantifiersEngine* d_qe;

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1791,6 +1791,7 @@ set(regress_1_tests
   regress1/sygus/issue3633.smt2
   regress1/sygus/issue3634.smt2
   regress1/sygus/issue3635.smt2
+  regress1/sygus/issue3644.smt2
   regress1/sygus/issue3648.smt2
   regress1/sygus/issue3654.sy
   regress1/sygus/large-const-simp.sy

--- a/test/regress/regress1/sygus/issue3644.smt2
+++ b/test/regress/regress1/sygus/issue3644.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; COMMAND-LINE: --sygus-inference
+; COMMAND-LINE: --sygus-inference --no-check-models
 (set-logic LIA)
 (assert (forall ((a Int)) (=> (> a 0) (exists ((b Int)) (> a (* b 2))))))
 (check-sat)

--- a/test/regress/regress1/sygus/issue3644.smt2
+++ b/test/regress/regress1/sygus/issue3644.smt2
@@ -1,0 +1,5 @@
+; EXPECT: sat
+; COMMAND-LINE: --sygus-inference
+(set-logic LIA)
+(assert (forall ((a Int)) (=> (> a 0) (exists ((b Int)) (> a (* b 2))))))
+(check-sat)


### PR DESCRIPTION
This was an early hack to ensure `div_total` was printed as `div`, which is not necessary anymore since they print the same in the latest smt2 printer.  Moreover the code did not handle parametric operators properly.

Fixes #3644.