### PR TITLE
Utility function for getting component types

### DIFF
--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -526,17 +526,23 @@ Node substituteCaptureAvoiding(TNode n,
 void getComponentTypes(
     TypeNode t, std::unordered_set<TypeNode, TypeNodeHashFunction>& types)
 {
-  if (types.find(t) != types.end())
+  std::vector<TypeNode> toProcess;
+  toProcess.push_back(t);
+  do
   {
-    // already visited
-    return;
-  }
-  types.insert(t);
-  // otherwise, we get component types from the children
-  for (unsigned i = 0, nchild = t.getNumChildren(); i < nchild; i++)
-  {
-    getComponentTypes(t[i], types);
-  }
+    TypeNode curr = toProcess.back();
+    toProcess.pop_back();
+    // if not already visited
+    if (types.find(t) == types.end())
+    {
+      types.insert(t);
+      // get component types from the children
+      for (unsigned i = 0, nchild = t.getNumChildren(); i < nchild; i++)
+      {
+        toProcess.push_back(t[i]);
+      }
+    }
+  } while (!toProcess.empty());
 }
 
 }  // namespace expr

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -18,6 +18,7 @@
 #include "expr/node_algorithm.h"
 
 #include "expr/attribute.h"
+#include "expr/dtype.h"
 
 namespace CVC4 {
 namespace expr {
@@ -520,6 +521,22 @@ Node substituteCaptureAvoiding(TNode n,
   } while (!visit.empty());
   Assert(visited.find(n) != visited.end());
   return visited[n];
+}
+
+void getComponentTypes(
+    TypeNode t, std::unordered_set<TypeNode, TypeNodeHashFunction>& types)
+{
+  if (types.find(t) != types.end())
+  {
+    // already visited
+    return;
+  }
+  types.insert(t);
+  // otherwise, we get component types from the children
+  for (unsigned i = 0, nchild = t.getNumChildren(); i < nchild; i++)
+  {
+    getComponentTypes(t[i], types);
+  }
 }
 
 }  // namespace expr

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -151,6 +151,15 @@ Node substituteCaptureAvoiding(TNode n,
                                std::vector<Node>& src,
                                std::vector<Node>& dest);
 
+/**
+ * Get component types in type t. This adds the types that t is built from.
+ * For example, if t is (Array T1 T2), then T1 and T2 are component types of t.
+ * @param t The type node under investigation
+ * @param types The set which component types are added to.
+ */
+void getComponentTypes(
+    TypeNode t, std::unordered_set<TypeNode, TypeNodeHashFunction>& types);
+
 }  // namespace expr
 }  // namespace CVC4
 

--- a/src/expr/node_algorithm.h
+++ b/src/expr/node_algorithm.h
@@ -152,8 +152,9 @@ Node substituteCaptureAvoiding(TNode n,
                                std::vector<Node>& dest);
 
 /**
- * Get component types in type t. This adds the types that t is built from.
- * For example, if t is (Array T1 T2), then T1 and T2 are component types of t.
+ * Get component types in type t. This adds all types that are subterms of t
+ * when viewed as a term. For example, if t is (Array T1 T2), then
+ * (Array T1 T2), T1 and T2 are component types of t.
  * @param t The type node under investigation
  * @param types The set which component types are added to.
  */


### PR DESCRIPTION
Towards experimental support for non-simply recursive datatypes (https://github.com/ajreynol/CVC4/tree/dtNonSimpleRec).  Adds a necessary utility function for collecting the "component types" of a type.