### PR TITLE
BV: Add missing type check for BITVECTOR_REPEAT_OP.

### DIFF
--- a/src/theory/bv/theory_bv_type_rules.h
+++ b/src/theory/bv/theory_bv_type_rules.h
@@ -302,6 +302,10 @@ class BitVectorRepeatTypeRule
       throw TypeCheckingExceptionPrivate(n, "expecting bit-vector term");
     }
     unsigned repeatAmount = n.getOperator().getConst<BitVectorRepeat>();
+    if (repeatAmount == 0)
+    {
+      throw TypeCheckingExceptionPrivate(n, "expecting number of repeats > 0");
+    }
     return nodeManager->mkBitVectorType(repeatAmount * t.getBitVectorSize());
   }
 }; /* class BitVectorRepeatTypeRule */

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -360,6 +360,7 @@ set(regress_0_tests
   regress0/bv/fuzz40.smtv1.smt2
   regress0/bv/fuzz41.smtv1.smt2
   regress0/bv/issue3621.smt2
+  regress0/bv/issue-4075.smt2
   regress0/bv/int_to_bv_err_on_demand_1.smt2
   regress0/bv/mul-neg-unsat.smt2
   regress0/bv/mul-negpow2.smt2

--- a/test/regress/regress0/bv/issue-4075.smt2
+++ b/test/regress/regress0/bv/issue-4075.smt2
@@ -1,0 +1,10 @@
+; EXPECT: (error "Parse Error: issue-4075.smt2:10.26: expecting number of repeats > 0
+; EXPECT:
+; EXPECT:  (simplify ((_ repeat 0) b))
+; EXPECT:                       ^
+; EXPECT:")
+; EXIT: 1
+(set-logic QF_BV)
+(define-sort a () (_ BitVec 4))
+(declare-const b a)
+(simplify ((_ repeat 0) b))


### PR DESCRIPTION
Fixes #4075.