### PR TITLE
Always introduce fresh variable for unconstrained APPLY_UF

### DIFF
--- a/src/preprocessing/passes/unconstrained_simplifier.cpp
+++ b/src/preprocessing/passes/unconstrained_simplifier.cpp
@@ -577,10 +577,7 @@ void UnconstrainedSimplifier::processUnconstrained()
             {
               currentSub = current;
             }
-            if (parent.getType() != current.getType())
-            {
-              currentSub = newUnconstrainedVar(parent.getType(), currentSub);
-            }
+            currentSub = newUnconstrainedVar(parent.getType(), currentSub);
             current = parent;
           }
           else
@@ -779,6 +776,7 @@ void UnconstrainedSimplifier::processUnconstrained()
     }
     if (!currentSub.isNull())
     {
+              Trace("ajr-temp") << "Unc var " << currentSub << " for " << current << " parent " << parent << std::endl;
       Assert(currentSub.isVar());
       d_substitutions.addSubstitution(current, currentSub, false);
     }
@@ -830,7 +828,11 @@ PreprocessingPassResult UnconstrainedSimplifier::applyInternal(
     //    d_substitutions.print(Message.getStream());
     for (Node& assertion : assertions)
     {
-      assertion = Rewriter::rewrite(d_substitutions.apply(assertion));
+      Trace("ajr-temp") << "Assertion " << assertion << std::endl;
+      assertion = d_substitutions.apply(assertion);
+      Trace("ajr-temp") << "Subs " << assertion << std::endl;
+      assertion = Rewriter::rewrite(assertion);
+      Trace("ajr-temp") << "Rewrite " << assertion << std::endl;
     }
   }
 

--- a/src/preprocessing/passes/unconstrained_simplifier.cpp
+++ b/src/preprocessing/passes/unconstrained_simplifier.cpp
@@ -778,7 +778,8 @@ void UnconstrainedSimplifier::processUnconstrained()
     }
     if (!currentSub.isNull())
     {
-              Trace("ajr-temp") << "Unc var " << currentSub << " for " << current << " parent " << parent << std::endl;
+      Trace("unc-simp") << "UnconstrainedSimplifier::processUnconstrained: introduce " << currentSub << " for " << current
+                        << ", parent " << parent << std::endl;
       Assert(currentSub.isVar());
       d_substitutions.addSubstitution(current, currentSub, false);
     }
@@ -830,11 +831,7 @@ PreprocessingPassResult UnconstrainedSimplifier::applyInternal(
     //    d_substitutions.print(Message.getStream());
     for (Node& assertion : assertions)
     {
-      Trace("ajr-temp") << "Assertion " << assertion << std::endl;
-      assertion = d_substitutions.apply(assertion);
-      Trace("ajr-temp") << "Subs " << assertion << std::endl;
-      assertion = Rewriter::rewrite(assertion);
-      Trace("ajr-temp") << "Rewrite " << assertion << std::endl;
+      assertion = Rewriter::rewrite(d_substitutions.apply(assertion));
     }
   }
 

--- a/src/preprocessing/passes/unconstrained_simplifier.cpp
+++ b/src/preprocessing/passes/unconstrained_simplifier.cpp
@@ -577,6 +577,8 @@ void UnconstrainedSimplifier::processUnconstrained()
             {
               currentSub = current;
             }
+            // always introduce a new variable; it is unsound to try to reuse
+            // currentSub as the variable, see issue #4469.
             currentSub = newUnconstrainedVar(parent.getType(), currentSub);
             current = parent;
           }

--- a/src/preprocessing/passes/unconstrained_simplifier.cpp
+++ b/src/preprocessing/passes/unconstrained_simplifier.cpp
@@ -778,8 +778,10 @@ void UnconstrainedSimplifier::processUnconstrained()
     }
     if (!currentSub.isNull())
     {
-      Trace("unc-simp") << "UnconstrainedSimplifier::processUnconstrained: introduce " << currentSub << " for " << current
-                        << ", parent " << parent << std::endl;
+      Trace("unc-simp")
+          << "UnconstrainedSimplifier::processUnconstrained: introduce "
+          << currentSub << " for " << current << ", parent " << parent
+          << std::endl;
       Assert(currentSub.isVar());
       d_substitutions.addSubstitution(current, currentSub, false);
     }

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -552,6 +552,7 @@ set(regress_0_tests
   regress0/issue1063-overloading-dt-sel.smt2
   regress0/issue2832-qualId.smt2
   regress0/issue4010-sort-inf-var.smt2
+  regress0/issue4469-unc-no-reuse-var.smt2
   regress0/ite.cvc
   regress0/ite2.smt2
   regress0/ite3.smt2

--- a/test/regress/regress0/issue4469-unc-no-reuse-var.smt2
+++ b/test/regress/regress0/issue4469-unc-no-reuse-var.smt2
@@ -1,0 +1,7 @@
+; COMMAND-LINE: --unconstrained-simp --no-check-models
+; EXPECT: sat
+(set-logic QF_AUFBVLIA)
+(declare-fun a () Int)
+(declare-fun b (Int) Int)
+(assert (distinct (b a) (b (b a))))
+(check-sat)


### PR DESCRIPTION
Fixes an unsoundness in unconstrained simplification, fixes #4469.