### PR TITLE
Fix quoting of options on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ addons:
   - python3-setuptools
   - swig3.0
 before_install:
- - eval "${MATRIX_EVAL}"
  # Clang does not play nice with ccache (at least the versions offered by
  # Travis), use a workaround:
  # https://github.com/travis-ci/travis-ci/issues/5383#issuecomment-224630584
@@ -107,22 +106,37 @@ matrix:
     # Test with GCC
     - compiler: gcc
       env:
-        - TRAVIS_CVC4=yes TRAVIS_WITH_LFSC=yes TRAVIS_CVC4_CONFIG='production --language-bindings=java --lfsc' TRAVIS_PYTHON="python"
+        - TRAVIS_CVC4=yes
+        - TRAVIS_WITH_LFSC=yes
+        - TRAVIS_CVC4_CONFIG="production --language-bindings=java --lfsc"
+        - TRAVIS_PYTHON=python
     - compiler: gcc
       env:
-        - TRAVIS_CVC4=yes TRAVIS_WITH_LFSC=yes TRAVIS_CVC4_CONFIG='debug --symfpu --lfsc --no-debug-symbols' TRAVIS_PYTHON="python"
+        - TRAVIS_CVC4=yes
+        - TRAVIS_WITH_LFSC=yes
+        - TRAVIS_CVC4_CONFIG="debug --symfpu --lfsc --no-debug-symbols"
+        - TRAVIS_PYTHON=python
     # Test python bindings
     - compiler: gcc
       env:
-        - TRAVIS_CVC4=yes TRAVIS_WITH_LFSC=yes TRAVIS_CVC4_CONFIG="production --python-bindings --python2" TRAVIS_PYTHON="python"
+        - TRAVIS_CVC4=yes
+        - TRAVIS_WITH_LFSC=yes
+        - TRAVIS_CVC4_CONFIG="production --python-bindings --python2"
+        - TRAVIS_PYTHON=python
     - compiler: gcc
       env:
-        - TRAVIS_CVC4=yes TRAVIS_WITH_LFSC=yes TRAVIS_CVC4_CONFIG="production --python-bindings --python3" TRAVIS_PYTHON="python3"
+        - TRAVIS_CVC4=yes
+        - TRAVIS_WITH_LFSC=yes
+        - TRAVIS_CVC4_CONFIG="production --python-bindings --python3"
+        - TRAVIS_PYTHON=python3
     #
     # Test with Clang
     - compiler: clang
       env:
-        - TRAVIS_CVC4=yes TRAVIS_WITH_LFSC=yes TRAVIS_CVC4_CONFIG='debug --symfpu --cln --gpl --no-debug-symbols --no-proofs' TRAVIS_PYTHON="python"
+        - TRAVIS_CVC4=yes
+        - TRAVIS_WITH_LFSC=yes
+        - TRAVIS_CVC4_CONFIG="debug --symfpu --cln --gpl --no-debug-symbols --no-proofs"
+        - TRAVIS_PYTHON=python
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
For some reason, Travis has started to treat our `TRAVIS_CVC4_CONFIG`
environment variable wrong, leading to failing builds. Travis started to
wrap the argument into double quotes, so when we had single quotes
around our argument list, the arguments were treated as a single
argument and when we had double quotes, the second pair of double quotes
terminated the first one permaturely. Declaring the environment
variables individually seems to work as expected, so this commit is
moving to that format.