### PR TITLE
Fix invariant template inference for trivially infeasible conjecture

### DIFF
--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -163,7 +163,12 @@ void CegSingleInv::initialize(Node q)
   std::vector<Node> sivars;
   d_sip->getSingleInvocationVariables(sivars);
   Node invariant = d_sip->getFunctionInvocationFor(prog);
-  Assert(!invariant.isNull());
+  if (invariant.isNull())
+  {
+    // the conjecture did not have an instance of the invariant
+    // (e.g. it is trivially true/false).
+    return;
+  }
   invariant = invariant.substitute(sivars.begin(),
                                    sivars.end(),
                                    prog_templ_vars.begin(),

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -948,6 +948,7 @@ set(regress_0_tests
   regress0/sygus/no-syntax-test.sy
   regress0/sygus/parity-AIG-d0.sy
   regress0/sygus/parse-bv-let.sy
+  regress0/sygus/pbe-pred-contra.sy
   regress0/sygus/pLTL-sygus-syntax-err.sy
   regress0/sygus/real-si-all.sy
   regress0/sygus/sygus-no-wf.sy

--- a/test/regress/regress0/sygus/pbe-pred-contra.sy
+++ b/test/regress/regress0/sygus/pbe-pred-contra.sy
@@ -1,0 +1,7 @@
+; COMMAND_LINE: --cegqi-si=none --sygus-out=status
+; EXPECT: unknown
+(set-logic LIA)
+(synth-fun P ((x Int)) Bool)
+(constraint (P 54))
+(constraint (not (P 54)))
+(check-synth)


### PR DESCRIPTION
Was crashing if we had a trivially infeasible conjecture and disabled single invocation.