### PR TITLE
Fix a deadlock in the signature tests.

### DIFF
--- a/test/signatures/run_test.py
+++ b/test/signatures/run_test.py
@@ -111,12 +111,11 @@ def main():
     result = subprocess.Popen(cmd,
                               stderr=subprocess.STDOUT,
                               stdout=subprocess.PIPE)
-    code = result.wait()
-    if 0 != code:
-        stdout = result.stdout.read()
+    (stdout, _) = result.communicate()
+    if 0 != result.returncode:
         if stdout:
             print(stdout.decode())
-    return code
+    return result.returncode
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* wait() deadlocks if the OS pipe fills
* communicate() does not

This is essentially a duplicate of [this](https://github.com/CVC4/LFSC/pull/38).