### PR TITLE
Increase the minimum version of CMake due to the use of 'APPEND' with strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.4)
 
 #-----------------------------------------------------------------------------#
 # Project configuration

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.4)
 
 project(cvc4-examples)
 


### PR DESCRIPTION
## Issue

When trying to do some due diligence with #4696 I tried to build CVC4 with CMake 3.2, which is the currently listed CMake minimum. However, I got this:

```
CMake Error at CMakeLists.txt:245 (string):
  string does not recognize sub-command APPEND


CMake Error at CMakeLists.txt:246 (string):
  string does not recognize sub-command APPEND


CMake Error at CMakeLists.txt:247 (string):
  string does not recognize sub-command APPEND
```

(not a warning; an error)

This is because `string(APPEND` was added in [3.4](https://cmake.org/cmake/help/v3.4/command/string.html), so 3.2 isn't a valid minimum.

## Changes

Given the use of `string(APPEND` and that CMake 3.4 was released nearly 5 years ago ([2015-11-12](https://cmake.org/files/v3.4/?C=M;O=A)) I opted to bump the version of CMake rather than change the `string(APPEND`s.

CVC4's GitHub Actions use `ubuntu-latest` (for Linux at least), which corresponds to [`ubuntu-18.04`](https://github.com/actions/virtual-environments) -- in 18.04, [the default CMake version is 3.10](https://launchpad.net/ubuntu/bionic/+source/cmake).

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>