### PR TITLE
Refactor sygus stats

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -592,6 +592,8 @@ libcvc4_add_sources(
   theory/quantifiers/sygus/sygus_process_conj.h
   theory/quantifiers/sygus/sygus_repair_const.cpp
   theory/quantifiers/sygus/sygus_repair_const.h
+  theory/quantifiers/sygus/sygus_stats.cpp
+  theory/quantifiers/sygus/sygus_stats.h
   theory/quantifiers/sygus/sygus_unif.cpp
   theory/quantifiers/sygus/sygus_unif.h
   theory/quantifiers/sygus/sygus_unif_io.cpp

--- a/src/theory/quantifiers/sygus/sygus_stats.cpp
+++ b/src/theory/quantifiers/sygus/sygus_stats.cpp
@@ -1,0 +1,54 @@
+/*********************                                                        */
+/*! \file sygus_stats.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds, Tim King, Morgan Deters
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief A shared statistics class for sygus.
+ **
+ **/
+
+#include "theory/quantifiers/sygus/sygus_stats.h"
+
+#include "smt/smt_statistics_registry.h"
+
+namespace CVC4 {
+namespace theory {
+namespace quantifiers {
+
+SygusStatistics::SygusStatistics()
+    : d_cegqi_lemmas_ce("SynthEngine::cegqi_lemmas_ce", 0),
+      d_cegqi_lemmas_refine("SynthEngine::cegqi_lemmas_refine", 0),
+      d_cegqi_si_lemmas("SynthEngine::cegqi_lemmas_si", 0),
+      d_solutions("SynthConjecture::solutions", 0),
+      d_filtered_solutions("SynthConjecture::filtered_solutions", 0),
+      d_candidate_rewrites_print("SynthConjecture::candidate_rewrites_print", 0)
+
+{
+  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_ce);
+  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_refine);
+  smtStatisticsRegistry()->registerStat(&d_cegqi_si_lemmas);
+  smtStatisticsRegistry()->registerStat(&d_solutions);
+  smtStatisticsRegistry()->registerStat(&d_filtered_solutions);
+  smtStatisticsRegistry()->registerStat(&d_candidate_rewrites_print);
+}
+
+SygusStatistics::~SygusStatistics()
+{
+  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_ce);
+  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_refine);
+  smtStatisticsRegistry()->unregisterStat(&d_cegqi_si_lemmas);
+  smtStatisticsRegistry()->unregisterStat(&d_solutions);
+  smtStatisticsRegistry()->unregisterStat(&d_filtered_solutions);
+  smtStatisticsRegistry()->unregisterStat(&d_candidate_rewrites_print);
+}
+
+
+}  // namespace quantifiers
+}  // namespace theory
+} /* namespace CVC4 */

--- a/src/theory/quantifiers/sygus/sygus_stats.cpp
+++ b/src/theory/quantifiers/sygus/sygus_stats.cpp
@@ -48,7 +48,6 @@ SygusStatistics::~SygusStatistics()
   smtStatisticsRegistry()->unregisterStat(&d_candidate_rewrites_print);
 }
 
-
 }  // namespace quantifiers
 }  // namespace theory
 } /* namespace CVC4 */

--- a/src/theory/quantifiers/sygus/sygus_stats.h
+++ b/src/theory/quantifiers/sygus/sygus_stats.h
@@ -1,0 +1,52 @@
+/*********************                                                        */
+/*! \file sygus_stats.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief A shared statistics class for sygus.
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef CVC4__THEORY__QUANTIFIERS__SYGUS_STATS_H
+#define CVC4__THEORY__QUANTIFIERS__SYGUS_STATS_H
+
+#include "util/statistics_registry.h"
+
+namespace CVC4 {
+namespace theory {
+namespace quantifiers {
+
+/**
+ * All statistics managed for the synth engine.
+ */
+class SygusStatistics
+{
+ public:
+  SygusStatistics();
+  ~SygusStatistics();
+  /** Number of counterexample lemmas */
+  IntStat d_cegqi_lemmas_ce;
+  /** Number of refinement lemmas */
+  IntStat d_cegqi_lemmas_refine;
+  /** Number of single invocation lemmas */
+  IntStat d_cegqi_si_lemmas;
+  /** Number of solutions printed (could be >1 for --sygus-stream) */
+  IntStat d_solutions;
+  /** Number of solutions filtered */
+  IntStat d_filtered_solutions;
+  /** Number of candidate rewrites printed (for --sygus-rr) */
+  IntStat d_candidate_rewrites_print;
+};
+
+}  // namespace quantifiers
+}  // namespace theory
+} /* namespace CVC4 */
+
+#endif

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -43,9 +43,12 @@ namespace CVC4 {
 namespace theory {
 namespace quantifiers {
 
-SynthConjecture::SynthConjecture(QuantifiersEngine* qe, SynthEngine* p)
+SynthConjecture::SynthConjecture(QuantifiersEngine* qe,
+                                 SynthEngine* p,
+                                 SygusStatistics& s)
     : d_qe(qe),
       d_parent(p),
+      d_stats(s),
       d_tds(qe->getTermDatabaseSygus()),
       d_hasSolution(false),
       d_ceg_si(new CegSingleInv(qe, this)),
@@ -810,7 +813,7 @@ Node SynthConjecture::getEnumeratedValue(Node e, bool& activeIncomplete)
                    == options::SygusActiveGenMode::ENUM
                || options::sygusActiveGenMode()
                       == options::SygusActiveGenMode::AUTO);
-        d_evg[e].reset(new SygusEnumerator(d_tds, this));
+        d_evg[e].reset(new SygusEnumerator(d_tds, this, d_stats));
       }
     }
     Trace("sygus-active-gen")
@@ -1058,7 +1061,7 @@ void SynthConjecture::printSynthSolution(std::ostream& out)
       ss << prog;
       std::string f(ss.str());
       f.erase(f.begin());
-      ++(d_parent->d_statistics.d_solutions);
+      ++(d_stats.d_solutions);
 
       bool is_unique_term = true;
 
@@ -1102,11 +1105,11 @@ void SynthConjecture::printSynthSolution(std::ostream& out)
         is_unique_term = d_exprm[prog].addTerm(sol, out, rew_print);
         if (rew_print)
         {
-          ++(d_parent->d_statistics.d_candidate_rewrites_print);
+          ++(d_stats.d_candidate_rewrites_print);
         }
         if (!is_unique_term)
         {
-          ++(d_parent->d_statistics.d_filtered_solutions);
+          ++(d_stats.d_filtered_solutions);
         }
       }
       if (is_unique_term)

--- a/src/theory/quantifiers/sygus/synth_conjecture.cpp
+++ b/src/theory/quantifiers/sygus/synth_conjecture.cpp
@@ -813,7 +813,7 @@ Node SynthConjecture::getEnumeratedValue(Node e, bool& activeIncomplete)
                    == options::SygusActiveGenMode::ENUM
                || options::sygusActiveGenMode()
                       == options::SygusActiveGenMode::AUTO);
-        d_evg[e].reset(new SygusEnumerator(d_tds, this, d_stats));
+        d_evg[e].reset(new SygusEnumerator(d_tds, this));
       }
     }
     Trace("sygus-active-gen")

--- a/src/theory/quantifiers/sygus/synth_conjecture.h
+++ b/src/theory/quantifiers/sygus/synth_conjecture.h
@@ -36,6 +36,7 @@ namespace theory {
 namespace quantifiers {
 
 class SynthEngine;
+class SygusStatistics;
 
 /**
  * A base class for generating values for actively-generated enumerators.
@@ -71,7 +72,7 @@ class EnumValGenerator
 class SynthConjecture
 {
  public:
-  SynthConjecture(QuantifiersEngine* qe, SynthEngine* p);
+  SynthConjecture(QuantifiersEngine* qe, SynthEngine* p, SygusStatistics& s);
   ~SynthConjecture();
   /** presolve */
   void presolve();
@@ -174,6 +175,8 @@ class SynthConjecture
   QuantifiersEngine* d_qe;
   /** pointer to the synth engine that owns this */
   SynthEngine* d_parent;
+  /** reference to the statistics of parent */
+  SygusStatistics& d_stats;
   /** term database sygus of d_qe */
   TermDbSygus* d_tds;
   /** The feasible guard. */

--- a/src/theory/quantifiers/sygus/synth_conjecture.h
+++ b/src/theory/quantifiers/sygus/synth_conjecture.h
@@ -30,13 +30,13 @@
 #include "theory/quantifiers/sygus/sygus_pbe.h"
 #include "theory/quantifiers/sygus/sygus_process_conj.h"
 #include "theory/quantifiers/sygus/sygus_repair_const.h"
+#include "theory/quantifiers/sygus/sygus_stats.h"
 
 namespace CVC4 {
 namespace theory {
 namespace quantifiers {
 
 class SynthEngine;
-class SygusStatistics;
 
 /**
  * A base class for generating values for actively-generated enumerators.

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -32,11 +32,39 @@ namespace CVC4 {
 namespace theory {
 namespace quantifiers {
 
+SygusStatistics::SygusStatistics()
+    : d_cegqi_lemmas_ce("SynthEngine::cegqi_lemmas_ce", 0),
+      d_cegqi_lemmas_refine("SynthEngine::cegqi_lemmas_refine", 0),
+      d_cegqi_si_lemmas("SynthEngine::cegqi_lemmas_si", 0),
+      d_solutions("SynthConjecture::solutions", 0),
+      d_filtered_solutions("SynthConjecture::filtered_solutions", 0),
+      d_candidate_rewrites_print("SynthConjecture::candidate_rewrites_print",
+                                 0)
+
+{
+  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_ce);
+  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_refine);
+  smtStatisticsRegistry()->registerStat(&d_cegqi_si_lemmas);
+  smtStatisticsRegistry()->registerStat(&d_solutions);
+  smtStatisticsRegistry()->registerStat(&d_filtered_solutions);
+  smtStatisticsRegistry()->registerStat(&d_candidate_rewrites_print);
+}
+
+SygusStatistics::~SygusStatistics()
+{
+  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_ce);
+  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_refine);
+  smtStatisticsRegistry()->unregisterStat(&d_cegqi_si_lemmas);
+  smtStatisticsRegistry()->unregisterStat(&d_solutions);
+  smtStatisticsRegistry()->unregisterStat(&d_filtered_solutions);
+  smtStatisticsRegistry()->unregisterStat(&d_candidate_rewrites_print);
+}
+
 SynthEngine::SynthEngine(QuantifiersEngine* qe, context::Context* c)
     : QuantifiersModule(qe), d_tds(qe->getTermDatabaseSygus())
 {
   d_conjs.push_back(std::unique_ptr<SynthConjecture>(
-      new SynthConjecture(d_quantEngine, this)));
+      new SynthConjecture(d_quantEngine, this, d_statistics)));
   d_conj = d_conjs.back().get();
 }
 
@@ -267,7 +295,7 @@ void SynthEngine::assignConjecture(Node q)
   if (d_conjs.back()->isAssigned())
   {
     d_conjs.push_back(std::unique_ptr<SynthConjecture>(
-        new SynthConjecture(d_quantEngine, this)));
+        new SynthConjecture(d_quantEngine, this, d_statistics)));
   }
   d_conjs.back()->assign(q);
 }
@@ -422,33 +450,6 @@ void SynthEngine::preregisterAssertion(Node n)
     Trace("cegqi") << "Preregister sygus conjecture : " << n << std::endl;
     d_conj->preregisterConjecture(n);
   }
-}
-
-SynthEngine::Statistics::Statistics()
-    : d_cegqi_lemmas_ce("SynthEngine::cegqi_lemmas_ce", 0),
-      d_cegqi_lemmas_refine("SynthEngine::cegqi_lemmas_refine", 0),
-      d_cegqi_si_lemmas("SynthEngine::cegqi_lemmas_si", 0),
-      d_solutions("SynthConjecture::solutions", 0),
-      d_filtered_solutions("SynthConjecture::filtered_solutions", 0),
-      d_candidate_rewrites_print("SynthConjecture::candidate_rewrites_print", 0)
-
-{
-  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_ce);
-  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_refine);
-  smtStatisticsRegistry()->registerStat(&d_cegqi_si_lemmas);
-  smtStatisticsRegistry()->registerStat(&d_solutions);
-  smtStatisticsRegistry()->registerStat(&d_filtered_solutions);
-  smtStatisticsRegistry()->registerStat(&d_candidate_rewrites_print);
-}
-
-SynthEngine::Statistics::~Statistics()
-{
-  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_ce);
-  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_refine);
-  smtStatisticsRegistry()->unregisterStat(&d_cegqi_si_lemmas);
-  smtStatisticsRegistry()->unregisterStat(&d_solutions);
-  smtStatisticsRegistry()->unregisterStat(&d_filtered_solutions);
-  smtStatisticsRegistry()->unregisterStat(&d_candidate_rewrites_print);
 }
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -38,8 +38,7 @@ SygusStatistics::SygusStatistics()
       d_cegqi_si_lemmas("SynthEngine::cegqi_lemmas_si", 0),
       d_solutions("SynthConjecture::solutions", 0),
       d_filtered_solutions("SynthConjecture::filtered_solutions", 0),
-      d_candidate_rewrites_print("SynthConjecture::candidate_rewrites_print",
-                                 0)
+      d_candidate_rewrites_print("SynthConjecture::candidate_rewrites_print", 0)
 
 {
   smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_ce);

--- a/src/theory/quantifiers/sygus/synth_engine.cpp
+++ b/src/theory/quantifiers/sygus/synth_engine.cpp
@@ -18,7 +18,6 @@
 #include "options/quantifiers_options.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
-#include "smt/smt_statistics_registry.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 #include "theory/quantifiers/term_util.h"
@@ -31,33 +30,6 @@ using namespace std;
 namespace CVC4 {
 namespace theory {
 namespace quantifiers {
-
-SygusStatistics::SygusStatistics()
-    : d_cegqi_lemmas_ce("SynthEngine::cegqi_lemmas_ce", 0),
-      d_cegqi_lemmas_refine("SynthEngine::cegqi_lemmas_refine", 0),
-      d_cegqi_si_lemmas("SynthEngine::cegqi_lemmas_si", 0),
-      d_solutions("SynthConjecture::solutions", 0),
-      d_filtered_solutions("SynthConjecture::filtered_solutions", 0),
-      d_candidate_rewrites_print("SynthConjecture::candidate_rewrites_print", 0)
-
-{
-  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_ce);
-  smtStatisticsRegistry()->registerStat(&d_cegqi_lemmas_refine);
-  smtStatisticsRegistry()->registerStat(&d_cegqi_si_lemmas);
-  smtStatisticsRegistry()->registerStat(&d_solutions);
-  smtStatisticsRegistry()->registerStat(&d_filtered_solutions);
-  smtStatisticsRegistry()->registerStat(&d_candidate_rewrites_print);
-}
-
-SygusStatistics::~SygusStatistics()
-{
-  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_ce);
-  smtStatisticsRegistry()->unregisterStat(&d_cegqi_lemmas_refine);
-  smtStatisticsRegistry()->unregisterStat(&d_cegqi_si_lemmas);
-  smtStatisticsRegistry()->unregisterStat(&d_solutions);
-  smtStatisticsRegistry()->unregisterStat(&d_filtered_solutions);
-  smtStatisticsRegistry()->unregisterStat(&d_candidate_rewrites_print);
-}
 
 SynthEngine::SynthEngine(QuantifiersEngine* qe, context::Context* c)
     : QuantifiersModule(qe), d_tds(qe->getTermDatabaseSygus())

--- a/src/theory/quantifiers/sygus/synth_engine.h
+++ b/src/theory/quantifiers/sygus/synth_engine.h
@@ -21,32 +21,11 @@
 #include "context/cdhashmap.h"
 #include "theory/quantifiers/quant_util.h"
 #include "theory/quantifiers/sygus/synth_conjecture.h"
+#include "theory/quantifiers/sygus/sygus_stats.h"
 
 namespace CVC4 {
 namespace theory {
 namespace quantifiers {
-
-/**
- * All statistics managed for the synth engine.
- */
-class SygusStatistics
-{
- public:
-  SygusStatistics();
-  ~SygusStatistics();
-  /** Number of counterexample lemmas */
-  IntStat d_cegqi_lemmas_ce;
-  /** Number of refinement lemmas */
-  IntStat d_cegqi_lemmas_refine;
-  /** Number of single invocation lemmas */
-  IntStat d_cegqi_si_lemmas;
-  /** Number of solutions printed (could be >1 for --sygus-stream) */
-  IntStat d_solutions;
-  /** Number of solutions filtered */
-  IntStat d_filtered_solutions;
-  /** Number of candidate rewrites printed (for --sygus-rr) */
-  IntStat d_candidate_rewrites_print;
-};
 
 class SynthEngine : public QuantifiersModule
 {

--- a/src/theory/quantifiers/sygus/synth_engine.h
+++ b/src/theory/quantifiers/sygus/synth_engine.h
@@ -26,7 +26,7 @@ namespace CVC4 {
 namespace theory {
 namespace quantifiers {
 
-/** 
+/**
  * All statistics managed for the synth engine.
  */
 class SygusStatistics

--- a/src/theory/quantifiers/sygus/synth_engine.h
+++ b/src/theory/quantifiers/sygus/synth_engine.h
@@ -26,6 +26,28 @@ namespace CVC4 {
 namespace theory {
 namespace quantifiers {
 
+/** 
+ * All statistics managed for the synth engine.
+ */
+class SygusStatistics
+{
+ public:
+  SygusStatistics();
+  ~SygusStatistics();
+  /** Number of counterexample lemmas */
+  IntStat d_cegqi_lemmas_ce;
+  /** Number of refinement lemmas */
+  IntStat d_cegqi_lemmas_refine;
+  /** Number of single invocation lemmas */
+  IntStat d_cegqi_si_lemmas;
+  /** Number of solutions printed (could be >1 for --sygus-stream) */
+  IntStat d_solutions;
+  /** Number of solutions filtered */
+  IntStat d_filtered_solutions;
+  /** Number of candidate rewrites printed (for --sygus-rr) */
+  IntStat d_candidate_rewrites_print;
+};
+
 class SynthEngine : public QuantifiersModule
 {
   typedef context::CDHashMap<Node, bool, NodeHashFunction> NodeBoolMap;
@@ -72,21 +94,6 @@ class SynthEngine : public QuantifiersModule
    */
   void preregisterAssertion(Node n);
 
- public:
-  class Statistics
-  {
-   public:
-    IntStat d_cegqi_lemmas_ce;
-    IntStat d_cegqi_lemmas_refine;
-    IntStat d_cegqi_si_lemmas;
-    IntStat d_solutions;
-    IntStat d_filtered_solutions;
-    IntStat d_candidate_rewrites_print;
-    Statistics();
-    ~Statistics();
-  }; /* class SynthEngine::Statistics */
-  Statistics d_statistics;
-
  private:
   /** term database sygus of d_qe */
   TermDbSygus* d_tds;
@@ -100,6 +107,8 @@ class SynthEngine : public QuantifiersModule
    * preregisterAssertion.
    */
   SynthConjecture* d_conj;
+  /** The statistics */
+  SygusStatistics d_statistics;
   /** assign quantified formula q as a conjecture
    *
    * This method either assigns q to a synthesis conjecture object in d_conjs,

--- a/src/theory/quantifiers/sygus/synth_engine.h
+++ b/src/theory/quantifiers/sygus/synth_engine.h
@@ -20,8 +20,8 @@
 
 #include "context/cdhashmap.h"
 #include "theory/quantifiers/quant_util.h"
-#include "theory/quantifiers/sygus/synth_conjecture.h"
 #include "theory/quantifiers/sygus/sygus_stats.h"
+#include "theory/quantifiers/sygus/synth_conjecture.h"
 
 namespace CVC4 {
 namespace theory {


### PR DESCRIPTION
This makes the sygus statistics class standalone.  This will make it possible to define further statistics without accessing data in the SynthEngine.