### PR TITLE
Ensure that :named terms are made global in the symbol table.

### DIFF
--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -1362,7 +1362,7 @@ api::Term Smt2::setNamedAttribute(api::Term& expr, const SExpr& sexpr)
   // check that sexpr is a fresh function symbol, and reserve it
   reserveSymbolAtAssertionLevel(name);
   // define it
-  api::Term func = bindVar(name, expr.getSort(), ExprManager::VAR_FLAG_DEFINED || ExprManager::VAR_FLAG_GLOBAL);
+  api::Term func = bindVar(name, expr.getSort(), ExprManager::VAR_FLAG_DEFINED | ExprManager::VAR_FLAG_GLOBAL);
   // remember the last term to have been given a :named attribute
   setLastNamedTerm(expr, name);
   return func;

--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -1362,7 +1362,7 @@ api::Term Smt2::setNamedAttribute(api::Term& expr, const SExpr& sexpr)
   // check that sexpr is a fresh function symbol, and reserve it
   reserveSymbolAtAssertionLevel(name);
   // define it
-  api::Term func = bindVar(name, expr.getSort(), ExprManager::VAR_FLAG_DEFINED);
+  api::Term func = bindVar(name, expr.getSort(), ExprManager::VAR_FLAG_DEFINED || ExprManager::VAR_FLAG_GLOBAL);
   // remember the last term to have been given a :named attribute
   setLastNamedTerm(expr, name);
   return func;


### PR DESCRIPTION
In #4320, it was found that we throw an exception when calling `(get-value x)` where `x` is a named term that was named within a scope (for example a let expression).
According to section 4.1.6 of SMTLIB v2.6, named terms should be made available globally, as if they were defined by `define-fun` directly before the command containing the `:named x`.
While some care seemed to be taken, `x` would still vanish from the symbol table. This PR fixes this issue by setting `ExprManager::VAR_FLAG_GLOBAL` on `x`.

While it fixes the example from #4320, I'd really like someone with more experience to check it.
In particular: does this flag do the right thing in combination with `(push)` and `(pop)`? In my understanding of the SMTLIB standard, the following should be possible (allowing to redeclare the same named term within different scopes):
> (push)
> (assert (let ((a (! true :named b))) a))
> (check-sat)
> (pop)
> (push)
> (assert (let ((a (! false :named b))) a))
> (check-sat)
> (pop)

This, however, fails with the current PR as `b` remains in the symbol after `(pop)`, thus giving:

> (error "Parse Error: test.smt2:6.34: Symbol 'b' previously declared as a variable
>
>  (assert (let ((a (! false :named b))) a))
>                                   ^
> ")

I mark this as do not merge until this has been clarified.

Fixed #4320.