### PR TITLE
Fix rewrite rules sat regressions

### DIFF
--- a/test/regress/regress1/rewriterules/datatypes_sat.smt2
+++ b/test/regress/regress1/rewriterules/datatypes_sat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --rewrite-rules --quiet
+; COMMAND-LINE: --rewrite-rules --no-check-models
 ;; try to solve datatypes with rewriterules
 (set-logic AUFLIA)
 (set-info :status sat)

--- a/test/regress/regress1/rewriterules/length_gen_020_sat.smt2
+++ b/test/regress/regress1/rewriterules/length_gen_020_sat.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --rewrite-rules --quiet
+; COMMAND-LINE: --rewrite-rules --no-check-models
 ;; Same than length.smt2 but the nil case is not a rewrite rule
 ;; So here the rewrite rules have no guards length
 


### PR DESCRIPTION
Quantifier rewrite rules are not robust to preprocessing within our check-model infrastructure. This disables check-model on 2 satisfiable rewrite rules regressions.  Fixes nightlies.