### PR TITLE
Improve error message for unsupported exponents

### DIFF
--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -249,7 +249,7 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
 
         // Todo improve the exception thrown
         std::stringstream ss;
-        ss << "The exponent of the POW(^) operator can only be a constant positive number below " << INT_MAX << ". ";
+        ss << "The exponent of the POW(^) operator can only be a constant positive integral number below " << INT_MAX << ". ";
         ss << "Exception occurred in:" << std::endl;
         ss << "  " << t;
         throw LogicException(ss.str());

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -249,8 +249,8 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
 
         // Todo improve the exception thrown
         std::stringstream ss;
-        ss << "The POW(^) operator can only be used with a natural number ";
-        ss << "in the exponent.  Exception occurred in:" << std::endl;
+        ss << "The exponent of the POW(^) operator can only be a constant positive number below " << INT_MAX << ". ";
+        ss << "Exception occurred in:" << std::endl;
         ss << "  " << t;
         throw LogicException(ss.str());
       }

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -229,8 +229,8 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
           if(exp.sgn() == 0){
             return RewriteResponse(REWRITE_DONE, mkRationalNode(Rational(1)));
           }else if(exp.sgn() > 0 && exp.isIntegral()){
-            CVC4::Rational r(INT_MAX);
-            if( exp<r ){
+            CVC4::Rational r(expr::NodeValue::MAX_CHILDREN);
+            if( exp <= r ){
               unsigned num = exp.getNumerator().toUnsignedInt();
               if( num==1 ){
                 return RewriteResponse(REWRITE_AGAIN, base);
@@ -249,7 +249,7 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
 
         // Todo improve the exception thrown
         std::stringstream ss;
-        ss << "The exponent of the POW(^) operator can only be a constant positive integral number below " << INT_MAX << ". ";
+        ss << "The exponent of the POW(^) operator can only be a positive integral constant below " << (expr::NodeValue::MAX_CHILDREN+1) << ". ";
         ss << "Exception occurred in:" << std::endl;
         ss << "  " << t;
         throw LogicException(ss.str());

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -230,7 +230,8 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
             return RewriteResponse(REWRITE_DONE, mkRationalNode(Rational(1)));
           }else if(exp.sgn() > 0 && exp.isIntegral()){
             CVC4::Rational r(expr::NodeValue::MAX_CHILDREN);
-            if( exp <= r ){
+            if (exp <= r)
+            {
               unsigned num = exp.getNumerator().toUnsignedInt();
               if( num==1 ){
                 return RewriteResponse(REWRITE_AGAIN, base);
@@ -249,7 +250,9 @@ RewriteResponse ArithRewriter::postRewriteTerm(TNode t){
 
         // Todo improve the exception thrown
         std::stringstream ss;
-        ss << "The exponent of the POW(^) operator can only be a positive integral constant below " << (expr::NodeValue::MAX_CHILDREN+1) << ". ";
+        ss << "The exponent of the POW(^) operator can only be a positive "
+              "integral constant below "
+           << (expr::NodeValue::MAX_CHILDREN + 1) << ". ";
         ss << "Exception occurred in:" << std::endl;
         ss << "  " << t;
         throw LogicException(ss.str());

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -1247,6 +1247,7 @@ set(regress_1_tests
   regress1/arith/bug547.1.smt2
   regress1/arith/bug716.0.smt2
   regress1/arith/bug716.1.cvc
+  regress1/arith/bug716.2.cvc
   regress1/arith/div.03.smt2
   regress1/arith/div.06.smt2
   regress1/arith/div.08.smt2

--- a/test/regress/regress1/arith/bug716.1.cvc
+++ b/test/regress/regress1/arith/bug716.1.cvc
@@ -1,4 +1,4 @@
-% EXPECT: The exponent of the POW(^) operator can only be a constant positive number below 2147483647. Exception occurred in:
+% EXPECT: The exponent of the POW(^) operator can only be a constant positive integral number below 2147483647. Exception occurred in:
 % EXPECT:   2 ^ x
 % EXIT: 1
 x: INT;

--- a/test/regress/regress1/arith/bug716.1.cvc
+++ b/test/regress/regress1/arith/bug716.1.cvc
@@ -1,4 +1,4 @@
-% EXPECT: The POW(^) operator can only be used with a natural number in the exponent.  Exception occurred in:
+% EXPECT: The exponent of the POW(^) operator can only be a constant positive number below 2147483647. Exception occurred in:
 % EXPECT:   2 ^ x
 % EXIT: 1
 x: INT;

--- a/test/regress/regress1/arith/bug716.2.cvc
+++ b/test/regress/regress1/arith/bug716.2.cvc
@@ -1,6 +1,6 @@
 % EXPECT: The exponent of the POW(^) operator can only be a positive integral constant below 67108864. Exception occurred in:
-% EXPECT:   2 ^ x
+% EXPECT:   x ^ 67108864
 % EXIT: 1
 x: INT;
-ASSERT 2^x = 8;
+ASSERT x^67108864 = 8;
 QUERY x=3;


### PR DESCRIPTION
We have had a few issues where essentially users misinterpreted the error message about which types of exponents are supported for `(^ base exp)`. Given that this is rewritten to a multiplication of length `exp`, we only support reasonably small natural numbers.
This PR improves the error message.
Fixes #4692 
Note that there is another limit on the number of children of the multiplication (see #3695), and we might want to copy this check into this rewriter as well...