### PR TITLE
turning class into namespace

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -4017,7 +4017,7 @@ bool SmtEngine::getAbduct(const Expr& conj, const Type& grammarType, Expr& abd)
   d_abdConj = conjn.toExpr();
   asserts.push_back(conjn);
   std::string name("A");
-  Node aconj = theory::quantifiers::SygusAbduct::mkAbductionConjecture(
+  Node aconj = theory::quantifiers::sygus_abduct::mkAbductionConjecture(
       name, asserts, axioms, TypeNode::fromType(grammarType));
   // should be a quantified conjecture with one function-to-synthesize
   Assert(aconj.getKind() == kind::FORALL && aconj[0].getNumChildren() == 1);

--- a/src/theory/quantifiers/sygus/sygus_abduct.cpp
+++ b/src/theory/quantifiers/sygus/sygus_abduct.cpp
@@ -34,9 +34,7 @@ namespace CVC4 {
 namespace theory {
 namespace quantifiers {
 
-SygusAbduct::SygusAbduct() {}
-
-Node SygusAbduct::mkAbductionConjecture(const std::string& name,
+Node sygus_abduct::mkAbductionConjecture(const std::string& name,
                                         const std::vector<Node>& asserts,
                                         const std::vector<Node>& axioms,
                                         TypeNode abdGType)

--- a/src/theory/quantifiers/sygus/sygus_abduct.h
+++ b/src/theory/quantifiers/sygus/sygus_abduct.h
@@ -80,9 +80,9 @@ Node mkAbductionConjecture(const std::string& name,
                                   const std::vector<Node>& axioms,
                                   TypeNode abdGType);
 
+}  // namespace sygus_abduct
 }  // namespace quantifiers
 }  // namespace theory
 }  // namespace CVC4
-}  // namespace sygus_abduct
 
 #endif /* CVC4__THEORY__QUANTIFIERS__SYGUS_ABDUCT_H */

--- a/src/theory/quantifiers/sygus/sygus_abduct.h
+++ b/src/theory/quantifiers/sygus/sygus_abduct.h
@@ -25,7 +25,9 @@ namespace CVC4 {
 namespace theory {
 namespace quantifiers {
 
-/** SygusAbduct
+namespace sygus_abduct {
+
+ /** 
  *
  * A utility that turns a set of quantifier-free assertions into
  * a sygus conjecture that encodes an abduction problem. In detail, if our
@@ -53,38 +55,34 @@ namespace quantifiers {
  * In other words, A( y ) must be consistent with our axioms Fa and imply
  * ~F( x ). We encode this conjecture using SygusSideConditionAttribute.
  */
-class SygusAbduct
-{
- public:
-  SygusAbduct();
 
-  /**
-   * Returns the sygus conjecture corresponding to the abduction problem for
-   * input problem (F above) given by asserts, and axioms (Fa above) given by
-   * axioms. Note that axioms is expected to be a subset of asserts.
-   *
-   * The argument name is the name for the abduct-to-synthesize.
-   *
-   * The type abdGType (if non-null) is a sygus datatype type that encodes the
-   * grammar that should be used for solutions of the abduction conjecture.
-   *
-   * The relationship between the free variables of asserts and the formal
-   * rgument list of the abduct-to-synthesize are tracked by the attribute
-   * SygusVarToTermAttribute.
-   *
-   * In particular, solutions to the synthesis conjecture will be in the form
-   * of a closed term (lambda varlist. t). The intended solution, which is a
-   * term whose free variables are a subset of asserts, is the term
-   * t * { varlist -> SygusVarToTermAttribute(varlist) }.
-   */
-  static Node mkAbductionConjecture(const std::string& name,
-                                    const std::vector<Node>& asserts,
-                                    const std::vector<Node>& axioms,
-                                    TypeNode abdGType);
-};
+/**
+ * Returns the sygus conjecture corresponding to the abduction problem for
+ * input problem (F above) given by asserts, and axioms (Fa above) given by
+ * axioms. Note that axioms is expected to be a subset of asserts.
+ *
+ * The argument name is the name for the abduct-to-synthesize.
+ *
+ * The type abdGType (if non-null) is a sygus datatype type that encodes the
+ * grammar that should be used for solutions of the abduction conjecture.
+ *
+ * The relationship between the free variables of asserts and the formal
+ * rgument list of the abduct-to-synthesize are tracked by the attribute
+ * SygusVarToTermAttribute.
+ *
+ * In particular, solutions to the synthesis conjecture will be in the form
+ * of a closed term (lambda varlist. t). The intended solution, which is a
+ * term whose free variables are a subset of asserts, is the term
+ * t * { varlist -> SygusVarToTermAttribute(varlist) }.
+ */
+Node mkAbductionConjecture(const std::string& name,
+                                  const std::vector<Node>& asserts,
+                                  const std::vector<Node>& axioms,
+                                  TypeNode abdGType);
 
 }  // namespace quantifiers
 }  // namespace theory
 }  // namespace CVC4
+}  // namespace sygus_abduct
 
 #endif /* CVC4__THEORY__QUANTIFIERS__SYGUS_ABDUCT_H */


### PR DESCRIPTION
The abduction module is based on a class that has no fields and includes a single function which is static. 
According to my understanding of [the relevant part of the coding guidelines](https://github.com/CVC4/CVC4/wiki/Code-Style-Guidelines#nonmember-static-member-and-global-functions), this module should be in a namespace rather than a class. 
Am I correct? 