### PR TITLE
Revert semantic change from refactoring

### DIFF
--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -1629,7 +1629,7 @@ void TheoryStrings::checkExtfEval( int effort ) {
             Trace("strings-extf") << "  resolve extf : " << sn << " -> " << nrc << std::endl;
             d_im.sendInference(
                 einfo.d_exp, conc, effort == 0 ? "EXTF" : "EXTF-N", true);
-            if (!d_state.isInConflict())
+            if (d_state.isInConflict())
             {
               Trace("strings-extf-debug") << "  conflict, return." << std::endl;
               return;


### PR DESCRIPTION
In PR #3398, a minor change was introduced: One of the checks for
whether there is a conflict or not was flipped
(https://github.com/CVC4/CVC4/pull/3398/files#diff-62fffb0d9df0385909621e424bdcef72R1652). This commit reverts that change.