### PR TITLE
Reinstantiate support for conjunctions in facts

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -947,6 +947,7 @@ set(regress_0_tests
   regress0/strings/issue3497.smt2
   regress0/strings/issue3657-evalLeq.smt2
   regress0/strings/issue4070.smt2
+  regress0/strings/issue4376.smt2
   regress0/strings/itos-entail.smt2
   regress0/strings/large-model.smt2
   regress0/strings/leadingzero001.smt2

--- a/test/regress/regress0/strings/issue4376.smt2
+++ b/test/regress/regress0/strings/issue4376.smt2
@@ -1,0 +1,11 @@
+; COMMAND-LINE: --strings-exp --strings-eager
+(set-info :status sat)
+(set-logic QF_SLIA)
+(declare-const i0 Int)
+(declare-const Str1 String)
+(declare-const Str9 String)
+(declare-const Str11 String)
+(declare-const Str15 String)
+(assert (= (str.++ Str1 "ijruldtzyp") Str15))
+(assert (= (str.++ (str.++ Str1 "ijruldtzyp") Str11 (int.to.str i0)) Str15 Str9))
+(check-sat)


### PR DESCRIPTION
Fixes #4376. Commit 6255c0356bd78140a9cf075491c1d4608ac27704 removed
support for conjunctions in the conclusion of facts. However,
`F_ENDPOINT_EMP` generates a conjunction in the conclusion of the
inference if multiple components are inferred to be empty. This commit
reinstantiates support for conjunctions in the conclusion of facts.