### PR TITLE
Fix case where approximation for sqrt is exact

### DIFF
--- a/src/theory/arith/nl_model.cpp
+++ b/src/theory/arith/nl_model.cpp
@@ -1200,8 +1200,8 @@ bool NlModel::getApproximateSqrt(Node c, Node& l, Node& u, unsigned iter) const
     Rational curr_sq = curr * curr;
     if (curr_sq == rc)
     {
-      rl = curr_sq;
-      ru = curr_sq;
+      rl = curr;
+      ru = curr;
       break;
     }
     else if (curr_sq < rc)

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -558,6 +558,7 @@ set(regress_0_tests
   regress0/nl/issue3411.smt2
   regress0/nl/issue3475.smt2
   regress0/nl/issue3652.smt2
+  regress0/nl/issue3719.smt2
   regress0/nl/magnitude-wrong-1020-m.smt2
   regress0/nl/mult-po.smt2
   regress0/nl/nia-wrong-tl.smt2

--- a/test/regress/regress0/nl/issue3719.smt2
+++ b/test/regress/regress0/nl/issue3719.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_NRA)
+(set-info :status sat)
+(declare-fun a () Real)
+(assert (= (* 4 a a) 9))
+(check-sat)


### PR DESCRIPTION
Fixes #3719. 

This was triggered by a case where the approximate computation for a sqrt was exact (e.g. sqrt(9)=3 in this example).