### PR TITLE
Fix CVC4_EXTRAVERSION variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CVC4_MINOR   9) # Minor component of the version of CVC4.
 set(CVC4_RELEASE 0) # Release component of the version of CVC4.
 
 # Extraversion component of the version of CVC4.
-set(CVC4_EXTRAVERSION "")
+set(CVC4_EXTRAVERSION "-prerelease")
 
 # Shared library versioning. Increment SOVERSION for every new CVC4 release.
 set(CVC4_SOVERSION 7)


### PR DESCRIPTION
When I created the PR for 733083c3bb6700b70ff31c3a679d519f493b680f, it
did not contain the change from `"" -> "-prerelease"` because at the
time `master` still had `CVC4_EXTRAVERSION` set to `"-prerelease"`. This
commit fixes `CVC4_EXTRAVERSION`.