### PR TITLE
Fix shadowing bug in `TheorySetsPrivate::eqNotifyPostMerge()`

### DIFF
--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -97,7 +97,6 @@ void TheorySetsPrivate::eqNotifyPostMerge(TNode t1, TNode t2)
     {
       s2 = e2->d_singleton;
       EqcInfo* e1 = getOrMakeEqcInfo(t1);
-      Node s1;
       Trace("sets-prop-debug") << "Merging singletons..." << std::endl;
       if (e1)
       {


### PR DESCRIPTION
A local declaration of `s1` was shadowing `s1`, which meant that the
non-local definition of `s1` could never be not null. This meant that
parts of the code were never run. This commit fixes the issue by
removing the local declaration.