### PR TITLE
disable cadical from QF_NIA comp script

### DIFF
--- a/contrib/competitions/smt-comp/run-script-smtcomp-current
+++ b/contrib/competitions/smt-comp/run-script-smtcomp-current
@@ -39,11 +39,11 @@ QF_NIA)
   trywith 60 --nl-ext-tplanes --decision=justification
   trywith 60 --no-nl-ext-tplanes --decision=internal
   # this totals up to more than 40 minutes, although notice that smaller bit-widths may quickly fail
-  trywith 600 --solve-int-as-bv=2   --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 600 --solve-int-as-bv=4   --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 600 --solve-int-as-bv=8   --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 600 --solve-int-as-bv=16  --bv-sat-solver=cadical --no-bv-abstraction
-  trywith 1200 --solve-int-as-bv=32 --bv-sat-solver=cadical --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=2   --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=4   --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=8   --no-bv-abstraction
+  trywith 600 --solve-int-as-bv=16  --no-bv-abstraction
+  trywith 1200 --solve-int-as-bv=32 --no-bv-abstraction
   finishwith --nl-ext-tplanes --decision=internal
   ;;
 QF_NRA)


### PR DESCRIPTION
The competition script uses `--solve-int-as-bv` for `QF_NIA`. This pass is incompatible with eager bit-blasting and hence also with `cadical`.