### PR TITLE
Fix rep set increment for empty domains

### DIFF
--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -383,8 +383,9 @@ int RepSetIterator::do_reset_increment( int i, bool initial ) {
       emptyDomain = true;
     }
     //force next iteration if currently an empty domain
-    if( emptyDomain ){
-    Trace("rsi-debug") << "This is an empty domain, increment." << std::endl;
+    if( emptyDomain )
+    {
+      Trace("rsi-debug") << "This is an empty domain, increment." << std::endl;
       return increment();
     }
   }

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -371,8 +371,8 @@ int RepSetIterator::incrementAtIndex(int i)
 }
 
 int RepSetIterator::do_reset_increment( int i, bool initial ) {
-  bool emptyDomain = false;
   for( unsigned ii=(i+1); ii<d_index.size(); ii++ ){
+    bool emptyDomain = false;
     int ri_res = resetIndex( ii, initial );
     if( ri_res==-1 ){
       //failed
@@ -384,15 +384,11 @@ int RepSetIterator::do_reset_increment( int i, bool initial ) {
     }
     //force next iteration if currently an empty domain
     if( emptyDomain ){
-      d_index[ii] = domainSize(ii)-1;
+    Trace("rsi-debug") << "This is an empty domain, increment." << std::endl;
+      return increment();
     }
   }
-  if( emptyDomain ){
-    Trace("rsi-debug") << "This is an empty domain, increment." << std::endl;
-    return increment();
-  }else{
-    return i;
-  }
+  return i;
 }
 
 int RepSetIterator::increment(){

--- a/src/theory/rep_set.cpp
+++ b/src/theory/rep_set.cpp
@@ -383,7 +383,7 @@ int RepSetIterator::do_reset_increment( int i, bool initial ) {
       emptyDomain = true;
     }
     //force next iteration if currently an empty domain
-    if( emptyDomain )
+    if (emptyDomain)
     {
       Trace("rsi-debug") << "This is an empty domain, increment." << std::endl;
       return increment();

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1228,6 +1228,7 @@ set(regress_1_tests
   regress1/fmf/german73.smt2
   regress1/fmf/issue2034-preinit.smt2
   regress1/fmf/issue3587.smt2
+  regress1/fmf/issue3615.smt2
   regress1/fmf/issue3626.smt2
   regress1/fmf/issue916-fmf-or.smt2
   regress1/fmf/jasmin-cdt-crash.smt2

--- a/test/regress/regress1/fmf/issue3615.smt2
+++ b/test/regress/regress1/fmf/issue3615.smt2
@@ -1,0 +1,6 @@
+; COMMAND-LINE: --fmf-bound
+; EXPECT: sat
+(set-logic UFLIA)
+(declare-fun f (Int) Bool)
+(assert (forall ((x Int) (y Int)) (or (>= x 0) (<= x 0) (< y 0) (> y x) (f x))))
+(check-sat)


### PR DESCRIPTION
In some cases, a domain of a quantified formula could be empty due to the current value considered for another bound variable (see y in the regression for x = 0).  The code did not properly increment the iterator in this case.

Fixes #3615.