### PR TITLE
New C++ API: Remove support for (reset).

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -4106,11 +4106,6 @@ void Solver::push(uint32_t nscopes) const
 }
 
 /**
- *  ( reset )
- */
-void Solver::reset(void) const { d_smtEngine->reset(); }
-
-/**
  *  ( reset-assertions )
  */
 void Solver::resetAssertions(void) const { d_smtEngine->resetAssertions(); }

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -2762,12 +2762,6 @@ class CVC4_PUBLIC Solver
   void push(uint32_t nscopes = 1) const;
 
   /**
-   * Reset the solver.
-   * SMT-LIB: ( reset )
-   */
-  void reset() const;
-
-  /**
    * Remove all assertions.
    * SMT-LIB: ( reset-assertions )
    */

--- a/src/api/python/cvc4.pxi
+++ b/src/api/python/cvc4.pxi
@@ -935,9 +935,6 @@ cdef class Solver:
     def push(self, nscopes=1):
         self.csolver.push(nscopes)
 
-    def reset(self):
-        self.csolver.reset()
-
     def resetAssertions(self):
         self.csolver.resetAssertions()
 

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -49,15 +49,13 @@ void setNoLimitCPU() {
 void printStatsIncremental(std::ostream& out, const std::string& prvsStatsString, const std::string& curStatsString);
 
 CommandExecutor::CommandExecutor(Options& options)
-    : d_solver(nullptr),
-      d_smtEngine(nullptr),
+    : d_solver(new api::Solver(&options)),
+      d_smtEngine(d_solver->getSmtEngine()),
       d_options(options),
       d_stats("driver"),
       d_result(),
       d_replayStream(nullptr)
 {
-  d_solver.reset(new api::Solver(&options));
-  d_smtEngine = d_solver->getSmtEngine();
 }
 
 void CommandExecutor::flushStatistics(std::ostream& out) const

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -18,6 +18,7 @@
 #include <iosfwd>
 #include <string>
 
+#include "api/cvc4cpp.h"
 #include "expr/expr_manager.h"
 #include "options/options.h"
 #include "smt/command.h"
@@ -32,27 +33,28 @@ class Solver;
 
 namespace main {
 
-class CommandExecutor {
-private:
+class CommandExecutor
+{
+ private:
   std::string d_lastStatistics;
 
-protected:
- api::Solver* d_solver;
- SmtEngine* d_smtEngine;
- Options& d_options;
- StatisticsRegistry d_stats;
- Result d_result;
- ExprStream* d_replayStream;
+ protected:
+  std::unique_ptr<api::Solver> d_solver;
+  SmtEngine* d_smtEngine;
+  Options& d_options;
+  StatisticsRegistry d_stats;
+  Result d_result;
+  ExprStream* d_replayStream;
 
-public:
- CommandExecutor(api::Solver* solver, Options& options);
+ public:
+  CommandExecutor(Options& options);
 
- virtual ~CommandExecutor()
- {
-   if (d_replayStream != NULL)
-   {
-     delete d_replayStream;
-   }
+  virtual ~CommandExecutor()
+  {
+    if (d_replayStream != NULL)
+    {
+      delete d_replayStream;
+    }
   }
 
   /**
@@ -61,6 +63,9 @@ public:
    * overridden by a derived class).
    */
   bool doCommand(CVC4::Command* cmd);
+
+  /** Get a pointer to the solver object owned by this CommandExecutor. */
+  api::Solver* getSolver() { return d_solver.get(); }
 
   Result getResult() const { return d_result; }
   void reset();
@@ -96,7 +101,7 @@ protected:
 private:
   CommandExecutor();
 
-};/* class CommandExecutor */
+}; /* class CommandExecutor */
 
 bool smtEngineInvoke(SmtEngine* smt, Command* cmd, std::ostream *out);
 

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -181,16 +181,15 @@ int runCvc4(int argc, char* argv[], Options& opts) {
   // important even for muzzled builds (to get result output right)
   (*(opts.getOut())) << language::SetLanguage(opts.getOutputLanguage());
 
-  // Create the expression manager using appropriate options
-  std::unique_ptr<api::Solver> solver;
-  solver.reset(new api::Solver(&opts));
-  pExecutor = new CommandExecutor(solver.get(), opts);
+  // Create the command executor to execute the parsed commands
+  pExecutor = new CommandExecutor(opts);
 
   std::unique_ptr<Parser> replayParser;
   if (opts.getReplayInputFilename() != "")
   {
     std::string replayFilename = opts.getReplayInputFilename();
-    ParserBuilder replayParserBuilder(solver.get(), replayFilename, opts);
+    ParserBuilder replayParserBuilder(
+        pExecutor->getSolver(), replayFilename, opts);
 
     if( replayFilename == "-") {
       if( inputFromStdin ) {
@@ -229,7 +228,7 @@ int runCvc4(int argc, char* argv[], Options& opts) {
         pExecutor->doCommand(cmd);
         delete cmd;
       }
-      InteractiveShell shell(solver.get());
+      InteractiveShell shell(pExecutor->getSolver());
       if(opts.getInteractivePrompt()) {
         Message() << Configuration::getPackageName()
                   << " " << Configuration::getVersionString();
@@ -282,7 +281,7 @@ int runCvc4(int argc, char* argv[], Options& opts) {
         // delete cmd;
       }
 
-      ParserBuilder parserBuilder(solver.get(), filename, opts);
+      ParserBuilder parserBuilder(pExecutor->getSolver(), filename, opts);
 
       if( inputFromStdin ) {
 #if defined(CVC4_COMPETITION_MODE) && !defined(CVC4_SMTCOMP_APPLICATION_TRACK)
@@ -443,7 +442,7 @@ int runCvc4(int argc, char* argv[], Options& opts) {
         delete cmd;
       }
 
-      ParserBuilder parserBuilder(solver.get(), filename, opts);
+      ParserBuilder parserBuilder(pExecutor->getSolver(), filename, opts);
 
       if( inputFromStdin ) {
 #if defined(CVC4_COMPETITION_MODE) && !defined(CVC4_SMTCOMP_APPLICATION_TRACK)

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -900,6 +900,7 @@ set(regress_0_tests
   regress0/smtlib/global-decls.smt2
   regress0/smtlib/issue4028.smt2
   regress0/smtlib/reason-unknown.smt2
+  regress0/smtlib/reset.smt2
   regress0/smtlib/reset-assertions1.smt2
   regress0/smtlib/reset-assertions2.smt2
   regress0/smtlib/reset-assertions-global.smt2

--- a/test/regress/regress0/smtlib/reset.smt2
+++ b/test/regress/regress0/smtlib/reset.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --produce-models
+; EXPECT: true
+; EXPECT: false
+; EXPECT: true
+(get-option :produce-models)
+(set-option :produce-models false)
+(get-option :produce-models)
+(reset)
+(get-option :produce-models)


### PR DESCRIPTION
Supporting SMT-LIB's `(reset)` command on the API level is dangerous and not required -- it's sufficient to just destroy the solver object and create a new one if necessary. It's dangerous because invalidated objects can be passed in after a reset, and we would need to find a clean way to guard against this. We want to guard against this in the future, but for now it is cleaner to make it explicit (by not having this functionality in the API but forcing the user to destroy and recreate the solver object) that these objects can't be reused.