### PR TITLE
Set isClosed argument to false in ProofEqEngine::assertFact 

### DIFF
--- a/src/theory/arith/congruence_manager.cpp
+++ b/src/theory/arith/congruence_manager.cpp
@@ -555,7 +555,7 @@ void ArithCongruenceManager::assertLitToEqualityEngine(
         Trace("arith-pfee") << std::endl;
       }
       // The proof equality engine *does* ref-count for us...
-      d_pfee->assertFact(lit, reason, d_pfGenEe.get(), false, "ArithCongruenceManager");
+      d_pfee->assertFact(lit, reason, d_pfGenEe.get());
     }
   }
   else

--- a/src/theory/arith/congruence_manager.cpp
+++ b/src/theory/arith/congruence_manager.cpp
@@ -555,7 +555,7 @@ void ArithCongruenceManager::assertLitToEqualityEngine(
         Trace("arith-pfee") << std::endl;
       }
       // The proof equality engine *does* ref-count for us...
-      d_pfee->assertFact(lit, reason, d_pfGenEe.get());
+      d_pfee->assertFact(lit, reason, d_pfGenEe.get(), false, "ArithCongruenceManager");
     }
   }
   else

--- a/src/theory/uf/proof_equality_engine.cpp
+++ b/src/theory/uf/proof_equality_engine.cpp
@@ -187,7 +187,8 @@ bool ProofEqEngine::assertFact(Node lit, Node exp, ProofStepBuffer& psb)
   return assertFactInternal(atom, polarity, exp);
 }
 
-bool ProofEqEngine::assertFact(Node lit, Node exp, ProofGenerator* pg)
+bool ProofEqEngine::assertFact(
+    Node lit, Node exp, ProofGenerator* pg, bool isClosed, const char* ctx)
 {
   Trace("pfee") << "pfee::assertFact " << lit << ", exp = " << exp
                 << " via generator" << std::endl;
@@ -201,7 +202,7 @@ bool ProofEqEngine::assertFact(Node lit, Node exp, ProofGenerator* pg)
       return false;
     }
     // note the proof generator is responsible for remembering the explanation
-    d_proof.addLazyStep(lit, pg);
+    d_proof.addLazyStep(lit, pg, isClosed, ctx);
   }
   // second, assert it to the equality engine
   return assertFactInternal(atom, polarity, exp);

--- a/src/theory/uf/proof_equality_engine.cpp
+++ b/src/theory/uf/proof_equality_engine.cpp
@@ -187,8 +187,7 @@ bool ProofEqEngine::assertFact(Node lit, Node exp, ProofStepBuffer& psb)
   return assertFactInternal(atom, polarity, exp);
 }
 
-bool ProofEqEngine::assertFact(
-    Node lit, Node exp, ProofGenerator* pg, bool isClosed, const char* ctx)
+bool ProofEqEngine::assertFact(Node lit, Node exp, ProofGenerator* pg)
 {
   Trace("pfee") << "pfee::assertFact " << lit << ", exp = " << exp
                 << " via generator" << std::endl;
@@ -202,7 +201,7 @@ bool ProofEqEngine::assertFact(
       return false;
     }
     // note the proof generator is responsible for remembering the explanation
-    d_proof.addLazyStep(lit, pg, isClosed, ctx);
+    d_proof.addLazyStep(lit, pg, false);
   }
   // second, assert it to the equality engine
   return assertFactInternal(atom, polarity, exp);

--- a/src/theory/uf/proof_equality_engine.h
+++ b/src/theory/uf/proof_equality_engine.h
@@ -146,17 +146,17 @@ class ProofEqEngine : public EagerProofGenerator
                   ProofGenerator* pg,
                   bool isClosed = true,
                   const char* ctx = "ProofEqEngine::assertFact");
-      //-------------------------- assert conflicts
-      /**
-       * This method is called when the equality engine of this class is
-       * inconsistent (false has been proven) by a contradictory literal lit.
-       * This returns the trust node corresponding to the current conflict.
-       *
-       * @param lit The conflicting literal, which must rewrite to false.
-       * @return The trust node capturing the fact that this class can provide a
-       * proof for this conflict.
-       */
-      TrustNode assertConflict(Node lit);
+  //-------------------------- assert conflicts
+  /**
+   * This method is called when the equality engine of this class is
+   * inconsistent (false has been proven) by a contradictory literal lit.
+   * This returns the trust node corresponding to the current conflict.
+   *
+   * @param lit The conflicting literal, which must rewrite to false.
+   * @return The trust node capturing the fact that this class can provide a
+   * proof for this conflict.
+   */
+  TrustNode assertConflict(Node lit);
   /**
    * Get proven conflict from contradictory facts. This method is called when
    * the proof rule with premises exp and arguments args implies a contradiction

--- a/src/theory/uf/proof_equality_engine.h
+++ b/src/theory/uf/proof_equality_engine.h
@@ -135,6 +135,9 @@ class ProofEqEngine : public EagerProofGenerator
    * the premises that are used when calling explain(lit).
    * @param pg The proof generator that can provide a proof concluding lit
    * from free asumptions in exp.
+   * @param isClosed Whether to expect that pg can provide a closed proof for
+   * this fact.
+   * @param ctx The context we are in (for debugging).
    * @return true if this fact was processed by this method. If lit already
    * holds in the equality engine, this method returns false.
    */

--- a/src/theory/uf/proof_equality_engine.h
+++ b/src/theory/uf/proof_equality_engine.h
@@ -149,8 +149,8 @@ class ProofEqEngine : public EagerProofGenerator
   //-------------------------- assert conflicts
   /**
    * This method is called when the equality engine of this class is
-   * inconsistent (false has been proven) by a contradictory literal lit.
-   * This returns the trust node corresponding to the current conflict.
+   * inconsistent (false has been proven) by a contradictory literal lit. This
+   * returns the trust node corresponding to the current conflict.
    *
    * @param lit The conflicting literal, which must rewrite to false.
    * @return The trust node capturing the fact that this class can provide a

--- a/src/theory/uf/proof_equality_engine.h
+++ b/src/theory/uf/proof_equality_engine.h
@@ -138,18 +138,22 @@ class ProofEqEngine : public EagerProofGenerator
    * @return true if this fact was processed by this method. If lit already
    * holds in the equality engine, this method returns false.
    */
-  bool assertFact(Node lit, Node exp, ProofGenerator* pg);
-  //-------------------------- assert conflicts
-  /**
-   * This method is called when the equality engine of this class is
-   * inconsistent (false has been proven) by a contradictory literal lit. This
-   * returns the trust node corresponding to the current conflict.
-   *
-   * @param lit The conflicting literal, which must rewrite to false.
-   * @return The trust node capturing the fact that this class can provide a
-   * proof for this conflict.
-   */
-  TrustNode assertConflict(Node lit);
+  bool assertFact(Node lit,
+                  Node exp,
+                  ProofGenerator* pg,
+                  bool isClosed = true,
+                  const char* ctx = "ProofEqEngine::assertFact");
+      //-------------------------- assert conflicts
+      /**
+       * This method is called when the equality engine of this class is
+       * inconsistent (false has been proven) by a contradictory literal lit.
+       * This returns the trust node corresponding to the current conflict.
+       *
+       * @param lit The conflicting literal, which must rewrite to false.
+       * @return The trust node capturing the fact that this class can provide a
+       * proof for this conflict.
+       */
+      TrustNode assertConflict(Node lit);
   /**
    * Get proven conflict from contradictory facts. This method is called when
    * the proof rule with premises exp and arguments args implies a contradiction

--- a/src/theory/uf/proof_equality_engine.h
+++ b/src/theory/uf/proof_equality_engine.h
@@ -135,17 +135,12 @@ class ProofEqEngine : public EagerProofGenerator
    * the premises that are used when calling explain(lit).
    * @param pg The proof generator that can provide a proof concluding lit
    * from free asumptions in exp.
-   * @param isClosed Whether to expect that pg can provide a closed proof for
-   * this fact.
-   * @param ctx The context we are in (for debugging).
    * @return true if this fact was processed by this method. If lit already
    * holds in the equality engine, this method returns false.
    */
   bool assertFact(Node lit,
                   Node exp,
-                  ProofGenerator* pg,
-                  bool isClosed = true,
-                  const char* ctx = "ProofEqEngine::assertFact");
+                  ProofGenerator* pg);
   //-------------------------- assert conflicts
   /**
    * This method is called when the equality engine of this class is


### PR DESCRIPTION
It's supposed to take open proofs.

Question: Why not have `ProofEqEngine::assertFact` **always** pass `isClosed=false` to `addLazyStep`? Doesn't the interface of `ProofEqEngine::assertFact` require that the proof is open?