### PR TITLE
Allow PBE symmetry breaking with sygus stream

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -1138,7 +1138,6 @@ header = "options/quantifiers_options.h"
   long       = "sygus-unif-pi=MODE"
   type       = "SygusUnifPiMode"
   default    = "NONE"
-  read_only  = true
   help       = "mode for synthesis via piecewise-indepedent unification"
   help_mode  = "Modes for piecewise-independent unification."
 [[option.mode.NONE]]

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2035,11 +2035,6 @@ void SmtEngine::setDefaults() {
       if (!options::sygusUnifPbe.wasSetByUser())
       {
         options::sygusUnifPbe.set(false);
-        // also disable PBE-specific symmetry breaking unless PBE was enabled
-        if (!options::sygusSymBreakPbe.wasSetByUser())
-        {
-          options::sygusSymBreakPbe.set(false);
-        }
       }
       if (!options::sygusInvTemplMode.wasSetByUser())
       {

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2003,8 +2003,9 @@ void SmtEngine::setDefaults() {
     }
     // Whether we must use "basic" sygus algorithms. A non-basic sygus algorithm
     // is one that is specialized for returning a single solution. Non-basic
-    // sygus algorithms currently include the PBE solver, static template
-    // inference for invariant synthesis, and single invocation techniques.
+    // sygus algorithms currently include the PBE solver, UNIF+PI, static
+    // template inference for invariant synthesis, and single invocation
+    // techniques.
     bool reqBasicSygus = false;
     if (options::produceAbducts())
     {

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2036,6 +2036,10 @@ void SmtEngine::setDefaults() {
       {
         options::sygusUnifPbe.set(false);
       }
+      if (options::sygusUnifPi.wasSetByUser())
+      {
+        options::sygusUnifPi.set(options::SygusUnifPiMode::NONE);
+      }
       if (!options::sygusInvTemplMode.wasSetByUser())
       {
         options::sygusInvTemplMode.set(options::SygusInvTemplMode::NONE);


### PR DESCRIPTION
This led to an unexpected performance decrease in pLTL synthesis benchmarks.

There is no reason to disable this kind of symmetry breaking when sygus-stream is enabled.