### PR TITLE
Ensure disequality splits are processed as lemmas

### DIFF
--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -1872,7 +1872,7 @@ void CoreSolver::processDeq(Node ni, Node nj)
               antec,
               nm->mkNode(
                   OR, nm->mkNode(AND, eq1, sk.eqNode(firstChar).negate()), eq2),
-              Inference::DEQ_DISL_FIRST_CHAR_STRING_SPLIT);
+              Inference::DEQ_DISL_FIRST_CHAR_STRING_SPLIT, true);
           d_im.sendPhaseRequirement(eq1, true);
           return;
         }
@@ -1920,7 +1920,7 @@ void CoreSolver::processDeq(Node ni, Node nj)
         d_im.sendInference(antec,
                            antecNewLits,
                            nm->mkNode(AND, conc),
-                           Inference::DEQ_DISL_STRINGS_SPLIT);
+                           Inference::DEQ_DISL_STRINGS_SPLIT, true);
         return;
       }
     }

--- a/src/theory/strings/core_solver.cpp
+++ b/src/theory/strings/core_solver.cpp
@@ -1872,7 +1872,8 @@ void CoreSolver::processDeq(Node ni, Node nj)
               antec,
               nm->mkNode(
                   OR, nm->mkNode(AND, eq1, sk.eqNode(firstChar).negate()), eq2),
-              Inference::DEQ_DISL_FIRST_CHAR_STRING_SPLIT, true);
+              Inference::DEQ_DISL_FIRST_CHAR_STRING_SPLIT,
+              true);
           d_im.sendPhaseRequirement(eq1, true);
           return;
         }
@@ -1920,7 +1921,8 @@ void CoreSolver::processDeq(Node ni, Node nj)
         d_im.sendInference(antec,
                            antecNewLits,
                            nm->mkNode(AND, conc),
-                           Inference::DEQ_DISL_STRINGS_SPLIT, true);
+                           Inference::DEQ_DISL_STRINGS_SPLIT,
+                           true);
         return;
       }
     }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1752,6 +1752,7 @@ set(regress_1_tests
   regress1/strings/issue3272.smt2
   regress1/strings/issue3357.smt2
   regress1/strings/issue3657-unexpectedUnsatCVC4.smt2
+  regress1/strings/issue4379.smt2
   regress1/strings/kaluza-fl.smt2
   regress1/strings/loop002.smt2
   regress1/strings/loop003.smt2

--- a/test/regress/regress1/strings/issue4379.smt2
+++ b/test/regress/regress1/strings/issue4379.smt2
@@ -1,0 +1,9 @@
+; COMMAND-LINE: --strings-exp
+; EXPECT: sat
+(set-logic QF_SLIA)
+(set-info :status sat)
+(declare-const i7 Int)
+(declare-const Str8 String)
+(declare-const Str17 String)
+(assert (distinct (str.++ "" "rvhhcn" "" Str8 (int.to.str 56)) (str.++ "" (int.to.str i7) "" Str17) Str17))
+(check-sat)


### PR DESCRIPTION
Fixes #4379.  This was caused by a splitting lemma rewriting to a conjunction, being processed as a fact, and having a pending phase requirement sent out assuming the inference was to be processed as a lemma. This forces 2 of the splits in the core solver to be always processed as lemmas.