### PR TITLE
Fix memory leak in unit test node_algorithm_black

### DIFF
--- a/test/unit/expr/node_algorithm_black.h
+++ b/test/unit/expr/node_algorithm_black.h
@@ -32,13 +32,6 @@ using namespace CVC4::kind;
 
 class NodeAlgorithmBlack : public CxxTest::TestSuite
 {
- private:
-  NodeManager* d_nodeManager;
-  NodeManagerScope* d_scope;
-  TypeNode* d_intTypeNode;
-  TypeNode* d_boolTypeNode;
-  TypeNode* d_bvTypeNode;
-
  public:
   void setUp() override
   {
@@ -51,8 +44,9 @@ class NodeAlgorithmBlack : public CxxTest::TestSuite
 
   void tearDown() override
   {
-    delete d_intTypeNode;
+    delete d_bvTypeNode;
     delete d_boolTypeNode;
+    delete d_intTypeNode;
     delete d_scope;
     delete d_nodeManager;
   }
@@ -216,4 +210,11 @@ class NodeAlgorithmBlack : public CxxTest::TestSuite
     TS_ASSERT_EQUALS(subs.size(), 1);
     TS_ASSERT_EQUALS(subs[x], a);
   }
+
+ private:
+  NodeManager* d_nodeManager;
+  NodeManagerScope* d_scope;
+  TypeNode* d_intTypeNode;
+  TypeNode* d_boolTypeNode;
+  TypeNode* d_bvTypeNode;
 };


### PR DESCRIPTION
Commit ccd4500c03685952ebf571b3539bd9e29c829cb5 modified the unit test
`node_algorithm_black`. It added `d_bvTypeNode` as a data member to the
class and initialized it in `setUp()` but did not free it in
`tearDown()`, which set off ASan. This commit fixes `tearDown()` to free
`d_bvTypeNode`.

Marking this as major because it should fix the nightlies.