### PR TITLE
New C++ API: Rename Solver::mkTermInternal.

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -2386,7 +2386,7 @@ Term Solver::mkTermFromKind(Kind kind) const
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
 
-Term Solver::mkTermInternal(Kind kind, const std::vector<Term>& children) const
+Term Solver::mkTermHelper(Kind kind, const std::vector<Term>& children) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
   for (size_t i = 0, size = children.size(); i < size; ++i)
@@ -3259,12 +3259,12 @@ Term Solver::mkTerm(Kind kind, Term child1, Term child2) const
 Term Solver::mkTerm(Kind kind, Term child1, Term child2, Term child3) const
 {
   // need to use internal term call to check e.g. associative construction
-  return mkTermInternal(kind, std::vector<Term>{child1, child2, child3});
+  return mkTermHelper(kind, std::vector<Term>{child1, child2, child3});
 }
 
 Term Solver::mkTerm(Kind kind, const std::vector<Term>& children) const
 {
-  return mkTermInternal(kind, children);
+  return mkTermHelper(kind, children);
 }
 
 Term Solver::mkTerm(Op op) const

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -2852,7 +2852,7 @@ class CVC4_PUBLIC Solver
    * @param children the children of the term
    * @return the Term
    */
-  Term mkTermInternal(Kind kind, const std::vector<Term>& children) const;
+  Term mkTermHelper(Kind kind, const std::vector<Term>& children) const;
 
   /**
    * Create a vector of datatype sorts, using unresolved sorts.


### PR DESCRIPTION
This is for consistency with the other helper functions.