### PR TITLE
Do not parse ->/lambda unless --uf-ho enabled

### DIFF
--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2630,8 +2630,8 @@ CHAR_TOK : { PARSER_STATE->isTheoryEnabled(theory::THEORY_STRINGS) }? 'char';
 TUPLE_CONST_TOK: { PARSER_STATE->isTheoryEnabled(theory::THEORY_DATATYPES) }? 'mkTuple';
 TUPLE_SEL_TOK: { PARSER_STATE->isTheoryEnabled(theory::THEORY_DATATYPES) }? 'tupSel';
 
-HO_ARROW_TOK : { PARSER_STATE->getLogic().isHigherOrder() }? '->';
-HO_LAMBDA_TOK : { PARSER_STATE->getLogic().isHigherOrder() }? 'lambda';
+HO_ARROW_TOK : { PARSER_STATE->isHoEnabled() }? '->';
+HO_LAMBDA_TOK : { PARSER_STATE->isHoEnabled() }? 'lambda';
 
 /**
  * A sequence of printable ASCII characters (except backslash) that starts

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -315,6 +315,12 @@ bool Smt2::isTheoryEnabled(theory::TheoryId theory) const
   return d_logic.isTheoryEnabled(theory);
 }
 
+bool Smt2::isHoEnabled() const
+{
+  return getLogic().isHigherOrder()
+         && d_solver->getExprManager()->getOptions().getUfHo();
+}
+
 bool Smt2::logicIsSet() {
   return d_logicSet;
 }

--- a/src/parser/smt2/smt2.h
+++ b/src/parser/smt2/smt2.h
@@ -98,6 +98,13 @@ class Smt2 : public Parser
 
   bool isTheoryEnabled(theory::TheoryId theory) const;
 
+  /**
+   * Checks if higher-order support is enabled.
+   *
+   * @return true if higher-order support is enabled, false otherwise
+   */
+  bool isHoEnabled() const;
+
   bool logicIsSet() override;
 
   /**

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -539,6 +539,7 @@ set(regress_0_tests
   regress0/ho/ho-matching-nested-app.smt2
   regress0/ho/ho-std-fmf.smt2
   regress0/ho/hoa0008.smt2
+  regress0/ho/issue4477.smt2
   regress0/ho/ite-apply-eq.smt2
   regress0/ho/lambda-equality-non-canon.smt2
   regress0/ho/match-middle.smt2

--- a/test/regress/regress0/ho/issue4477.smt2
+++ b/test/regress/regress0/ho/issue4477.smt2
@@ -1,0 +1,11 @@
+; REQUIRES: no-competition
+; SCRUBBER: grep -o "Symbol '->' not declared"
+; EXPECT: Symbol '->' not declared 
+; EXIT: 1
+(set-logic ALL)
+(declare-sort s 0)
+(declare-fun a () s)
+(declare-fun b () s)
+(declare-fun c (s) s)
+(assert (forall ((d (-> s s))) (distinct (d a) (c a) b)))
+(check-sat)


### PR DESCRIPTION
Fixes #4477. Logic `ALL` includes higher-order but we currently do not
support solving higher-order problems unless `--uf-ho` is enabled. This
commit changes the condition under which we parse `->` and `lambda` to
only enabled parsing of those symbols if the logic allows higher-order
constraints and `--uf-ho` is enabled.