### PR TITLE
Expand the definition of a "simple" farkas proof.

### DIFF
--- a/src/proof/arith_proof.cpp
+++ b/src/proof/arith_proof.cpp
@@ -1156,8 +1156,10 @@ void LFSCArithProof::printTheoryLemmaProof(std::vector<Expr>& lemma,
   }
   else
   {
+    AlwaysAssert(false) << "arith hole!";
     os << "\n; Arithmetic proofs which use reasoning more complex than Farkas "
-          "proofs are currently unsupported\n(clausify_false trust)\n";
+          "proofs and bound tightening are currently unsupported\n"
+          "(clausify_false trust)\n";
   }
 }
 

--- a/src/proof/arith_proof.cpp
+++ b/src/proof/arith_proof.cpp
@@ -1156,7 +1156,6 @@ void LFSCArithProof::printTheoryLemmaProof(std::vector<Expr>& lemma,
   }
   else
   {
-    AlwaysAssert(false) << "arith hole!";
     os << "\n; Arithmetic proofs which use reasoning more complex than Farkas "
           "proofs and bound tightening are currently unsupported\n"
           "(clausify_false trust)\n";

--- a/src/theory/arith/constraint.cpp
+++ b/src/theory/arith/constraint.cpp
@@ -502,11 +502,11 @@ bool Constraint::hasSimpleFarkasProof() const
   }
 
   // For each antecdent ...
-  for (AntecedentId i = getConstraintRule().d_antecedentEnd;
-       i != AntecedentIdSentinel;
-       --i)
+  AntecedentId i = getConstraintRule().d_antecedentEnd;
+  for (ConstraintCP a = d_database->getAntecedent(i);
+       a != NullConstraint;
+       a = d_database->getAntecedent(--i))
   {
-    ConstraintCP a = d_database->getAntecedent(i);
     // ... that antecdent must be an assumption ...
     if (a->isAssumption())
     {

--- a/src/theory/arith/constraint.cpp
+++ b/src/theory/arith/constraint.cpp
@@ -503,8 +503,7 @@ bool Constraint::hasSimpleFarkasProof() const
 
   // For each antecdent ...
   AntecedentId i = getConstraintRule().d_antecedentEnd;
-  for (ConstraintCP a = d_database->getAntecedent(i);
-       a != NullConstraint;
+  for (ConstraintCP a = d_database->getAntecedent(i); a != NullConstraint;
        a = d_database->getAntecedent(--i))
   {
     // ... that antecdent must be an assumption ...

--- a/src/theory/arith/constraint.h
+++ b/src/theory/arith/constraint.h
@@ -496,15 +496,16 @@ class Constraint {
 
   /**
    * @brief Returns whether this constraint is provable using a Farkas
-   * proof that has input assertions as its antecedents.
+   * proof applied to (possibly tightened) input assertions.
    *
    * An example of a constraint that has a simple Farkas proof:
    *    x <= 0 proven from x + y <= 0 and x - y <= 0.
    *
-   * An example of a constraint that does not have a simple Farkas proof:
+   * An example of another constraint that has a simple Farkas proof:
    *    x <= 0 proven from x + y <= 0 and x - y <= 0.5 for integers x, y
-   *       (since integer reasoning is also required!).
-   * Another example of a constraint that might be proven without a simple
+   *       (integer bound-tightening is applied first!).
+   *
+   * An example of a constraint that might be proven **without** a simple
    * Farkas proof:
    *    x < 0 proven from not(x == 0) and not(x > 0).
    *

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -4954,7 +4954,7 @@ bool TheoryArithPrivate::rowImplicationCanBeApplied(RowIndex ridx, bool rowUp, C
         Assert(coeffs != RationalVectorPSentinel);
         Assert(conflictInFarkasCoefficientOrder.getNumChildren()
                == coeffs->size());
-        if (implied->hasSimpleFarkasProof())
+        if (std::all_of(explain.begin(), explain.end(), [](ConstraintCP c) { return c->isAssumption() || c->hasIntTightenProof(); }))
         {
           d_containing.d_proofRecorder->saveFarkasCoefficients(
               conflictInFarkasCoefficientOrder, coeffs);

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -4954,7 +4954,9 @@ bool TheoryArithPrivate::rowImplicationCanBeApplied(RowIndex ridx, bool rowUp, C
         Assert(coeffs != RationalVectorPSentinel);
         Assert(conflictInFarkasCoefficientOrder.getNumChildren()
                == coeffs->size());
-        if (std::all_of(explain.begin(), explain.end(), [](ConstraintCP c) { return c->isAssumption() || c->hasIntTightenProof(); }))
+        if (std::all_of(explain.begin(), explain.end(), [](ConstraintCP c) {
+              return c->isAssumption() || c->hasIntTightenProof();
+            }))
         {
           d_containing.d_proofRecorder->saveFarkasCoefficients(
               conflictInFarkasCoefficientOrder, coeffs);

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -2188,8 +2188,11 @@ void TheoryArithPrivate::outputConflicts(){
         }
 
         Assert(conflict.getNumChildren() == pf.d_farkasCoefficients->size());
-        d_containing.d_proofRecorder->saveFarkasCoefficients(
-            conflictInFarkasCoefficientOrder, pf.d_farkasCoefficients);
+        if (confConstraint->hasSimpleFarkasProof())
+        {
+          d_containing.d_proofRecorder->saveFarkasCoefficients(
+              conflictInFarkasCoefficientOrder, pf.d_farkasCoefficients);
+        }
       })
       if(Debug.isOn("arith::normalize::external")){
         conflict = flattenAndSort(conflict);
@@ -4951,8 +4954,11 @@ bool TheoryArithPrivate::rowImplicationCanBeApplied(RowIndex ridx, bool rowUp, C
         Assert(coeffs != RationalVectorPSentinel);
         Assert(conflictInFarkasCoefficientOrder.getNumChildren()
                == coeffs->size());
-        d_containing.d_proofRecorder->saveFarkasCoefficients(
-            conflictInFarkasCoefficientOrder, coeffs);
+        if (implied->hasSimpleFarkasProof())
+        {
+          d_containing.d_proofRecorder->saveFarkasCoefficients(
+              conflictInFarkasCoefficientOrder, coeffs);
+        }
       })
       outputLemma(clause);
     }else{


### PR DESCRIPTION
Before, a "simple farkas proof" was one that just applied the farkas
lemma.

Now it allows for the antecedents to (optionally) be tightened.

Note that hasSimpleFarkasProof was (and is) dead code.

We will use it to decide whether to print a proof or a hole.