### PR TITLE
Fix dump-unsat-cores-full

### DIFF
--- a/src/options/options_public_functions.cpp
+++ b/src/options/options_public_functions.cpp
@@ -75,7 +75,7 @@ bool Options::getDumpSynth() const{
 }
 
 bool Options::getDumpUnsatCores() const{
-  return (*this)[options::dumpUnsatCores];
+  return (*this)[options::dumpUnsatCores] || (*this)[options::dumpUnsatCoresFull];
 }
 
 bool Options::getEarlyExit() const{

--- a/src/options/options_public_functions.cpp
+++ b/src/options/options_public_functions.cpp
@@ -75,7 +75,9 @@ bool Options::getDumpSynth() const{
 }
 
 bool Options::getDumpUnsatCores() const{
-  return (*this)[options::dumpUnsatCores] || (*this)[options::dumpUnsatCoresFull];
+  // dump unsat cores full enables dumpUnsatCores
+  return (*this)[options::dumpUnsatCores]
+         || (*this)[options::dumpUnsatCoresFull];
 }
 
 bool Options::getEarlyExit() const{

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -463,6 +463,7 @@ set(regress_0_tests
   regress0/declare-funs.smt2
   regress0/define-fun-model.smt2
   regress0/distinct.smtv1.smt2
+  regress0/dump-unsat-core-full.smt2
   regress0/simple-dump-model.smt2
   regress0/expect/scrub.01.smtv1.smt2
   regress0/expect/scrub.03.smt2

--- a/test/regress/regress0/dump-unsat-core-full.smt2
+++ b/test/regress/regress0/dump-unsat-core-full.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --dump-unsat-cores-full
+; EXPECT: unsat
+; EXPECT: (
+; EXPECT: (and (= x y) (< x y))
+; EXPECT: )
+(set-logic QF_LIA)
+(set-info :status unsat)
+(declare-fun x () Int)
+(declare-fun y () Int)
+(assert (and (= x y) (< x y)))
+(check-sat)

--- a/test/regress/regress0/dump-unsat-core-full.smt2
+++ b/test/regress/regress0/dump-unsat-core-full.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: proof
 ; COMMAND-LINE: --dump-unsat-cores-full
 ; EXPECT: unsat
 ; EXPECT: (


### PR DESCRIPTION
This adds a fix to ensure dump-unsat-cores-full works by modifying the public options function. This options currently does not work since dumpUnsatCores is only set internally now  This fix is only required until options are refactored so that SmtEngine owns the authoritative copy of options.