### PR TITLE
Remove mergePredicates from EqualityEngine interface

### DIFF
--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -483,10 +483,10 @@ bool TheoryModel::assertEqualityEngine(const eq::EqualityEngine* ee,
             first = false;
           }
           else {
-            Node eq = *eqc_i.eqNode(rep);
+            Node eq = (*eqc_i).eqNode(rep);
             Trace("model-builder-assertions")
                 << "(assert " << eq << ");" << std::endl;
-            d_equalityEngine->assertEquality(e, true, Node::null());
+            d_equalityEngine->assertEquality(eq, true, Node::null());
             if (!d_equalityEngine->consistent())
             {
               return false;

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -483,8 +483,9 @@ bool TheoryModel::assertEqualityEngine(const eq::EqualityEngine* ee,
             first = false;
           }
           else {
-            Trace("model-builder-assertions") << "(assert (= " << *eqc_i << " " << rep << "));" << endl;
-            d_equalityEngine->mergePredicates(*eqc_i, rep, Node::null());
+            Node eq = *eqc_i.eqNode(rep);
+            Trace("model-builder-assertions") << "(assert " << eq << ");" << std::endl;
+            d_equalityEngine->assertEquality(e, true, Node::null());
             if (!d_equalityEngine->consistent())
             {
               return false;

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -484,7 +484,8 @@ bool TheoryModel::assertEqualityEngine(const eq::EqualityEngine* ee,
           }
           else {
             Node eq = *eqc_i.eqNode(rep);
-            Trace("model-builder-assertions") << "(assert " << eq << ");" << std::endl;
+            Trace("model-builder-assertions")
+                << "(assert " << eq << ");" << std::endl;
             d_equalityEngine->assertEquality(e, true, Node::null());
             if (!d_equalityEngine->consistent())
             {

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -449,12 +449,6 @@ void EqualityEngine::assertPredicate(TNode t, bool polarity, TNode reason, unsig
   propagate();
 }
 
-void EqualityEngine::mergePredicates(TNode p, TNode q, TNode reason) {
-  Debug("equality") << d_name << "::eq::mergePredicates(" << p << "," << q << ")" << std::endl;
-  assertEqualityInternal(p, q, reason);
-  propagate();
-}
-
 void EqualityEngine::assertEquality(TNode eq, bool polarity, TNode reason, unsigned pid) {
   Debug("equality") << d_name << "::eq::addEquality(" << eq << "," << (polarity ? "true" : "false") << ")" << std::endl;
   if (polarity) {

--- a/src/theory/uf/equality_engine.h
+++ b/src/theory/uf/equality_engine.h
@@ -804,11 +804,6 @@ public:
   void assertPredicate(TNode p, bool polarity, TNode reason, unsigned pid = MERGED_THROUGH_EQUALITY);
 
   /**
-   * Adds predicate p and q and makes them equal.
-   */
-  void mergePredicates(TNode p, TNode q, TNode reason);
-
-  /**
    * Adds an equality eq with the given polarity to the database.
    *
    * @param eq the (non-negated) equality


### PR DESCRIPTION
This function was equivalent to asserting an equality. Removing it for the sake of simplicity.