### PR TITLE
Fix dump models and dump proofs

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -148,13 +148,15 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
   // dump the model/proof/unsat core if option is set
   if (status) {
     std::vector<std::unique_ptr<Command> > getterCommands;
-    if (d_options.getDumpModels() &&
-        (res.asSatisfiabilityResult() == Result::SAT ||
-         (res.isUnknown() && res.whyUnknown() == Result::INCOMPLETE))) {
+    if (d_options.getDumpModels()
+        && (res.asSatisfiabilityResult() == Result::SAT
+            || (res.isUnknown() && res.whyUnknown() == Result::INCOMPLETE)))
+    {
       getterCommands.emplace_back(new GetModelCommand());
     }
-    if (d_options.getDumpProofs() &&
-        res.asSatisfiabilityResult() == Result::UNSAT) {
+    if (d_options.getDumpProofs()
+        && res.asSatisfiabilityResult() == Result::UNSAT)
+    {
       getterCommands.emplace_back(new GetProofCommand());
     }
 

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -148,12 +148,12 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
   // dump the model/proof/unsat core if option is set
   if (status) {
     std::vector<std::unique_ptr<Command> > getterCommands;
-    if (d_options.getProduceModels() && d_options.getDumpModels() &&
+    if (d_options.getDumpModels() &&
         (res.asSatisfiabilityResult() == Result::SAT ||
          (res.isUnknown() && res.whyUnknown() == Result::INCOMPLETE))) {
       getterCommands.emplace_back(new GetModelCommand());
     }
-    if (d_options.getProof() && d_options.getDumpProofs() &&
+    if (d_options.getDumpProofs() &&
         res.asSatisfiabilityResult() == Result::UNSAT) {
       getterCommands.emplace_back(new GetProofCommand());
     }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -463,6 +463,7 @@ set(regress_0_tests
   regress0/declare-funs.smt2
   regress0/define-fun-model.smt2
   regress0/distinct.smtv1.smt2
+  regress0/simple-dump-model.smt2
   regress0/expect/scrub.01.smtv1.smt2
   regress0/expect/scrub.03.smt2
   regress0/expect/scrub.06.cvc

--- a/test/regress/regress0/simple-dump-model.smt2
+++ b/test/regress/regress0/simple-dump-model.smt2
@@ -1,0 +1,13 @@
+; COMMAND-LINE: --dump-models
+; EXPECT: sat
+; EXPECT: (model
+; EXPECT: (define-fun x () Int 1)
+; EXPECT: (define-fun y () Int 1)
+; EXPECT: )
+(set-logic QF_LIA)
+(set-info :status sat)
+(declare-fun x () Int)
+(declare-fun y () Int)
+(assert (and (<= x y) (> x 0)))
+(assert (= y 1))
+(check-sat)


### PR DESCRIPTION
A recent commit (https://github.com/CVC4/CVC4/commit/45e489e2d48e3edde15be2187e32893fc35d859b) made it so that dump-models did not automatically enable produce-models in the global options object, but instead the SmtEngine enabled produce-models internally.  The code for dump-models and dump-proofs was (perhaps out of paranoia) checking produce-models and produce-proofs.  This removes this check, which is the correct thing to do since SmtEngine internally ensures produce-models is set.