### PR TITLE
Explain non-emptiness by non-zero length in strings

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -1238,7 +1238,9 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
       Node nc = nfncv[index];
       Assert(!nc.isConst()) << "Other string is not constant.";
       Assert(nc.getKind() != STRING_CONCAT) << "Other string is not CONCAT.";
-      if (!ee->areDisequal(nc, emp, true))
+      // explanation for why nc is non-empty
+      Node expNonEmpty = d_state.explainNonEmpty(nc);
+      if (expNonEmpty.isNull())
       {
         // The non-constant side may be equal to the empty string. Split on
         // whether it is.
@@ -1273,8 +1275,7 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
 
       // At this point, we know that `nc` is non-empty, so we add that to our
       // explanation.
-      Node ncnz = nc.eqNode(emp).negate();
-      info.d_ant.push_back(ncnz);
+      info.d_ant.push_back(expNonEmpty);
 
       size_t ncIndex = index + 1;
       Node nextConstStr = nfnc.collectConstantStringAt(ncIndex);

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -987,7 +987,6 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
                                   TypeNode stype)
 {
   NodeManager* nm = NodeManager::currentNM();
-  eq::EqualityEngine* ee = d_state.getEqualityEngine();
   Node emp = Word::mkEmptyWord(stype);
 
   const std::vector<Node>& nfiv = nfi.d_nf;
@@ -1704,7 +1703,6 @@ void CoreSolver::processDeq(Node ni, Node nj)
   NodeManager* nm = NodeManager::currentNM();
   NormalForm& nfni = getNormalForm(ni);
   NormalForm& nfnj = getNormalForm(nj);
-  eq::EqualityEngine* ee = d_state.getEqualityEngine();
 
   if (nfni.d_nf.size() <= 1 && nfnj.d_nf.size() <= 1)
   {
@@ -1794,6 +1792,7 @@ void CoreSolver::processDeq(Node ni, Node nj)
           //
           // E.g. x ++ x' ++ ... != "abc" ++ y' ++ ... ^ len(x) != len(y) --->
           //      x = "" v x != ""
+          Node emp = Word::mkEmptyWord(nck.getType());
           d_im.sendSplit(nck, emp, Inference::DEQ_DISL_EMP_SPLIT);
           return;
         }

--- a/src/theory/strings/solver_state.cpp
+++ b/src/theory/strings/solver_state.cpp
@@ -15,6 +15,7 @@
 #include "theory/strings/solver_state.h"
 
 #include "theory/strings/theory_strings_utils.h"
+#include "theory/strings/word.h"
 
 using namespace std;
 using namespace CVC4::context;
@@ -34,7 +35,9 @@ SolverState::SolverState(context::Context* c,
       d_conflict(c, false),
       d_pendingConflict(c)
 {
+  d_zero = NodeManager::currentNM()->mkConst(Rational(0));
 }
+
 SolverState::~SolverState()
 {
   for (std::pair<const Node, EqcInfo*>& it : d_eqcInfo)
@@ -238,6 +241,22 @@ Node SolverState::getLengthExp(Node t, std::vector<Node>& exp, Node te)
 Node SolverState::getLength(Node t, std::vector<Node>& exp)
 {
   return getLengthExp(t, exp, t);
+}
+
+Node SolverState::explainNonEmpty(Node s)
+{
+  Assert(s.getType().isStringLike());
+  Node emp = Word::mkEmptyWord(s.getType());
+  if (d_ee.areDisequal(s, emp, true))
+  {
+    return s.eqNode(emp).negate();
+  }
+  Node sLen = utils::mkNLength(s);
+  if (d_ee.areDisequal(sLen,d_zero, true))
+  {
+    return sLen.eqNode(d_zero).negate();
+  }
+  return Node::null();
 }
 
 void SolverState::setConflict() { d_conflict = true; }

--- a/src/theory/strings/solver_state.cpp
+++ b/src/theory/strings/solver_state.cpp
@@ -247,12 +247,12 @@ Node SolverState::explainNonEmpty(Node s)
 {
   Assert(s.getType().isStringLike());
   Node emp = Word::mkEmptyWord(s.getType());
-  if (areDisequal(s, emp, false))
+  if (areDisequal(s, emp))
   {
     return s.eqNode(emp).negate();
   }
   Node sLen = utils::mkNLength(s);
-  if (areDisequal(sLen, d_zero, false))
+  if (areDisequal(sLen, d_zero))
   {
     return sLen.eqNode(d_zero).negate();
   }

--- a/src/theory/strings/solver_state.cpp
+++ b/src/theory/strings/solver_state.cpp
@@ -247,12 +247,12 @@ Node SolverState::explainNonEmpty(Node s)
 {
   Assert(s.getType().isStringLike());
   Node emp = Word::mkEmptyWord(s.getType());
-  if (d_ee.areDisequal(s, emp, true))
+  if (areDisequal(s, emp, false))
   {
     return s.eqNode(emp).negate();
   }
   Node sLen = utils::mkNLength(s);
-  if (d_ee.areDisequal(sLen, d_zero, true))
+  if (areDisequal(sLen, d_zero, false))
   {
     return sLen.eqNode(d_zero).negate();
   }

--- a/src/theory/strings/solver_state.cpp
+++ b/src/theory/strings/solver_state.cpp
@@ -252,7 +252,7 @@ Node SolverState::explainNonEmpty(Node s)
     return s.eqNode(emp).negate();
   }
   Node sLen = utils::mkNLength(s);
-  if (d_ee.areDisequal(sLen,d_zero, true))
+  if (d_ee.areDisequal(sLen, d_zero, true))
   {
     return sLen.eqNode(d_zero).negate();
   }

--- a/src/theory/strings/solver_state.h
+++ b/src/theory/strings/solver_state.h
@@ -119,11 +119,11 @@ class SolverState
   /** shorthand for getLengthExp(t, exp, t) */
   Node getLength(Node t, std::vector<Node>& exp);
   /** explain non-empty
-   * 
+   *
    * This returns an explanation of why string-like term is non-empty in the
    * current context, if such an explanation exists. Otherwise, this returns
    * the null node.
-   * 
+   *
    * Note that an explanation is a (conjunction of) literals that currently hold
    * in the equality engine.
    */

--- a/src/theory/strings/solver_state.h
+++ b/src/theory/strings/solver_state.h
@@ -118,6 +118,16 @@ class SolverState
   Node getLengthExp(Node t, std::vector<Node>& exp, Node te);
   /** shorthand for getLengthExp(t, exp, t) */
   Node getLength(Node t, std::vector<Node>& exp);
+  /** explain non-empty
+   * 
+   * This returns an explanation of why string-like term is non-empty in the
+   * current context, if such an explanation exists. Otherwise, this returns
+   * the null node.
+   * 
+   * Note that an explanation is a (conjunction of) literals that currently hold
+   * in the equality engine.
+   */
+  Node explainNonEmpty(Node s);
   /**
    * Get the above information for equivalence class eqc. If doMake is true,
    * we construct a new information class if one does not exist. The term eqc
@@ -153,6 +163,8 @@ class SolverState
                         std::vector<std::vector<Node> >& cols,
                         std::vector<Node>& lts);
  private:
+  /** Common constants */
+  Node d_zero;
   /** Pointer to the SAT context object used by the theory of strings. */
   context::Context* d_context;
   /** Reference to equality engine of the theory of strings. */


### PR DESCRIPTION
Several kinds of splitting lemmas in the strings solver can sometimes be avoided by observing that str.len(x) != 0 implies that x is non-empty.  This generalizes the check for whether x is non-empty is explainable in the current context.