### PR TITLE
Refactor inference manager in strings to be amenable to proofs

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2289,7 +2289,7 @@ void CoreSolver::checkLengthsEqc() {
   }
 }
 
-bool CoreSolver::processInferInfo(const CoreInferInfo& ii)
+bool CoreSolver::processInferInfo(CoreInferInfo& ii)
 {
   // rewrite the conclusion, ensure non-trivial
   ii.d_conc = Rewriter::rewrite(ii.d_conc);

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2308,6 +2308,17 @@ bool CoreSolver::processInferInfo(CoreInferInfo& ii)
   }
   // send the inference, which is a lemma
   d_im.sendInference(ii, true);
+  
+  // FIXME
+  for (const std::pair<const LengthStatus, std::vector<Node> >& sks :
+        ii.d_new_skolem)
+  {
+    for (const Node& n : sks.second)
+    {
+      d_termReg.registerTermAtomic(n, sks.first);
+    }
+  }
+  
   return true;
 }
 

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -914,7 +914,7 @@ void CoreSolver::processNEqc(std::vector<NormalForm>& normal_forms,
                              TypeNode stype)
 {
   //the possible inferences
-  std::vector< CoreInferInfo > pinfer;
+  std::vector<CoreInferInfo> pinfer;
   // loop over all pairs 
   for(unsigned i=0; i<normal_forms.size()-1; i++) {
     //unify each normalform[j] with normal_forms[i]
@@ -1341,7 +1341,7 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
               << "Const Split: " << prea << " is removed from " << stra
               << " due to " << strb << ", p=" << p << std::endl;
           iinfo.d_conc = nc.eqNode(isRev ? utils::mkNConcat(sk, prea)
-                                        : utils::mkNConcat(prea, sk));
+                                         : utils::mkNConcat(prea, sk));
           iinfo.d_new_skolem[LENGTH_SPLIT].push_back(sk);
           iinfo.d_id = Inference::SSPLIT_CST_PROP;
           pinfer.push_back(info);
@@ -1501,10 +1501,10 @@ bool CoreSolver::detectLoop(NormalForm& nfi,
 
 //xs(zy)=t(yz)xr
 CoreSolver::ProcessLoopResult CoreSolver::processLoop(NormalForm& nfi,
-                                                            NormalForm& nfj,
-                                                            int loop_index,
-                                                            int index,
-                                                            CoreInferInfo& info)
+                                                      NormalForm& nfj,
+                                                      int loop_index,
+                                                      int index,
+                                                      CoreInferInfo& info)
 {
   if (options::stringProcessLoopMode() == options::ProcessLoopMode::ABORT)
   {

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -981,7 +981,8 @@ void CoreSolver::processNEqc(std::vector<NormalForm>& normal_forms,
   Trace("strings-solve") << "...choose #" << use_index << std::endl;
   if (!processInferInfo(pinfer[use_index]))
   {
-    Assert(false) << "Failed to process infer info " << pinfer[use_index] << std::endl;
+    Assert(false) << "Failed to process infer info " << pinfer[use_index]
+                  << std::endl;
   }
 }
 

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -967,10 +967,8 @@ void CoreSolver::processNEqc(std::vector<NormalForm>& normal_forms,
   {
     CoreInferInfo& ipii = pinfer[i];
     Trace("strings-solve") << "#" << i << ": From " << ipii.d_i << " / "
-                           << ipii.d_j << " (rev=" << ipii.d_rev
-                           << ") : ";
-    Trace("strings-solve") << ipii.d_conc << " by " << ipii.d_id
-                           << std::endl;
+                           << ipii.d_j << " (rev=" << ipii.d_rev << ") : ";
+    Trace("strings-solve") << ipii.d_conc << " by " << ipii.d_id << std::endl;
     if (!set_use_index || ipii.d_id < min_id
         || (ipii.d_id == min_id && ipii.d_index > max_index))
     {
@@ -1343,7 +1341,7 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
               << "Const Split: " << prea << " is removed from " << stra
               << " due to " << strb << ", p=" << p << std::endl;
           info.d_conc = nc.eqNode(isRev ? utils::mkNConcat(sk, prea)
-                                         : utils::mkNConcat(prea, sk));
+                                        : utils::mkNConcat(prea, sk));
           info.d_new_skolem[LENGTH_SPLIT].push_back(sk);
           info.d_id = Inference::SSPLIT_CST_PROP;
           pinfer.push_back(info);

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2296,14 +2296,11 @@ bool CoreSolver::processInferInfo(CoreInferInfo& ii)
   // rewrite the conclusion, ensure non-trivial
   ii.d_conc = Rewriter::rewrite(ii.d_conc);
   
-  //FIXME
-  /*
   if (ii.isTrivial())
   {
     // rewrote to true
     return false;
   }
-  */
   // process the state change to this solver
   if (!ii.d_nf_pair[0].isNull())
   {
@@ -2312,16 +2309,6 @@ bool CoreSolver::processInferInfo(CoreInferInfo& ii)
   }
   // send the inference, which is a lemma
   d_im.sendInference(ii, true);
-  
-  // FIXME
-  for (const std::pair<const LengthStatus, std::vector<Node> >& sks :
-        ii.d_new_skolem)
-  {
-    for (const Node& n : sks.second)
-    {
-      d_termReg.registerTermAtomic(n, sks.first);
-    }
-  }
   
   return true;
 }

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -963,7 +963,7 @@ void CoreSolver::processNEqc(std::vector<NormalForm>& normal_forms,
                          << ") : " << std::endl;
   Inference min_id = Inference::NONE;
   unsigned max_index = 0;
-  for (unsigned i=0, psize = pinfer.size(); i<psize; i++)
+  for (unsigned i = 0, psize = pinfer.size(); i < psize; i++)
   {
     CoreInferInfo& ipii = pinfer[i];
     InferInfo& ii = ipii.d_infer;
@@ -983,7 +983,7 @@ void CoreSolver::processNEqc(std::vector<NormalForm>& normal_forms,
   if (!processInferInfo(pinfer[use_index]))
   {
     Unhandled() << "Failed to process infer info " << pinfer[use_index].d_infer
-                  << std::endl;
+                << std::endl;
   }
 }
 
@@ -1347,7 +1347,7 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
               << "Const Split: " << prea << " is removed from " << stra
               << " due to " << strb << ", p=" << p << std::endl;
           iinfo.d_conc = nc.eqNode(isRev ? utils::mkNConcat(sk, prea)
-                                        : utils::mkNConcat(prea, sk));
+                                         : utils::mkNConcat(prea, sk));
           iinfo.d_new_skolem[LENGTH_SPLIT].push_back(sk);
           iinfo.d_id = Inference::SSPLIT_CST_PROP;
           pinfer.push_back(info);
@@ -1372,9 +1372,10 @@ void CoreSolver::processSimpleNEq(NormalForm& nfi,
       Trace("strings-csp") << "Const Split: " << firstChar
                            << " is removed from " << stra << " (serial) "
                            << std::endl;
-      NormalForm::getExplanationForPrefixEq(nfi, nfj, index, index, iinfo.d_ant);
+      NormalForm::getExplanationForPrefixEq(
+          nfi, nfj, index, index, iinfo.d_ant);
       iinfo.d_conc = nc.eqNode(isRev ? utils::mkNConcat(sk, firstChar)
-                                    : utils::mkNConcat(firstChar, sk));
+                                     : utils::mkNConcat(firstChar, sk));
       iinfo.d_new_skolem[LENGTH_SPLIT].push_back(sk);
       iinfo.d_id = Inference::SSPLIT_CST;
       pinfer.push_back(info);
@@ -1546,7 +1547,7 @@ CoreSolver::ProcessLoopResult CoreSolver::processLoop(NormalForm& nfi,
   Trace("strings-loop") << r << std::endl;
 
   Node emp = Word::mkEmptyWord(stype);
-  
+
   InferInfo& iinfo = info.d_infer;
   if (s_zy.isConst() && r.isConst() && r != emp)
   {
@@ -2124,8 +2125,9 @@ void CoreSolver::addNormalFormPair( Node n1, Node n2 ){
   }
   if( !isNormalFormPair( n1, n2 ) ){
     int index = 0;
-    NodeIntMap::const_iterator it = d_nfPairs.find( n1 );
-    if( it!=d_nfPairs.end() ){
+    NodeIntMap::const_iterator it = d_nfPairs.find(n1);
+    if (it != d_nfPairs.end())
+    {
       index = (*it).second;
     }
     d_nfPairs[n1] = index + 1;
@@ -2146,8 +2148,9 @@ bool CoreSolver::isNormalFormPair( Node n1, Node n2 ) {
     return isNormalFormPair(n2,n1);
   }
   //Trace("strings-debug") << "is normal form pair. " << n1 << " " << n2 << std::endl;
-  NodeIntMap::const_iterator it = d_nfPairs.find( n1 );
-  if( it!=d_nfPairs.end() ){
+  NodeIntMap::const_iterator it = d_nfPairs.find(n1);
+  if (it != d_nfPairs.end())
+  {
     Assert(d_nf_pairs_data.find(n1) != d_nf_pairs_data.end());
     for( int i=0; i<(*it).second; i++ ){
       Assert(i < (int)d_nf_pairs_data[n1].size());
@@ -2316,10 +2319,10 @@ bool CoreSolver::processInferInfo(CoreInferInfo& cii)
   {
     d_im.sendPhaseRequirement(pp.first, pp.second);
   }
-    
+
   // send the inference, which is a lemma
   d_im.sendInference(ii, true);
-    
+
   return true;
 }
 

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2295,7 +2295,7 @@ bool CoreSolver::processInferInfo(CoreInferInfo& ii)
 {
   // rewrite the conclusion, ensure non-trivial
   ii.d_conc = Rewriter::rewrite(ii.d_conc);
-  
+
   if (ii.isTrivial())
   {
     // rewrote to true
@@ -2309,7 +2309,7 @@ bool CoreSolver::processInferInfo(CoreInferInfo& ii)
   }
   // send the inference, which is a lemma
   d_im.sendInference(ii, true);
-  
+
   return true;
 }
 

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -981,7 +981,7 @@ void CoreSolver::processNEqc(std::vector<NormalForm>& normal_forms,
   Trace("strings-solve") << "...choose #" << use_index << std::endl;
   if (!processInferInfo(pinfer[use_index]))
   {
-    Assert(false) << "Failed to process infer info " << pinfer[use_index]
+    Unhandled() << "Failed to process infer info " << pinfer[use_index]
                   << std::endl;
   }
 }

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2289,8 +2289,15 @@ void CoreSolver::checkLengthsEqc() {
   }
 }
 
-void CoreSolver::processInferInfo(const CoreInferInfo& ii)
+bool CoreSolver::processInferInfo(const CoreInferInfo& ii)
 {
+  // rewrite the conclusion, ensure non-trivial
+  ii.d_conc = Rewriter::rewrite(ii.d_conc);
+  if (ii.isTrivial())
+  {
+    // rewrote to true
+    return false;
+  }
   // process the state change to this solver
   if (!ii.d_nf_pair[0].isNull())
   {
@@ -2299,8 +2306,8 @@ void CoreSolver::processInferInfo(const CoreInferInfo& ii)
   }
   // send the inference, which is a lemma
   d_im.sendInference(ii, true);
+  return true;
 }
-
 
 }/* CVC4::theory::strings namespace */
 }/* CVC4::theory namespace */

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -979,7 +979,10 @@ void CoreSolver::processNEqc(std::vector<NormalForm>& normal_forms,
     }
   }
   Trace("strings-solve") << "...choose #" << use_index << std::endl;
-  processInferInfo(pinfer[use_index]);
+  if (!processInferInfo(pinfer[use_index]))
+  {
+    Assert(false) << "Failed to process infer info " << pinfer[use_index] << std::endl;
+  }
 }
 
 void CoreSolver::processSimpleNEq(NormalForm& nfi,

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -2295,11 +2295,15 @@ bool CoreSolver::processInferInfo(CoreInferInfo& ii)
 {
   // rewrite the conclusion, ensure non-trivial
   ii.d_conc = Rewriter::rewrite(ii.d_conc);
+  
+  //FIXME
+  /*
   if (ii.isTrivial())
   {
     // rewrote to true
     return false;
   }
+  */
   // process the state change to this solver
   if (!ii.d_nf_pair[0].isNull())
   {

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -41,7 +41,7 @@ class CoreInferInfo : public InferInfo
 {
  public:
   CoreInferInfo();
-  ~CoreInferInfo(){}
+  ~CoreInferInfo() {}
   /**
    * The index in the normal forms under which this inference is addressing.
    * For example, if the inference is inferring x = y from |x|=|y| and

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -224,7 +224,7 @@ class CoreSolver
    * This processes the infer info ii as an inference. In more detail, it calls
    * the inference manager to process the inference, and updates the set of
    * normal form pairs. Returns true if the conclusion of ii was not true
-   * after rewriting, in which case this method does nothing.
+   * after rewriting. If the conclusion is true, this method does nothing.
    */
   bool processInferInfo(CoreInferInfo& ii);
   /** Add that (n1,n2) is a normal form pair in the current context. */

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -37,11 +37,17 @@ namespace strings {
  * by the inference manager, the side effects it generates for the core solver,
  * and information used for heuristics and debugging.
  */
-class CoreInferInfo : public InferInfo
+class CoreInferInfo
 {
  public:
   CoreInferInfo();
   ~CoreInferInfo() {}
+  /** The infer info of this class */
+  InferInfo d_infer;
+  /**
+   * The pending phase requirements, see InferenceManager::sendPhaseRequirement.
+   */
+  std::map<Node, bool> d_pendingPhase;
   /**
    * The index in the normal forms under which this inference is addressing.
    * For example, if the inference is inferring x = y from |x|=|y| and
@@ -52,7 +58,7 @@ class CoreInferInfo : public InferInfo
   /**
    * The normal form pair that is cached as a result of this inference.
    */
-  Node d_nf_pair[2];
+  Node d_nfPair[2];
   /** for debugging
    *
    * The base pair of strings d_i/d_j that led to the inference, and whether
@@ -436,7 +442,7 @@ class CoreSolver
    * indepedent map from nodes to lists of nodes to model this, given by
    * the two data members below.
    */
-  NodeIntMap d_nf_pairs;
+  NodeIntMap d_nfPairs;
   std::map<Node, std::vector<Node> > d_nf_pairs_data;
   /** list of non-congruent concat terms in each equivalence class */
   std::map<Node, std::vector<Node> > d_eqc;

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -217,9 +217,10 @@ class CoreSolver
   /**
    * This processes the infer info ii as an inference. In more detail, it calls
    * the inference manager to process the inference, and updates the set of
-   * normal form pairs.
+   * normal form pairs. Returns true if the conclusion of ii was not true
+   * after rewriting, in which case this method does nothing.
    */
-  void processInferInfo(const CoreInferInfo& ii);
+  bool processInferInfo(const CoreInferInfo& ii);
   /** Add that (n1,n2) is a normal form pair in the current context. */
   void addNormalFormPair(Node n1, Node n2);
   /** Is (n1,n2) a normal form pair in the current context? */

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -63,7 +63,7 @@ class CoreInferInfo
   Node d_j;
   bool d_rev;
 };
-  
+
 /** The core solver for the theory of strings
  *
  * This implements techniques for handling (dis)equalities involving

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -32,9 +32,10 @@ namespace theory {
 namespace strings {
 
 /**
- * This data structure encapsulates an inference for strings. This includes
- * the form of the inference, as well as the side effects it generates for the
- * core solver.
+ * This data structure encapsulates an inference for the core solver of the
+ * theory of strings. This includes the form of the inference to be processed
+ * by the inference manager, the side effects it generates for the core solver,
+ * and information used for heuristics and debugging.
  */
 class CoreInferInfo : public InferInfo
 {

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -36,12 +36,11 @@ namespace strings {
  * the form of the inference, as well as the side effects it generates for the
  * core solver.
  */
-class CoreInferInfo
+class CoreInferInfo : public InferInfo
 {
  public:
   CoreInferInfo();
-  /** The pending inference */
-  InferInfo d_infer;
+  ~CoreInferInfo(){}
   /**
    * The index in the normal forms under which this inference is addressing.
    * For example, if the inference is inferring x = y from |x|=|y| and

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -31,6 +31,39 @@ namespace CVC4 {
 namespace theory {
 namespace strings {
 
+/**
+ * This data structure encapsulates an inference for strings. This includes
+ * the form of the inference, as well as the side effects it generates for the
+ * core solver.
+ */
+class CoreInferInfo
+{
+ public:
+  CoreInferInfo();
+  /** The pending inference */
+  InferInfo d_infer;
+  /**
+   * The index in the normal forms under which this inference is addressing.
+   * For example, if the inference is inferring x = y from |x|=|y| and
+   *   w ++ x ++ ... = w ++ y ++ ...
+   * then d_index is 1, since x and y are at index 1 in these concat terms.
+   */
+  unsigned d_index;
+  /**
+   * The normal form pair that is cached as a result of this inference.
+   */
+  Node d_nf_pair[2];
+  /** for debugging
+   *
+   * The base pair of strings d_i/d_j that led to the inference, and whether
+   * (d_rev) we were processing the normal forms of these strings in reverse
+   * direction.
+   */
+  Node d_i;
+  Node d_j;
+  bool d_rev;
+};
+  
 /** The core solver for the theory of strings
  *
  * This implements techniques for handling (dis)equalities involving
@@ -183,10 +216,10 @@ class CoreSolver
  private:
   /**
    * This processes the infer info ii as an inference. In more detail, it calls
-   * the inference manager to process the inference, it introduces Skolems, and
-   * updates the set of normal form pairs.
+   * the inference manager to process the inference, and updates the set of
+   * normal form pairs.
    */
-  void doInferInfo(const InferInfo& ii);
+  void processInferInfo(const CoreInferInfo& ii);
   /** Add that (n1,n2) is a normal form pair in the current context. */
   void addNormalFormPair(Node n1, Node n2);
   /** Is (n1,n2) a normal form pair in the current context? */
@@ -253,7 +286,7 @@ class CoreSolver
    *
    * This method is called when two equal terms have normal forms nfi and nfj.
    * It adds (typically at most one) possible inference to the vector pinfer.
-   * This inference is in the form of an InferInfo object, which stores the
+   * This inference is in the form of an CoreInferInfo object, which stores the
    * necessary information regarding how to process the inference.
    *
    * index: The index in the normal form vectors (nfi.d_nf and nfj.d_nf) that
@@ -280,7 +313,7 @@ class CoreSolver
                         unsigned& index,
                         bool isRev,
                         unsigned rproc,
-                        std::vector<InferInfo>& pinfer,
+                        std::vector<CoreInferInfo>& pinfer,
                         TypeNode stype);
   //--------------------------end for checkNormalFormsEq
 
@@ -309,7 +342,7 @@ class CoreSolver
                                 NormalForm& nfj,
                                 int loop_index,
                                 int index,
-                                InferInfo& info);
+                                CoreInferInfo& info);
   //--------------------------end for checkNormalFormsEq with loops
 
   //--------------------------for checkNormalFormsDeq

--- a/src/theory/strings/core_solver.h
+++ b/src/theory/strings/core_solver.h
@@ -220,7 +220,7 @@ class CoreSolver
    * normal form pairs. Returns true if the conclusion of ii was not true
    * after rewriting, in which case this method does nothing.
    */
-  bool processInferInfo(const CoreInferInfo& ii);
+  bool processInferInfo(CoreInferInfo& ii);
   /** Add that (n1,n2) is a normal form pair in the current context. */
   void addNormalFormPair(Node n1, Node n2);
   /** Is (n1,n2) a normal form pair in the current context? */

--- a/src/theory/strings/infer_info.cpp
+++ b/src/theory/strings/infer_info.cpp
@@ -92,7 +92,40 @@ std::ostream& operator<<(std::ostream& out, Inference i)
   return out;
 }
 
-InferInfo::InferInfo() : d_id(Inference::NONE), d_index(0), d_rev(false) {}
+InferInfo::InferInfo() : d_id(Inference::NONE) {}
+
+bool InferInfo::isTrivial() const
+{
+  return d_conc.isConst() && d_conc.getConst<bool>();
+}
+
+bool InferInfo::isConflict() const
+{
+  return d_conc.isConst() && !d_conc.getConst<bool>() && d_antn.empty();
+}
+
+bool InferInfo::isFact() const
+{
+  TNode atom = d_conc.getKind()==kind::NOT ? d_conc[0] : d_conc;
+  // no double negation or double (conjunctive) conclusions
+  Assert (atom.getKind()!=kind::NOT && atom.getKind()!=kind::AND);
+  return !atom.isConst() && atom.getKind()!=OR && d_antn.empty();
+}
+
+std::ostream& operator<<(std::ostream& out, const InferInfo& ii)
+{
+  out << "(infer " << d_id << " " << d_conc;
+  if (!d_ant.empty())
+  {
+    out << ":ant " << d_ant;
+  }
+  if (!d_antn.empty())
+  {
+    out << ":antn " << d_antn;
+  }
+  out << ")";
+  return out;
+}
 
 }  // namespace strings
 }  // namespace theory

--- a/src/theory/strings/infer_info.cpp
+++ b/src/theory/strings/infer_info.cpp
@@ -96,16 +96,19 @@ InferInfo::InferInfo() : d_id(Inference::NONE) {}
 
 bool InferInfo::isTrivial() const
 {
+  Assert (!d_conc.isNull());
   return d_conc.isConst() && d_conc.getConst<bool>();
 }
 
 bool InferInfo::isConflict() const
 {
+  Assert (!d_conc.isNull());
   return d_conc.isConst() && !d_conc.getConst<bool>() && d_antn.empty();
 }
 
 bool InferInfo::isFact() const
 {
+  Assert (!d_conc.isNull());
   TNode atom = d_conc.getKind()==kind::NOT ? d_conc[0] : d_conc;
   // no double negation or double (conjunctive) conclusions
   Assert (atom.getKind()!=kind::NOT && atom.getKind()!=kind::AND);

--- a/src/theory/strings/infer_info.cpp
+++ b/src/theory/strings/infer_info.cpp
@@ -110,8 +110,6 @@ bool InferInfo::isFact() const
 {
   Assert(!d_conc.isNull());
   TNode atom = d_conc.getKind() == kind::NOT ? d_conc[0] : d_conc;
-  // no double negation or double (conjunctive) conclusions
-  Assert(atom.getKind() != kind::NOT && atom.getKind() != kind::AND);
   return !atom.isConst() && atom.getKind() != kind::OR && d_antn.empty();
 }
 

--- a/src/theory/strings/infer_info.cpp
+++ b/src/theory/strings/infer_info.cpp
@@ -118,11 +118,11 @@ std::ostream& operator<<(std::ostream& out, const InferInfo& ii)
   out << "(infer " << ii.d_id << " " << ii.d_conc;
   if (!ii.d_ant.empty())
   {
-    out << ":ant (" << ii.d_ant << ")";
+    out << " :ant (" << ii.d_ant << ")";
   }
   if (!ii.d_antn.empty())
   {
-    out << ":antn (" << ii.d_antn << ")";
+    out << " :antn (" << ii.d_antn << ")";
   }
   out << ")";
   return out;

--- a/src/theory/strings/infer_info.cpp
+++ b/src/theory/strings/infer_info.cpp
@@ -109,19 +109,19 @@ bool InferInfo::isFact() const
   TNode atom = d_conc.getKind()==kind::NOT ? d_conc[0] : d_conc;
   // no double negation or double (conjunctive) conclusions
   Assert (atom.getKind()!=kind::NOT && atom.getKind()!=kind::AND);
-  return !atom.isConst() && atom.getKind()!=OR && d_antn.empty();
+  return !atom.isConst() && atom.getKind()!=kind::OR && d_antn.empty();
 }
 
 std::ostream& operator<<(std::ostream& out, const InferInfo& ii)
 {
-  out << "(infer " << d_id << " " << d_conc;
-  if (!d_ant.empty())
+  out << "(infer " << ii.d_id << " " << ii.d_conc;
+  if (!ii.d_ant.empty())
   {
-    out << ":ant " << d_ant;
+    out << ":ant (" << ii.d_ant << ")";
   }
-  if (!d_antn.empty())
+  if (!ii.d_antn.empty())
   {
-    out << ":antn " << d_antn;
+    out << ":antn (" << ii.d_antn << ")";
   }
   out << ")";
   return out;

--- a/src/theory/strings/infer_info.cpp
+++ b/src/theory/strings/infer_info.cpp
@@ -96,23 +96,23 @@ InferInfo::InferInfo() : d_id(Inference::NONE) {}
 
 bool InferInfo::isTrivial() const
 {
-  Assert (!d_conc.isNull());
+  Assert(!d_conc.isNull());
   return d_conc.isConst() && d_conc.getConst<bool>();
 }
 
 bool InferInfo::isConflict() const
 {
-  Assert (!d_conc.isNull());
+  Assert(!d_conc.isNull());
   return d_conc.isConst() && !d_conc.getConst<bool>() && d_antn.empty();
 }
 
 bool InferInfo::isFact() const
 {
-  Assert (!d_conc.isNull());
-  TNode atom = d_conc.getKind()==kind::NOT ? d_conc[0] : d_conc;
+  Assert(!d_conc.isNull());
+  TNode atom = d_conc.getKind() == kind::NOT ? d_conc[0] : d_conc;
   // no double negation or double (conjunctive) conclusions
-  Assert (atom.getKind()!=kind::NOT && atom.getKind()!=kind::AND);
-  return !atom.isConst() && atom.getKind()!=kind::OR && d_antn.empty();
+  Assert(atom.getKind() != kind::NOT && atom.getKind() != kind::AND);
+  return !atom.isConst() && atom.getKind() != kind::OR && d_antn.empty();
 }
 
 std::ostream& operator<<(std::ostream& out, const InferInfo& ii)

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -329,7 +329,7 @@ enum LengthStatus
 
 /**
  * An inference. This is a class to track an unprocessed call to either
- * sending a fact, lemma, or conflict that is waiting to be asserted to the
+ * send a fact, lemma, or conflict that is waiting to be asserted to the
  * equality engine or sent on the output channel.
  */
 class InferInfo

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -334,7 +334,7 @@ enum LengthStatus
  */
 struct InferInfo
 {
-  InferInfo(){}
+  InferInfo() {}
   ~InferInfo() {}
   /** The inference identifier */
   Inference d_id;

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -374,7 +374,7 @@ class InferInfo
 };
 
 /**
- * Writes an inference info name to a stream.
+ * Writes an inference info to a stream.
  *
  * @param out The stream to write to
  * @param ii The inference info to write to the stream

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -328,19 +328,17 @@ enum LengthStatus
 };
 
 /**
- * This data structure encapsulates an inference for strings. This includes
- * the form of the inference, as well as the side effects it generates.
+ * A pending inference. This is a helper class to track an unprocessed call to
+ * InferenceManager::sendInference that is waiting to be asserted as a fact to
+ * the equality engine.
  */
-class InferInfo
+struct InferInfo
 {
- public:
-  InferInfo();
-  /**
-   * The identifier for the inference, indicating the kind of reasoning used
-   * for this conclusion.
-   */
+  InferInfo(){}
+  ~InferInfo() {}
+  /** The inference identifier */
   Inference d_id;
-  /** The conclusion of the inference */
+  /** The conclusion */
   Node d_conc;
   /**
    * The antecedant(s) of the inference, interpreted conjunctively. These are
@@ -354,35 +352,15 @@ class InferInfo
    */
   std::vector<Node> d_antn;
   /**
+   * The pending phase requirements, see InferenceManager::sendPhaseRequirement.
+   */
+  std::map<Node, bool> d_pending_phase;
+  /**
    * A list of new skolems introduced as a result of this inference. They
    * are mapped to by a length status, indicating the length constraint that
    * can be assumed for them.
    */
   std::map<LengthStatus, std::vector<Node> > d_new_skolem;
-  /**
-   * The pending phase requirements, see InferenceManager::sendPhaseRequirement.
-   */
-  std::map<Node, bool> d_pending_phase;
-  /**
-   * The index in the normal forms under which this inference is addressing.
-   * For example, if the inference is inferring x = y from |x|=|y| and
-   *   w ++ x ++ ... = w ++ y ++ ...
-   * then d_index is 1, since x and y are at index 1 in these concat terms.
-   */
-  unsigned d_index;
-  /**
-   * The normal form pair that is cached as a result of this inference.
-   */
-  Node d_nf_pair[2];
-  /** for debugging
-   *
-   * The base pair of strings d_i/d_j that led to the inference, and whether
-   * (d_rev) we were processing the normal forms of these strings in reverse
-   * direction.
-   */
-  Node d_i;
-  Node d_j;
-  bool d_rev;
 };
 
 }  // namespace strings

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -328,9 +328,9 @@ enum LengthStatus
 };
 
 /**
- * A pending inference. This is a helper class to track an unprocessed call to
- * InferenceManager::sendInference that is waiting to be asserted as a fact to
- * the equality engine.
+ * An inference. This is a class to track an unprocessed call to either 
+ * sending a fact, lemma, or conflict that is waiting to be asserted to the
+ * equality engine or sent on the output channel.
  */
 class InferInfo
 {

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -358,10 +358,6 @@ class InferInfo
    * can be assumed for them.
    */
   std::map<LengthStatus, std::vector<Node> > d_new_skolem;
-  /**
-   * The pending phase requirements, see InferenceManager::sendPhaseRequirement.
-   */
-  std::map<Node, bool> d_pending_phase;
   /**  Is this infer info trivial? True if d_conc is true. */
   bool isTrivial() const;
   /**

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -353,15 +353,15 @@ public:
    */
   std::vector<Node> d_antn;
   /**
-   * The pending phase requirements, see InferenceManager::sendPhaseRequirement.
-   */
-  std::map<Node, bool> d_pending_phase;
-  /**
    * A list of new skolems introduced as a result of this inference. They
    * are mapped to by a length status, indicating the length constraint that
    * can be assumed for them.
    */
   std::map<LengthStatus, std::vector<Node> > d_new_skolem;
+  /**
+   * The pending phase requirements, see InferenceManager::sendPhaseRequirement.
+   */
+  std::map<Node, bool> d_pending_phase;
   /**  Is this infer info trivial? True if d_conc is true. */
   bool isTrivial() const;
   /** 

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -332,9 +332,10 @@ enum LengthStatus
  * InferenceManager::sendInference that is waiting to be asserted as a fact to
  * the equality engine.
  */
-struct InferInfo
+class InferInfo
 {
-  InferInfo() {}
+public:
+  InferInfo();
   ~InferInfo() {}
   /** The inference identifier */
   Inference d_id;
@@ -361,7 +362,29 @@ struct InferInfo
    * can be assumed for them.
    */
   std::map<LengthStatus, std::vector<Node> > d_new_skolem;
+  /**  Is this infer info trivial? True if d_conc is true. */
+  bool isTrivial() const;
+  /** 
+   * Does this infer info correspond to a conflict? True if d_conc is false
+   * and it has no new antecedants (d_antn).
+   */
+  bool isConflict() const;
+  /** 
+   * Does this infer info correspond to a "fact". A fact is an inference whose
+   * conclusion should be added as an equality or predicate to the equality
+   * engine with no new external antecedants (d_antn).
+   */
+  bool isFact() const;
 };
+
+/**
+ * Writes an inference info name to a stream.
+ *
+ * @param out The stream to write to
+ * @param ii The inference info to write to the stream
+ * @return The stream
+ */
+std::ostream& operator<<(std::ostream& out, const InferInfo& ii);
 
 }  // namespace strings
 }  // namespace theory

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -328,7 +328,7 @@ enum LengthStatus
 };
 
 /**
- * An inference. This is a class to track an unprocessed call to either 
+ * An inference. This is a class to track an unprocessed call to either
  * sending a fact, lemma, or conflict that is waiting to be asserted to the
  * equality engine or sent on the output channel.
  */

--- a/src/theory/strings/infer_info.h
+++ b/src/theory/strings/infer_info.h
@@ -334,7 +334,7 @@ enum LengthStatus
  */
 class InferInfo
 {
-public:
+ public:
   InferInfo();
   ~InferInfo() {}
   /** The inference identifier */
@@ -364,12 +364,12 @@ public:
   std::map<Node, bool> d_pending_phase;
   /**  Is this infer info trivial? True if d_conc is true. */
   bool isTrivial() const;
-  /** 
+  /**
    * Does this infer info correspond to a conflict? True if d_conc is false
    * and it has no new antecedants (d_antn).
    */
   bool isConflict() const;
-  /** 
+  /**
    * Does this infer info correspond to a "fact". A fact is an inference whose
    * conclusion should be added as an equality or predicate to the equality
    * engine with no new external antecedants (d_antn).

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -153,6 +153,7 @@ void InferenceManager::sendInference(const InferInfo& ii,
   // check if we should send a lemma or an inference
   if (!ii.isFact() || asLemma || options::stringInferAsLemmas())
   {
+    Trace("strings-infer-debug") << "...as lemma" << std::endl;
     sendLemma(ii);
     return;
   }
@@ -185,8 +186,8 @@ void InferenceManager::sendInference(const InferInfo& ii,
               << "  " << vars[i] << " -> " << subs[i] << std::endl;
         }
       }
-      Trace("strings-infer-debug") << "...as lemma" << std::endl;
-      sendLemma(iiSubsLem);
+      Trace("strings-infer-debug") << "...as symbolic lemma" << std::endl;
+      d_pendingLem.push_back(iiSubsLem);
       return;
     }
     if (Trace.isOn("strings-lemma-debug"))
@@ -199,7 +200,7 @@ void InferenceManager::sendInference(const InferInfo& ii,
     }
   }
   Trace("strings-infer-debug") << "...as fact" << std::endl;
-  // add to pending
+  // add to pending, to be processed as a fact
   d_pending.push_back(ii);
 }
 

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -331,8 +331,8 @@ void InferenceManager::doPendingFacts()
   while (!d_state.isInConflict() && i < d_pending.size())
   {
     InferInfo& ii = d_pending[i];
-    Assert (ii.d_conc.getKind()!=AND);
-    Assert (ii.d_antn.empty());
+    Assert(ii.d_conc.getKind() != AND);
+    Assert(ii.d_antn.empty());
     Node fact = ii.d_conc;
     Node exp = d_pending[i].d_exp;
     bool polarity = fact.getKind() != NOT;

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -122,11 +122,6 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
                                      Inference infer,
                                      bool asLemma)
 {
-  eq = eq.isNull() ? d_false : Rewriter::rewrite(eq);
-  if (eq==d_true)
-  {
-    return;
-  }
   // wrap in infer info and send below
   InferInfo ii;
   ii.d_id = infer;
@@ -148,7 +143,13 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
 void InferenceManager::sendInference(const InferInfo& ii,
                      bool asLemma)
 {
-  Assert (!ii.isTrivial());
+  // must rewrite the conclusion at this point
+  ii.d_conc = Rewriter::rewrite(ii.d_conc);
+  if (ii.isTrivial())
+  {
+    // rewrote to true, there is nothing to do
+    return true;
+  }
   Trace("strings-infer-debug") << "Strings::Infer: " << ii << std::endl;
   // check if we should send a lemma or an inference
   if (!ii.isFact() || asLemma || options::stringInferAsLemmas())

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -122,6 +122,11 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
                                      Inference infer,
                                      bool asLemma)
 {
+  eq = eq.isNull() ? d_false : Rewriter::rewrite(eq);
+  if (eq==d_true)
+  {
+    return;
+  }
   // wrap in infer info and send below
   InferInfo ii;
   ii.d_id = infer;
@@ -143,13 +148,7 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
 void InferenceManager::sendInference(const InferInfo& ii,
                      bool asLemma)
 {
-  // must rewrite the conclusion at this point
-  ii.d_conc = Rewriter::rewrite(ii.d_conc);
-  if (ii.isTrivial())
-  {
-    // rewrote to true, there is nothing to do
-    return true;
-  }
+  Assert (!ii.isTrivial());
   Trace("strings-infer-debug") << "Strings::Infer: " << ii << std::endl;
   // check if we should send a lemma or an inference
   if (!ii.isFact() || asLemma || options::stringInferAsLemmas())

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -235,7 +235,7 @@ bool InferenceManager::sendSplit(Node a, Node b, Inference infer, bool preq)
   InferInfo iiSplit;
   iiSplit.d_id = infer;
   iiSplit.d_conc = nm->mkNode(OR, eq, nm->mkNode(NOT, eq));
-  iiSplit.d_pending_phase[eq] = preq;
+  sendPhaseRequirement(eq, preq);
   d_pendingLem.push_back(iiSplit);
   return true;
 }
@@ -348,9 +348,9 @@ void InferenceManager::doPendingLemmas()
     d_out.lemma(lem);
 
     // Process the side effects of the inference info.
-    // [1] Register the new skolems from this inference. We register them here
-    // (lazily), since this is the moment when we have decided to use the
-    // inference at use_index that involves them.
+    // Register the new skolems from this inference. We register them here
+    // (lazily), since this is the moment when we have decided to process the
+    // inference.
     for (const std::pair<const LengthStatus, std::vector<Node> >& sks :
          ii.d_new_skolem)
     {
@@ -358,11 +358,6 @@ void InferenceManager::doPendingLemmas()
       {
         d_termReg.registerTermAtomic(n, sks.first);
       }
-    }
-    // [2] process the associated pending phase, add to map to process below
-    for (const std::pair<const Node, bool> pp : ii.d_pending_phase)
-    {
-      sendPhaseRequirement(pp.first, pp.second);
     }
   }
   // process the pending require phase calls

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -148,16 +148,18 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
 void InferenceManager::sendInference(const InferInfo& ii, bool asLemma)
 {
   Assert(!ii.isTrivial());
-  Trace("strings-infer-debug") << "sendInference: " << ii << ", asLemma = " << asLemma << std::endl;
+  Trace("strings-infer-debug")
+      << "sendInference: " << ii << ", asLemma = " << asLemma << std::endl;
   // check if we should send a conflict, lemma or a fact
   if (asLemma || options::stringInferAsLemmas() || !ii.isFact())
   {
     if (ii.isConflict())
     {
       Trace("strings-infer-debug") << "...as conflict" << std::endl;
-      Trace("strings-lemma")
-          << "Strings::Conflict: " << ii.d_ant << " by " << ii.d_id << std::endl;
-    Trace("strings-conflict") << "CONFLICT: inference conflict " << ii.d_ant << " by " << ii.d_id << std::endl;
+      Trace("strings-lemma") << "Strings::Conflict: " << ii.d_ant << " by "
+                             << ii.d_id << std::endl;
+      Trace("strings-conflict") << "CONFLICT: inference conflict " << ii.d_ant
+                                << " by " << ii.d_id << std::endl;
       // we must fully explain it
       Node conf = mkExplain(ii.d_ant);
       Trace("strings-assert") << "(assert (not " << conf << ")) ; conflict "
@@ -282,7 +284,8 @@ void InferenceManager::doPendingFacts()
     Trace("strings-assert") << "(assert (=> " << exp << " " << fact
                             << ")) ; fact " << ii.d_id << std::endl;
     // only keep stats if we process it here
-    Trace("strings-lemma") << "Strings::Fact: " << fact << " from " << exp << " by " << ii.d_id << std::endl;
+    Trace("strings-lemma") << "Strings::Fact: " << fact << " from " << exp
+                           << " by " << ii.d_id << std::endl;
     d_statistics.d_inferences << ii.d_id;
     // assert it as a pending fact
     bool polarity = fact.getKind() != NOT;
@@ -337,7 +340,8 @@ void InferenceManager::doPendingLemmas()
     Trace("strings-pending") << "Process pending lemma : " << lem << std::endl;
     Trace("strings-assert")
         << "(assert " << lem << ") ; lemma " << ii.d_id << std::endl;
-    Trace("strings-lemma") << "Strings::Lemma: " << lem << " by " << ii.d_id << std::endl;
+    Trace("strings-lemma") << "Strings::Lemma: " << lem << " by " << ii.d_id
+                           << std::endl;
     // only keep stats if we process it here
     d_statistics.d_inferences << ii.d_id;
     ++(d_statistics.d_lemmasInfer);

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -148,19 +148,18 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
 void InferenceManager::sendInference(const InferInfo& ii, bool asLemma)
 {
   Assert(!ii.isTrivial());
-  Trace("strings-infer-debug") << "Strings::Infer: " << ii << ", asLemma = " << asLemma << std::endl;
+  Trace("strings-infer-debug") << "sendInference: " << ii << ", asLemma = " << asLemma << std::endl;
   // check if we should send a conflict, lemma or a fact
   if (asLemma || options::stringInferAsLemmas() || !ii.isFact())
   {
     if (ii.isConflict())
     {
       Trace("strings-infer-debug") << "...as conflict" << std::endl;
+      Trace("strings-lemma")
+          << "Strings::Conflict: " << ii.d_ant << " by " << ii.d_id << std::endl;
+    Trace("strings-conflict") << "CONFLICT: inference conflict " << ii.d_ant << " by " << ii.d_id << std::endl;
       // we must fully explain it
       Node conf = mkExplain(ii.d_ant);
-      Trace("strings-conflict")
-          << "Strings::Conflict : " << ii.d_id << " : " << conf << std::endl;
-      Trace("strings-lemma")
-          << "Strings::Conflict : " << ii.d_id << " : " << conf << std::endl;
       Trace("strings-assert") << "(assert (not " << conf << ")) ; conflict "
                               << ii.d_id << std::endl;
       ++(d_statistics.d_conflictsInfer);
@@ -235,8 +234,6 @@ bool InferenceManager::sendSplit(Node a, Node b, Inference infer, bool preq)
   iiSplit.d_id = infer;
   iiSplit.d_conc = nm->mkNode(OR, eq, nm->mkNode(NOT, eq));
   iiSplit.d_pending_phase[eq] = preq;
-  Trace("strings-lemma") << "Strings::Lemma " << infer
-                         << " SPLIT : " << iiSplit.d_conc << std::endl;
   d_pendingLem.push_back(iiSplit);
   return true;
 }
@@ -285,6 +282,7 @@ void InferenceManager::doPendingFacts()
     Trace("strings-assert") << "(assert (=> " << exp << " " << fact
                             << ")) ; fact " << ii.d_id << std::endl;
     // only keep stats if we process it here
+    Trace("strings-lemma") << "Strings::Fact: " << fact << " from " << exp << " by " << ii.d_id << std::endl;
     d_statistics.d_inferences << ii.d_id;
     // assert it as a pending fact
     bool polarity = fact.getKind() != NOT;
@@ -339,6 +337,7 @@ void InferenceManager::doPendingLemmas()
     Trace("strings-pending") << "Process pending lemma : " << lem << std::endl;
     Trace("strings-assert")
         << "(assert " << lem << ") ; lemma " << ii.d_id << std::endl;
+    Trace("strings-lemma") << "Strings::Lemma: " << lem << " by " << ii.d_id << std::endl;
     // only keep stats if we process it here
     d_statistics.d_inferences << ii.d_id;
     ++(d_statistics.d_lemmasInfer);

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -158,10 +158,10 @@ void InferenceManager::sendInference(const InferInfo& ii, bool asLemma)
       Node conf = mkExplain(ii.d_ant);
       Trace("strings-conflict")
           << "Strings::Conflict : " << ii.d_id << " : " << conf << std::endl;
-      Trace("strings-lemma") << "Strings::Conflict : " << ii.d_id << " : " << conf
-                            << std::endl;
-      Trace("strings-assert")
-          << "(assert (not " << conf << ")) ; conflict " << ii.d_id << std::endl;
+      Trace("strings-lemma")
+          << "Strings::Conflict : " << ii.d_id << " : " << conf << std::endl;
+      Trace("strings-assert") << "(assert (not " << conf << ")) ; conflict "
+                              << ii.d_id << std::endl;
       ++(d_statistics.d_conflictsInfer);
       // only keep stats if we process it here
       d_statistics.d_inferences << ii.d_id;

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -150,7 +150,7 @@ void InferenceManager::sendInference(const InferInfo& ii, bool asLemma)
   Assert(!ii.isTrivial());
   Trace("strings-infer-debug") << "Strings::Infer: " << ii << std::endl;
   // check if we should send a lemma or an inference
-  if (!ii.isFact() || asLemma || options::stringInferAsLemmas())
+  if (asLemma || options::stringInferAsLemmas() || !ii.isFact())
   {
     if (ii.isConflict())
     {

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -123,7 +123,7 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
                                      bool asLemma)
 {
   eq = eq.isNull() ? d_false : Rewriter::rewrite(eq);
-  if (eq==d_true)
+  if (eq == d_true)
   {
     return;
   }
@@ -133,7 +133,7 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
   ii.d_conc = eq;
   ii.d_ant = exp;
   ii.d_antn = expn;
-  sendInference(ii,asLemma);
+  sendInference(ii, asLemma);
 }
 
 void InferenceManager::sendInference(const std::vector<Node>& exp,
@@ -145,10 +145,9 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
   sendInference(exp, expn, eq, infer, asLemma);
 }
 
-void InferenceManager::sendInference(const InferInfo& ii,
-                     bool asLemma)
+void InferenceManager::sendInference(const InferInfo& ii, bool asLemma)
 {
-  Assert (!ii.isTrivial());
+  Assert(!ii.isTrivial());
   Trace("strings-infer-debug") << "Strings::Infer: " << ii << std::endl;
   // check if we should send a lemma or an inference
   if (!ii.isFact() || asLemma || options::stringInferAsLemmas())
@@ -168,8 +167,8 @@ void InferenceManager::sendInference(const InferInfo& ii,
     }
     if (unproc.empty())
     {
-      Node eqs =
-          ii.d_conc.substitute(vars.begin(), vars.end(), subs.begin(), subs.end());
+      Node eqs = ii.d_conc.substitute(
+          vars.begin(), vars.end(), subs.begin(), subs.end());
       InferInfo iiSubsLem;
       // keep the same id for now, since we are transforming the form of the
       // inference, not the root reason.
@@ -177,7 +176,8 @@ void InferenceManager::sendInference(const InferInfo& ii,
       iiSubsLem.d_conc = eqs;
       if (Trace.isOn("strings-lemma-debug"))
       {
-        Trace("strings-lemma-debug") << "Strings::Infer " << iiSubsLem << std::endl;
+        Trace("strings-lemma-debug")
+            << "Strings::Infer " << iiSubsLem << std::endl;
         Trace("strings-lemma-debug")
             << "Strings::Infer Alternate : " << eqs << std::endl;
         for (unsigned i = 0, nvars = vars.size(); i < nvars; i++)
@@ -289,8 +289,8 @@ void InferenceManager::doPendingFacts()
     Node exp = utils::mkAnd(ii.d_ant);
     bool polarity = fact.getKind() != NOT;
     TNode atom = polarity ? fact : fact[0];
-    Trace("strings-assert") << "(assert (=> " << exp << " " << fact << ")) ; fact " << ii.d_id
-                            << std::endl;
+    Trace("strings-assert") << "(assert (=> " << exp << " " << fact
+                            << ")) ; fact " << ii.d_id << std::endl;
     // only keep stats if we process it here
     d_statistics.d_inferences << ii.d_id;
     assertPendingFact(atom, polarity, exp);
@@ -310,12 +310,12 @@ void InferenceManager::doPendingLemmas()
   {
     return;
   }
-  NodeManager * nm = NodeManager::currentNM();
-  for (unsigned i=0, psize = d_pendingLem.size(); i<psize; i++)
+  NodeManager* nm = NodeManager::currentNM();
+  for (unsigned i = 0, psize = d_pendingLem.size(); i < psize; i++)
   {
     InferInfo& ii = d_pendingLem[i];
-    Assert (!ii.isTrivial());
-    Assert (!ii.isConflict());
+    Assert(!ii.isTrivial());
+    Assert(!ii.isConflict());
     // get the explanation
     Node eqExp;
     if (options::stringRExplainLemmas())
@@ -336,8 +336,8 @@ void InferenceManager::doPendingLemmas()
       lem = nm->mkNode(IMPLIES, eqExp, lem);
     }
     Trace("strings-pending") << "Process pending lemma : " << lem << std::endl;
-    Trace("strings-assert") << "(assert " << lem << ") ; lemma " << ii.d_id
-                            << std::endl;
+    Trace("strings-assert")
+        << "(assert " << lem << ") ; lemma " << ii.d_id << std::endl;
     // only keep stats if we process it here
     d_statistics.d_inferences << ii.d_id;
     ++(d_statistics.d_lemmasInfer);
@@ -347,7 +347,7 @@ void InferenceManager::doPendingLemmas()
     // (lazily), since this is the moment when we have decided to use the
     // inference at use_index that involves them.
     for (const std::pair<const LengthStatus, std::vector<Node> >& sks :
-        ii.d_new_skolem)
+         ii.d_new_skolem)
     {
       for (const Node& n : sks.second)
       {
@@ -364,7 +364,7 @@ void InferenceManager::doPendingLemmas()
   for (const std::pair<const Node, bool>& prp : d_pendingReqPhase)
   {
     Trace("strings-pending") << "Require phase : " << prp.first
-                              << ", polarity = " << prp.second << std::endl;
+                             << ", polarity = " << prp.second << std::endl;
     d_out.requirePhase(prp.first, prp.second);
   }
   d_pendingLem.clear();

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -148,8 +148,8 @@ void InferenceManager::sendInference(const std::vector<Node>& exp,
 void InferenceManager::sendInference(const InferInfo& ii, bool asLemma)
 {
   Assert(!ii.isTrivial());
-  Trace("strings-infer-debug") << "Strings::Infer: " << ii << std::endl;
-  // check if we should send a lemma or an inference
+  Trace("strings-infer-debug") << "Strings::Infer: " << ii << ", asLemma = " << asLemma << std::endl;
+  // check if we should send a conflict, lemma or a fact
   if (asLemma || options::stringInferAsLemmas() || !ii.isFact())
   {
     if (ii.isConflict())
@@ -308,6 +308,9 @@ void InferenceManager::doPendingLemmas()
 {
   if (d_state.isInConflict())
   {
+    // just clear the pending vectors, nothing else to do
+    d_pendingLem.clear();
+    d_pendingReqPhase.clear();
     return;
   }
   NodeManager* nm = NodeManager::currentNM();

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -234,10 +234,12 @@ bool InferenceManager::sendSplit(Node a, Node b, Inference infer, bool preq)
   InferInfo iiSplit;
   iiSplit.d_id = infer;
   iiSplit.d_conc = nm->mkNode(OR, eq, nm->mkNode(NOT, eq));
-  iiSplit.d_pending_phase[eq] = preq;
+  // FIXME
+  //iiSplit.d_pending_phase[eq] = preq;
   Trace("strings-lemma") << "Strings::Lemma " << infer
                          << " SPLIT : " << iiSplit.d_conc << std::endl;
   d_pendingLem.push_back(iiSplit);
+  sendPhaseRequirement(eq,preq);
   return true;
 }
 
@@ -309,6 +311,7 @@ void InferenceManager::doPendingLemmas()
     return;
   }
   NodeManager* nm = NodeManager::currentNM();
+  /*  FIXME
   for (unsigned i = 0, psize = d_pendingLem.size(); i < psize; i++)
   {
     InferInfo& ii = d_pendingLem[i];
@@ -330,6 +333,7 @@ void InferenceManager::doPendingLemmas()
       sendPhaseRequirement(pp.first, pp.second);
     }
   }
+  */
   for (unsigned i = 0, psize = d_pendingLem.size(); i < psize; i++)
   {
     InferInfo& ii = d_pendingLem[i];

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -285,7 +285,7 @@ void InferenceManager::doPendingFacts()
     // with no new external assumptions (ii.d_antn).
     Assert(ii.isFact());
     Node fact = ii.d_conc;
-    Node exp = utils::mkAnd(d_pending[i].d_ant);
+    Node exp = utils::mkAnd(ii.d_ant);
     bool polarity = fact.getKind() != NOT;
     TNode atom = polarity ? fact : fact[0];
     Trace("strings-assert") << "(assert (=> " << exp << " " << fact << ")) ; fact " << ii.d_id

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -159,8 +159,8 @@ class InferenceManager
 
   /** Send inference
    *
-   * Makes the appropriate call to send inference based on the infer info
-   * data structure (see sendInference documentation above).
+   * This implements the above methods for the InferInfo object. It is called
+   * by the methods above.
    */
   void sendInference(const InferInfo& i,
                      bool asLemma = false);

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -144,7 +144,7 @@ class InferenceManager
    * of each type.
    *
    * If the flag asLemma is true, then this method will send a lemma instead
-   * of an inference whenever applicable.
+   * of a fact whenever applicable.
    */
   void sendInference(const std::vector<Node>& exp,
                      const std::vector<Node>& exp_n,
@@ -165,6 +165,9 @@ class InferenceManager
    * The inference info ii should have a rewritten conclusion and should not be
    * trivial (InferInfo::isTrivial). It is the responsibility of the caller to
    * ensure this.
+   * 
+   * If the flag asLemma is true, then this method will send a lemma instead
+   * of a fact whenever applicable.
    */
   void sendInference(const InferInfo& ii, bool asLemma = false);
   /** Send split
@@ -186,7 +189,10 @@ class InferenceManager
    *
    * This method is called to indicate this class should send a phase
    * requirement request to the output channel for literal lit to be
-   * decided with polarity pol.
+   * decided with polarity pol. This requirement is processed at the same time
+   * lemmas are sent on the output channel of this class during this call to
+   * check. This means if the current lemmas of this class are abandoned (due
+   * to a conflict), the phase requirement is not processed.
    */
   void sendPhaseRequirement(Node lit, bool pol);
   /**

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -161,8 +161,12 @@ class InferenceManager
    *
    * This implements the above methods for the InferInfo object. It is called
    * by the methods above.
+   *
+   * The inference info ii should have a rewritten conclusion and should not be
+   * trivial (InferInfo::isTrivial). It is the responsibility of the caller to
+   * ensure this.
    */
-  void sendInference(const InferInfo& i, bool asLemma = false);
+  void sendInference(const InferInfo& ii, bool asLemma = false);
   /** Send split
    *
    * This requests that ( a = b V a != b ) is sent on the output channel as a

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -165,7 +165,7 @@ class InferenceManager
    * The inference info ii should have a rewritten conclusion and should not be
    * trivial (InferInfo::isTrivial). It is the responsibility of the caller to
    * ensure this.
-   * 
+   *
    * If the flag asLemma is true, then this method will send a lemma instead
    * of a fact whenever applicable.
    */

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -162,8 +162,7 @@ class InferenceManager
    * This implements the above methods for the InferInfo object. It is called
    * by the methods above.
    */
-  void sendInference(const InferInfo& i,
-                     bool asLemma = false);
+  void sendInference(const InferInfo& i, bool asLemma = false);
   /** Send split
    *
    * This requests that ( a = b V a != b ) is sent on the output channel as a

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -281,17 +281,6 @@ class InferenceManager
    * of atom, including calls to registerTerm.
    */
   void assertPendingFact(Node atom, bool polarity, Node exp);
-  /**
-   * Indicates that ant => conc should be sent on the output channel of this
-   * class. This will either trigger an immediate call to the conflict
-   * method of the output channel of this class of conc is false, or adds the
-   * above lemma to the lemma cache d_pending_lem, which may be flushed
-   * later within the current call to TheoryStrings::check.
-   *
-   * The argument infer identifies the reason for inference, used for
-   * debugging.
-   */
-  void sendLemma(const InferInfo& lem);
   /** Reference to the solver state of the theory of strings. */
   SolverState& d_state;
   /** Reference to the term registry of theory of strings */

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -292,7 +292,7 @@ class InferenceManager
    * The argument infer identifies the reason for inference, used for
    * debugging.
    */
-  void sendLemma(InferInfo& lem);
+  void sendLemma(const InferInfo& lem);
   /** Reference to the solver state of the theory of strings. */
   SolverState& d_state;
   /** Reference to the term registry of theory of strings */

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -162,7 +162,8 @@ class InferenceManager
    * Makes the appropriate call to send inference based on the infer info
    * data structure (see sendInference documentation above).
    */
-  void sendInference(const InferInfo& i);
+  void sendInference(const InferInfo& i,
+                     bool asLemma = false);
   /** Send split
    *
    * This requests that ( a = b V a != b ) is sent on the output channel as a
@@ -291,7 +292,7 @@ class InferenceManager
    * The argument infer identifies the reason for inference, used for
    * debugging.
    */
-  void sendLemma(Node ant, Node conc, Inference infer);
+  void sendLemma(InferInfo& lem);
   /** Reference to the solver state of the theory of strings. */
   SolverState& d_state;
   /** Reference to the term registry of theory of strings */
@@ -316,7 +317,7 @@ class InferenceManager
   /** A map from literals to their pending phase requirement */
   std::map<Node, bool> d_pendingReqPhase;
   /** A list of pending lemmas to be sent on the output channel. */
-  std::vector<Node> d_pendingLem;
+  std::vector<InferInfo> d_pendingLem;
   /**
    * The keep set of this class. This set is maintained to ensure that
    * facts and their explanations are ref-counted. Since facts and their

--- a/src/theory/strings/inference_manager.h
+++ b/src/theory/strings/inference_manager.h
@@ -35,29 +35,6 @@ namespace CVC4 {
 namespace theory {
 namespace strings {
 
-/**
- * A pending inference. This is a helper class to track an unprocessed call to
- * InferenceManager::sendInference that is waiting to be asserted as a fact to
- * the equality engine.
- */
-struct PendingInfer
-{
-  PendingInfer(Inference i, Node fact, Node exp)
-      : d_infer(i), d_fact(fact), d_exp(exp)
-  {
-  }
-  ~PendingInfer() {}
-  /** The inference identifier */
-  Inference d_infer;
-  /** The conclusion */
-  Node d_fact;
-  /**
-   * Its explanation. This is a conjunction of literals that hold in the
-   * equality engine in the current context.
-   */
-  Node d_exp;
-};
-
 /** Inference Manager
  *
  * The purpose of this class is to process inference steps for strategies
@@ -139,7 +116,7 @@ class InferenceManager
    * equality engine of the theory of strings. On the other hand, the set
    * exp_n ("explanations new") contain nodes that are not explainable by the
    * theory of strings. This method may call sendLemma or otherwise add a
-   * PendingInfer to d_pending, indicating a fact should be asserted to the
+   * InferInfo to d_pending, indicating a fact should be asserted to the
    * equality engine. Overall, the result of this method is one of the
    * following:
    *
@@ -335,7 +312,7 @@ class InferenceManager
    * The list of pending literals to assert to the equality engine along with
    * their explanation.
    */
-  std::vector<PendingInfer> d_pending;
+  std::vector<InferInfo> d_pending;
   /** A map from literals to their pending phase requirement */
   std::map<Node, bool> d_pendingReqPhase;
   /** A list of pending lemmas to be sent on the output channel. */


### PR DESCRIPTION
This is a key refactoring towards proofs for strings.

This ensures that InferInfo is maintained until just before facts, lemmas and conflicts are processed.  This allows us both to:
(1) track more accurate stats and debug information,
(2) have enough information to ensure that proofs can be constructed at the moment facts, lemmas, and conflicts are processed.

Changes in this PR:
- PendingInfer and InferInfo were merged, CoreInferInfo is now the previous equivalent of InferInfo, extended with core-solver-specific information, which is only used by CoreSolver.
- sendInference( const InferInfo& info, ... ) is now the central method for sending inferences which is called by the other variants, not the other way around.
- sendLemma is inlined into sendInference(...) for clarity. 
- doPendingLemmas and doPendingFacts are extended to process the side effects of the inference infos.

There is actually a further issue with pending inferences related to eagerly processing the side effect of CoreInferInfo before we know the lemma is sent. I believe this issue does not occur in practice based on our strategy. Further refactoring could tighten this, e.g. virtual void InferInfo::processSideEffect. I will do this in another PR.

Further refactoring can address whether `asLemma` should be a field of InferInfo (it probably should), and whether we should explicitly check for AND in conclusions instead of making it the responsibility of the user of this class.