### PR TITLE
Handle cases in --sygus-rr where evaluation is not constant

### DIFF
--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -809,7 +809,9 @@ void SygusSampler::checkEquivalent(Node bv, Node bvr)
     }
     if (!ptDisequalConst)
     {
-      Notice() << "Warning: " << bv << " and " << bvr << " evaluate to different (non-constant) values on point:" << std::endl;
+      Notice() << "Warning: " << bv << " and " << bvr
+               << " evaluate to different (non-constant) values on point:"
+               << std::endl;
       Notice() << ptOut.str();
       return;
     }
@@ -826,8 +828,7 @@ void SygusSampler::checkEquivalent(Node bv, Node bvr)
     Assert(vars.size() == pt.size());
     (*out) << ptOut.str();
     Assert(bve != bvre);
-    (*out) << "where they evaluate to " << bve << " and " << bvre
-           << std::endl;
+    (*out) << "where they evaluate to " << bve << " and " << bvre << std::endl;
 
     if (options::sygusRewVerifyAbort())
     {

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -781,6 +781,7 @@ void SygusSampler::checkEquivalent(Node bv, Node bvr)
 
   // see if they evaluate to same thing on all sample points
   bool ptDisequal = false;
+  bool ptDisequalConst = false;
   unsigned pt_index = 0;
   Node bve, bvre;
   for (unsigned i = 0, npoints = getNumSamplePoints(); i < npoints; i++)
@@ -791,29 +792,41 @@ void SygusSampler::checkEquivalent(Node bv, Node bvr)
     {
       ptDisequal = true;
       pt_index = i;
-      break;
+      if (bve.isConst() && bvre.isConst())
+      {
+        ptDisequalConst = true;
+        break;
+      }
     }
   }
   // bv and bvr should be equivalent under examples
   if (ptDisequal)
   {
+    std::stringstream ptOut;
+    for (unsigned i = 0, size = pt.size(); i < size; i++)
+    {
+      ptOut << "  " << vars[i] << " -> " << pt[i] << std::endl;
+    }
+    if (!ptDisequalConst)
+    {
+      Notice() << "Warning: " << bv << " and " << bvr << " evaluate to different (non-constant) values on point:" << std::endl;
+      Notice() << ptOut.str();
+      return;
+    }
     // we have detected unsoundness in the rewriter
     Options& nodeManagerOptions = NodeManager::currentNM()->getOptions();
     std::ostream* out = nodeManagerOptions.getOut();
     (*out) << "(unsound-rewrite " << bv << " " << bvr << ")" << std::endl;
     // debugging information
-    (*out) << "; unsound: are not equivalent for : " << std::endl;
+    (*out) << "Terms are not equivalent for : " << std::endl;
     std::vector<Node> vars;
     getVariables(vars);
     std::vector<Node> pt;
     getSamplePoint(pt_index, pt);
     Assert(vars.size() == pt.size());
-    for (unsigned i = 0, size = pt.size(); i < size; i++)
-    {
-      (*out) << "; unsound:    " << vars[i] << " -> " << pt[i] << std::endl;
-    }
+    (*out) << ptOut.str();
     Assert(bve != bvre);
-    (*out) << "; unsound: where they evaluate to " << bve << " and " << bvre
+    (*out) << "where they evaluate to " << bve << " and " << bvre
            << std::endl;
 
     if (options::sygusRewVerifyAbort())

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -802,6 +802,11 @@ void SygusSampler::checkEquivalent(Node bv, Node bvr)
   // bv and bvr should be equivalent under examples
   if (ptDisequal)
   {
+    std::vector<Node> vars;
+    getVariables(vars);
+    std::vector<Node> pt;
+    getSamplePoint(pt_index, pt);
+    Assert(vars.size() == pt.size());
     std::stringstream ptOut;
     for (unsigned i = 0, size = pt.size(); i < size; i++)
     {
@@ -821,11 +826,6 @@ void SygusSampler::checkEquivalent(Node bv, Node bvr)
     (*out) << "(unsound-rewrite " << bv << " " << bvr << ")" << std::endl;
     // debugging information
     (*out) << "Terms are not equivalent for : " << std::endl;
-    std::vector<Node> vars;
-    getVariables(vars);
-    std::vector<Node> pt;
-    getSamplePoint(pt_index, pt);
-    Assert(vars.size() == pt.size());
     (*out) << ptOut.str();
     Assert(bve != bvre);
     (*out) << "where they evaluate to " << bve << " and " << bvre << std::endl;


### PR DESCRIPTION
Throws warning instead of error if two terms with the same rewritten form evaluate differently, but the evaluation is non-constant.

Fixes #4096 and fixes #4089.