### PR TITLE
When building statically, enforce enabling GPL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,12 @@ else()
     message(WARNING "Disabling unit tests since static build is enabled.")
     set(ENABLE_UNIT_TESTING OFF)
   endif()
+
+  if (NOT ENABLE_GPL)
+    message(FATAL_ERROR "Building statically creates a GPL-licensed binary. "
+                        "You must configure CVC4 with `--gpl` to build with "
+                        "`--static`.")
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
## Issue

When building statically, CVC4 directly links in `gmp.a` (and LGPL library). Statically linking GMP in this way makes the final CVC4 binaries GPL licensed (because the user cannot replace the GMP code, which is the point of LGPL).

## Resolution

This PR changes CVC4's CMakeLists such it is not possible to create a static build without enabling `--gpl`.

## Discussion

It has been pointed out to me (correctly so!) that _potentially_ someone could build CVC4 with a "drop-in replacement" for GMP that is not LGPL licensed -- that's 100% correct (this is the same for `readline` vs. `libedit` -- `libedit` is a BSD-licensed drop-in replacement for `readline`). However, I am not aware of any "drop-in replacement" for GMP (at all), let alone one that isn't LGPL licensed.

This means, to me, on the "balance of probability" if someone is linking statically, they will **most likely** be creating GPL licensed binaries.

The purpose of this PR (and in adding the requirement for `--gpl`) was to ensure that someone cannot (accidentally) create a static archive of CVC4 that they mistakenly believe is BSD licensed.



Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>