### PR TITLE
[GitHub] Add link to fuzzing guidelines in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Bugs found with fuzzers
+    url: https://github.com/CVC4/CVC4/wiki/Fuzzing-CVC4
+    about: Please read the guidelines before submitting bugs found with a fuzzer


### PR DESCRIPTION
The PR adds a link to the fuzzing guidelines when creating issues: https://github.com/4tXJ7f/CVC4/issues/new/choose