### PR TITLE
Eliminate remaining references to parent TheoryStrings object

### DIFF
--- a/src/theory/strings/extf_solver.cpp
+++ b/src/theory/strings/extf_solver.cpp
@@ -35,7 +35,7 @@ ExtfSolver::ExtfSolver(context::Context* c,
                        StringsRewriter& rewriter,
                        BaseSolver& bs,
                        CoreSolver& cs,
-                       ExtTheory* et,
+                       ExtTheory& et,
                        SequencesStatistics& statistics)
     : d_state(s),
       d_im(im),
@@ -50,19 +50,19 @@ ExtfSolver::ExtfSolver(context::Context* c,
       d_extfInferCache(c),
       d_reduced(u)
 {
-  d_extt->addFunctionKind(kind::STRING_SUBSTR);
-  d_extt->addFunctionKind(kind::STRING_STRIDOF);
-  d_extt->addFunctionKind(kind::STRING_ITOS);
-  d_extt->addFunctionKind(kind::STRING_STOI);
-  d_extt->addFunctionKind(kind::STRING_STRREPL);
-  d_extt->addFunctionKind(kind::STRING_STRREPLALL);
-  d_extt->addFunctionKind(kind::STRING_STRCTN);
-  d_extt->addFunctionKind(kind::STRING_IN_REGEXP);
-  d_extt->addFunctionKind(kind::STRING_LEQ);
-  d_extt->addFunctionKind(kind::STRING_TO_CODE);
-  d_extt->addFunctionKind(kind::STRING_TOLOWER);
-  d_extt->addFunctionKind(kind::STRING_TOUPPER);
-  d_extt->addFunctionKind(kind::STRING_REV);
+  d_extt.addFunctionKind(kind::STRING_SUBSTR);
+  d_extt.addFunctionKind(kind::STRING_STRIDOF);
+  d_extt.addFunctionKind(kind::STRING_ITOS);
+  d_extt.addFunctionKind(kind::STRING_STOI);
+  d_extt.addFunctionKind(kind::STRING_STRREPL);
+  d_extt.addFunctionKind(kind::STRING_STRREPLALL);
+  d_extt.addFunctionKind(kind::STRING_STRCTN);
+  d_extt.addFunctionKind(kind::STRING_IN_REGEXP);
+  d_extt.addFunctionKind(kind::STRING_LEQ);
+  d_extt.addFunctionKind(kind::STRING_TO_CODE);
+  d_extt.addFunctionKind(kind::STRING_TOLOWER);
+  d_extt.addFunctionKind(kind::STRING_TOUPPER);
+  d_extt.addFunctionKind(kind::STRING_REV);
 
   d_true = NodeManager::currentNM()->mkConst(true);
   d_false = NodeManager::currentNM()->mkConst(false);
@@ -126,7 +126,7 @@ bool ExtfSolver::doReduction(int effort, Node n)
           }
           // this depends on the current assertions, so this
           // inference is context-dependent
-          d_extt->markReduced(n, true);
+          d_extt.markReduced(n, true);
           return true;
         }
         else
@@ -173,7 +173,7 @@ bool ExtfSolver::doReduction(int effort, Node n)
     Trace("strings-red-lemma") << "Reduction (positive contains) lemma : " << n
                                << " => " << eq << std::endl;
     // context-dependent because it depends on the polarity of n itself
-    d_extt->markReduced(n, true);
+    d_extt.markReduced(n, true);
   }
   else if (k != kind::STRING_TO_CODE)
   {
@@ -206,7 +206,7 @@ void ExtfSolver::checkExtfReductions(int effort)
   // Notice we don't make a standard call to ExtTheory::doReductions here,
   // since certain optimizations like context-dependent reductions and
   // stratifying effort levels are done in doReduction below.
-  std::vector<Node> extf = d_extt->getActive();
+  std::vector<Node> extf = d_extt.getActive();
   Trace("strings-process") << "  checking " << extf.size() << " active extf"
                            << std::endl;
   for (const Node& n : extf)
@@ -234,7 +234,7 @@ void ExtfSolver::checkExtfEval(int effort)
   d_extfInfoTmp.clear();
   NodeManager* nm = NodeManager::currentNM();
   bool has_nreduce = false;
-  std::vector<Node> terms = d_extt->getActive();
+  std::vector<Node> terms = d_extt.getActive();
   for (const Node& n : terms)
   {
     // Setup information about n, including if it is equal to a constant.
@@ -281,7 +281,7 @@ void ExtfSolver::checkExtfEval(int effort)
       {
         if (effort < 3)
         {
-          d_extt->markReduced(n);
+          d_extt.markReduced(n);
           Trace("strings-extf-debug")
               << "  resolvable by evaluation..." << std::endl;
           std::vector<Node> exps;
@@ -445,7 +445,7 @@ void ExtfSolver::checkExtfEval(int effort)
         }
         Trace("strings-extf-list") << std::endl;
       }
-      if (d_extt->isActive(n) && einfo.d_modelActive)
+      if (d_extt.isActive(n) && einfo.d_modelActive)
       {
         has_nreduce = true;
       }
@@ -525,10 +525,10 @@ void ExtfSolver::checkExtfInference(Node n,
               // we are in conflict
               d_im.sendInference(in.d_exp, conc, Inference::CTN_DECOMPOSE);
             }
-            else if (d_extt->hasFunctionKind(conc.getKind()))
+            else if (d_extt.hasFunctionKind(conc.getKind()))
             {
               // can mark as reduced, since model for n implies model for conc
-              d_extt->markReduced(conc);
+              d_extt.markReduced(conc);
             }
           }
         }
@@ -613,7 +613,7 @@ void ExtfSolver::checkExtfInference(Node n,
         // satisfied by all models of str.contains( x, y ) ^ x=z and thus can
         // be ignored.
         Trace("strings-extf-debug") << "  redundant." << std::endl;
-        d_extt->markReduced(n);
+        d_extt.markReduced(n);
       }
     }
     return;
@@ -680,7 +680,7 @@ bool ExtfSolver::hasExtendedFunctions() const { return d_hasExtf.get(); }
 
 std::vector<Node> ExtfSolver::getActive(Kind k) const
 {
-  return d_extt->getActive(k);
+  return d_extt.getActive(k);
 }
 
 }  // namespace strings

--- a/src/theory/strings/extf_solver.cpp
+++ b/src/theory/strings/extf_solver.cpp
@@ -678,10 +678,6 @@ std::vector<Node> ExtfSolver::getActive(Kind k) const
 {
   return d_extt->getActive(k);
 }
-void markReduced(Node n, bool contextDepend)
-{
-  d_extt->markReduced(n, contextDepend);
-}
 
 }  // namespace strings
 }  // namespace theory

--- a/src/theory/strings/extf_solver.cpp
+++ b/src/theory/strings/extf_solver.cpp
@@ -678,6 +678,10 @@ std::vector<Node> ExtfSolver::getActive(Kind k) const
 {
   return d_extt->getActive(k);
 }
+void markReduced(Node n, bool contextDepend)
+{
+  d_extt->markReduced(n, contextDepend);
+}
 
 }  // namespace strings
 }  // namespace theory

--- a/src/theory/strings/extf_solver.h
+++ b/src/theory/strings/extf_solver.h
@@ -147,6 +147,7 @@ class ExtfSolver
    * checkExtfEval.
    */
   const std::map<Node, ExtfInfoTmp>& getInfo() const;
+  //---------------------------------- information about ExtTheory
   /** Are there any active extended functions? */
   bool hasExtendedFunctions() const;
   /**
@@ -154,7 +155,13 @@ class ExtfSolver
    * context (see ExtTheory::getActive).
    */
   std::vector<Node> getActive(Kind k) const;
-
+  /** 
+   * Mark that extended function is reduced. If contextDepend is true,
+   * then this mark is SAT-context dependent, otherwise it is user-context
+   * dependent (see ExtTheory::markReduced).
+   */
+  void markReduced(Node n, bool contextDepend = true);
+  //---------------------------------- end information about ExtTheory
  private:
   /** do reduction
    *

--- a/src/theory/strings/extf_solver.h
+++ b/src/theory/strings/extf_solver.h
@@ -155,12 +155,6 @@ class ExtfSolver
    * context (see ExtTheory::getActive).
    */
   std::vector<Node> getActive(Kind k) const;
-  /** 
-   * Mark that extended function is reduced. If contextDepend is true,
-   * then this mark is SAT-context dependent, otherwise it is user-context
-   * dependent (see ExtTheory::markReduced).
-   */
-  void markReduced(Node n, bool contextDepend = true);
   //---------------------------------- end information about ExtTheory
  private:
   /** do reduction

--- a/src/theory/strings/extf_solver.h
+++ b/src/theory/strings/extf_solver.h
@@ -91,7 +91,7 @@ class ExtfSolver
              StringsRewriter& rewriter,
              BaseSolver& bs,
              CoreSolver& cs,
-             ExtTheory* et,
+             ExtTheory& et,
              SequencesStatistics& statistics);
   ~ExtfSolver();
 
@@ -191,7 +191,7 @@ class ExtfSolver
   /** reference to the core solver, used for certain queries */
   CoreSolver& d_csolver;
   /** the extended theory object for the theory of strings */
-  ExtTheory* d_extt;
+  ExtTheory& d_extt;
   /** Reference to the statistics for the theory of strings/sequences. */
   SequencesStatistics& d_statistics;
   /** preprocessing utility, for performing strings reductions */

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -382,12 +382,14 @@ void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp)
   {
     // we must ensure these terms are registered
     Trace("strings-pending-debug") << "  Register term" << std::endl;
-    for (unsigned j = 0; j < 2; j++)
+    for (const Node& t : atom)
     {
       // terms in the equality engine are already registered, hence skip
-      if (!ee->hasTerm(atom[j]))
+      // currently done for only string-like terms, but this could potentially
+      // be avoided.
+      if (!ee->hasTerm(t) && t.getType().isStringLike())
       {
-        d_termReg.registerTerm(atom[j], 0);
+        d_termReg.registerTerm(t, 0);
       }
     }
     Trace("strings-pending-debug") << "  Now assert equality" << std::endl;

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -32,7 +32,7 @@ InferenceManager::InferenceManager(context::Context* c,
                                    context::UserContext* u,
                                    SolverState& s,
                                    TermRegistry& tr,
-                                   ExtTheory* e,
+                                   ExtTheory& e,
                                    OutputChannel& out,
                                    SequencesStatistics& statistics)
     : d_state(s),
@@ -430,7 +430,7 @@ void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp)
   // Collect extended function terms in the atom. Notice that we must register
   // all extended functions occurring in assertions and shared terms. We
   // make a similar call to registerTermRec in TheoryStrings::addSharedTerm.
-  d_extt->registerTermRec(atom);
+  d_extt.registerTermRec(atom);
   Trace("strings-pending-debug") << "  Finished collect terms" << std::endl;
 }
 
@@ -540,15 +540,15 @@ void InferenceManager::explain(TNode literal,
 void InferenceManager::markCongruent(Node a, Node b)
 {
   Assert(a.getKind() == b.getKind());
-  if (d_extt->hasFunctionKind(a.getKind()))
+  if (d_extt.hasFunctionKind(a.getKind()))
   {
-    d_extt->markCongruent(a, b);
+    d_extt.markCongruent(a, b);
   }
 }
 
 void InferenceManager::markReduced(Node n, bool contextDepend)
 {
-  d_extt->markReduced(n, contextDepend);
+  d_extt.markReduced(n, contextDepend);
 }
 
 }  // namespace strings

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -14,13 +14,13 @@
 
 #include "theory/strings/inference_manager.h"
 
+#include "expr/attribute.h"
 #include "expr/kind.h"
 #include "options/strings_options.h"
 #include "theory/ext_theory.h"
 #include "theory/rewriter.h"
 #include "theory/strings/theory_strings_utils.h"
 #include "theory/strings/word.h"
-#include "expr/attribute.h"
 
 using namespace std;
 using namespace CVC4::context;
@@ -30,8 +30,11 @@ namespace CVC4 {
 namespace theory {
 namespace strings {
 
-struct StringsProxyVarAttributeId {};
-typedef expr::Attribute< StringsProxyVarAttributeId, bool > StringsProxyVarAttribute;
+struct StringsProxyVarAttributeId
+{
+};
+typedef expr::Attribute<StringsProxyVarAttributeId, bool>
+    StringsProxyVarAttribute;
 
 InferenceManager::InferenceManager(context::Context* c,
                                    context::UserContext* u,
@@ -40,11 +43,7 @@ InferenceManager::InferenceManager(context::Context* c,
                                    ExtTheory* e,
                                    OutputChannel& out,
                                    SequencesStatistics& statistics)
-    : d_state(s),
-      d_termReg(tr),
-      d_out(out),
-      d_statistics(statistics),
-      d_keep(c)
+    : d_state(s), d_termReg(tr), d_out(out), d_statistics(statistics), d_keep(c)
 {
   NodeManager* nm = NodeManager::currentNM();
   d_zero = nm->mkConst(Rational(0));
@@ -368,17 +367,21 @@ void InferenceManager::doPendingLemmas()
   d_pendingReqPhase.clear();
 }
 
-
-void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp) {
+void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp)
+{
   eq::EqualityEngine* ee = d_state.getEqualityEngine();
-  Trace("strings-pending") << "Assert pending fact : " << atom << " " << polarity << " from " << exp << std::endl;
+  Trace("strings-pending") << "Assert pending fact : " << atom << " "
+                           << polarity << " from " << exp << std::endl;
   Assert(atom.getKind() != OR) << "Infer error: a split.";
-  if( atom.getKind()==EQUAL ){
+  if (atom.getKind() == EQUAL)
+  {
     Trace("strings-pending-debug") << "  Now assert equality" << std::endl;
-    ee->assertEquality( atom, polarity, exp );
+    ee->assertEquality(atom, polarity, exp);
     Trace("strings-pending-debug") << "  Finished assert equality" << std::endl;
-  } else {
-    ee->assertPredicate( atom, polarity, exp );
+  }
+  else
+  {
+    ee->assertPredicate(atom, polarity, exp);
     if (atom.getKind() == STRING_IN_REGEXP)
     {
       if (polarity && atom[1].getKind() == REGEXP_CONCAT)
@@ -410,7 +413,7 @@ void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp) {
   // Collect extended function terms in the atom. Notice that we must register
   // all extended functions occurring in assertions and shared terms. We
   // make a similar call to registerTermRec in TheoryStrings::addSharedTerm.
-  d_extt->registerTermRec( atom );
+  d_extt->registerTermRec(atom);
   Trace("strings-pending-debug") << "  Finished collect terms" << std::endl;
 }
 

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -44,6 +44,14 @@ InferenceManager::InferenceManager(context::Context* c,
   d_false = nm->mkConst(false);
 }
 
+void InferenceManager::sendAssumption(TNode lit)
+{
+  bool polarity = lit.getKind() != kind::NOT;
+  TNode atom = polarity ? lit : lit[0];
+  //assert pending fact
+  assertPendingFact( atom, polarity, lit );
+}
+
 bool InferenceManager::sendInternalInference(std::vector<Node>& exp,
                                              Node conc,
                                              Inference infer)

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -48,8 +48,8 @@ void InferenceManager::sendAssumption(TNode lit)
 {
   bool polarity = lit.getKind() != kind::NOT;
   TNode atom = polarity ? lit : lit[0];
-  //assert pending fact
-  assertPendingFact( atom, polarity, lit );
+  // assert pending fact
+  assertPendingFact(atom, polarity, lit);
 }
 
 bool InferenceManager::sendInternalInference(std::vector<Node>& exp,
@@ -377,11 +377,12 @@ void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp)
   {
     // we must ensure these terms are registered
     Trace("strings-pending-debug") << "  Register term" << std::endl;
-    for( unsigned j=0; j<2; j++ ) {
+    for (unsigned j = 0; j < 2; j++)
+    {
       // terms in the equality engine are already registered, hence skip
       if (!d_equalityEngine.hasTerm(atom[j]))
       {
-        d_termReg.registerTerm( atom[j], 0 );
+        d_termReg.registerTerm(atom[j], 0);
       }
     }
     Trace("strings-pending-debug") << "  Now assert equality" << std::endl;

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -367,6 +367,15 @@ void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp)
   Assert(atom.getKind() != OR) << "Infer error: a split.";
   if (atom.getKind() == EQUAL)
   {
+    // we must ensure these terms are registered
+    Trace("strings-pending-debug") << "  Register term" << std::endl;
+    for( unsigned j=0; j<2; j++ ) {
+      // terms in the equality engine are already registered, hence skip
+      if (!d_equalityEngine.hasTerm(atom[j]))
+      {
+        d_termReg.registerTerm( atom[j], 0 );
+      }
+    }
     Trace("strings-pending-debug") << "  Now assert equality" << std::endl;
     ee->assertEquality(atom, polarity, exp);
     Trace("strings-pending-debug") << "  Finished assert equality" << std::endl;

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -35,7 +35,7 @@ InferenceManager::InferenceManager(context::Context* c,
                                    ExtTheory* e,
                                    OutputChannel& out,
                                    SequencesStatistics& statistics)
-    : d_state(s), d_termReg(tr), d_out(out), d_statistics(statistics), d_keep(c)
+    : d_state(s), d_termReg(tr), d_extt(e), d_out(out), d_statistics(statistics), d_keep(c)
 {
   NodeManager* nm = NodeManager::currentNM();
   d_zero = nm->mkConst(Rational(0));

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -296,10 +296,7 @@ void InferenceManager::sendPhaseRequirement(Node lit, bool pol)
   d_pendingReqPhase[lit] = pol;
 }
 
-void InferenceManager::setIncomplete()
-{
-  d_out.setIncomplete();
-}
+void InferenceManager::setIncomplete() { d_out.setIncomplete(); }
 
 Node InferenceManager::getProxyVariableFor(Node n) const
 {

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -31,7 +31,7 @@ namespace strings {
 InferenceManager::InferenceManager(context::Context* c,
                                    context::UserContext* u,
                                    SolverState& s,
-                                   TermRegistry& skc,
+                                   TermRegistry& tr,
                                    ExtTheory* e,
                                    OutputChannel& out,
                                    SequencesStatistics& statistics)

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -14,8 +14,6 @@
 
 #include "theory/strings/inference_manager.h"
 
-#include "expr/attribute.h"
-#include "expr/kind.h"
 #include "options/strings_options.h"
 #include "theory/ext_theory.h"
 #include "theory/rewriter.h"
@@ -29,12 +27,6 @@ using namespace CVC4::kind;
 namespace CVC4 {
 namespace theory {
 namespace strings {
-
-struct StringsProxyVarAttributeId
-{
-};
-typedef expr::Attribute<StringsProxyVarAttributeId, bool>
-    StringsProxyVarAttribute;
 
 InferenceManager::InferenceManager(context::Context* c,
                                    context::UserContext* u,

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -18,7 +18,6 @@
 #include "options/strings_options.h"
 #include "theory/ext_theory.h"
 #include "theory/rewriter.h"
-#include "theory/strings/theory_strings.h"
 #include "theory/strings/theory_strings_utils.h"
 #include "theory/strings/word.h"
 
@@ -30,15 +29,14 @@ namespace CVC4 {
 namespace theory {
 namespace strings {
 
-InferenceManager::InferenceManager(TheoryStrings& p,
-                                   context::Context* c,
+InferenceManager::InferenceManager(context::Context* c,
                                    context::UserContext* u,
                                    SolverState& s,
                                    SkolemCache& skc,
+                                   ExtTheory* e,
                                    OutputChannel& out,
                                    SequencesStatistics& statistics)
-    : d_parent(p),
-      d_state(s),
+    : d_state(s),
       d_skCache(skc),
       d_out(out),
       d_statistics(statistics),
@@ -779,11 +777,15 @@ void InferenceManager::setIncomplete() { d_out.setIncomplete(); }
 void InferenceManager::markCongruent(Node a, Node b)
 {
   Assert(a.getKind() == b.getKind());
-  ExtTheory* eth = d_parent.getExtTheory();
-  if (eth->hasFunctionKind(a.getKind()))
+  if (d_extt->hasFunctionKind(a.getKind()))
   {
-    eth->markCongruent(a, b);
+    d_extt->markCongruent(a, b);
   }
+}
+
+void markReduced(Node n, bool contextDepend)
+{
+  d_extt->markReduced(n, contextDepend);
 }
 
 }  // namespace strings

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -298,6 +298,11 @@ void InferenceManager::sendPhaseRequirement(Node lit, bool pol)
   d_pendingReqPhase[lit] = pol;
 }
 
+void InferenceManager::setIncomplete()
+{
+  d_out.setIncomplete();
+}
+
 Node InferenceManager::getProxyVariableFor(Node n) const
 {
   NodeNodeMap::const_iterator it = d_proxyVar.find(n);
@@ -456,18 +461,12 @@ Node InferenceManager::getRegisterTermAtomicLemma(
     Node neq_empty = n.eqNode(d_emptyString).negate();
     Node len_n_gt_z = nm->mkNode(GT, n_len, d_zero);
     Node len_geq_one = nm->mkNode(AND, neq_empty, len_n_gt_z);
-    Trace("strings-lemma") << "Strings::Lemma SK-GEQ-ONE : " << len_geq_one
-                           << std::endl;
-    Trace("strings-assert") << "(assert " << len_geq_one << ")" << std::endl;
     return len_geq_one;
   }
 
   if (s == LENGTH_ONE)
   {
     Node len_one = n_len.eqNode(d_one);
-    Trace("strings-lemma") << "Strings::Lemma SK-ONE : " << len_one
-                           << std::endl;
-    Trace("strings-assert") << "(assert " << len_one << ")" << std::endl;
     return len_one;
   }
   Assert(s == LENGTH_SPLIT);
@@ -483,8 +482,6 @@ Node InferenceManager::getRegisterTermAtomicLemma(
   {
     Node lem = nm->mkNode(OR, case_empty, case_nempty);
     lems.push_back(lem);
-    Trace("strings-lemma") << "Strings::Lemma LENGTH >= 0 : " << lem
-                           << std::endl;
     // prefer trying the empty case first
     // notice that requirePhase must only be called on rewritten literals that
     // occur in the CNF stream.
@@ -498,8 +495,6 @@ Node InferenceManager::getRegisterTermAtomicLemma(
   else if (!case_empty.getConst<bool>())
   {
     // the rewriter knows that n is non-empty
-    Trace("strings-lemma") << "Strings::Lemma LENGTH > 0 (non-empty): "
-                           << case_nempty << std::endl;
     lems.push_back(case_nempty);
   }
   else

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -35,7 +35,12 @@ InferenceManager::InferenceManager(context::Context* c,
                                    ExtTheory* e,
                                    OutputChannel& out,
                                    SequencesStatistics& statistics)
-    : d_state(s), d_termReg(tr), d_extt(e), d_out(out), d_statistics(statistics), d_keep(c)
+    : d_state(s),
+      d_termReg(tr),
+      d_extt(e),
+      d_out(out),
+      d_statistics(statistics),
+      d_keep(c)
 {
   NodeManager* nm = NodeManager::currentNM();
   d_zero = nm->mkConst(Rational(0));

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -380,7 +380,7 @@ void InferenceManager::assertPendingFact(Node atom, bool polarity, Node exp)
     for (unsigned j = 0; j < 2; j++)
     {
       // terms in the equality engine are already registered, hence skip
-      if (!d_equalityEngine.hasTerm(atom[j]))
+      if (!ee->hasTerm(atom[j]))
       {
         d_termReg.registerTerm(atom[j], 0);
       }

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -295,9 +295,7 @@ class InferenceManager
    * equality engine of this class.
    */
   void sendInfer(Node eq_exp, Node eq, Inference infer);
-  /**
-   * This is a reference to the solver state of the theory of strings.
-   */
+  /** Reference to the solver state of the theory of strings. */
   SolverState& d_state;
   /** Reference to the term registry of theory of strings */
   TermRegistry& d_termReg;

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -23,13 +23,13 @@
 #include "context/cdhashset.h"
 #include "context/context.h"
 #include "expr/node.h"
+#include "theory/ext_theory.h"
 #include "theory/output_channel.h"
 #include "theory/strings/infer_info.h"
 #include "theory/strings/sequences_stats.h"
 #include "theory/strings/skolem_cache.h"
 #include "theory/strings/solver_state.h"
 #include "theory/uf/equality_engine.h"
-#include "theory/ext_theory.h"
 
 namespace CVC4 {
 namespace theory {
@@ -306,7 +306,7 @@ class InferenceManager
    * theory.
    */
   void markCongruent(Node a, Node b);
-  /** 
+  /**
    * Mark that extended function is reduced. If contextDepend is true,
    * then this mark is SAT-context dependent, otherwise it is user-context
    * dependent (see ExtTheory::markReduced).

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -79,6 +79,13 @@ class InferenceManager
                    OutputChannel& out,
                    SequencesStatistics& statistics);
   ~InferenceManager() {}
+  
+  /** send assumption 
+   * 
+   * This is called when a fact is asserted to TheoryStrings. It adds lit
+   * to the equality engine maintained by this class immediately.
+   */
+  void sendAssumption(TNode lit);
 
   /** send internal inferences
    *
@@ -194,7 +201,7 @@ class InferenceManager
    *
    * This method asserts pending facts (d_pending) with explanations
    * (d_pendingExp) to the equality engine of the theory of strings via calls
-   * to assertPendingFact in the theory of strings.
+   * to assertPendingFact.
    *
    * It terminates early if a conflict is encountered, for instance, by
    * equality reasoning within the equality engine.

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -79,9 +79,9 @@ class InferenceManager
                    OutputChannel& out,
                    SequencesStatistics& statistics);
   ~InferenceManager() {}
-  
-  /** send assumption 
-   * 
+
+  /** send assumption
+   *
    * This is called when a fact is asserted to TheoryStrings. It adds lit
    * to the equality engine maintained by this class immediately.
    */

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -75,7 +75,7 @@ class InferenceManager
                    context::UserContext* u,
                    SolverState& s,
                    TermRegistry& tr,
-                   ExtTheory* e,
+                   ExtTheory& e,
                    OutputChannel& out,
                    SequencesStatistics& statistics);
   ~InferenceManager() {}
@@ -300,7 +300,7 @@ class InferenceManager
   /** Reference to the term registry of theory of strings */
   TermRegistry& d_termReg;
   /** the extended theory object for the theory of strings */
-  ExtTheory* d_extt;
+  ExtTheory& d_extt;
   /** A reference to the output channel of the theory of strings. */
   OutputChannel& d_out;
   /** Reference to the statistics for the theory of strings/sequences. */

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -29,12 +29,11 @@
 #include "theory/strings/skolem_cache.h"
 #include "theory/strings/solver_state.h"
 #include "theory/uf/equality_engine.h"
+#include "theory/ext_theory.h"
 
 namespace CVC4 {
 namespace theory {
 namespace strings {
-
-class TheoryStrings;
 
 /** Inference Manager
  *
@@ -72,11 +71,11 @@ class InferenceManager
   typedef context::CDHashMap<Node, Node, NodeHashFunction> NodeNodeMap;
 
  public:
-  InferenceManager(TheoryStrings& p,
-                   context::Context* c,
+  InferenceManager(context::Context* c,
                    context::UserContext* u,
                    SolverState& s,
                    SkolemCache& skc,
+                   ExtTheory* e,
                    OutputChannel& out,
                    SequencesStatistics& statistics);
   ~InferenceManager() {}
@@ -175,9 +174,6 @@ class InferenceManager
    * decided with polarity pol.
    */
   void sendPhaseRequirement(Node lit, bool pol);
-  
-  /** Set incomplete on the output channel of TheoryStrings */
-  void setIncomplete();
 
   //---------------------------- proxy variables and length elaboration
   /** Get symbolic definition
@@ -302,6 +298,7 @@ class InferenceManager
    * channel's setIncomplete method.
    */
   void setIncomplete();
+  // ------------------------------------------------- extended theory
   /**
    * Mark that terms a and b are congruent in the current context.
    * This makes a call to markCongruent in the extended theory object of
@@ -309,6 +306,13 @@ class InferenceManager
    * theory.
    */
   void markCongruent(Node a, Node b);
+  /** 
+   * Mark that extended function is reduced. If contextDepend is true,
+   * then this mark is SAT-context dependent, otherwise it is user-context
+   * dependent (see ExtTheory::markReduced).
+   */
+  void markReduced(Node n, bool contextDepend = true);
+  // ------------------------------------------------- end extended theory
 
  private:
   /**
@@ -340,19 +344,15 @@ class InferenceManager
   Node getRegisterTermAtomicLemma(Node n,
                                   LengthStatus s,
                                   std::map<Node, bool>& reqPhase);
-
-  /** the parent theory of strings object */
-  TheoryStrings& d_parent;
   /**
    * This is a reference to the solver state of the theory of strings.
    */
   SolverState& d_state;
   /** cache of all skolems */
   SkolemCache& d_skCache;
-  /** the output channel
-   *
-   * This is a reference to the output channel of the theory of strings.
-   */
+  /** the extended theory object for the theory of strings */
+  ExtTheory* d_extt;
+  /** A reference to the output channel of the theory of strings. */
   OutputChannel& d_out;
 
   /** Reference to the statistics for the theory of strings/sequences. */

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -175,6 +175,9 @@ class InferenceManager
    * decided with polarity pol.
    */
   void sendPhaseRequirement(Node lit, bool pol);
+  
+  /** Set incomplete on the output channel of TheoryStrings */
+  void setIncomplete();
 
   //---------------------------- proxy variables and length elaboration
   /** Get symbolic definition

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -174,6 +174,12 @@ class InferenceManager
    * decided with polarity pol.
    */
   void sendPhaseRequirement(Node lit, bool pol);
+  /**
+   * Set that we are incomplete for the current set of assertions (in other
+   * words, we must answer "unknown" instead of "sat"); this calls the output
+   * channel's setIncomplete method.
+   */
+  void setIncomplete();
 
   //---------------------------- proxy variables and length elaboration
   /** Get symbolic definition
@@ -292,12 +298,6 @@ class InferenceManager
    * the node corresponding to their conjunction.
    */
   void explain(TNode literal, std::vector<TNode>& assumptions) const;
-  /**
-   * Set that we are incomplete for the current set of assertions (in other
-   * words, we must answer "unknown" instead of "sat"); this calls the output
-   * channel's setIncomplete method.
-   */
-  void setIncomplete();
   // ------------------------------------------------- extended theory
   /**
    * Mark that terms a and b are congruent in the current context.
@@ -315,6 +315,15 @@ class InferenceManager
   // ------------------------------------------------- end extended theory
 
  private:
+  /** assert pending fact
+   *
+   * This asserts atom with polarity to the equality engine of this class,
+   * where exp is the explanation of why (~) atom holds.
+   *
+   * This call may trigger further initialization steps involving the terms
+   * of atom, including calls to registerTerm.
+   */
+  void assertPendingFact(Node atom, bool polarity, Node exp);
   /**
    * Indicates that ant => conc should be sent on the output channel of this
    * class. This will either trigger an immediate call to the conflict

--- a/src/theory/strings/regexp_solver.cpp
+++ b/src/theory/strings/regexp_solver.cpp
@@ -40,6 +40,7 @@ RegExpSolver::RegExpSolver(SolverState& s,
                            context::UserContext* u)
     : d_state(s),
       d_im(im),
+      d_csolver(cs),
       d_esolver(es),
       d_statistics(stats),
       d_regexp_ucached(u),

--- a/src/theory/strings/regexp_solver.cpp
+++ b/src/theory/strings/regexp_solver.cpp
@@ -20,7 +20,6 @@
 
 #include "options/strings_options.h"
 #include "theory/ext_theory.h"
-#include "theory/strings/theory_strings.h"
 #include "theory/strings/theory_strings_utils.h"
 #include "theory/theory_model.h"
 
@@ -366,14 +365,14 @@ bool RegExpSolver::checkEqcInclusion(std::vector<Node>& mems)
           {
             // ~str.in.re(x, R1) includes ~str.in.re(x, R2) --->
             //   mark ~str.in.re(x, R2) as reduced
-            d_esolver->markReduced(m2Lit);
+            d_im.markReduced(m2Lit);
             remove.insert(m2);
           }
           else
           {
             // str.in.re(x, R1) includes str.in.re(x, R2) --->
             //   mark str.in.re(x, R1) as reduced
-            d_esolver->markReduced(m1Lit);
+            d_im.markReduced(m1Lit);
             remove.insert(m1);
 
             // We don't need to process m1 anymore
@@ -494,12 +493,12 @@ bool RegExpSolver::checkEqcIntersect(const std::vector<Node>& mems)
     {
       // if R1 = intersect( R1, R2 ), then x in R1 ^ x in R2 is equivalent
       // to x in R1, hence x in R2 can be marked redundant.
-      d_esolver->markReduced(m);
+      d_im.markReduced(m);
     }
     else if (mres == m)
     {
       // same as above, opposite direction
-      d_esolver->markReduced(mi);
+      d_im.markReduced(mi);
     }
     else
     {
@@ -514,8 +513,8 @@ bool RegExpSolver::checkEqcIntersect(const std::vector<Node>& mems)
       }
       d_im.sendInference(vec_nodes, mres, Inference::RE_INTER_INFER, true);
       // both are reduced
-      d_esolver->markReduced(m);
-      d_esolver->markReduced(mi);
+      d_im.markReduced(m);
+      d_im.markReduced(mi);
       // do not send more than one lemma for this class
       return true;
     }

--- a/src/theory/strings/regexp_solver.h
+++ b/src/theory/strings/regexp_solver.h
@@ -46,9 +46,9 @@ class RegExpSolver
   typedef context::CDHashSet<Node, NodeHashFunction> NodeSet;
 
  public:
-  RegExpSolver(TheoryStrings& p,
-               SolverState& s,
+  RegExpSolver(SolverState& s,
                InferenceManager& im,
+               CoreSolver& cs,
                ExtfSolver& es,
                SequencesStatistics& stats,
                context::Context* c,
@@ -113,12 +113,12 @@ class RegExpSolver
   Node d_emptyRegexp;
   Node d_true;
   Node d_false;
-  /** the parent of this object */
-  TheoryStrings& d_parent;
   /** The solver state of the parent of this object */
   SolverState& d_state;
   /** the output channel of the parent of this object */
   InferenceManager& d_im;
+  /** reference to the core solver, used for certain queries */
+  CoreSolver& d_csolver;
   /** reference to the extended function solver of the parent */
   ExtfSolver& d_esolver;
   /** Reference to the statistics for the theory of strings/sequences. */

--- a/src/theory/strings/regexp_solver.h
+++ b/src/theory/strings/regexp_solver.h
@@ -34,8 +34,6 @@ namespace CVC4 {
 namespace theory {
 namespace strings {
 
-class TheoryStrings;
-
 class RegExpSolver
 {
   typedef context::CDList<Node> NodeList;

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -89,7 +89,8 @@ TheoryStrings::TheoryStrings(context::Context* c,
   setupExtTheory();
   ExtTheory* extt = getExtTheory();
   // initialize the inference manager, which requires the extended theory
-  d_im.reset(new InferenceManager(c, u, d_state, d_sk_cache, extt, out, d_statistics));
+  d_im.reset(
+      new InferenceManager(c, u, d_state, d_sk_cache, extt, out, d_statistics));
   // initialize the solvers
   d_bsolver.reset(new BaseSolver(c, u, d_state, *d_im));
   d_csolver.reset(new CoreSolver(c, u, d_state, *d_im, d_sk_cache, d_bsolver));
@@ -103,8 +104,8 @@ TheoryStrings::TheoryStrings(context::Context* c,
                                  *d_csolver,
                                  extt,
                                  d_statistics));
-  d_rsolver.reset(
-      new RegExpSolver(d_state, *d_im, *d_csolver, *d_esolver, d_statistics, c, u));
+  d_rsolver.reset(new RegExpSolver(
+      d_state, *d_im, *d_csolver, *d_esolver, d_statistics, c, u));
 
   // The kinds we are treating as function application in congruence
   d_equalityEngine.addFunctionKind(kind::STRING_LENGTH);

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -99,7 +99,7 @@ TheoryStrings::TheoryStrings(context::Context* c,
                                  extt,
                                  d_statistics));
   d_rsolver.reset(
-      new RegExpSolver(*this, d_state, d_im, *d_esolver, d_statistics, c, u));
+      new RegExpSolver(d_state, d_im, d_csolver, *d_esolver, d_statistics, c, u));
 
   // The kinds we are treating as function application in congruence
   d_equalityEngine.addFunctionKind(kind::STRING_LENGTH);

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -875,8 +875,7 @@ void TheoryStrings::checkCodes()
         if (!d_state.areEqual(cc, vc))
         {
           std::vector<Node> emptyVec;
-          d_im->sendInference(
-              emptyVec, cc.eqNode(vc), Inference::CODE_PROXY);
+          d_im->sendInference(emptyVec, cc.eqNode(vc), Inference::CODE_PROXY);
         }
         const_codes.push_back(vc);
       }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -587,8 +587,6 @@ void TheoryStrings::check(Effort e) {
 
   TimerStat::CodeTimer checkTimer(d_checkTime);
 
-  bool polarity;
-  TNode atom;
   // Trace("strings-process") << "Theory of strings, check : " << e << std::endl;
   Trace("strings-check-debug")
       << "Theory of strings, check : " << e << std::endl;
@@ -876,8 +874,9 @@ void TheoryStrings::checkCodes()
         Node vc = nm->mkNode(STRING_TO_CODE, cp);
         if (!d_state.areEqual(cc, vc))
         {
+          std::vector<Node> emptyVec;
           d_im->sendInference(
-              d_empty_vec, cc.eqNode(vc), Inference::CODE_PROXY);
+              emptyVec, cc.eqNode(vc), Inference::CODE_PROXY);
         }
         const_codes.push_back(vc);
       }
@@ -915,7 +914,8 @@ void TheoryStrings::checkCodes()
           // str.code(x)==-1 V str.code(x)!=str.code(y) V x==y
           Node inj_lem = nm->mkNode(kind::OR, eq_no, deq, eqn);
           d_im->sendPhaseRequirement(deq, false);
-          d_im->sendInference(d_empty_vec, inj_lem, Inference::CODE_INJ);
+          std::vector<Node> emptyVec;
+          d_im->sendInference(emptyVec, inj_lem, Inference::CODE_INJ);
         }
       }
     }

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -86,7 +86,7 @@ TheoryStrings::TheoryStrings(context::Context* c,
   ExtTheory* extt = getExtTheory();
   // initialize the inference manager, which requires the extended theory
   d_im.reset(
-      new InferenceManager(c, u, d_state, d_termReg, extt, out, d_statistics));
+      new InferenceManager(c, u, d_state, d_termReg, *extt, out, d_statistics));
   // initialize the solvers
   d_bsolver.reset(new BaseSolver(c, u, d_state, *d_im));
   d_csolver.reset(new CoreSolver(c, u, d_state, *d_im, d_termReg, *d_bsolver));
@@ -98,7 +98,7 @@ TheoryStrings::TheoryStrings(context::Context* c,
                                  d_rewriter,
                                  *d_bsolver,
                                  *d_csolver,
-                                 extt,
+                                 *extt,
                                  d_statistics));
   d_rsolver.reset(new RegExpSolver(
       d_state, *d_im, *d_csolver, *d_esolver, d_statistics, c, u));

--- a/src/theory/strings/theory_strings.cpp
+++ b/src/theory/strings/theory_strings.cpp
@@ -932,7 +932,8 @@ void TheoryStrings::checkCodes()
         Node vc = nm->mkNode(STRING_TO_CODE, cp);
         if (!d_state.areEqual(cc, vc))
         {
-          d_im->sendInference(d_empty_vec, cc.eqNode(vc), Inference::CODE_PROXY);
+          d_im->sendInference(
+              d_empty_vec, cc.eqNode(vc), Inference::CODE_PROXY);
         }
         const_codes.push_back(vc);
       }

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -227,7 +227,7 @@ class TheoryStrings : public Theory {
   /** The solver state object */
   SolverState d_state;
   /** The (custom) output channel of the theory of strings */
-  InferenceManager d_im;
+  std::unique_ptr<InferenceManager> d_im;
   // preReg cache
   NodeSet d_pregistered_terms_cache;
   NodeSet d_registered_terms_cache;
@@ -358,12 +358,12 @@ private:
    * The base solver, responsible for reasoning about congruent terms and
    * inferring constants for equivalence classes.
    */
-  BaseSolver d_bsolver;
+  std::unique_ptr<BaseSolver> d_bsolver;
   /**
    * The core solver, responsible for reasoning about string concatenation
    * with length constraints.
    */
-  CoreSolver d_csolver;
+  std::unique_ptr<CoreSolver> d_csolver;
   /**
    * Extended function solver, responsible for reductions and simplifications
    * involving extended string functions.

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -203,18 +203,6 @@ class TheoryStrings : public Theory {
     SolverState& d_state;
   };/* class TheoryStrings::NotifyClass */
 
-  //--------------------------- helper functions
-  /** get normal string
-   *
-   * This method returns the node that is equivalent to the normal form of x,
-   * and adds the corresponding explanation to nf_exp.
-   *
-   * For example, if x = y ++ z is an assertion in the current context, then
-   * this method returns the term y ++ z and adds x = y ++ z to nf_exp.
-   */
-  Node getNormalString(Node x, std::vector<Node>& nf_exp);
-  //-------------------------- end helper functions
-
  private:
   // Constants
   Node d_emptyString;

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -227,7 +227,8 @@ class TheoryStrings : public Theory {
   TermRegistry d_termReg;
   /** The (custom) output channel of the theory of strings */
   std::unique_ptr<InferenceManager> d_im;
-private:
+
+ private:
 
   std::map< Node, Node > d_eqc_to_len_term;
 

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -93,9 +93,6 @@ enum InferStep
 };
 std::ostream& operator<<(std::ostream& out, Inference i);
 
-struct StringsProxyVarAttributeId {};
-typedef expr::Attribute< StringsProxyVarAttributeId, bool > StringsProxyVarAttribute;
-
 class TheoryStrings : public Theory {
   friend class InferenceManager;
   typedef context::CDList<Node> NodeList;

--- a/src/theory/strings/theory_strings.h
+++ b/src/theory/strings/theory_strings.h
@@ -229,7 +229,6 @@ class TheoryStrings : public Theory {
   std::unique_ptr<InferenceManager> d_im;
 
  private:
-
   std::map< Node, Node > d_eqc_to_len_term;
 
 


### PR DESCRIPTION
This PR makes it so that the module dependencies in the theory of strings are acyclic.  This is important for further organization towards proofs for strings.

The main change in this PR is to ensure that InferenceManager has a pointer to ExtTheory, which is needed for several of its methods.  This required changing several solvers into unique_ptr to properly initialize.