### PR TITLE
Fix regression output

### DIFF
--- a/test/regress/regress1/quantifiers/qid-debug-inst.smt2
+++ b/test/regress/regress1/quantifiers/qid-debug-inst.smt2
@@ -5,9 +5,10 @@
 
 (set-logic UFLIA)
 (declare-fun P (Int) Bool)
+(declare-fun R (Int) Bool)
 (declare-fun Q (Int) Bool)
-(assert (forall ((x Int)) (! (P x) :qid |myQuant1|)))
+(assert (forall ((x Int)) (! (=> (R x) (P x)) :qid |myQuant1|)))
 (assert (forall ((x Int)) (! (=> (P x) (Q x)) :qid |myQuant2|)))
-(assert (P 5))
+(assert (R 5))
 (assert (not (Q 5)))
 (check-sat)


### PR DESCRIPTION
This regression output was unexpected previously since conflict-based instantiation caught a conflict early, this makes it so that the output of this regression should be deterministic.

Fixes regress1.