### PR TITLE
SyGuS must use total bitvector division

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2006,6 +2006,11 @@ void SmtEngine::setDefaults() {
     //do not allow partial functions
     if (!options::bitvectorDivByZeroConst())
     {
+      if (options::bitvectorDivByZeroConst.wasSetByUser())
+      {
+        throw OptionException(
+            "--no-bv-div-zero-const is not supported with SyGuS");
+      }
       Notice()
           << "SmtEngine: setting bv-div-zero-const to true to support SyGuS"
           << std::endl;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2004,8 +2004,11 @@ void SmtEngine::setDefaults() {
       }
     }
     //do not allow partial functions
-    if( !options::bitvectorDivByZeroConst() ){
-      Notice() << "SmtEngine: setting bv-div-zero-const to true to support SyGuS" << std::endl;
+    if (!options::bitvectorDivByZeroConst())
+    {
+      Notice()
+          << "SmtEngine: setting bv-div-zero-const to true to support SyGuS"
+          << std::endl;
       options::bitvectorDivByZeroConst.set( true );
     }
     if( !options::dtRewriteErrorSel.wasSetByUser() ){

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2004,7 +2004,8 @@ void SmtEngine::setDefaults() {
       }
     }
     //do not allow partial functions
-    if( !options::bitvectorDivByZeroConst.wasSetByUser() ){
+    if( !options::bitvectorDivByZeroConst() ){
+      Notice() << "SmtEngine: setting bv-div-zero-const to true to support SyGuS" << std::endl;
       options::bitvectorDivByZeroConst.set( true );
     }
     if( !options::dtRewriteErrorSel.wasSetByUser() ){


### PR DESCRIPTION
Our SyGuS utilities are not designed to deal with partial bitvector division. If a user forced an older version of SMT-LIB semantics while using SyGuS, this led to a number of issues.

For now, we disable this option when it is combined with SyGuS, regardless of whether the user turns it on.

A more permanent solution will be to remove the old SMT-LIB semantics option `bv-div-zero-const` entirely.

Fixes #4097 and fixes #4088 and fixes #4104.