### PR TITLE
update example in README to use ctest.

### DIFF
--- a/test/regress/README.md
+++ b/test/regress/README.md
@@ -12,7 +12,7 @@ By default, each invocation of CVC4 is done with a 10 minute timeout. To use a
 different timeout, set the `TEST_TIMEOUT` environment variable:
 
 ```
-TEST_TIMEOUT=0.5 make regress0
+TEST_TIMEOUT=0.5 ctest -L regress0
 ```
 
 This runs regression tests from level 0 with a 0.5 second timeout.


### PR DESCRIPTION
An example for restricting timeout in tests uses the old `make regress0` instead of the new `ctest -L regress0`