### PR TITLE
Modularize more steps in the strings strategy

### DIFF
--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -4568,7 +4568,7 @@ void TheoryStrings::initializeStrategy()
     }
     addStrategyStep(CHECK_NORMAL_FORMS_EQ);
     addStrategyStep(CHECK_EXTF_EVAL, 1);
-    if (!options::stringEagerLen())
+    if (!options::stringEagerLen() && options::stringLenNorm())
     {
       addStrategyStep(CHECK_LENGTH_EQC, 0, false);
       addStrategyStep(CHECK_REGISTER_TERMS_NF);

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -4162,8 +4162,7 @@ void TheoryStrings::checkNormalFormsDeq()
         {
           Trace("strings-solve") << "- Verify disequalities are processed for "
                                  << cols[i][0] << ", normal form : ";
-          printConcat(getNormalForm(cols[i][0]).d_nf,
-                                  "strings-solve");
+          printConcat(getNormalForm(cols[i][0]).d_nf, "strings-solve");
           Trace("strings-solve")
               << "... #eql = " << cols[i].size() << std::endl;
         }
@@ -4184,11 +4183,9 @@ void TheoryStrings::checkNormalFormsDeq()
                 if (Trace.isOn("strings-solve"))
                 {
                   Trace("strings-solve") << "- Compare " << cols[i][j] << " ";
-                  printConcat(getNormalForm(cols[i][j]).d_nf,
-                                          "strings-solve");
+                  printConcat(getNormalForm(cols[i][j]).d_nf, "strings-solve");
                   Trace("strings-solve") << " against " << cols[i][k] << " ";
-                  printConcat(getNormalForm(cols[i][k]).d_nf,
-                                          "strings-solve");
+                  printConcat(getNormalForm(cols[i][k]).d_nf, "strings-solve");
                   Trace("strings-solve") << "..." << std::endl;
                 }
                 processDeq(cols[i][j], cols[i][k]);

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -68,6 +68,8 @@ enum InferStep
   CHECK_CYCLES,
   // check flat forms
   CHECK_FLAT_FORMS,
+  // check register terms pre-normal forms
+  CHECK_REGISTER_TERMS_PRE_NF,
   // check normal forms equalities
   CHECK_NORMAL_FORMS_EQ,
   // check normal forms disequalities
@@ -76,6 +78,8 @@ enum InferStep
   CHECK_CODES,
   // check lengths for equivalence classes
   CHECK_LENGTH_EQC,
+  // check register terms for normal forms
+  CHECK_REGISTER_TERMS_NF,
   // check extended function reductions
   CHECK_EXTF_REDUCTION,
   // check regular expression memberships
@@ -768,6 +772,12 @@ private:
    * Must call checkCycles before this function in a strategy.
    */
   void checkFlatForms();
+  /** check register terms pre-normal forms
+   *
+   * This calls registerTerm(n,2) on all non-congruent strings in the
+   * equality engine of this class.
+   */
+  void checkRegisterTermsPreNormalForm();
   /** check normal forms equalities
    *
    * This applies an inference schema based on "normal forms". The normal form
@@ -845,6 +855,13 @@ private:
    * shown to be helpful.
    */
   void checkLengthsEqc();
+  /** check register terms for normal forms
+   *
+   * This calls registerTerm(str.++(t1, ..., tn ), 3) on the normal forms
+   * (t1, ..., tn) of all string equivalence classes { s1, ..., sm } such that
+   * there does not exist a term of the form str.len(si) in the current context.
+   */
+  void checkRegisterTermsNormalForms();
   /** check extended function reductions
    *
    * This adds "reduction" lemmas for each active extended function in this SAT


### PR DESCRIPTION
This separates portions of strategy steps that involve "registerTerm" to their own steps.  This is required for moving these strategy steps within the planned core solver for strings.

The behavior of the solver should essentially remain unchanged in this PR.