### PR TITLE
Fix arith congruence manager's contexts

### DIFF
--- a/src/theory/arith/congruence_manager.cpp
+++ b/src/theory/arith/congruence_manager.cpp
@@ -47,9 +47,9 @@ ArithCongruenceManager::ArithCongruenceManager(
       d_ee(d_notify, c, "theory::arith::ArithCongruenceManager", true),
       d_pnm(pnm),
       d_pfGenEe(
-          new EagerProofGenerator(pnm, u, "ArithCongruenceManager::pfGenEe")),
+          new EagerProofGenerator(pnm, c, "ArithCongruenceManager::pfGenEe")),
       d_pfGenExplain(new EagerProofGenerator(
-          pnm, c, "ArithCongruenceManager::pfGenExplain")),
+          pnm, u, "ArithCongruenceManager::pfGenExplain")),
       d_pfee(new eq::ProofEqEngine(c, u, d_ee, pnm))
 {
   d_ee.addFunctionKind(kind::NONLINEAR_MULT);


### PR DESCRIPTION
The theory-facing one should be user-dependent.
The ee-facing one should be sat-dependent.

I'll post again once the regressions pass, but this seems to be good.