### PR TITLE
Fix large models for strings

### DIFF
--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -304,8 +304,13 @@ bool TheoryStrings::collectModelInfo(TheoryModel* m)
     }
     else
     {
-      Assert(len_value.getConst<Rational>() <= Rational(String::maxSize()))
-          << "Exceeded UINT32_MAX in string model";
+      // must throw logic exception if we cannot construct the string
+      if (len_value.getConst<Rational>() > Rational(String::maxSize()))
+      {
+        std::stringstream ss;
+        ss << "Cannot generate model with string whose length exceeds UINT32_MAX";
+        throw LogicException(ss.str());
+      }
       unsigned lvalue =
           len_value.getConst<Rational>().getNumerator().toUnsignedInt();
       std::map<unsigned, Node>::iterator itvu = values_used.find(lvalue);

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -913,6 +913,7 @@ set(regress_0_tests
   regress0/strings/issue3497.smt2
   regress0/strings/issue3657-evalLeq.smt2
   regress0/strings/itos-entail.smt2
+  regress0/strings/large-model.smt2
   regress0/strings/leadingzero001.smt2
   regress0/strings/loop001.smt2
   regress0/strings/model001.smt2

--- a/test/regress/regress0/strings/large-model.smt2
+++ b/test/regress/regress0/strings/large-model.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --lang=smt2.6.1 --check-models
+; EXPECT: (error "Cannot generate model with string whose length exceeds UINT32_MAX")
+; EXIT: 1
+(set-logic SLIA)
+(declare-fun x () String)
+(assert (> (str.len x) 100000000000000000000000000000000000000000000000000))
+(check-sat)


### PR DESCRIPTION
Fixes #3375. 

Marking as "major" since in fact we produce incorrect models in production without the fix.