### PR TITLE
Hide options for and related to the BV abstraction module.

### DIFF
--- a/src/options/bv_options.toml
+++ b/src/options/bv_options.toml
@@ -204,7 +204,7 @@ header = "options/bv_options.h"
 
 [[option]]
   name       = "bvAbstraction"
-  category   = "expert"
+  category   = "undocumented"
   long       = "bv-abstraction"
   type       = "bool"
   default    = "false"
@@ -212,7 +212,7 @@ header = "options/bv_options.h"
 
 [[option]]
   name       = "skolemizeArguments"
-  category   = "expert"
+  category   = "undocumented"
   long       = "bv-skolemize"
   type       = "bool"
   default    = "false"


### PR DESCRIPTION
All things related to the current BV solver are obsolete in the sense
that we are working on a new BV solver implementation. The BV abstraction
module has several issues and is quite hacky, it should only be enabled
in experimental settings. We don't want to remove it yet though, we want
to keep it around for future evaluation purposes. This commit
categorizes the option to enable the module and a second option related
to the module as 'undocumented'.