### PR TITLE
Fix regression output related to sygus+bv-div-zero

### DIFF
--- a/test/regress/regress1/sygus/issue3995-fmf-var-op.smt2
+++ b/test/regress/regress1/sygus/issue3995-fmf-var-op.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: unsat
-; COMMAND-LINE: --sygus-inference --fmf-bound --uf-ho --no-bv-div-zero-const
+; COMMAND-LINE: --sygus-inference --fmf-bound --uf-ho
 (set-logic ALL)
 (declare-fun a () (_ BitVec 1))
 (assert (bvsgt (bvsmod a a) #b0))


### PR DESCRIPTION
Recent merges made a benchmark output a warning message that broke regress1, this fixes it.