### PR TITLE
Fix abduction with datatypes

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_abduct.cpp
+++ b/src/theory/quantifiers/sygus/sygus_abduct.cpp
@@ -58,6 +58,12 @@ Node SygusAbduct::mkAbductionConjecture(const std::string& name,
   for (const Node& s : symset)
   {
     TypeNode tn = s.getType();
+    if (tn.isConstructor() || tn.isSelector() || tn.isTester())
+    {
+      // datatype symbols should be considered interpreted symbols here, not
+      // (higher-order) variables.
+      continue;
+    }
     // Notice that we allow for non-first class (e.g. function) variables here.
     // This is applicable to the case where we are doing get-abduct in a logic
     // with UF.

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -2317,6 +2317,7 @@ set(regression_disabled_tests
   regress0/unconstrained/bvconcat.smt2
   regress0/unconstrained/bvdiv.smtv1.smt2
   ###
+  regress1/abduct-dt.smt2
   regress1/arith/arith-int-001.cvc
   regress1/arith/arith-int-002.cvc
   regress1/arith/arith-int-003.cvc

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1200,6 +1200,7 @@ set(regress_0_tests
 # Regression level 1 tests
 
 set(regress_1_tests
+  regress1/abduct-dt.smt2
   regress1/arith/arith-int-004.cvc
   regress1/arith/arith-int-011.cvc
   regress1/arith/arith-int-012.cvc
@@ -2317,7 +2318,6 @@ set(regression_disabled_tests
   regress0/unconstrained/bvconcat.smt2
   regress0/unconstrained/bvdiv.smtv1.smt2
   ###
-  regress1/abduct-dt.smt2
   regress1/arith/arith-int-001.cvc
   regress1/arith/arith-int-002.cvc
   regress1/arith/arith-int-003.cvc

--- a/test/regress/regress1/abduct-dt.smt2
+++ b/test/regress/regress1/abduct-dt.smt2
@@ -1,0 +1,8 @@
+; COMMAND-LINE: --produce-abducts
+; SCRUBBER: grep -v -E '(\(define-fun)'
+; EXIT: 0
+(set-logic ALL)
+(declare-datatypes ((List 0)) (((nil) (cons (head Int) (tail List)))))
+(declare-fun x () List)
+(assert (distinct x nil))
+(get-abduct A (= x (cons (head x) (tail x))))


### PR DESCRIPTION
Previously we were treating constructor/selector/tester symbols as arguments to the abduct-to-synthesize.