### PR TITLE
Increase stack size for Windows builds to 100 MB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,10 @@ add_check_c_cxx_flag("-Wimplicit-fallthrough")
 # cdlist.h warnings. Remove when fixed.
 add_check_cxx_flag("-Wno-class-memaccess")
 
+if (WIN32)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,100000000")
+endif ()
+
 #-----------------------------------------------------------------------------#
 # Use ld.gold if available
 
@@ -669,6 +673,7 @@ message("")
 message("CPPLAGS (-D...)                : ${CVC4_DEFINITIONS}")
 message("CXXFLAGS                       : ${CMAKE_CXX_FLAGS}")
 message("CFLAGS                         : ${CMAKE_C_FLAGS}")
+message("Linker flags                   : ${CMAKE_EXE_LINKER_FLAGS}")
 message("")
 message("Install prefix                 : ${CMAKE_INSTALL_PREFIX}")
 message("")


### PR DESCRIPTION
Fixes #3528. The default stack size for Windows builds is very limited
(it seems to be 1 MB). This leads to problems for some of our users'
benchmarks (see the previously mentioned issue and another email that
we've received recently). Bumping the stack size to 100 MB seems to
solve the issues for the benchmarks that we have received. This of
course does not mean that we shouldn't continue working towards making
less of our code recursive.