### PR TITLE
Handle `expectedType` in TheoryProofEngine

### DIFF
--- a/src/proof/theory_proof.cpp
+++ b/src/proof/theory_proof.cpp
@@ -905,10 +905,12 @@ void LFSCTheoryProofEngine::printBoundTermAsType(Expr term,
       if (count > LET_COUNT)
       {
         os << "let" << id;
+        Debug("pf::tp::letmap") << "Using let map for " << term << std::endl;
         return;
       }
     }
   }
+  Debug("pf::tp::letmap") << "Skipping let map for " << term << std::endl;
 
   printTheoryTerm(term, os, map, expectedType);
 }

--- a/src/proof/theory_proof.cpp
+++ b/src/proof/theory_proof.cpp
@@ -176,18 +176,19 @@ void TheoryProofEngine::printConstantDisequalityProof(std::ostream& os, Expr c1,
   getTheoryProof(theory::Theory::theoryOf(c1))->printConstantDisequalityProof(os, c1, c2, globalLetMap);
 }
 
-  void TheoryProofEngine::printTheoryTerm(Expr term,
-                       std::ostream& os,
-                       const ProofLetMap& map,
-                       TypeNode expectedType)
-  {
-    this->printTheoryTermAsType(term, os, map, expectedType);
-  }
+void TheoryProofEngine::printTheoryTerm(Expr term,
+                                        std::ostream& os,
+                                        const ProofLetMap& map,
+                                        TypeNode expectedType)
+{
+  this->printTheoryTermAsType(term, os, map, expectedType);
+}
 
 TypeNode TheoryProofEngine::equalityType(const Expr& left, const Expr& right)
 {
   Assert(theory::Theory::theoryOf(left) == theory::Theory::theoryOf(right));
-  return getTheoryProof(theory::Theory::theoryOf(left))->equalityType(left, right);
+  return getTheoryProof(theory::Theory::theoryOf(left))
+      ->equalityType(left, right);
 }
 
 void TheoryProofEngine::registerTerm(Expr term) {
@@ -883,13 +884,17 @@ void LFSCTheoryProofEngine::printBoundTermAsType(Expr term,
   // Since let-abbreviated terms are abbreviated with their default type, only
   // use the let map if there is no expectedType or the expectedType matches
   // the default.
-  if (expectedType.isNull() || TypeNode::fromType(term.getType()) == expectedType) {
+  if (expectedType.isNull()
+      || TypeNode::fromType(term.getType()) == expectedType)
+  {
     ProofLetMap::const_iterator it = map.find(term);
-    if (it != map.end()) {
+    if (it != map.end())
+    {
       unsigned id = it->second.id;
       unsigned count = it->second.count;
 
-      if (count > LET_COUNT) {
+      if (count > LET_COUNT)
+      {
         os << "let" << id;
         return;
       }
@@ -930,7 +935,9 @@ void LFSCTheoryProofEngine::printCoreTerm(Expr term,
 
   switch(k) {
   case kind::ITE: {
-    TypeNode armType = expectedType.isNull() ? TypeNode::fromType(term.getType()) : expectedType;
+    TypeNode armType = expectedType.isNull()
+                           ? TypeNode::fromType(term.getType())
+                           : expectedType;
     bool useFormulaType = term.getType().isBoolean();
     Assert(term[1].getType().isSubtypeOf(term.getType()));
     Assert(term[2].getType().isSubtypeOf(term.getType()));
@@ -986,7 +993,8 @@ void LFSCTheoryProofEngine::printCoreTerm(Expr term,
     return;
   }
 
-  case kind::DISTINCT: {
+  case kind::DISTINCT:
+  {
     // Distinct nodes can have any number of chidlren.
     Assert(term.getNumChildren() >= 2);
     TypeNode armType = equalityType(term[0], term[1]);
@@ -1368,13 +1376,13 @@ void TheoryProof::printRewriteProof(std::ostream& os, const Node &n1, const Node
   os << "))";
 }
 
-  void TheoryProof::printOwnedTerm(Expr term,
-                      std::ostream& os,
-                      const ProofLetMap& map,
-                      TypeNode expectedType)
-  {
-    this->printOwnedTermAsType(term, os, map, expectedType);
-  }
+void TheoryProof::printOwnedTerm(Expr term,
+                                 std::ostream& os,
+                                 const ProofLetMap& map,
+                                 TypeNode expectedType)
+{
+  this->printOwnedTermAsType(term, os, map, expectedType);
+}
 
 TypeNode TheoryProof::equalityType(const Expr& left, const Expr& right)
 {

--- a/src/proof/theory_proof.cpp
+++ b/src/proof/theory_proof.cpp
@@ -186,9 +186,18 @@ void TheoryProofEngine::printTheoryTerm(Expr term,
 
 TypeNode TheoryProofEngine::equalityType(const Expr& left, const Expr& right)
 {
-  Assert(theory::Theory::theoryOf(left) == theory::Theory::theoryOf(right));
-  return getTheoryProof(theory::Theory::theoryOf(left))
-      ->equalityType(left, right);
+  // Ask the two theories what they think..
+  TypeNode leftType = getTheoryProof(theory::Theory::theoryOf(left))->equalityType(left, right);
+  TypeNode rightType = getTheoryProof(theory::Theory::theoryOf(right))->equalityType(left, right);
+
+  // Error if the disagree.
+  Assert(leftType.isNull() || rightType.isNull() || leftType == rightType)
+    << "TheoryProofEngine::equalityType(" << left << ", " << right << "):" << std::endl
+    << "theories disagree about the type of an equality:" << std::endl
+    << "\tleft: " << leftType << std::endl
+    << "\tright:" << rightType;
+
+  return leftType.isNull() ? rightType : leftType;
 }
 
 void TheoryProofEngine::registerTerm(Expr term) {
@@ -1386,7 +1395,11 @@ void TheoryProof::printOwnedTerm(Expr term,
 
 TypeNode TheoryProof::equalityType(const Expr& left, const Expr& right)
 {
-  Assert(left.getType() == right.getType());
+  Assert(left.getType() == right.getType())
+    << "TheoryProof::equalityType(" << left << ", " << right << "):" << std::endl
+    << "types disagree:" << std::endl
+    << "\tleft: " << left.getType() << std::endl
+    << "\tright:" << right.getType();
   return TypeNode::fromType(left.getType());
 }
 

--- a/src/proof/theory_proof.cpp
+++ b/src/proof/theory_proof.cpp
@@ -176,6 +176,20 @@ void TheoryProofEngine::printConstantDisequalityProof(std::ostream& os, Expr c1,
   getTheoryProof(theory::Theory::theoryOf(c1))->printConstantDisequalityProof(os, c1, c2, globalLetMap);
 }
 
+  void TheoryProofEngine::printTheoryTerm(Expr term,
+                       std::ostream& os,
+                       const ProofLetMap& map,
+                       TypeNode expectedType)
+  {
+    this->printTheoryTermAsType(term, os, map, expectedType);
+  }
+
+TypeNode TheoryProofEngine::equalityType(const Expr& left, const Expr& right)
+{
+  Assert(theory::Theory::theoryOf(left) == theory::Theory::theoryOf(right));
+  return getTheoryProof(theory::Theory::theoryOf(left))->equalityType(left, right);
+}
+
 void TheoryProofEngine::registerTerm(Expr term) {
   Debug("pf::tp::register") << "TheoryProofEngine::registerTerm: registering term: " << term << std::endl;
 
@@ -947,7 +961,7 @@ void LFSCTheoryProofEngine::printCoreTerm(Expr term,
 
   case kind::EQUAL: {
     bool booleanCase = term[0].getType().isBoolean();
-    TypeNode armType = TypeNode::fromType(term[0].getType());
+    TypeNode armType = equalityType(term[0], term[1]);
 
     os << "(";
     if (booleanCase) {
@@ -975,7 +989,7 @@ void LFSCTheoryProofEngine::printCoreTerm(Expr term,
   case kind::DISTINCT: {
     // Distinct nodes can have any number of chidlren.
     Assert(term.getNumChildren() >= 2);
-    TypeNode armType = TypeNode::fromType(term[0].getType());
+    TypeNode armType = equalityType(term[0], term[1]);
 
     if (term.getNumChildren() == 2) {
       os << "(not (= ";
@@ -993,6 +1007,7 @@ void LFSCTheoryProofEngine::printCoreTerm(Expr term,
 
       for (unsigned i = 0; i < term.getNumChildren(); ++i) {
         for (unsigned j = i + 1; j < term.getNumChildren(); ++j) {
+          TypeNode armType = equalityType(term[i], term[j]);
           if ((i != 0) || (j != 1)) {
             os << "(not (= ";
             printSort(term[0].getType(), os);
@@ -1351,6 +1366,20 @@ void TheoryProof::printRewriteProof(std::ostream& os, const Node &n1, const Node
   os << " ";
   d_proofEngine->printBoundTerm(n2.toExpr(), os, emptyMap);
   os << "))";
+}
+
+  void TheoryProof::printOwnedTerm(Expr term,
+                      std::ostream& os,
+                      const ProofLetMap& map,
+                      TypeNode expectedType)
+  {
+    this->printOwnedTermAsType(term, os, map, expectedType);
+  }
+
+TypeNode TheoryProof::equalityType(const Expr& left, const Expr& right)
+{
+  Assert(left.getType() == right.getType());
+  return TypeNode::fromType(left.getType());
 }
 
 bool TheoryProof::match(TNode n1, TNode n2)

--- a/src/proof/theory_proof.h
+++ b/src/proof/theory_proof.h
@@ -198,14 +198,15 @@ public:
   void printTheoryTerm(Expr term,
                        std::ostream& os,
                        const ProofLetMap& map,
-                       TypeNode expectedType = TypeNode())
-  {
-    this->printTheoryTermAsType(term, os, map, expectedType);
-  }
+                       TypeNode expectedType = TypeNode());
   virtual void printTheoryTermAsType(Expr term,
                                      std::ostream& os,
                                      const ProofLetMap& map,
                                      TypeNode expectedType) = 0;
+  /**
+   * Calls `TheoryProof::equalityType` on the appropriate theory.
+   */
+  TypeNode equalityType(const Expr& left, const Expr& right);
 
   bool printsAsBool(const Node &n);
 };
@@ -306,14 +307,27 @@ protected:
   void printOwnedTerm(Expr term,
                       std::ostream& os,
                       const ProofLetMap& map,
-                      TypeNode expectedType = TypeNode())
-  {
-    this->printOwnedTermAsType(term, os, map, expectedType);
-  }
+                      TypeNode expectedType = TypeNode());
+
   virtual void printOwnedTermAsType(Expr term,
                                     std::ostream& os,
                                     const ProofLetMap& map,
                                     TypeNode expectedType) = 0;
+
+  /**
+   * Return the type (at the SMT level, the sort) of an equality or disequality
+   * between `left` and `right`.
+   *
+   * The default implementation asserts that the two have the same type, and
+   * returns it.
+   *
+   * A theory may want to do something else.
+   *
+   * For example, the theory of arithmetic allows equalities between Reals and
+   * Integers. In this case the integer is upcast to a real, and the equality
+   * is over reals.
+   */
+  virtual TypeNode equalityType(const Expr& left, const Expr& right);
 
   /**
    * Print the proof representation of the given type that belongs to some theory.

--- a/src/proof/theory_proof.h
+++ b/src/proof/theory_proof.h
@@ -227,7 +227,7 @@ public:
   void printCoreTerm(Expr term,
                      std::ostream& os,
                      const ProofLetMap& map,
-                     Type expectedType = Type());
+                     TypeNode expectedType = TypeNode());
   void printLetTerm(Expr term, std::ostream& os) override;
   void printBoundTermAsType(Expr term,
                             std::ostream& os,


### PR DESCRIPTION
`TheoryProofEngine` now uses the `expectedType` optional argument.
  * When printing terms, it sets this for theories that it dispatches too
  * It occasionally asks theories for help determining the `expectedType` using `equalityType`, which has a sensible default implementation.
  * It is mindful of `expectedType` when using the let map.

I also moved to hpp function implementations into the cpp.