### PR TITLE
Fix expected output on arith regression

### DIFF
--- a/test/regress/regress1/arith/bug547.1.smt2
+++ b/test/regress/regress1/arith/bug547.1.smt2
@@ -1,5 +1,5 @@
-; COMMAND-LINE: --rewrite-divk
-; EXPECT: unknown
+; COMMAND-LINE: --rewrite-divk --nl-ext-tplanes
+; EXPECT: sat
 (set-logic QF_NIA)
 (declare-fun x () Int)
 (declare-fun y () Int)


### PR DESCRIPTION
A benchmark went unknown -> sat, likely due to the arith-brab commit, thus leading to a failure on regress1.

This updates the status on this benchmark (also adds --nl-ext-tplanes to it).

FYI @amaleewilson .