### PR TITLE
Use TypeNode in UninterpretedConstant

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -3596,7 +3596,7 @@ Term Solver::mkUninterpretedConst(Sort sort, int32_t index) const
   CVC4_API_SOLVER_CHECK_SORT(sort);
 
   return mkValHelper<CVC4::UninterpretedConstant>(
-      CVC4::UninterpretedConstant(*sort.d_type, index));
+      CVC4::UninterpretedConstant(TypeNode::fromType(*sort.d_type), index));
 
   CVC4_API_SOLVER_TRY_CATCH_END;
 }

--- a/src/expr/uninterpreted_constant.h
+++ b/src/expr/uninterpreted_constant.h
@@ -16,62 +16,50 @@
 
 #include "cvc4_public.h"
 
-#pragma once
+#ifndef CVC4__UNINTERPRETED_CONSTANT_H
+#define CVC4__UNINTERPRETED_CONSTANT_H
 
 #include <iosfwd>
+#include <memory>
 
-#include "expr/type.h"
+#include "util/integer.h"
 
 namespace CVC4 {
 
-class CVC4_PUBLIC UninterpretedConstant {
+class TypeNode;
+
+class UninterpretedConstant
+{
  public:
-  UninterpretedConstant(Type type, Integer index);
+  UninterpretedConstant(const TypeNode& type, Integer index);
+  ~UninterpretedConstant();
 
-  Type getType() const { return d_type; }
-  const Integer& getIndex() const { return d_index; }
-  bool operator==(const UninterpretedConstant& uc) const
-  {
-    return d_type == uc.d_type && d_index == uc.d_index;
-  }
-  bool operator!=(const UninterpretedConstant& uc) const
-  {
-    return !(*this == uc);
-  }
+  UninterpretedConstant(const UninterpretedConstant& other);
 
-  bool operator<(const UninterpretedConstant& uc) const
-  {
-    return d_type < uc.d_type ||
-           (d_type == uc.d_type && d_index < uc.d_index);
-  }
-  bool operator<=(const UninterpretedConstant& uc) const
-  {
-    return d_type < uc.d_type ||
-           (d_type == uc.d_type && d_index <= uc.d_index);
-  }
-  bool operator>(const UninterpretedConstant& uc) const
-  {
-    return !(*this <= uc);
-  }
-  bool operator>=(const UninterpretedConstant& uc) const
-  {
-    return !(*this < uc);
-  }
+  const TypeNode& getType() const;
+  const Integer& getIndex() const;
+  bool operator==(const UninterpretedConstant& uc) const;
+  bool operator!=(const UninterpretedConstant& uc) const;
+  bool operator<(const UninterpretedConstant& uc) const;
+  bool operator<=(const UninterpretedConstant& uc) const;
+  bool operator>(const UninterpretedConstant& uc) const;
+  bool operator>=(const UninterpretedConstant& uc) const;
 
  private:
-  const Type d_type;
+  std::unique_ptr<TypeNode> d_type;
   const Integer d_index;
-};/* class UninterpretedConstant */
+}; /* class UninterpretedConstant */
 
-std::ostream& operator<<(std::ostream& out, const UninterpretedConstant& uc) CVC4_PUBLIC;
+std::ostream& operator<<(std::ostream& out, const UninterpretedConstant& uc);
 
 /**
  * Hash function for the BitVector constants.
  */
-struct CVC4_PUBLIC UninterpretedConstantHashFunction {
-  inline size_t operator()(const UninterpretedConstant& uc) const {
-    return TypeHashFunction()(uc.getType()) * IntegerHashFunction()(uc.getIndex());
-  }
-};/* struct UninterpretedConstantHashFunction */
+struct CVC4_PUBLIC UninterpretedConstantHashFunction
+{
+  size_t operator()(const UninterpretedConstant& uc) const;
+}; /* struct UninterpretedConstantHashFunction */
 
-}/* CVC4 namespace */
+}  // namespace CVC4
+
+#endif /* CVC4__UNINTERPRETED_CONSTANT_H */

--- a/src/theory/builtin/theory_builtin_type_rules.h
+++ b/src/theory/builtin/theory_builtin_type_rules.h
@@ -96,7 +96,7 @@ class SExprTypeRule {
 class UninterpretedConstantTypeRule {
  public:
   inline static TypeNode computeType(NodeManager* nodeManager, TNode n, bool check) {
-    return TypeNode::fromType(n.getConst<UninterpretedConstant>().getType());
+    return n.getConst<UninterpretedConstant>().getType();
   }
 };/* class UninterpretedConstantTypeRule */
 

--- a/src/theory/builtin/type_enumerator.h
+++ b/src/theory/builtin/type_enumerator.h
@@ -60,7 +60,8 @@ class UninterpretedSortEnumerator : public TypeEnumeratorBase<UninterpretedSortE
     if(isFinished()) {
       throw NoMoreValuesException(getType());
     }
-    return NodeManager::currentNM()->mkConst(UninterpretedConstant(getType().toType(), d_count));
+    return NodeManager::currentNM()->mkConst(
+        UninterpretedConstant(getType(), d_count));
   }
 
   UninterpretedSortEnumerator& operator++() override

--- a/src/theory/datatypes/datatypes_rewriter.cpp
+++ b/src/theory/datatypes/datatypes_rewriter.cpp
@@ -720,7 +720,7 @@ Node DatatypesRewriter::normalizeCodatatypeConstantEqc(
     {
       int debruijn = depth - it->second - 1;
       return NodeManager::currentNM()->mkConst(
-          UninterpretedConstant(n.getType().toType(), debruijn));
+          UninterpretedConstant(n.getType(), debruijn));
     }
     std::vector<Node> children;
     bool childChanged = false;

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -1642,7 +1642,8 @@ Node TheoryDatatypes::getCodatatypesValue( Node n, std::map< Node, Node >& eqc_c
   std::map< Node, int >::iterator itv = vmap.find( n );
   if( itv!=vmap.end() ){
     int debruijn = depth - 1 - itv->second;
-    return NodeManager::currentNM()->mkConst(UninterpretedConstant(n.getType().toType(), debruijn));
+    return NodeManager::currentNM()->mkConst(
+        UninterpretedConstant(n.getType(), debruijn));
   }else if( n.getType().isDatatype() ){
     Node nc = eqc_cons[n];
     if( !nc.isNull() ){

--- a/src/theory/datatypes/type_enumerator.cpp
+++ b/src/theory/datatypes/type_enumerator.cpp
@@ -107,7 +107,7 @@ Node DatatypesEnumerator::getTermEnum( TypeNode tn, unsigned i ){
      if (d_child_enum)
      {
        ret = NodeManager::currentNM()->mkConst(
-           UninterpretedConstant(d_type.toType(), d_size_limit));
+           UninterpretedConstant(d_type, d_size_limit));
      }
      else
      {

--- a/src/theory/rewriter.cpp
+++ b/src/theory/rewriter.cpp
@@ -333,7 +333,8 @@ Node Rewriter::rewriteTo(theory::TheoryId theoryId,
 #ifdef CVC4_ASSERTIONS
           RewriteResponse r2 =
               d_theoryRewriters[newTheoryId]->postRewrite(response.d_node);
-          Assert(r2.d_node == response.d_node);
+          Assert(r2.d_node == response.d_node)
+              << r2.d_node << " != " << response.d_node;
 #endif
           rewriteStackTop.d_node = response.d_node;
           break;

--- a/test/unit/theory/theory_sets_type_enumerator_white.h
+++ b/test/unit/theory/theory_sets_type_enumerator_white.h
@@ -86,13 +86,11 @@ class SetEnumeratorWhite : public CxxTest::TestSuite
 
   void testSetOfUF()
   {
-    TypeNode typeNode = d_nm->mkSort("Atom");
-    Type sort = typeNode.toType();
-    SetEnumerator setEnumerator(d_nm->mkSetType(typeNode));
+    TypeNode sort = d_nm->mkSort("Atom");
+    SetEnumerator setEnumerator(d_nm->mkSetType(sort));
 
     Node actual0 = *setEnumerator;
-    Node expected0 =
-        d_nm->mkConst(EmptySet(d_nm->mkSetType(typeNode)));
+    Node expected0 = d_nm->mkConst(EmptySet(d_nm->mkSetType(sort)));
     TS_ASSERT_EQUALS(expected0, actual0);
     TS_ASSERT(!setEnumerator.isFinished());
 

--- a/test/unit/theory/type_enumerator_white.h
+++ b/test/unit/theory/type_enumerator_white.h
@@ -70,11 +70,9 @@ class TypeEnumeratorWhite : public CxxTest::TestSuite {
   }
 
   void testUF() {
-    TypeNode sortn = d_nm->mkSort("T");
-    Type sort = sortn.toType();
-    TypeNode sortn2 = d_nm->mkSort("U");
-    Type sort2 = sortn2.toType();
-    TypeEnumerator te(sortn);
+    TypeNode sort = d_nm->mkSort("T");
+    TypeNode sort2 = d_nm->mkSort("U");
+    TypeEnumerator te(sort);
     TS_ASSERT_EQUALS(*te, d_nm->mkConst(UninterpretedConstant(sort, 0)));
     for(size_t i = 1; i < 100; ++i) {
       TS_ASSERT_DIFFERS(*te, d_nm->mkConst(UninterpretedConstant(sort, i)));

--- a/test/unit/util/array_store_all_white.h
+++ b/test/unit/util/array_store_all_white.h
@@ -50,7 +50,7 @@ class ArrayStoreAllWhite : public CxxTest::TestSuite
     ArrayStoreAll(d_nm->mkArrayType(d_nm->integerType(), d_nm->realType()),
                   d_nm->mkConst(Rational(9, 2)));
     ArrayStoreAll(d_nm->mkArrayType(d_nm->mkSort("U"), usort),
-                  d_nm->mkConst(UninterpretedConstant(usort.toType(), 0)));
+                  d_nm->mkConst(UninterpretedConstant(usort, 0)));
     ArrayStoreAll(d_nm->mkArrayType(d_nm->mkBitVectorType(8), d_nm->realType()),
                   d_nm->mkConst(Rational(0)));
     ArrayStoreAll(
@@ -62,7 +62,7 @@ class ArrayStoreAllWhite : public CxxTest::TestSuite
   {
     TS_ASSERT_THROWS(ArrayStoreAll(d_nm->integerType(),
                                    d_nm->mkConst(UninterpretedConstant(
-                                       d_nm->mkSort("U").toType(), 0))),
+                                       d_nm->mkSort("U"), 0))),
                      IllegalArgumentException&);
     TS_ASSERT_THROWS(
         ArrayStoreAll(d_nm->integerType(), d_nm->mkConst(Rational(9, 2))),


### PR DESCRIPTION
This commit changes `UninterpretedConstant` to use `TypeNode` instead of
`Type`.