### PR TITLE
Regression tests for arithmetic proofs.

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -3,6 +3,11 @@
 
 set(regress_0_tests
   regress0/arith/ackermann.real.smt2
+  regress0/arith/arith-eq.smt2
+  regress0/arith/arith-mixed.smt2
+  regress0/arith/arith-strict.smt2
+  regress0/arith/arith-mixed-types-tighten.smt2
+  regress0/arith/arith-mixed-types-no-tighten.smt2
   regress0/arith/arith.01.cvc
   regress0/arith/arith.02.cvc
   regress0/arith/arith.03.cvc

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -5,6 +5,7 @@ set(regress_0_tests
   regress0/arith/ackermann.real.smt2
   regress0/arith/arith-eq.smt2
   regress0/arith/arith-mixed.smt2
+  regress0/arith/arith-tighten-1.smt2
   regress0/arith/arith-strict.smt2
   regress0/arith/arith-mixed-types-tighten.smt2
   regress0/arith/arith-mixed-types-no-tighten.smt2

--- a/test/regress/regress0/arith/arith-eq.smt2
+++ b/test/regress/regress0/arith/arith-eq.smt2
@@ -1,0 +1,15 @@
+; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; EXPECT: unsat
+(set-logic QF_LRA)
+(set-info :smt-lib-version 2.0)
+
+(declare-fun x () Real)
+(declare-fun y () Real)
+(declare-fun z () Real)
+
+(assert (= z 0))
+(assert (= (* 3 x) y))
+(assert (= (+ 1 (* 5 x)) y))
+(assert (= (+ 7 (* 4 x)) y))
+
+(check-sat)

--- a/test/regress/regress0/arith/arith-eq.smt2
+++ b/test/regress/regress0/arith/arith-eq.smt2
@@ -1,7 +1,6 @@
 ; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LRA)
-(set-info :smt-lib-version 2.0)
 
 (declare-fun x () Real)
 (declare-fun y () Real)

--- a/test/regress/regress0/arith/arith-eq.smt2
+++ b/test/regress/regress0/arith/arith-eq.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LRA)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
@@ -1,7 +1,6 @@
 ; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LIRA)
-(set-info :smt-lib-version 2.0)
 
 (declare-fun x () Real)
 (declare-fun n () Int)

--- a/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
@@ -1,0 +1,18 @@
+; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; EXPECT: unsat
+(set-logic QF_LIRA)
+(set-info :smt-lib-version 2.0)
+
+(declare-fun x () Real)
+(declare-fun n () Int)
+
+(assert
+    (and
+        (>= (+ x n) 1)
+        (<= n 0)
+        (<= x 0)
+    )
+)
+
+(check-sat)
+

--- a/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
@@ -6,6 +6,7 @@
 (declare-fun x () Real)
 (declare-fun n () Int)
 
+; Even though `n` is an integer, this would be UNSAT for real `n`, so the integrality can be ignored.
 (assert
     (and
         (>= (+ x n) 1)

--- a/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-no-tighten.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LIRA)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
@@ -1,7 +1,6 @@
 ; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LIRA)
-(set-info :smt-lib-version 2.0)
 
 (declare-fun x_44 () Real)
 (declare-fun x_45 () Real)

--- a/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
@@ -1,0 +1,31 @@
+; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; EXPECT: unsat
+(set-logic QF_LIRA)
+(set-info :smt-lib-version 2.0)
+
+(declare-fun x_44 () Real)
+(declare-fun x_45 () Real)
+
+(declare-fun termITE_30 () Int)
+(declare-fun termITE_3 () Real)
+(declare-fun termITE_4 () Real)
+(declare-fun termITE_8 () Real)
+(declare-fun termITE_9 () Real)
+(declare-fun termITE_31 () Int)
+
+(assert
+    (let ((_let_0 (* (- 1.0) termITE_3)))
+        (and
+            (>= (+ termITE_8 (* (- 1.0) termITE_9)) 0.0)
+            (not (>= termITE_31 2))
+            (>= (+ (* (- 1.0) x_44) (/ termITE_31 1)) 0.0)
+            (>= (+ x_44 (* (- 1.0) termITE_4)) 0.0)
+            (not (>= (+ _let_0 (* (/ 1 2) termITE_8)) 0.0))
+            (>= (+ (* (- 1.0) x_45) termITE_9) 0.0)
+            (>= (+ x_45 (/ (* (- 1) termITE_30) 1)) 0.0)
+            (>= termITE_30 2)
+            (>= (+ _let_0 termITE_4) 0.0)))
+)
+
+(check-sat)
+

--- a/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
@@ -6,6 +6,7 @@
 (declare-fun x_44 () Real)
 (declare-fun x_45 () Real)
 
+; This test is a subset of one of the `../lemmas` tests. I think `../lemmas/sc_init_frame_gap.induction.smtv1.smt2`.
 (declare-fun termITE_30 () Int)
 (declare-fun termITE_3 () Real)
 (declare-fun termITE_4 () Real)
@@ -17,6 +18,7 @@
     (let ((_let_0 (* (- 1.0) termITE_3)))
         (and
             (>= (+ termITE_8 (* (- 1.0) termITE_9)) 0.0)
+            ; This literal can be tightened to `termITE_31 <= 1`.
             (not (>= termITE_31 2))
             (>= (+ (* (- 1.0) x_44) (/ termITE_31 1)) 0.0)
             (>= (+ x_44 (* (- 1.0) termITE_4)) 0.0)

--- a/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
+++ b/test/regress/regress0/arith/arith-mixed-types-tighten.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LIRA)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/arith/arith-mixed.smt2
+++ b/test/regress/regress0/arith/arith-mixed.smt2
@@ -1,7 +1,6 @@
 ; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LRA)
-(set-info :smt-lib-version 2.0)
 
 (declare-fun x () Real)
 (declare-fun y () Real)

--- a/test/regress/regress0/arith/arith-mixed.smt2
+++ b/test/regress/regress0/arith/arith-mixed.smt2
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; EXPECT: unsat
+(set-logic QF_LRA)
+(set-info :smt-lib-version 2.0)
+
+(declare-fun x () Real)
+(declare-fun y () Real)
+(declare-fun z () Real)
+
+(assert (< y 0))
+(assert (>= y x))
+(assert (>= y (- x)))
+
+(check-sat)

--- a/test/regress/regress0/arith/arith-mixed.smt2
+++ b/test/regress/regress0/arith/arith-mixed.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LRA)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/arith/arith-mixed.smt2
+++ b/test/regress/regress0/arith/arith-mixed.smt2
@@ -7,6 +7,7 @@
 (declare-fun y () Real)
 (declare-fun z () Real)
 
+; Both strict and non-strict inequalities.
 (assert (< y 0))
 (assert (>= y x))
 (assert (>= y (- x)))

--- a/test/regress/regress0/arith/arith-strict.smt2
+++ b/test/regress/regress0/arith/arith-strict.smt2
@@ -1,0 +1,14 @@
+; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; EXPECT: unsat
+(set-logic QF_LRA)
+(set-info :smt-lib-version 2.0)
+
+(declare-fun x () Real)
+(declare-fun y () Real)
+(declare-fun z () Real)
+
+(assert (< y 0))
+(assert (> y x))
+(assert (> y (- x)))
+
+(check-sat)

--- a/test/regress/regress0/arith/arith-strict.smt2
+++ b/test/regress/regress0/arith/arith-strict.smt2
@@ -1,7 +1,6 @@
 ; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LRA)
-(set-info :smt-lib-version 2.0)
 
 (declare-fun x () Real)
 (declare-fun y () Real)

--- a/test/regress/regress0/arith/arith-strict.smt2
+++ b/test/regress/regress0/arith/arith-strict.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LRA)
 (set-info :smt-lib-version 2.0)

--- a/test/regress/regress0/arith/arith-tighten-1.smt2
+++ b/test/regress/regress0/arith/arith-tighten-1.smt2
@@ -1,0 +1,18 @@
+; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; EXPECT: unsat
+(set-logic QF_LIRA)
+(set-info :smt-lib-version 2.0)
+
+(declare-fun n () Int)
+
+; tests tightenings of the form [Int] >= r   to [Int] >= ceiling(r)
+; where r is a real.
+(assert
+    (and
+        (>= n 1.5)
+        (<= n 1.9)
+    )
+)
+
+(check-sat)
+

--- a/test/regress/regress0/arith/arith-tighten-1.smt2
+++ b/test/regress/regress0/arith/arith-tighten-1.smt2
@@ -1,7 +1,6 @@
 ; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LIRA)
-(set-info :smt-lib-version 2.0)
 
 (declare-fun n () Int)
 

--- a/test/regress/regress0/arith/arith-tighten-1.smt2
+++ b/test/regress/regress0/arith/arith-tighten-1.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --no-check-models  --no-check-unsat-cores --no-check-proofs
+; COMMAND-LINE: --no-check-unsat-cores --no-check-proofs
 ; EXPECT: unsat
 (set-logic QF_LIRA)
 (set-info :smt-lib-version 2.0)


### PR DESCRIPTION
These tests are designed to test interesting cases of arithmetic proofs,
such as mixing integers and reals, equalities, and tightening bounds.

Right now, they have the --no-check-proofs flag set, which prevents them
from testing the proof machinery. However, once we check that machinery
into master, we'll remove that flag, thus enabling the full effect of
the tests.