### PR TITLE
Remove `--strings-binary-csp` option

### DIFF
--- a/src/options/strings_options.toml
+++ b/src/options/strings_options.toml
@@ -190,15 +190,6 @@ header = "options/strings_options.h"
   help       = "use model guessing to avoid string extended function reductions"
 
 [[option]]
-  name       = "stringBinaryCsp"
-  category   = "regular"
-  long       = "strings-binary-csp"
-  type       = "bool"
-  default    = "false"
-  read_only  = true
-  help       = "use binary search when splitting strings"
-
-[[option]]
   name       = "stringLenPropCsp"
   category   = "regular"
   long       = "strings-lprop-csp"

--- a/src/theory/strings/infer_info.cpp
+++ b/src/theory/strings/infer_info.cpp
@@ -29,7 +29,6 @@ std::ostream& operator<<(std::ostream& out, Inference i)
     case INFER_SSPLIT_VAR_PROP: out << "S-Split(VAR)-prop"; break;
     case INFER_LEN_SPLIT: out << "Len-Split(Len)"; break;
     case INFER_LEN_SPLIT_EMP: out << "Len-Split(Emp)"; break;
-    case INFER_SSPLIT_CST_BINARY: out << "S-Split(CST-P)-binary"; break;
     case INFER_SSPLIT_CST: out << "S-Split(CST-P)"; break;
     case INFER_SSPLIT_VAR: out << "S-Split(VAR)"; break;
     case INFER_FLOOP: out << "F-Loop"; break;

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -57,11 +57,6 @@ enum Inference
   //     z = "" V z != ""
   // This is inferred when, e.g. x = y, x = z ++ x1, y = y1 ++ z
   INFER_LEN_SPLIT_EMP,
-  // string split constant binary, for example:
-  //     x1 = "aaaa" ++ x1' V "aaaa" = x1 ++ x1'
-  // This is inferred when, e.g. x = y, x = x1 ++ x2, y = "aaaaaaaa" ++ y2.
-  // This inference is disabled by default and is enabled by stringBinaryCsp().
-  INFER_SSPLIT_CST_BINARY,
   // string split constant
   //    x = y, x = "c" ++ x2, y = y1 ++ y2, y1 != ""
   //      implies y1 = "c" ++ y1'

--- a/src/theory/strings/skolem_cache.h
+++ b/src/theory/strings/skolem_cache.h
@@ -59,10 +59,6 @@ class SkolemCache
     //    exists k. a = "c" ++ k
     SK_ID_VC_SPT,
     SK_ID_VC_SPT_REV,
-    // a != "" ^ b = "cccccccc" ^ len(a)!=len(b) a ++ a' = b = b' =>
-    //    exists k. a = "cccc" ++ k OR ( len(k) > 0 ^ "cccc" = a ++ k )
-    SK_ID_VC_BIN_SPT,
-    SK_ID_VC_BIN_SPT_REV,
     // a != "" ^ b != "" ^ len(a)!=len(b) ^ a ++ a' = b ++ b' =>
     //    exists k. len( k )>0 ^ ( a ++ k = b OR a = b ++ k )
     SK_ID_V_SPT,


### PR DESCRIPTION
This commit removes the `--strings-binary-csp` option, which was
splitting a long constant into two halves instead of splitting off
characters one-by-one. The option wasn't really used.