### PR TITLE
Fix assertion related to isAssignable

### DIFF
--- a/src/theory/theory_model_builder.cpp
+++ b/src/theory/theory_model_builder.cpp
@@ -788,13 +788,12 @@ bool TheoryEngineModelBuilder::buildModel(Model* m)
         {
           Assert(!evaluable || assignOne);
           // this assertion ensures that if we are assigning to a term of
-          // Boolean type, then the term is either a variable or an APPLY_UF.
+          // Boolean type, then the term must be assignable.
           // Note we only assign to terms of Boolean type if the term occurs in
           // a singleton equivalence class; otherwise the term would have been
           // in the equivalence class of true or false and would not need
           // assigning.
-          Assert(!t.isBoolean() || (*i2).isVar()
-                 || (*i2).getKind() == kind::APPLY_UF);
+          Assert(!t.isBoolean() || isAssignable(*i2));
           Node n;
           if (itAssigner != eqcToAssigner.end())
           {

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -75,6 +75,7 @@ set(regress_0_tests
   regress0/arrays/incorrect8.minimized.smtv1.smt2
   regress0/arrays/incorrect8.smtv1.smt2
   regress0/arrays/incorrect9.smtv1.smt2
+  regress0/arrays/issue3813-massign-assert.smt2
   regress0/arrays/swap_t1_np_nf_ai_00005_007.cvc.smtv1.smt2
   regress0/arrays/x2.smtv1.smt2
   regress0/arrays/x3.smtv1.smt2

--- a/test/regress/regress0/arrays/issue3813-massign-assert.smt2
+++ b/test/regress/regress0/arrays/issue3813-massign-assert.smt2
@@ -1,0 +1,8 @@
+; EXPECT: sat
+; COMMAND-LINE: --check-unsat-cores
+(set-logic ALL)
+(set-info :status sat)
+(declare-fun a () (Array Int Bool))
+(declare-fun b () (Array Int Bool))
+(assert (= a (store b 0 true)))
+(check-sat)


### PR DESCRIPTION
Fixes #3813. 

It appears that an assertion was hardcoded to check whether a term was a variable or APPLY_UF application whereas this check should use `isAssignable`.  This avoids an assertion failure on the given benchmark.

Previously the context of the assertion failure was (with -t model-builder-debug):
```
Look at eqc : (select (store b 0 BOOLEAN_TERM_VARIABLE_287) 0)
do normalize on (store ((as const (Array Int Bool)) false) 0 (select (store b 0 BOOLEAN_TERM_VARIABLE_287) 0))
    eqc (select (store b 0 BOOLEAN_TERM_VARIABLE_287) 0) is assignable=1, evaluable=0
Fatal failure within virtual bool CVC4::theory::TheoryEngineModelBuilder::buildModel(CVC4::Model*) at /space/ajreynol/cvc4-ajr/src/theory/theory_model_builder.cpp:796
Check failure

 !t.isBoolean() || (*i2).isVar() || (*i2).getKind() == kind::APPLY_UF

```

May be related to https://github.com/CVC4/CVC4/issues/3687.