### PR TITLE
When printing a separation logic model, ensure that the heap and nil are separate

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1358,13 +1358,16 @@ void Smt2Printer::toStream(std::ostream& out, const Model& m) const
   this->Printer::toStream(out, m);
   out << ")" << endl;
   //print the heap model, if it exists
-  Expr h, neq;
-  if( m.getHeapModel( h, neq ) ){
+  Expr h, nil;
+  if (m.getHeapModel(h, nil))
+  {
     // description of the heap+what nil is equal to fully describes model
     out << "(heap" << endl;
     out << h << endl;
-    out << neq << endl;
-    out << ")" << std::endl;
+    out << ")" << endl;
+    out << "(nil" << endl;
+    out << nil << endl;
+    out << ")" << endl;
   }
 }
 


### PR DESCRIPTION
## Issue

When formatting a model for a separation logic formula, CVC4 reports the `nil` element as part of the heap:

```
(heap
(sep (pto 1 3735928560) (pto 0 3735928559))
(= (as sep.nil Int) 4222467823)
)
```

which is confusing as the `nil` element *is not* part of the heap!

## Resolution

This PR changes it such that the `nil` term gets printed as its own (separate 😛) part of the model:

```
(heap
(sep (pto 1 3735928560) (pto 0 3735928559))
)
(nil
(= (as sep.nil Int) 4222467823)
)
```

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>