### PR TITLE
Do not enable unconstrained simplification if arithmetic is present

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -302,8 +302,8 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
   // Disable options incompatible with incremental solving, unsat cores, and
   // proofs or output an error if enabled explicitly. It is also currently
   // incompatible with arithmetic, force the option off.
-  if (options::incrementalSolving() || options::unsatCores()
-      || options::proof() || logic.isTheoryEnabled(THEORY_ARITH))
+  if (options::incrementalSolving() || options::unsatCores() || options::proof()
+      || logic.isTheoryEnabled(THEORY_ARITH))
   {
     if (options::unconstrainedSimp())
     {

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -300,9 +300,10 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
   }
 
   // Disable options incompatible with incremental solving, unsat cores, and
-  // proofs or output an error if enabled explicitly
+  // proofs or output an error if enabled explicitly. It is also currently
+  // incompatible with arithmetic, force the option off.
   if (options::incrementalSolving() || options::unsatCores()
-      || options::proof())
+      || options::proof() || logic.isTheoryEnabled(THEORY_ARITH))
   {
     if (options::unconstrainedSimp())
     {

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -302,7 +302,8 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
   // Disable options incompatible with incremental solving, unsat cores, and
   // proofs or output an error if enabled explicitly. It is also currently
   // incompatible with arithmetic, force the option off.
-  if (options::incrementalSolving() || options::unsatCores() || options::proof())
+  if (options::incrementalSolving() || options::unsatCores()
+      || options::proof())
   {
     if (options::unconstrainedSimp())
     {
@@ -327,8 +328,8 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
                      && !options::produceAssignments()
                      && !options::checkModels()
                      && logic.isTheoryEnabled(THEORY_ARRAYS)
-                         && logic.isTheoryEnabled(THEORY_BV)
-                         && !logic.isTheoryEnabled(THEORY_ARITH);
+                     && logic.isTheoryEnabled(THEORY_BV)
+                     && !logic.isTheoryEnabled(THEORY_ARITH);
       Trace("smt") << "setting unconstrained simplification to " << uncSimp
                    << std::endl;
       options::unconstrainedSimp.set(uncSimp);

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -302,8 +302,7 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
   // Disable options incompatible with incremental solving, unsat cores, and
   // proofs or output an error if enabled explicitly. It is also currently
   // incompatible with arithmetic, force the option off.
-  if (options::incrementalSolving() || options::unsatCores() || options::proof()
-      || logic.isTheoryEnabled(THEORY_ARITH))
+  if (options::incrementalSolving() || options::unsatCores() || options::proof())
   {
     if (options::unconstrainedSimp())
     {
@@ -327,8 +326,9 @@ void setDefaults(SmtEngine& smte, LogicInfo& logic)
       bool uncSimp = !logic.isQuantified() && !options::produceModels()
                      && !options::produceAssignments()
                      && !options::checkModels()
-                     && (logic.isTheoryEnabled(THEORY_ARRAYS)
-                         && logic.isTheoryEnabled(THEORY_BV));
+                     && logic.isTheoryEnabled(THEORY_ARRAYS)
+                         && logic.isTheoryEnabled(THEORY_BV)
+                         && !logic.isTheoryEnabled(THEORY_ARITH);
       Trace("smt") << "setting unconstrained simplification to " << uncSimp
                    << std::endl;
       options::unconstrainedSimp.set(uncSimp);


### PR DESCRIPTION
For now we do not enable unconstrained simplification when arithmetic is present. Post SMT COMP, we should investigate making arithmetic not output lemmas during preprocessing (https://github.com/CVC4/cvc4-wishues/issues/71).