### PR TITLE
[SMT-COMP] Workaround for `tear-down-incremental`

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -105,13 +105,7 @@ void CommandExecutor::reset()
   {
     flushStatistics(*d_options.getErr());
   }
-  /* We have to keep options passed via CL on reset. These options are stored
-   * in CommandExecutor::d_options (populated and created in the driver), and
-   * CommandExecutor::d_options only contains *these* options since the
-   * NodeManager copies the options into a new options object before SmtEngine
-   * configures additional options based on the given CL options.
-   * We can thus safely reuse CommandExecutor::d_options here. */
-  d_solver.reset(new api::Solver(&d_options));
+  d_solver->getSmtEngine()->reset();
 }
 
 bool CommandExecutor::doCommandSingleton(Command* cmd)


### PR DESCRIPTION
This commit implements a temporary fix for the
`--tear-down-incremental=X` option. The issue is that `reset()` now
replaces the `Solver` instance being used. However, the symbol table of
the parser holds references to `Expr`s from the old `ExprManager` (and
the pointer to `SmtEngine` in `CommandExecutor` is stale after
replacing the `Solver` but that is an easy fix). For the competition,
the easiest fix is to call `SmtEngine::reset()`. In experiments,
`--tear-down-incremental=X` performs significantly better and avoids
correctness issues.

Note: This PR is against `smtcomp2020` and will not be merged to `master`.