### PR TITLE
Replace conditional rewrite pass in quantifiers with the extended rewriter

### DIFF
--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -193,7 +193,7 @@ header = "options/quantifiers_options.h"
   category   = "regular"
   long       = "ext-rewrite-quant"
   type       = "bool"
-  default    = "true"
+  default    = "false"
   read_only  = true
   help       = "apply extended rewriting to bodies of quantified formulas"
 

--- a/src/options/quantifiers_options.toml
+++ b/src/options/quantifiers_options.toml
@@ -189,13 +189,13 @@ header = "options/quantifiers_options.h"
   help       = "eliminate extended arithmetic symbols in quantified formulas"
 
 [[option]]
-  name       = "condRewriteQuant"
+  name       = "extRewriteQuant"
   category   = "regular"
-  long       = "cond-rewrite-quant"
+  long       = "ext-rewrite-quant"
   type       = "bool"
   default    = "true"
   read_only  = true
-  help       = "conditional rewriting of quantified formulas"
+  help       = "apply extended rewriting to bodies of quantified formulas"
 
 [[option]]
   name       = "globalNegate"

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -21,12 +21,12 @@
 #include "theory/datatypes/theory_datatypes_utils.h"
 #include "theory/quantifiers/bv_inverter.h"
 #include "theory/quantifiers/ematching/trigger.h"
+#include "theory/quantifiers/extended_rewrite.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/skolemize.h"
 #include "theory/quantifiers/term_database.h"
 #include "theory/quantifiers/term_util.h"
 #include "theory/strings/theory_strings_utils.h"
-#include "theory/quantifiers/extended_rewrite.h"
 
 using namespace std;
 using namespace CVC4::kind;
@@ -45,7 +45,7 @@ std::ostream& operator<<(std::ostream& out, RewriteStep s)
     case COMPUTE_AGGRESSIVE_MINISCOPING:
       out << "COMPUTE_AGGRESSIVE_MINISCOPING";
       break;
-    case COMPUTE_EXT_REWRITE: out << "COMPUTE_EXT_REWRITE";break;
+    case COMPUTE_EXT_REWRITE: out << "COMPUTE_EXT_REWRITE"; break;
     case COMPUTE_PROCESS_TERMS: out << "COMPUTE_PROCESS_TERMS"; break;
     case COMPUTE_PRENEX: out << "COMPUTE_PRENEX"; break;
     case COMPUTE_VAR_ELIMINATION: out << "COMPUTE_VAR_ELIMINATION"; break;
@@ -601,16 +601,16 @@ Node QuantifiersRewriter::computeExtendedRewrite(Node q)
   // apply extended rewriter
   ExtendedRewriter er;
   Node bodyr = er.extendedRewrite(body);
-  if (body!=bodyr)
+  if (body != bodyr)
   {
     std::vector<Node> children;
     children.push_back(q[0]);
     children.push_back(bodyr);
-    if (q.getNumChildren()==3)
+    if (q.getNumChildren() == 3)
     {
       children.push_back(q[2]);
     }
-    return NodeManager::currentNM()->mkNode(FORALL,children);
+    return NodeManager::currentNM()->mkNode(FORALL, children);
   }
   return q;
 }
@@ -1900,18 +1900,26 @@ Node QuantifiersRewriter::computeOperation(Node f,
     return computeMiniscoping( args, n, qa );
   }else if( computeOption==COMPUTE_AGGRESSIVE_MINISCOPING ){
     return computeAggressiveMiniscoping( args, n );
-  }else if (computeOption == COMPUTE_EXT_REWRITE){
+  }
+  else if (computeOption == COMPUTE_EXT_REWRITE)
+  {
     return computeExtendedRewrite(f);
-  }else if( computeOption==COMPUTE_PROCESS_TERMS ){
+  }
+  else if (computeOption == COMPUTE_PROCESS_TERMS)
+  {
     std::vector< Node > new_conds;
     n = computeProcessTerms( n, args, new_conds, f, qa );
     if( !new_conds.empty() ){
       new_conds.push_back( n );
       n = NodeManager::currentNM()->mkNode( OR, new_conds );
     }
-  }else if( computeOption==COMPUTE_COND_SPLIT ){
+  }
+  else if (computeOption == COMPUTE_COND_SPLIT)
+  {
     n = computeCondSplit(n, args, qa);
-  }else if( computeOption==COMPUTE_PRENEX ){
+  }
+  else if (computeOption == COMPUTE_PRENEX)
+  {
     if (options::prenexQuant() == options::PrenexQuantMode::DISJ_NORMAL
         || options::prenexQuant() == options::PrenexQuantMode::NORMAL)
     {
@@ -1924,7 +1932,9 @@ Node QuantifiersRewriter::computeOperation(Node f,
       n = computePrenex( n, args, nargs, true, false );
       Assert(nargs.empty());
     }
-  }else if( computeOption==COMPUTE_VAR_ELIMINATION ){
+  }
+  else if (computeOption == COMPUTE_VAR_ELIMINATION)
+  {
     n = computeVarElimination( n, args, qa );
   }
   Trace("quantifiers-rewrite-debug") << "Compute Operation: return " << n << ", " << args.size() << std::endl;

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -391,7 +391,6 @@ void QuantifiersRewriter::computeDtTesterIteSplit( Node n, std::map< Node, Node 
 
 Node QuantifiersRewriter::computeProcessTerms( Node body, std::vector< Node >& new_vars, std::vector< Node >& new_conds, Node q, QAttributes& qa ){
   std::map< Node, Node > cache;
-  std::map< Node, Node > icache;
   if( qa.isFunDef() ){
     Node h = QuantAttributes::getFunDefHead( q );
     Assert(!h.isNull());
@@ -402,7 +401,6 @@ Node QuantifiersRewriter::computeProcessTerms( Node body, std::vector< Node >& n
     {
       Node r = computeProcessTerms2(fbody,
                                     cache,
-                                    icache,
                                     new_vars,
                                     new_conds,
                                     false);
@@ -415,14 +413,13 @@ Node QuantifiersRewriter::computeProcessTerms( Node body, std::vector< Node >& n
   }
   return computeProcessTerms2(body,
                               cache,
-                              icache,
                               new_vars,
                               new_conds,
                               options::elimExtArithQuant());
 }
 
 Node QuantifiersRewriter::computeProcessTerms2( Node body, 
-                                                std::map< Node, Node >& cache, std::map< Node, Node >& icache,
+                                                std::map< Node, Node >& cache,
                                                 std::vector< Node >& new_vars, std::vector< Node >& new_conds, bool elimExtArith ) {
   NodeManager* nm = NodeManager::currentNM();
   Trace("quantifiers-rewrite-term-debug2") << "computeProcessTerms " << body << std::endl;
@@ -434,7 +431,7 @@ Node QuantifiersRewriter::computeProcessTerms2( Node body,
   std::vector< Node > children;
   for( size_t i=0; i<body.getNumChildren(); i++ ){
     //do the recursive call on children
-    Node nn = computeProcessTerms2( body[i], cache, icache, new_vars, new_conds, elimExtArith );
+    Node nn = computeProcessTerms2( body[i], cache, new_vars, new_conds, elimExtArith );
     children.push_back( nn );
     changed = changed || nn!=body[i];
   }

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -34,20 +34,21 @@ using namespace CVC4::context;
 namespace CVC4 {
 namespace theory {
 namespace quantifiers {
-  
+
 std::ostream& operator<<(std::ostream& out, RewriteStep s)
 {
   switch (s)
   {
-    case COMPUTE_ELIM_SYMBOLS:out << "COMPUTE_ELIM_SYMBOLS";break;
-  case COMPUTE_MINISCOPING:out << "COMPUTE_MINISCOPING";break;
-  case COMPUTE_AGGRESSIVE_MINISCOPING:out << "COMPUTE_AGGRESSIVE_MINISCOPING";break;
-  case COMPUTE_PROCESS_TERMS:out << "COMPUTE_PROCESS_TERMS";break;
-  case COMPUTE_PRENEX:out << "COMPUTE_PRENEX";break;
-  case COMPUTE_VAR_ELIMINATION:out << "COMPUTE_VAR_ELIMINATION";break;
-  case COMPUTE_COND_SPLIT:out << "COMPUTE_COND_SPLIT";break;
-  default: out << "UnknownRewriteStep";
-  break;
+    case COMPUTE_ELIM_SYMBOLS: out << "COMPUTE_ELIM_SYMBOLS"; break;
+    case COMPUTE_MINISCOPING: out << "COMPUTE_MINISCOPING"; break;
+    case COMPUTE_AGGRESSIVE_MINISCOPING:
+      out << "COMPUTE_AGGRESSIVE_MINISCOPING";
+      break;
+    case COMPUTE_PROCESS_TERMS: out << "COMPUTE_PROCESS_TERMS"; break;
+    case COMPUTE_PRENEX: out << "COMPUTE_PRENEX"; break;
+    case COMPUTE_VAR_ELIMINATION: out << "COMPUTE_VAR_ELIMINATION"; break;
+    case COMPUTE_COND_SPLIT: out << "COMPUTE_COND_SPLIT"; break;
+    default: out << "UnknownRewriteStep"; break;
   }
   return out;
 }
@@ -202,7 +203,8 @@ RewriteResponse QuantifiersRewriter::postRewrite(TNode in) {
       //compute attributes
       QAttributes qa;
       QuantAttributes::computeQuantAttributes( in, qa );
-      for( unsigned i=0; i<COMPUTE_LAST; ++i ){
+      for (unsigned i = 0; i < COMPUTE_LAST; ++i)
+      {
         RewriteStep op = static_cast<RewriteStep>(i);
         if( doOperation( in, op, qa ) ){
           ret = computeOperation( in, op, qa );
@@ -1996,7 +1998,10 @@ Node QuantifiersRewriter::computeAggressiveMiniscoping( std::vector< Node >& arg
   return mkForAll( args, body, qa );
 }
 
-bool QuantifiersRewriter::doOperation( Node q, RewriteStep computeOption, QAttributes& qa ){
+bool QuantifiersRewriter::doOperation(Node q,
+                                      RewriteStep computeOption,
+                                      QAttributes& qa)
+{
   bool is_strict_trigger =
       qa.d_hasPattern
       && options::userPatternsQuant() == options::UserPatMode::TRUST;
@@ -2039,7 +2044,10 @@ bool QuantifiersRewriter::doOperation( Node q, RewriteStep computeOption, QAttri
 }
 
 //general method for computing various rewrites
-Node QuantifiersRewriter::computeOperation( Node f, RewriteStep computeOption, QAttributes& qa ){
+Node QuantifiersRewriter::computeOperation(Node f,
+                                           RewriteStep computeOption,
+                                           QAttributes& qa)
+{
   Trace("quantifiers-rewrite-debug") << "Compute operation " << computeOption << " on " << f << " " << qa.d_qid_num << std::endl;
   std::vector< Node > args;
   for( unsigned i=0; i<f[0].getNumChildren(); i++ ){

--- a/src/theory/quantifiers/quantifiers_rewriter.cpp
+++ b/src/theory/quantifiers/quantifiers_rewriter.cpp
@@ -34,6 +34,23 @@ using namespace CVC4::context;
 namespace CVC4 {
 namespace theory {
 namespace quantifiers {
+  
+std::ostream& operator<<(std::ostream& out, RewriteStep s)
+{
+  switch (s)
+  {
+    case COMPUTE_ELIM_SYMBOLS:out << "COMPUTE_ELIM_SYMBOLS";break;
+  case COMPUTE_MINISCOPING:out << "COMPUTE_MINISCOPING";break;
+  case COMPUTE_AGGRESSIVE_MINISCOPING:out << "COMPUTE_AGGRESSIVE_MINISCOPING";break;
+  case COMPUTE_PROCESS_TERMS:out << "COMPUTE_PROCESS_TERMS";break;
+  case COMPUTE_PRENEX:out << "COMPUTE_PRENEX";break;
+  case COMPUTE_VAR_ELIMINATION:out << "COMPUTE_VAR_ELIMINATION";break;
+  case COMPUTE_COND_SPLIT:out << "COMPUTE_COND_SPLIT";break;
+  default: out << "UnknownRewriteStep";
+  break;
+  }
+  return out;
+}
 
 bool QuantifiersRewriter::isLiteral( Node n ){
   switch( n.getKind() ){
@@ -166,7 +183,7 @@ RewriteResponse QuantifiersRewriter::postRewrite(TNode in) {
   Trace("quantifiers-rewrite-debug") << "post-rewriting " << in << std::endl;
   RewriteStatus status = REWRITE_DONE;
   Node ret = in;
-  int rew_op = -1;
+  RewriteStep rew_op = COMPUTE_LAST;
   //get the body
   if( in.getKind()==EXISTS ){
     std::vector< Node > children;
@@ -185,7 +202,8 @@ RewriteResponse QuantifiersRewriter::postRewrite(TNode in) {
       //compute attributes
       QAttributes qa;
       QuantAttributes::computeQuantAttributes( in, qa );
-      for( int op=0; op<COMPUTE_LAST; op++ ){
+      for( unsigned i=0; i<COMPUTE_LAST; ++i ){
+        RewriteStep op = static_cast<RewriteStep>(i);
         if( doOperation( in, op, qa ) ){
           ret = computeOperation( in, op, qa );
           if( ret!=in ){
@@ -1978,7 +1996,7 @@ Node QuantifiersRewriter::computeAggressiveMiniscoping( std::vector< Node >& arg
   return mkForAll( args, body, qa );
 }
 
-bool QuantifiersRewriter::doOperation( Node q, int computeOption, QAttributes& qa ){
+bool QuantifiersRewriter::doOperation( Node q, RewriteStep computeOption, QAttributes& qa ){
   bool is_strict_trigger =
       qa.d_hasPattern
       && options::userPatternsQuant() == options::UserPatMode::TRUST;
@@ -2021,7 +2039,7 @@ bool QuantifiersRewriter::doOperation( Node q, int computeOption, QAttributes& q
 }
 
 //general method for computing various rewrites
-Node QuantifiersRewriter::computeOperation( Node f, int computeOption, QAttributes& qa ){
+Node QuantifiersRewriter::computeOperation( Node f, RewriteStep computeOption, QAttributes& qa ){
   Trace("quantifiers-rewrite-debug") << "Compute operation " << computeOption << " on " << f << " " << qa.d_qid_num << std::endl;
   std::vector< Node > args;
   for( unsigned i=0; i<f[0].getNumChildren(); i++ ){

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -151,7 +151,6 @@ class QuantifiersRewriter : public TheoryRewriter
                              Node ipl);
   static Node computeProcessTerms2(Node body,
                                    std::map<Node, Node>& cache,
-                                   std::map<Node, Node>& icache,
                                    std::vector<Node>& new_vars,
                                    std::vector<Node>& new_conds,
                                    bool elimExtArith);
@@ -197,12 +196,29 @@ class QuantifiersRewriter : public TheoryRewriter
                                const std::vector<Node>& args,
                                QAttributes& qa);
   //-------------------------------------end conditional splitting
+  //------------------------------------- process terms
+  /** compute process terms
+   * 
+   * This takes as input a quantified formula q with attributes qa whose
+   * body is body.
+   * 
+   * This rewrite steps eliminates problematic terms from the bodies of
+   * quantified formulas, which includes performing:
+   * - Certain cases of ITE lifting,
+   * - Elimination of extended arithmetic functions like to_int/is_int/div/mod,
+   * - Elimination of select over store.
+   * 
+   * It may introduce new variables V into new_vars and new conditions C into
+   * new_conds. It returns a node retBody such that q of the form
+   *   forall X. body
+   * is equivalent to:
+   *   forall X, V. ( C => retBody )
+   */
+  static Node computeProcessTerms( Node body, std::vector< Node >& new_vars, std::vector< Node >& new_conds, Node q, QAttributes& qa );
  public:
   static Node computeElimSymbols( Node body );
   static Node computeMiniscoping( std::vector< Node >& args, Node body, QAttributes& qa );
   static Node computeAggressiveMiniscoping( std::vector< Node >& args, Node body );
-  //cache is dependent upon currCond, icache is not, new_conds are negated conditions
-  static Node computeProcessTerms( Node body, std::vector< Node >& new_vars, std::vector< Node >& new_conds, Node q, QAttributes& qa );
   static Node computePrenex( Node body, std::vector< Node >& args, std::vector< Node >& nargs, bool pol, bool prenexAgg );
   static Node computePrenexAgg( Node n, bool topLevel, std::map< unsigned, std::map< Node, Node > >& visited );
   static Node computeSplit( std::vector< Node >& args, Node body, QAttributes& qa );

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -219,6 +219,7 @@ class QuantifiersRewriter : public TheoryRewriter
                                   std::vector<Node>& new_conds,
                                   Node q,
                                   QAttributes& qa);
+  //------------------------------------- end process terms
 
  public:
   static Node computeElimSymbols( Node body );

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -150,8 +150,6 @@ class QuantifiersRewriter : public TheoryRewriter
                              Node n,
                              Node ipl);
   static Node computeProcessTerms2(Node body,
-                                   bool hasPol,
-                                   bool pol,
                                    std::map<Node, bool>& currCond,
                                    int nCurrCond,
                                    std::map<Node, Node>& cache,

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -204,7 +204,7 @@ class QuantifiersRewriter : public TheoryRewriter
    * This takes as input a quantified formula q with attributes qa whose
    * body is body.
    *
-   * This rewrite steps eliminates problematic terms from the bodies of
+   * This rewrite eliminates problematic terms from the bodies of
    * quantified formulas, which includes performing:
    * - Certain cases of ITE lifting,
    * - Elimination of extended arithmetic functions like to_int/is_int/div/mod,
@@ -225,7 +225,7 @@ class QuantifiersRewriter : public TheoryRewriter
   //------------------------------------- extended rewrite
   /** compute extended rewrite
    *
-   * This returns the result of apply the extended rewriter on the body
+   * This returns the result of applying the extended rewriter on the body
    * of quantified formula q.
    */
   static Node computeExtendedRewrite(Node q);

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -27,7 +27,7 @@ namespace quantifiers {
 
 struct QAttributes;
 
-/** 
+/**
  * List of steps used by the quantifiers rewriter, details on these steps
  * can be found in the class below.
  */
@@ -39,9 +39,9 @@ enum RewriteStep
   COMPUTE_MINISCOPING,
   /** Aggressive miniscoping */
   COMPUTE_AGGRESSIVE_MINISCOPING,
-  /** 
+  /**
    * Term processing (e.g. simplifying terms based on ITE conditions,
-   * eliminating extended arithmetic symbols). 
+   * eliminating extended arithmetic symbols).
    */
   COMPUTE_PROCESS_TERMS,
   /** Prenexing */
@@ -54,7 +54,6 @@ enum RewriteStep
   COMPUTE_LAST
 };
 std::ostream& operator<<(std::ostream& out, RewriteStep s);
-
 
 class QuantifiersRewriter : public TheoryRewriter
 {
@@ -212,14 +211,18 @@ class QuantifiersRewriter : public TheoryRewriter
   static Node computePrenexAgg( Node n, bool topLevel, std::map< unsigned, std::map< Node, Node > >& visited );
   static Node computeSplit( std::vector< Node >& args, Node body, QAttributes& qa );
 private:
-  static Node computeOperation( Node f, RewriteStep computeOption, QAttributes& qa );
+ static Node computeOperation(Node f,
+                              RewriteStep computeOption,
+                              QAttributes& qa);
+
 public:
  RewriteResponse preRewrite(TNode in) override;
  RewriteResponse postRewrite(TNode in) override;
 
 private:
   /** options */
-  static bool doOperation( Node f, RewriteStep computeOption, QAttributes& qa );
+ static bool doOperation(Node f, RewriteStep computeOption, QAttributes& qa);
+
 private:
   static Node preSkolemizeQuantifiers(Node n, bool polarity, std::vector< TypeNode >& fvTypes, std::vector<TNode>& fvs);
 public:

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -39,8 +39,10 @@ enum RewriteStep
   COMPUTE_MINISCOPING,
   /** Aggressive miniscoping */
   COMPUTE_AGGRESSIVE_MINISCOPING,
+  /** Apply the extended rewriter to quantified formula bodies */
+  COMPUTE_EXT_REWRITE,
   /**
-   * Term processing (e.g. simplifying terms based on ITE conditions,
+   * Term processing (e.g. simplifying terms based on ITE lifting,
    * eliminating extended arithmetic symbols).
    */
   COMPUTE_PROCESS_TERMS,
@@ -220,7 +222,14 @@ class QuantifiersRewriter : public TheoryRewriter
                                   Node q,
                                   QAttributes& qa);
   //------------------------------------- end process terms
-
+  //------------------------------------- extended rewrite
+  /** compute extended rewrite
+   *
+   * This returns the result of apply the extended rewriter on the body
+   * of quantified formula q.
+   */
+  static Node computeExtendedRewrite(Node q);
+  //------------------------------------- end extended rewrite
  public:
   static Node computeElimSymbols( Node body );
   static Node computeMiniscoping( std::vector< Node >& args, Node body, QAttributes& qa );

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -150,8 +150,6 @@ class QuantifiersRewriter : public TheoryRewriter
                              Node n,
                              Node ipl);
   static Node computeProcessTerms2(Node body,
-                                   std::map<Node, bool>& currCond,
-                                   int nCurrCond,
                                    std::map<Node, Node>& cache,
                                    std::map<Node, Node>& icache,
                                    std::vector<Node>& new_vars,

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -27,6 +27,35 @@ namespace quantifiers {
 
 struct QAttributes;
 
+/** 
+ * List of steps used by the quantifiers rewriter, details on these steps
+ * can be found in the class below.
+ */
+enum RewriteStep
+{
+  /** Eliminate symbols (e.g. implies, xor) */
+  COMPUTE_ELIM_SYMBOLS = 0,
+  /** Miniscoping */
+  COMPUTE_MINISCOPING,
+  /** Aggressive miniscoping */
+  COMPUTE_AGGRESSIVE_MINISCOPING,
+  /** 
+   * Term processing (e.g. simplifying terms based on ITE conditions,
+   * eliminating extended arithmetic symbols). 
+   */
+  COMPUTE_PROCESS_TERMS,
+  /** Prenexing */
+  COMPUTE_PRENEX,
+  /** Variable elimination */
+  COMPUTE_VAR_ELIMINATION,
+  /** Conditional splitting */
+  COMPUTE_COND_SPLIT,
+  /** Placeholder for end of steps */
+  COMPUTE_LAST
+};
+std::ostream& operator<<(std::ostream& out, RewriteStep s);
+
+
 class QuantifiersRewriter : public TheoryRewriter
 {
  public:
@@ -183,24 +212,14 @@ class QuantifiersRewriter : public TheoryRewriter
   static Node computePrenexAgg( Node n, bool topLevel, std::map< unsigned, std::map< Node, Node > >& visited );
   static Node computeSplit( std::vector< Node >& args, Node body, QAttributes& qa );
 private:
-  enum{
-    COMPUTE_ELIM_SYMBOLS = 0,
-    COMPUTE_MINISCOPING,
-    COMPUTE_AGGRESSIVE_MINISCOPING,
-    COMPUTE_PROCESS_TERMS,
-    COMPUTE_PRENEX,
-    COMPUTE_VAR_ELIMINATION,
-    COMPUTE_COND_SPLIT,
-    COMPUTE_LAST
-  };
-  static Node computeOperation( Node f, int computeOption, QAttributes& qa );
+  static Node computeOperation( Node f, RewriteStep computeOption, QAttributes& qa );
 public:
  RewriteResponse preRewrite(TNode in) override;
  RewriteResponse postRewrite(TNode in) override;
 
 private:
   /** options */
-  static bool doOperation( Node f, int computeOption, QAttributes& qa );
+  static bool doOperation( Node f, RewriteStep computeOption, QAttributes& qa );
 private:
   static Node preSkolemizeQuantifiers(Node n, bool polarity, std::vector< TypeNode >& fvTypes, std::vector<TNode>& fvs);
 public:

--- a/src/theory/quantifiers/quantifiers_rewriter.h
+++ b/src/theory/quantifiers/quantifiers_rewriter.h
@@ -198,23 +198,28 @@ class QuantifiersRewriter : public TheoryRewriter
   //-------------------------------------end conditional splitting
   //------------------------------------- process terms
   /** compute process terms
-   * 
+   *
    * This takes as input a quantified formula q with attributes qa whose
    * body is body.
-   * 
+   *
    * This rewrite steps eliminates problematic terms from the bodies of
    * quantified formulas, which includes performing:
    * - Certain cases of ITE lifting,
    * - Elimination of extended arithmetic functions like to_int/is_int/div/mod,
    * - Elimination of select over store.
-   * 
+   *
    * It may introduce new variables V into new_vars and new conditions C into
    * new_conds. It returns a node retBody such that q of the form
    *   forall X. body
    * is equivalent to:
    *   forall X, V. ( C => retBody )
    */
-  static Node computeProcessTerms( Node body, std::vector< Node >& new_vars, std::vector< Node >& new_conds, Node q, QAttributes& qa );
+  static Node computeProcessTerms(Node body,
+                                  std::vector<Node>& new_vars,
+                                  std::vector<Node>& new_conds,
+                                  Node q,
+                                  QAttributes& qa);
+
  public:
   static Node computeElimSymbols( Node body );
   static Node computeMiniscoping( std::vector< Node >& args, Node body, QAttributes& qa );

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1830,6 +1830,7 @@ set(regress_1_tests
   regress1/sygus/issue3648.smt2
   regress1/sygus/issue3649.sy
   regress1/sygus/issue3802-default-consts.sy
+  regress1/sygus/issue3839-cond-rewrite.smt2
   regress1/sygus/large-const-simp.sy
   regress1/sygus/let-bug-simp.sy
   regress1/sygus/list-head-x.sy

--- a/test/regress/regress0/quantifiers/agg-rew-test-cf.smt2
+++ b/test/regress/regress0/quantifiers/agg-rew-test-cf.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --ext-rewrite-quant
+; EXPECT: sat
 (set-logic UFLIA)
 (set-info :status sat)
 (declare-fun Q (Int Int) Bool)

--- a/test/regress/regress0/quantifiers/agg-rew-test.smt2
+++ b/test/regress/regress0/quantifiers/agg-rew-test.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --ext-rewrite-quant
+; EXPECT: sat
 (set-logic UFLIA)
 (set-info :status sat)
 (declare-fun Q (Int Int) Bool)

--- a/test/regress/regress1/sygus/issue3839-cond-rewrite.smt2
+++ b/test/regress/regress1/sygus/issue3839-cond-rewrite.smt2
@@ -1,0 +1,10 @@
+; EXPECT: sat
+; COMMAND-LINE: --sygus-inference
+(set-logic ALL)
+(declare-fun a () Int)
+(declare-fun b () Int)
+(assert (xor (> a 0) (not (and (ite (= a b) (> (* 4 a b) 1) true) (> (* a a) 0)))))
+(assert (= a b))
+(assert (> (* a b) 0))
+(check-sat)
+


### PR DESCRIPTION
Fixes #3839.

Previously, the quantifiers rewriter had a rewriting step that was an ad-hoc version of some of the rewrites that have been incorporated into the extended rewriter.  Moreover, the code for that pass was buggy.

This eliminates the previous conditional rewriting step from the "term process" rewrite pass in quantifiers.  It additional adds an optional (disabled by default) rewriting pass that calls the extended rewriter on the body of quantified formulas.  This subsumes the previous behavior and should not be buggy.

Notice that the indentation in computeProcessTerms changed and subsequently has been updated to the new coding standards.

This PR relies on https://github.com/CVC4/CVC4/pull/3840.