### PR TITLE
Enable configuration of Python path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,9 @@ endif()
 if(SYMFPU_DIR)
   list(APPEND CMAKE_PREFIX_PATH "${SYMFPU_DIR}")
 endif()
+if(PYTHON_DIR)
+  list(APPEND CMAKE_PREFIX_PATH "${PYTHON_DIR}")
+endif()
 
 # By default the contrib/get-* scripts install dependencies to deps/install.
 list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/deps/install")
@@ -677,6 +680,8 @@ message("CFLAGS                         : ${CMAKE_C_FLAGS}")
 message("Linker flags                   : ${CMAKE_EXE_LINKER_FLAGS}")
 message("")
 message("Install prefix                 : ${CMAKE_INSTALL_PREFIX}")
+message("")
+message("Python                         : ${PYTHON_EXECUTABLE}")
 message("")
 
 if(GPL_LIBS)

--- a/configure.sh
+++ b/configure.sh
@@ -77,6 +77,7 @@ Optional Path to Optional Packages:
   --gmp-dir=PATH           path to top level of GMP installation
   --lfsc-dir=PATH          path to top level of LFSC source tree
   --symfpu-dir=PATH        path to top level of SymFPU source tree
+  --python-dir=PATH        path to Python binary
 
 EOF
   exit 0
@@ -157,6 +158,7 @@ glpk_dir=default
 gmp_dir=default
 lfsc_dir=default
 symfpu_dir=default
+python_dir=default
 
 #--------------------------------------------------------------------------#
 
@@ -334,6 +336,9 @@ do
     --symfpu-dir) die "missing argument to $1 (try -h)" ;;
     --symfpu-dir=*) symfpu_dir=${1##*=} ;;
 
+    --python-dir) die "missing argument to $1 (try -h)" ;;
+    --python-dir=*) python_dir=${1##*=} ;;
+
     -*) die "invalid option '$1' (try -h)";;
 
     *) case $1 in
@@ -453,6 +458,8 @@ cmake_opts=""
   && cmake_opts="$cmake_opts -DLFSC_DIR=$lfsc_dir"
 [ "$symfpu_dir" != default ] \
   && cmake_opts="$cmake_opts -DSYMFPU_DIR=$symfpu_dir"
+[ "$python_dir" != default ] \
+  && cmake_opts="$cmake_opts -DPYTHON_DIR=$python_dir"
 [ "$install_prefix" != default ] \
   && cmake_opts="$cmake_opts -DCMAKE_INSTALL_PREFIX=$install_prefix"
 [ -n "$program_prefix" ] \


### PR DESCRIPTION
This commit adds the argument `--python-dir=PATH` to the `configure.sh`
script. This allows users to specify where to look for the Python
binary. This is useful when users want to use Python installed in a
virtualenv.