### PR TITLE
Split preprocessor from SmtEngine

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,6 +249,8 @@ libcvc4_add_sources(
   smt/model_blocker.h
   smt/options_manager.cpp
   smt/options_manager.h
+  smt/preprocessor.cpp
+  smt/preprocessor.h
   smt/preprocess_proof_generator.cpp
   smt/preprocess_proof_generator.h
   smt/process_assertions.cpp

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -4952,7 +4952,7 @@ Term Solver::getValue(Term term) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
   CVC4_API_SOLVER_CHECK_TERM(term);
-  return Term(this, d_smtEngine->getValue(term.d_node->toExpr()));
+  return Term(this, d_smtEngine->getValue(*term.d_node));
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
 

--- a/src/printer/cvc/cvc_printer.cpp
+++ b/src/printer/cvc/cvc_printer.cpp
@@ -1185,7 +1185,7 @@ void DeclareFunctionCommandToStream(std::ostream& out,
   {
     out << tn;
   }
-  Node val = Node::fromExpr(model.getSmtEngine()->getValue(n.toExpr()));
+  Node val = model.getSmtEngine()->getValue(n);
   if (options::modelUninterpDtEnum() && val.getKind() == kind::STORE)
   {
     TypeNode type_node = val[1].getType();

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1455,8 +1455,7 @@ void Smt2Printer::toStream(std::ostream& out,
       // don't print out internal stuff
       return;
     }
-    Node val =
-        Node::fromExpr(theory_model->getSmtEngine()->getValue(n.toExpr()));
+    Node val = theory_model->getSmtEngine()->getValue(n);
     if (val.getKind() == kind::LAMBDA)
     {
       out << "(define-fun " << n << " " << val[0] << " "

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1509,7 +1509,7 @@ void SimplifyCommand::invoke(SmtEngine* smtEngine)
 {
   try
   {
-    d_result = smtEngine->simplify(d_term);
+    d_result = smtEngine->simplify(Node::fromExpr(d_term)).toExpr();
     d_commandStatus = CommandSuccess::instance();
   }
   catch (UnsafeInterruptException& e)

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -1,0 +1,115 @@
+/*********************                                                        */
+/*! \file assertions.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The module for storing assertions for an SMT engine.
+ **/
+
+#include "smt/preprocessor.h"
+
+#include "smt/smt_engine.h"
+#include "options/smt_options.h"
+#include "smt/assertions.h"
+#include "smt/abstract_values.h"
+
+using namespace CVC4::theory;
+using namespace CVC4::kind;
+
+namespace CVC4 {
+namespace smt {
+
+Preprocessor::Preprocessor(SmtEngine& smt, context::UserContext* u, AbstractValues& abs)
+    :  d_propagator(true, true),
+        d_assertionsProcessed(u, false),
+        d_processor(smt, *smt.getResourceManager()),
+        d_rtf(u),
+        d_absValues(abs)
+{
+}
+
+Preprocessor::~Preprocessor()
+{
+}
+
+void Preprocessor::finishInit()
+{
+  
+}
+
+bool Preprocessor::processAssertions(Assertions& as)
+{
+  AssertionPipeline& ap = as.getAssertionPipeline();
+
+  Assert (ap.size()!=0);
+  
+  if (d_assertionsProcessed && options::incrementalSolving()) {
+    // TODO(b/1255): Substitutions in incremental mode should be managed with a
+    // proper data structure.
+    ap.enableStoreSubstsInAsserts();
+  }
+  else
+  {
+    ap.disableStoreSubstsInAsserts();
+  }
+
+  // process the assertions
+  bool noConflict = d_processor.apply(as);
+  
+  // mark that we've processed assertions
+  d_assertionsProcessed = true;
+}
+
+RemoveTermFormulas& getTermFormulaRemover()
+{
+  return d_rtf;
+}
+
+Node Preprocessor::expandDefinitions(const Node& ex)
+{
+  Trace("smt") << "SMT expandDefinitions(" << ex << ")" << endl;
+  // Substitute out any abstract values in ex.
+  Node e = d_absValues.substituteAbstractValues(ex);
+  if(options::typeChecking()) 
+  {
+    // Ensure expr is type-checked at this point.
+    e.getType(true);
+  }
+  std::unordered_map<Node, Node, NodeHashFunction> cache;
+  // expand only = true
+  return d_processor->expandDefinitions( e, cache, true);
+}
+
+Node Preprocessor::simplify(const Node& ex)
+{
+  Trace("smt") << "SMT simplify(" << ex << ")" << endl;
+  if(Dump.isOn("benchmark")) 
+  {
+    Dump("benchmark") << SimplifyCommand(ex);
+  }
+  Node e = d_absValues.substituteAbstractValues(ex);
+  if( options::typeChecking() ) 
+  {
+    // ensure expr is type-checked at this point
+    e.getType(true);
+  }
+  // Make sure all preprocessing is done
+  d_private->processAssertions(*d_asserts);
+  Node n = d_private->simplify(Node::fromExpr(e));
+  return n.toExpr();
+}
+
+Node Preprocessor::applySubstitutions(TNode node)
+{
+  return Rewriter::rewrite(
+      d_preprocessingPassContext->getTopLevelSubstitutions().apply(node));
+}
+
+}  // namespace smt
+}  // namespace CVC4

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -130,14 +130,14 @@ Node Preprocessor::simplify(const Node& node, bool removeItes)
   {
     Dump("benchmark") << SimplifyCommand(node.toExpr());
   }
-  Node no = d_absValues.substituteAbstractValues(node);
+  Node nas = d_absValues.substituteAbstractValues(node);
   if (options::typeChecking())
   {
     // ensure node is type-checked at this point
-    no.getType(true);
+    nas.getType(true);
   }
   std::unordered_map<Node, Node, NodeHashFunction> cache;
-  Node n = d_processor.expandDefinitions(e, cache);
+  Node n = d_processor.expandDefinitions(nas, cache);
   Node ns = applySubstitutions(n);
   if (removeItes)
   {

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -14,10 +14,10 @@
 
 #include "smt/preprocessor.h"
 
-#include "smt/smt_engine.h"
 #include "options/smt_options.h"
-#include "smt/assertions.h"
 #include "smt/abstract_values.h"
+#include "smt/assertions.h"
+#include "smt/smt_engine.h"
 
 using namespace CVC4::theory;
 using namespace CVC4::kind;
@@ -25,25 +25,28 @@ using namespace CVC4::kind;
 namespace CVC4 {
 namespace smt {
 
-Preprocessor::Preprocessor(SmtEngine& smt, context::UserContext* u, AbstractValues& abs)
-    :  d_propagator(true, true),
-        d_assertionsProcessed(u, false),
-        d_processor(smt, *smt.getResourceManager()),
-        d_rtf(u),
-        d_absValues(abs)
+Preprocessor::Preprocessor(SmtEngine& smt,
+                           context::UserContext* u,
+                           AbstractValues& abs)
+    : d_propagator(true, true),
+      d_assertionsProcessed(u, false),
+      d_processor(smt, *smt.getResourceManager()),
+      d_rtf(u),
+      d_absValues(abs)
 {
 }
 
 Preprocessor::~Preprocessor()
 {
-  if(d_propagator.getNeedsFinish()) {
+  if (d_propagator.getNeedsFinish())
+  {
     d_propagator.finish();
     d_propagator.setNeedsFinish(false);
   }
 }
 
 void Preprocessor::finishInit()
-{  
+{
   d_preprocessingPassContext.reset(
       new PreprocessingPassContext(&d_smt, &d_iteRemover, &d_propagator));
 
@@ -54,11 +57,12 @@ void Preprocessor::finishInit()
 bool Preprocessor::process(Assertions& as)
 {
   AssertionPipeline& ap = as.getAssertionPipeline();
-  
+
   // should not be called if empty
-  Assert (ap.size()!=0);
-  
-  if (d_assertionsProcessed && options::incrementalSolving()) {
+  Assert(ap.size() != 0);
+
+  if (d_assertionsProcessed && options::incrementalSolving())
+  {
     // TODO(b/1255): Substitutions in incremental mode should be managed with a
     // proper data structure.
     ap.enableStoreSubstsInAsserts();
@@ -90,35 +94,32 @@ void Preprocessor::clearLearnedLiterals()
   d_propagator.getLearnedLiterals().clear();
 }
 
-RemoveTermFormulas& getTermFormulaRemover()
-{
-  return d_rtf;
-}
+RemoveTermFormulas& getTermFormulaRemover() { return d_rtf; }
 
 Node Preprocessor::expandDefinitions(const Node& ex)
 {
   Trace("smt") << "SMT expandDefinitions(" << ex << ")" << endl;
   // Substitute out any abstract values in ex.
   Node e = d_absValues.substituteAbstractValues(ex);
-  if(options::typeChecking()) 
+  if (options::typeChecking())
   {
     // Ensure expr is type-checked at this point.
     e.getType(true);
   }
   std::unordered_map<Node, Node, NodeHashFunction> cache;
   // expand only = true
-  return d_processor->expandDefinitions( e, cache, true);
+  return d_processor->expandDefinitions(e, cache, true);
 }
 
 Node Preprocessor::simplify(const Node& ex, bool removeItes)
 {
   Trace("smt") << "SMT simplify(" << ex << ")" << endl;
-  if(Dump.isOn("benchmark")) 
+  if (Dump.isOn("benchmark"))
   {
     Dump("benchmark") << SimplifyCommand(ex);
   }
   Node e = d_absValues.substituteAbstractValues(ex);
-  if( options::typeChecking() ) 
+  if (options::typeChecking())
   {
     // ensure expr is type-checked at this point
     e.getType(true);

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -108,7 +108,8 @@ Node Preprocessor::expandDefinitions(const Node& e,
 }
 
 Node Preprocessor::expandDefinitions(
-    const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache)
+    const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache,
+                         bool expandOnly)
 {
   Trace("smt") << "SMT expandDefinitions(" << ex << ")" << endl;
   // Substitute out any abstract values in ex.

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -17,8 +17,8 @@
 #include "options/smt_options.h"
 #include "smt/abstract_values.h"
 #include "smt/assertions.h"
-#include "smt/smt_engine.h"
 #include "smt/command.h"
+#include "smt/smt_engine.h"
 
 using namespace CVC4::theory;
 using namespace CVC4::kind;
@@ -49,8 +49,8 @@ Preprocessor::~Preprocessor()
 
 void Preprocessor::finishInit()
 {
-  d_ppContext.reset(
-      new preprocessing::PreprocessingPassContext(&d_smt, &d_rtf, &d_propagator));
+  d_ppContext.reset(new preprocessing::PreprocessingPassContext(
+      &d_smt, &d_rtf, &d_propagator));
 
   // initialize the preprocessing passes
   d_processor.finishInit(d_ppContext.get());
@@ -96,10 +96,7 @@ void Preprocessor::clearLearnedLiterals()
   d_propagator.getLearnedLiterals().clear();
 }
 
-void Preprocessor::cleanup()
-{
-  d_processor.cleanup();
-}
+void Preprocessor::cleanup() { d_processor.cleanup(); }
 
 RemoveTermFormulas& Preprocessor::getTermFormulaRemover() { return d_rtf; }
 
@@ -109,7 +106,8 @@ Node Preprocessor::expandDefinitions(const Node& e)
   return expandDefinitions(e, cache);
 }
 
-Node Preprocessor::expandDefinitions(const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache)
+Node Preprocessor::expandDefinitions(
+    const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache)
 {
   Trace("smt") << "SMT expandDefinitions(" << ex << ")" << endl;
   // Substitute out any abstract values in ex.
@@ -129,7 +127,10 @@ Node Preprocessor::simplify(const Node& e, bool removeItes)
   return simplify(e, cache, removeItes);
 }
 
-Node Preprocessor::simplify(const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache, bool removeItes)
+Node Preprocessor::simplify(
+    const Node& ex,
+    std::unordered_map<Node, Node, NodeHashFunction>& cache,
+    bool removeItes)
 {
   Trace("smt") << "SMT simplify(" << ex << ")" << endl;
   if (Dump.isOn("benchmark"))
@@ -154,8 +155,7 @@ Node Preprocessor::simplify(const Node& ex, std::unordered_map<Node, Node, NodeH
 
 Node Preprocessor::applySubstitutions(TNode node)
 {
-  return Rewriter::rewrite(
-      d_ppContext->getTopLevelSubstitutions().apply(node));
+  return Rewriter::rewrite(d_ppContext->getTopLevelSubstitutions().apply(node));
 }
 
 }  // namespace smt

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -100,10 +100,11 @@ void Preprocessor::cleanup() { d_processor.cleanup(); }
 
 RemoveTermFormulas& Preprocessor::getTermFormulaRemover() { return d_rtf; }
 
-Node Preprocessor::expandDefinitions(const Node& e)
+Node Preprocessor::expandDefinitions(const Node& e,
+                         bool expandOnly)
 {
   std::unordered_map<Node, Node, NodeHashFunction> cache;
-  return expandDefinitions(e, cache);
+  return expandDefinitions(e, cache, expandOnly);
 }
 
 Node Preprocessor::expandDefinitions(
@@ -118,18 +119,11 @@ Node Preprocessor::expandDefinitions(
     e.getType(true);
   }
   // expand only = true
-  return d_processor.expandDefinitions(e, cache, true);
-}
-
-Node Preprocessor::simplify(const Node& e, bool removeItes)
-{
-  std::unordered_map<Node, Node, NodeHashFunction> cache;
-  return simplify(e, cache, removeItes);
+  return d_processor.expandDefinitions(e, cache, expandOnly);
 }
 
 Node Preprocessor::simplify(
     const Node& ex,
-    std::unordered_map<Node, Node, NodeHashFunction>& cache,
     bool removeItes)
 {
   Trace("smt") << "SMT simplify(" << ex << ")" << endl;
@@ -143,6 +137,7 @@ Node Preprocessor::simplify(
     // ensure expr is type-checked at this point
     e.getType(true);
   }
+  std::unordered_map<Node, Node, NodeHashFunction> cache;
   Node n = d_processor.expandDefinitions(e, cache);
   Node ns = applySubstitutions(n);
   if (removeItes)

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -18,6 +18,7 @@
 #include "smt/abstract_values.h"
 #include "smt/assertions.h"
 #include "smt/smt_engine.h"
+#include "smt/command.h"
 
 using namespace CVC4::theory;
 using namespace CVC4::kind;
@@ -28,11 +29,12 @@ namespace smt {
 Preprocessor::Preprocessor(SmtEngine& smt,
                            context::UserContext* u,
                            AbstractValues& abs)
-    : d_propagator(true, true),
+    : d_smt(smt),
+      d_absValues(abs),
+      d_propagator(true, true),
       d_assertionsProcessed(u, false),
       d_processor(smt, *smt.getResourceManager()),
-      d_rtf(u),
-      d_absValues(abs)
+      d_rtf(u)
 {
 }
 
@@ -47,16 +49,16 @@ Preprocessor::~Preprocessor()
 
 void Preprocessor::finishInit()
 {
-  d_preprocessingPassContext.reset(
-      new PreprocessingPassContext(&d_smt, &d_iteRemover, &d_propagator));
+  d_ppContext.reset(
+      new preprocessing::PreprocessingPassContext(&d_smt, &d_rtf, &d_propagator));
 
   // initialize the preprocessing passes
-  d_processor.finishInit(d_preprocessingPassContext.get());
+  d_processor.finishInit(d_ppContext.get());
 }
 
 bool Preprocessor::process(Assertions& as)
 {
-  AssertionPipeline& ap = as.getAssertionPipeline();
+  preprocessing::AssertionPipeline& ap = as.getAssertionPipeline();
 
   // should not be called if empty
   Assert(ap.size() != 0);
@@ -78,11 +80,11 @@ bool Preprocessor::process(Assertions& as)
 
 void Preprocessor::postprocess(Assertions& as)
 {
-  AssertionPipeline& ap = as.getAssertionPipeline();
+  preprocessing::AssertionPipeline& ap = as.getAssertionPipeline();
   // if incremental, compute which variables are assigned
   if (options::incrementalSolving())
   {
-    d_preprocessingPassContext->recordSymbolsInAssertions(ap.ref());
+    d_ppContext->recordSymbolsInAssertions(ap.ref());
   }
 
   // mark that we've processed assertions
@@ -94,9 +96,20 @@ void Preprocessor::clearLearnedLiterals()
   d_propagator.getLearnedLiterals().clear();
 }
 
-RemoveTermFormulas& getTermFormulaRemover() { return d_rtf; }
+void Preprocessor::cleanup()
+{
+  d_processor.cleanup();
+}
 
-Node Preprocessor::expandDefinitions(const Node& ex)
+RemoveTermFormulas& Preprocessor::getTermFormulaRemover() { return d_rtf; }
+
+Node Preprocessor::expandDefinitions(const Node& e)
+{
+  std::unordered_map<Node, Node, NodeHashFunction> cache;
+  return expandDefinitions(e, cache);
+}
+
+Node Preprocessor::expandDefinitions(const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache)
 {
   Trace("smt") << "SMT expandDefinitions(" << ex << ")" << endl;
   // Substitute out any abstract values in ex.
@@ -106,17 +119,22 @@ Node Preprocessor::expandDefinitions(const Node& ex)
     // Ensure expr is type-checked at this point.
     e.getType(true);
   }
-  std::unordered_map<Node, Node, NodeHashFunction> cache;
   // expand only = true
-  return d_processor->expandDefinitions(e, cache, true);
+  return d_processor.expandDefinitions(e, cache, true);
 }
 
-Node Preprocessor::simplify(const Node& ex, bool removeItes)
+Node Preprocessor::simplify(const Node& e, bool removeItes)
+{
+  std::unordered_map<Node, Node, NodeHashFunction> cache;
+  return simplify(e, cache, removeItes);
+}
+
+Node Preprocessor::simplify(const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache, bool removeItes)
 {
   Trace("smt") << "SMT simplify(" << ex << ")" << endl;
   if (Dump.isOn("benchmark"))
   {
-    Dump("benchmark") << SimplifyCommand(ex);
+    Dump("benchmark") << SimplifyCommand(ex.toExpr());
   }
   Node e = d_absValues.substituteAbstractValues(ex);
   if (options::typeChecking())
@@ -124,13 +142,12 @@ Node Preprocessor::simplify(const Node& ex, bool removeItes)
     // ensure expr is type-checked at this point
     e.getType(true);
   }
-  std::unordered_map<Node, Node, NodeHashFunction> cache;
   Node n = d_processor.expandDefinitions(in, cache);
   Node ns = applySubstitutions(n);
   if (removeItes)
   {
     // also remove ites if asked
-    ns = d_iteRemover.replace(ns);
+    ns = d_rtf.replace(ns);
   }
   return ns;
 }
@@ -143,7 +160,7 @@ Node Preprocessor::removeTermFormulas(const Node& e)
 Node Preprocessor::applySubstitutions(TNode node)
 {
   return Rewriter::rewrite(
-      d_preprocessingPassContext->getTopLevelSubstitutions().apply(node));
+      d_ppContext->getTopLevelSubstitutions().apply(node));
 }
 
 }  // namespace smt

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -61,7 +61,7 @@ bool Preprocessor::process(Assertions& as)
   preprocessing::AssertionPipeline& ap = as.getAssertionPipeline();
 
   // should not be called if empty
-  Assert(ap.size() != 0);
+  Assert(ap.size() != 0) << "Can only preprocess a non-empty list of assertions";
 
   if (d_assertionsProcessed && options::incrementalSolving())
   {
@@ -100,41 +100,41 @@ void Preprocessor::cleanup() { d_processor.cleanup(); }
 
 RemoveTermFormulas& Preprocessor::getTermFormulaRemover() { return d_rtf; }
 
-Node Preprocessor::expandDefinitions(const Node& e, bool expandOnly)
+Node Preprocessor::expandDefinitions(const Node& n, bool expandOnly)
 {
   std::unordered_map<Node, Node, NodeHashFunction> cache;
-  return expandDefinitions(e, cache, expandOnly);
+  return expandDefinitions(n, cache, expandOnly);
 }
 
 Node Preprocessor::expandDefinitions(
-    const Node& ex,
+    const Node& node,
     std::unordered_map<Node, Node, NodeHashFunction>& cache,
     bool expandOnly)
 {
-  Trace("smt") << "SMT expandDefinitions(" << ex << ")" << endl;
-  // Substitute out any abstract values in ex.
-  Node e = d_absValues.substituteAbstractValues(ex);
+  Trace("smt") << "SMT expandDefinitions(" << node << ")" << endl;
+  // Substitute out any abstract values in node.
+  Node n = d_absValues.substituteAbstractValues(node);
   if (options::typeChecking())
   {
-    // Ensure expr is type-checked at this point.
-    e.getType(true);
+    // Ensure node is type-checked at this point.
+    n.getType(true);
   }
   // expand only = true
-  return d_processor.expandDefinitions(e, cache, expandOnly);
+  return d_processor.expandDefinitions(n, cache, expandOnly);
 }
 
-Node Preprocessor::simplify(const Node& ex, bool removeItes)
+Node Preprocessor::simplify(const Node& node, bool removeItes)
 {
-  Trace("smt") << "SMT simplify(" << ex << ")" << endl;
+  Trace("smt") << "SMT simplify(" << node << ")" << endl;
   if (Dump.isOn("benchmark"))
   {
-    Dump("benchmark") << SimplifyCommand(ex.toExpr());
+    Dump("benchmark") << SimplifyCommand(node.toExpr());
   }
-  Node e = d_absValues.substituteAbstractValues(ex);
+  Node no = d_absValues.substituteAbstractValues(node);
   if (options::typeChecking())
   {
-    // ensure expr is type-checked at this point
-    e.getType(true);
+    // ensure node is type-checked at this point
+    no.getType(true);
   }
   std::unordered_map<Node, Node, NodeHashFunction> cache;
   Node n = d_processor.expandDefinitions(e, cache);

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -100,16 +100,16 @@ void Preprocessor::cleanup() { d_processor.cleanup(); }
 
 RemoveTermFormulas& Preprocessor::getTermFormulaRemover() { return d_rtf; }
 
-Node Preprocessor::expandDefinitions(const Node& e,
-                         bool expandOnly)
+Node Preprocessor::expandDefinitions(const Node& e, bool expandOnly)
 {
   std::unordered_map<Node, Node, NodeHashFunction> cache;
   return expandDefinitions(e, cache, expandOnly);
 }
 
 Node Preprocessor::expandDefinitions(
-    const Node& ex, std::unordered_map<Node, Node, NodeHashFunction>& cache,
-                         bool expandOnly)
+    const Node& ex,
+    std::unordered_map<Node, Node, NodeHashFunction>& cache,
+    bool expandOnly)
 {
   Trace("smt") << "SMT expandDefinitions(" << ex << ")" << endl;
   // Substitute out any abstract values in ex.
@@ -123,9 +123,7 @@ Node Preprocessor::expandDefinitions(
   return d_processor.expandDefinitions(e, cache, expandOnly);
 }
 
-Node Preprocessor::simplify(
-    const Node& ex,
-    bool removeItes)
+Node Preprocessor::simplify(const Node& ex, bool removeItes)
 {
   Trace("smt") << "SMT simplify(" << ex << ")" << endl;
   if (Dump.isOn("benchmark"))

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -1,5 +1,5 @@
 /*********************                                                        */
-/*! \file assertions.cpp
+/*! \file preprocessor.cpp
  ** \verbatim
  ** Top contributors (to current version):
  **   Andrew Reynolds
@@ -9,7 +9,7 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief The module for storing assertions for an SMT engine.
+ ** \brief The preprocessor of the SMT engine.
  **/
 
 #include "smt/preprocessor.h"
@@ -142,7 +142,7 @@ Node Preprocessor::simplify(const Node& ex, std::unordered_map<Node, Node, NodeH
     // ensure expr is type-checked at this point
     e.getType(true);
   }
-  Node n = d_processor.expandDefinitions(in, cache);
+  Node n = d_processor.expandDefinitions(e, cache);
   Node ns = applySubstitutions(n);
   if (removeItes)
   {
@@ -150,11 +150,6 @@ Node Preprocessor::simplify(const Node& ex, std::unordered_map<Node, Node, NodeH
     ns = d_rtf.replace(ns);
   }
   return ns;
-}
-
-Node Preprocessor::removeTermFormulas(const Node& e)
-{
-  return d_rtf.replace(e);
 }
 
 Node Preprocessor::applySubstitutions(TNode node)

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -82,7 +82,7 @@ class Preprocessor
   Node simplify(const Node& e, bool removeItes = false);
   /**
    * Expand the definitions in a term or formula e.  No other
-   * simplification or normalization is done. 
+   * simplification or normalization is done.
    *
    * @param e The node to expand
    * @param expandOnly if true, then the expandDefinitions function of

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -74,19 +74,19 @@ class Preprocessor
    * definitions, assertions, and the current partial model, if one
    * has been constructed.  It also involves theory normalization.
    *
-   * @param e The node to simplify
+   * @param n The node to simplify
    * @param removeItes Whether to remove ITE (and other terms with formulas in
    * term positions) from the result.
    * @return The simplified term.
    */
   Node simplify(const Node& n, bool removeItes = false);
   /**
-   * Expand the definitions in a term or formula e.  No other
+   * Expand the definitions in a term or formula n.  No other
    * simplification or normalization is done.
    *
-   * @param e The node to expand
+   * @param n The node to expand
    * @param expandOnly if true, then the expandDefinitions function of
-   * TheoryEngine is not called on subterms of e.
+   * TheoryEngine is not called on subterms of n.
    * @return The expanded term.
    */
   Node expandDefinitions(const Node& n, bool expandOnly = false);

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -37,11 +37,37 @@ class Preprocessor
  public:
   Preprocessor(SmtEngine& smt, context::UserContext* u, AbstractValues& abs);
   ~Preprocessor();
-    
   /**
    * Process the assertions that have been asserted.
    */
-  void processAssertions(Assertions& as);
+  void process(Assertions& as);
+  /**
+   * Postprocess
+   */
+  void postprocess(Assertions& as);
+  /** 
+   * Clear learned literals from the Boolean propagator.
+   */
+  void clearLearnedLiterals();
+  /**
+   * Simplify a formula without doing "much" work.  Does not involve
+   * the SAT Engine in the simplification, but uses the current
+   * definitions, assertions, and the current partial model, if one
+   * has been constructed.  It also involves theory normalization.
+   *
+   * @throw TypeCheckingException, LogicException, UnsafeInterruptException
+   *
+   * @todo (design) is this meant to give an equivalent or an
+   * equisatisfiable formula?
+   */
+  Node simplify(const Node& e, bool removeItes=false);
+  /**
+   * Expand the definitions in a term or formula.  No other
+   * simplification or normalization is done.
+   *
+   * @throw TypeCheckingException, LogicException, UnsafeInterruptException
+   */
+  Node expandDefinitions(const Node& e);
   /** 
    * Get term formula remover 
    */
@@ -53,8 +79,6 @@ private:
   booleans::CircuitPropagator d_propagator;
   /** Whether any assertions have been processed */
   context::CDO<bool> d_assertionsProcessed;
-  /** Cached true value */
-  //Node d_true;
   /** The preprocessing pass context */
   std::unique_ptr<PreprocessingPassContext> d_preprocessingPassContext;
   /** Process assertions module */

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -1,0 +1,69 @@
+/*********************                                                        */
+/*! \file preprocessor.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief The preprocessor of the SmtEngine.
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef CVC4__SMT__PREPROCESSOR_H
+#define CVC4__SMT__PREPROCESSOR_H
+
+#include <vector>
+
+#include "theory/booleans/circuit_propagator.h"
+#include "preprocessing/preprocessing_pass_context.h"
+#include "smt/process_assertions.h"
+#include "smt/term_formula_removal.h"
+
+namespace CVC4 {
+namespace smt {
+  
+class AbstractValues;
+
+/**
+ * The preprocessor module of an SMT engine.
+ */
+class Preprocessor
+{
+ public:
+  Preprocessor(SmtEngine& smt, context::UserContext* u, AbstractValues& abs);
+  ~Preprocessor();
+    
+  /**
+   * Process the assertions that have been asserted.
+   */
+  void processAssertions(Assertions& as);
+  /** 
+   * Get term formula remover 
+   */
+  RemoveTermFormulas& getTermFormulaRemover();
+private:
+  /** Reference to the abstract values utility */
+  AbstractValues& d_absValues; 
+  /** A circuit propagator for non-clausal propositional deduction */
+  booleans::CircuitPropagator d_propagator;
+  /** Whether any assertions have been processed */
+  context::CDO<bool> d_assertionsProcessed;
+  /** Cached true value */
+  //Node d_true;
+  /** The preprocessing pass context */
+  std::unique_ptr<PreprocessingPassContext> d_preprocessingPassContext;
+  /** Process assertions module */
+  ProcessAssertions d_processor;
+  /** Instance of the term formula remover */
+  RemoveTermFormulas d_rtf;
+};
+
+}  // namespace smt
+}  // namespace CVC4
+
+#endif

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -82,12 +82,12 @@ class Preprocessor
    * Expand the definitions in a term or formula.  No other
    * simplification or normalization is done.
    */
-  Node expandDefinitions(const Node& e,
-                         bool expandOnly = false);
+  Node expandDefinitions(const Node& e, bool expandOnly = false);
   /** Same as above, with a cache */
   Node expandDefinitions(
-      const Node& e, std::unordered_map<Node, Node, NodeHashFunction>& cache,
-                         bool expandOnly = false);
+      const Node& e,
+      std::unordered_map<Node, Node, NodeHashFunction>& cache,
+      bool expandOnly = false);
   /**
    * Get the underlying term formula remover utility.
    */

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -32,8 +32,11 @@ class AbstractValues;
 /**
  * The preprocessor module of an SMT engine.
  *
- * This class is responsible for preprocessing the set of assertions from
- * input before they are sent to the SMT solver.
+ * This class is responsible for:
+ * (1) preprocessing the set of assertions from input before they are sent to
+ * the SMT solver,
+ * (2) implementing methods for expanding and simplifying formulas. The latter
+ * takes into account the substitutions inferred by this class.
  */
 class Preprocessor
 {
@@ -60,7 +63,9 @@ class Preprocessor
    */
   void clearLearnedLiterals();
   /**
-   * Cleanup
+   * Cleanup, which deletes the processing passes owned by this module. This
+   * is required to be done explicitly so that passes are deleted before the
+   * objects they refer to in the SmtEngine destructor.
    */
   void cleanup();
   /**
@@ -68,8 +73,6 @@ class Preprocessor
    * the SAT Engine in the simplification, but uses the current
    * definitions, assertions, and the current partial model, if one
    * has been constructed.  It also involves theory normalization.
-   *
-   * @throw TypeCheckingException, LogicException, UnsafeInterruptException
    *
    * @todo (design) is this meant to give an equivalent or an
    * equisatisfiable formula?
@@ -82,15 +85,13 @@ class Preprocessor
   /**
    * Expand the definitions in a term or formula.  No other
    * simplification or normalization is done.
-   *
-   * @throw TypeCheckingException, LogicException, UnsafeInterruptException
    */
   Node expandDefinitions(const Node& e);
   /** Same as above, with a cache */
   Node expandDefinitions(
       const Node& e, std::unordered_map<Node, Node, NodeHashFunction>& cache);
   /**
-   * Get term formula remover
+   * Get the underlying term formula remover utility.
    */
   RemoveTermFormulas& getTermFormulaRemover();
 
@@ -105,11 +106,11 @@ class Preprocessor
   /** Reference to the abstract values utility */
   AbstractValues& d_absValues;
   /**
-   * A circuit propagator for non-clausal propositional deduction
+   * A circuit propagator for non-clausal propositional deduction.
    */
   theory::booleans::CircuitPropagator d_propagator;
   /**
-   * User-context-dependent flag of whether any assertions have been processed
+   * User-context-dependent flag of whether any assertions have been processed.
    */
   context::CDO<bool> d_assertionsProcessed;
   /** The preprocessing pass context */

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -40,7 +40,7 @@ class Preprocessor
  public:
   Preprocessor(SmtEngine& smt, context::UserContext* u, AbstractValues& abs);
   ~Preprocessor();
-  /** 
+  /**
    * Finish initialization
    */
   void finishInit();
@@ -59,7 +59,7 @@ class Preprocessor
    * Clear learned literals from the Boolean propagator.
    */
   void clearLearnedLiterals();
-  /** 
+  /**
    * Cleanup
    */
   void cleanup();
@@ -76,7 +76,9 @@ class Preprocessor
    */
   Node simplify(const Node& e, bool removeItes = false);
   /** Same as above, with a cache */
-  Node simplify(const Node& e, std::unordered_map<Node, Node, NodeHashFunction>& cache, bool removeItes = false);
+  Node simplify(const Node& e,
+                std::unordered_map<Node, Node, NodeHashFunction>& cache,
+                bool removeItes = false);
   /**
    * Expand the definitions in a term or formula.  No other
    * simplification or normalization is done.
@@ -85,14 +87,15 @@ class Preprocessor
    */
   Node expandDefinitions(const Node& e);
   /** Same as above, with a cache */
-  Node expandDefinitions(const Node& e, 
-  std::unordered_map<Node, Node, NodeHashFunction>& cache);
+  Node expandDefinitions(
+      const Node& e, std::unordered_map<Node, Node, NodeHashFunction>& cache);
   /**
    * Get term formula remover
    */
   RemoveTermFormulas& getTermFormulaRemover();
+
  private:
-  /** 
+  /**
    * Apply substitutions that have been inferred by preprocessing, return the
    * substituted form of node.
    */
@@ -101,24 +104,24 @@ class Preprocessor
   SmtEngine& d_smt;
   /** Reference to the abstract values utility */
   AbstractValues& d_absValues;
-  /** 
-   * A circuit propagator for non-clausal propositional deduction 
+  /**
+   * A circuit propagator for non-clausal propositional deduction
    */
   theory::booleans::CircuitPropagator d_propagator;
-  /** 
-   * User-context-dependent flag of whether any assertions have been processed 
+  /**
+   * User-context-dependent flag of whether any assertions have been processed
    */
   context::CDO<bool> d_assertionsProcessed;
   /** The preprocessing pass context */
   std::unique_ptr<preprocessing::PreprocessingPassContext> d_ppContext;
-  /** 
+  /**
    * Process assertions module, responsible for implementing the preprocessing
    * passes.
    */
   ProcessAssertions d_processor;
-  /** 
+  /**
    * The term formula remover, responsible for eliminating formulas that occur
-   * in term contexts. 
+   * in term contexts.
    */
   RemoveTermFormulas d_rtf;
 };

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -79,7 +79,7 @@ class Preprocessor
    * term positions) from the result.
    * @return The simplified term.
    */
-  Node simplify(const Node& e, bool removeItes = false);
+  Node simplify(const Node& n, bool removeItes = false);
   /**
    * Expand the definitions in a term or formula e.  No other
    * simplification or normalization is done.
@@ -89,10 +89,10 @@ class Preprocessor
    * TheoryEngine is not called on subterms of e.
    * @return The expanded term.
    */
-  Node expandDefinitions(const Node& e, bool expandOnly = false);
+  Node expandDefinitions(const Node& n, bool expandOnly = false);
   /** Same as above, with a cache of previous results. */
   Node expandDefinitions(
-      const Node& e,
+      const Node& n,
       std::unordered_map<Node, Node, NodeHashFunction>& cache,
       bool expandOnly = false);
   /**

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -78,18 +78,16 @@ class Preprocessor
    * equisatisfiable formula?
    */
   Node simplify(const Node& e, bool removeItes = false);
-  /** Same as above, with a cache */
-  Node simplify(const Node& e,
-                std::unordered_map<Node, Node, NodeHashFunction>& cache,
-                bool removeItes = false);
   /**
    * Expand the definitions in a term or formula.  No other
    * simplification or normalization is done.
    */
-  Node expandDefinitions(const Node& e);
+  Node expandDefinitions(const Node& e,
+                         bool expandOnly = false);
   /** Same as above, with a cache */
   Node expandDefinitions(
-      const Node& e, std::unordered_map<Node, Node, NodeHashFunction>& cache);
+      const Node& e, std::unordered_map<Node, Node, NodeHashFunction>& cache,
+                         bool expandOnly = false);
   /**
    * Get the underlying term formula remover utility.
    */

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -31,6 +31,9 @@ class AbstractValues;
 
 /**
  * The preprocessor module of an SMT engine.
+ *
+ * This class is responsible for preprocessing the set of assertions from
+ * input before they are sent to the SMT solver.
  */
 class Preprocessor
 {
@@ -88,13 +91,12 @@ class Preprocessor
    * Get term formula remover
    */
   RemoveTermFormulas& getTermFormulaRemover();
-
  private:
   /** 
    * Apply substitutions that have been inferred by preprocessing, return the
    * substituted form of node.
    */
-  Node applySubstitutions(TNode node)
+  Node applySubstitutions(TNode node);
   /** Reference to the parent SmtEngine */
   SmtEngine& d_smt;
   /** Reference to the abstract values utility */

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -74,16 +74,23 @@ class Preprocessor
    * definitions, assertions, and the current partial model, if one
    * has been constructed.  It also involves theory normalization.
    *
-   * @todo (design) is this meant to give an equivalent or an
-   * equisatisfiable formula?
+   * @param e The node to simplify
+   * @param removeItes Whether to remove ITE (and other terms with formulas in
+   * term positions) from the result.
+   * @return The simplified term.
    */
   Node simplify(const Node& e, bool removeItes = false);
   /**
-   * Expand the definitions in a term or formula.  No other
-   * simplification or normalization is done.
+   * Expand the definitions in a term or formula e.  No other
+   * simplification or normalization is done. 
+   *
+   * @param e The node to expand
+   * @param expandOnly if true, then the expandDefinitions function of
+   * TheoryEngine is not called on subterms of e.
+   * @return The expanded term.
    */
   Node expandDefinitions(const Node& e, bool expandOnly = false);
-  /** Same as above, with a cache */
+  /** Same as above, with a cache of previous results. */
   Node expandDefinitions(
       const Node& e,
       std::unordered_map<Node, Node, NodeHashFunction>& cache,

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -19,14 +19,14 @@
 
 #include <vector>
 
-#include "theory/booleans/circuit_propagator.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/process_assertions.h"
 #include "smt/term_formula_removal.h"
+#include "theory/booleans/circuit_propagator.h"
 
 namespace CVC4 {
 namespace smt {
-  
+
 class AbstractValues;
 
 /**
@@ -45,7 +45,7 @@ class Preprocessor
    * Postprocess
    */
   void postprocess(Assertions& as);
-  /** 
+  /**
    * Clear learned literals from the Boolean propagator.
    */
   void clearLearnedLiterals();
@@ -60,7 +60,7 @@ class Preprocessor
    * @todo (design) is this meant to give an equivalent or an
    * equisatisfiable formula?
    */
-  Node simplify(const Node& e, bool removeItes=false);
+  Node simplify(const Node& e, bool removeItes = false);
   /**
    * Expand the definitions in a term or formula.  No other
    * simplification or normalization is done.
@@ -68,13 +68,14 @@ class Preprocessor
    * @throw TypeCheckingException, LogicException, UnsafeInterruptException
    */
   Node expandDefinitions(const Node& e);
-  /** 
-   * Get term formula remover 
+  /**
+   * Get term formula remover
    */
   RemoveTermFormulas& getTermFormulaRemover();
-private:
+
+ private:
   /** Reference to the abstract values utility */
-  AbstractValues& d_absValues; 
+  AbstractValues& d_absValues;
   /** A circuit propagator for non-clausal propositional deduction */
   booleans::CircuitPropagator d_propagator;
   /** Whether any assertions have been processed */

--- a/src/smt/process_assertions.h
+++ b/src/smt/process_assertions.h
@@ -77,9 +77,11 @@ class ProcessAssertions
   /**
    * Expand definitions in term n. Return the expanded form of n.
    *
-   * If expandOnly is true, then the expandDefinitions function of TheoryEngine
-   * of the SmtEngine this calls is associated with is not called on subterms of
-   * n.
+   * @param n The node to expand
+   * @param cache Cache of previous results
+   * @param expandOnly if true, then the expandDefinitions function of
+   * TheoryEngine is not called on subterms of n.
+   * @return The expanded term.
    */
   Node expandDefinitions(TNode n,
                          NodeToNodeHashMap& cache,

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -456,8 +456,8 @@ SmtEngine::~SmtEngine()
     d_routListener.reset(nullptr);
     d_optm.reset(nullptr);
     d_pp.reset(nullptr),
-    // d_resourceManager must be destroyed before d_statisticsRegistry
-    d_resourceManager.reset(nullptr);
+        // d_resourceManager must be destroyed before d_statisticsRegistry
+        d_resourceManager.reset(nullptr);
     d_statisticsRegistry.reset(nullptr);
 
 
@@ -1037,7 +1037,7 @@ void SmtEngine::processAssertionsInternal()
   // introducing new ones
 
   d_pp->postprocess(*d_asserts);
-  
+
   // Push the formula to SAT
   {
     Chat() << "converting to CNF..." << endl;
@@ -1526,7 +1526,6 @@ Result SmtEngine::checkSynth()
    --------------------------------------------------------------------------
 */
 
-
 Node SmtEngine::simplify(const Node& ex)
 {
   Assert(ex.getExprManager() == d_exprManager);
@@ -1561,7 +1560,7 @@ Expr SmtEngine::getValue(const Node& ex) const
 
   // Substitute out any abstract values in ex and expand
   Node n = d_pp->expandDefinitions(ex);
-  
+
   Trace("smt") << "--- getting value of " << n << endl;
   // There are two ways model values for terms are computed (for historical
   // reasons).  One way is that used in check-model; the other is that
@@ -2091,9 +2090,12 @@ void SmtEngine::checkModel(bool hardFailure) {
     n = m->getValue(n);
     Notice() << "SmtEngine::checkModel(): -- get value : " << n << std::endl;
 
-    // Simplify the result and replace the already-known ITEs (this is important for ground ITEs under quantifiers).
+    // Simplify the result and replace the already-known ITEs (this is important
+    // for ground ITEs under quantifiers).
     n = d_pp->simplify(n, true);
-    Notice() << "SmtEngine::checkModel(): -- simplifies with ite replacement to  " << n << endl;
+    Notice()
+        << "SmtEngine::checkModel(): -- simplifies with ite replacement to  "
+        << n << endl;
 
     // Apply our model value substitutions (again), as things may have been simplified.
     Debug("boolean-terms") << "applying subses to " << n << endl;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -428,7 +428,7 @@ SmtEngine::~SmtEngine()
     d_definedFunctions->deleteSelf();
 
     //destroy all passes before destroying things that they refer to
-    d_private->getProcessAssertions()->cleanup();
+    d_pp->cleanup();
 
     // d_proofManager is always created when proofs are enabled at configure
     // time.  Because of this, this code should not be wrapped in PROOF() which
@@ -1683,8 +1683,8 @@ vector<pair<Expr, Expr>> SmtEngine::getAssignment()
       Trace("smt") << "--- getting value of " << as << endl;
 
       // Expand, then normalize
-      unordered_map<Node, Node, NodeHashFunction> cache;
-      Node n = d_private->getProcessAssertions()->expandDefinitions(as, cache);
+      std::unordered_map<Node, Node, NodeHashFunction> cache;
+      Node n = d_pp->expandDefinitions(as, cache);
       n = Rewriter::rewrite(n);
 
       Trace("smt") << "--- getting value of " << n << endl;
@@ -1821,7 +1821,7 @@ std::vector<Expr> SmtEngine::getExpandedAssertions()
   for (const Expr& e : easserts)
   {
     Node ea = Node::fromExpr(e);
-    Node eae = d_private->getProcessAssertions()->expandDefinitions(ea, cache);
+    Node eae = d_pp->expandDefinitions(ea, cache);
     eassertsProc.push_back(eae.toExpr());
   }
   return eassertsProc;
@@ -2074,7 +2074,7 @@ void SmtEngine::checkModel(bool hardFailure) {
     // Apply any define-funs from the problem.
     {
       unordered_map<Node, Node, NodeHashFunction> cache;
-      n = d_private->getProcessAssertions()->expandDefinitions(n, cache);
+      n = d_pp->expandDefinitions(n, cache);
     }
     Notice() << "SmtEngine::checkModel(): -- expands to " << n << endl;
 
@@ -2228,7 +2228,7 @@ void SmtEngine::checkSynthSolution()
     Trace("check-synth-sol") << "Retrieving assertion " << assertion << "\n";
     // Apply any define-funs from the problem.
     Node n =
-        d_private->getProcessAssertions()->expandDefinitions(assertion, cache);
+        d_pp->expandDefinitions(assertion, cache);
     Notice() << "SmtEngine::checkSynthSolution(): -- expands to " << n << endl;
     Trace("check-synth-sol") << "Expanded assertion " << n << "\n";
     if (conjs.find(n) == conjs.end())

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -92,7 +92,7 @@
 #include "smt/model_blocker.h"
 #include "smt/model_core_builder.h"
 #include "smt/options_manager.h"
-#include "smt/process_assertions.h"
+#include "smt/preprocessor.h"
 #include "smt/smt_engine_scope.h"
 #include "smt/smt_engine_stats.h"
 #include "smt/term_formula_removal.h"

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1522,7 +1522,6 @@ Result SmtEngine::checkSynth()
 
 Node SmtEngine::simplify(const Node& ex)
 {
-  Assert(ex.getExprManager() == d_exprManager);
   SmtScope smts(this);
   finalOptionsAreSet();
   doPendingPops();
@@ -1545,7 +1544,6 @@ Node SmtEngine::expandDefinitions(const Node& ex)
 // TODO(#1108): Simplify the error reporting of this method.
 Node SmtEngine::getValue(const Node& ex) const
 {
-  Assert(ex.getExprManager() == d_exprManager);
   SmtScope smts(this);
 
   Trace("smt") << "SMT getValue(" << ex << ")" << endl;

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -83,10 +83,10 @@
 #include "smt/abduction_solver.h"
 #include "smt/abstract_values.h"
 #include "smt/assertions.h"
-#include "smt/expr_names.h"
 #include "smt/command.h"
 #include "smt/defined_function.h"
 #include "smt/dump_manager.h"
+#include "smt/expr_names.h"
 #include "smt/listeners.h"
 #include "smt/logic_request.h"
 #include "smt/model_blocker.h"
@@ -252,7 +252,8 @@ SmtEngine::SmtEngine(ExprManager* em, Options* optr)
   d_resourceManager.reset(
       new ResourceManager(*d_statisticsRegistry.get(), d_options));
   d_optm.reset(new smt::OptionsManager(&d_options, d_resourceManager.get()));
-  d_pp.reset(new smt::Preprocessor(*this, d_userContext.get(), *d_absValues.get()));
+  d_pp.reset(
+      new smt::Preprocessor(*this, d_userContext.get(), *d_absValues.get()));
   d_private.reset(new smt::SmtEnginePrivate(*this));
   // listen to node manager events
   d_nodeManager->subscribeEvents(d_snmListener.get());
@@ -2219,8 +2220,7 @@ void SmtEngine::checkSynthSolution()
              << assertion << endl;
     Trace("check-synth-sol") << "Retrieving assertion " << assertion << "\n";
     // Apply any define-funs from the problem.
-    Node n =
-        d_pp->expandDefinitions(assertion, cache);
+    Node n = d_pp->expandDefinitions(assertion, cache);
     Notice() << "SmtEngine::checkSynthSolution(): -- expands to " << n << endl;
     Trace("check-synth-sol") << "Expanded assertion " << n << "\n";
     if (conjs.find(n) == conjs.end())

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1548,8 +1548,9 @@ Node SmtEngine::getValue(const Node& ex) const
 
   Trace("smt") << "SMT getValue(" << ex << ")" << endl;
   if(Dump.isOn("benchmark")) {
-    Dump("benchmark") << GetValueCommand(ex);
+    Dump("benchmark") << GetValueCommand(ex.toExpr());
   }
+  TypeNode expectedType = ex.getType();
 
   // Substitute out any abstract values in ex and expand
   Node n = d_pp->expandDefinitions(ex);
@@ -1601,7 +1602,7 @@ vector<Expr> SmtEngine::getValues(const vector<Expr>& exprs)
   vector<Expr> result;
   for (const Expr& e : exprs)
   {
-    result.push_back(getValue(e));
+    result.push_back(getValue(e).toExpr());
   }
   return result;
 }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1541,7 +1541,7 @@ Node SmtEngine::expandDefinitions(const Node& ex)
 }
 
 // TODO(#1108): Simplify the error reporting of this method.
-Expr SmtEngine::getValue(const Node& ex) const
+Node SmtEngine::getValue(const Node& ex) const
 {
   Assert(ex.getExprManager() == d_exprManager);
   SmtScope smts(this);
@@ -1573,10 +1573,8 @@ Expr SmtEngine::getValue(const Node& ex) const
     resultNode = m->getValue(n);
   }
   Trace("smt") << "--- got value " << n << " = " << resultNode << endl;
-  resultNode = postprocess(resultNode, expectedType);
-  Trace("smt") << "--- model-post returned " << resultNode << endl;
-  Trace("smt") << "--- model-post returned " << resultNode.getType() << endl;
-  Trace("smt") << "--- model-post expected " << expectedType << endl;
+  Trace("smt") << "--- type " << resultNode.getType() << endl;
+  Trace("smt") << "--- expected type " << expectedType << endl;
 
   // type-check the result we got
   // Notice that lambdas have function type, which does not respect the subtype
@@ -1595,7 +1593,7 @@ Expr SmtEngine::getValue(const Node& ex) const
     Trace("smt") << "--- abstract value >> " << resultNode << endl;
   }
 
-  return resultNode.toExpr();
+  return resultNode;
 }
 
 vector<Expr> SmtEngine::getValues(const vector<Expr>& exprs)

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -449,9 +449,9 @@ SmtEngine::~SmtEngine()
     d_snmListener.reset(nullptr);
     d_routListener.reset(nullptr);
     d_optm.reset(nullptr);
-    d_pp.reset(nullptr),
-        // d_resourceManager must be destroyed before d_statisticsRegistry
-        d_resourceManager.reset(nullptr);
+    d_pp.reset(nullptr);
+    // d_resourceManager must be destroyed before d_statisticsRegistry
+    d_resourceManager.reset(nullptr);
     d_statisticsRegistry.reset(nullptr);
 
 
@@ -1538,7 +1538,8 @@ Node SmtEngine::expandDefinitions(const Node& ex)
   SmtScope smts(this);
   finalOptionsAreSet();
   doPendingPops();
-  return d_pp->expandDefinitions(ex);
+  // set expandOnly flag to true
+  return d_pp->expandDefinitions(ex, true);
 }
 
 // TODO(#1108): Simplify the error reporting of this method.
@@ -2622,6 +2623,7 @@ void SmtEngine::pop() {
 
   // Clear out assertion queues etc., in case anything is still in there
   d_asserts->clearCurrent();
+  // clear the learned literals from the preprocessor
   d_pp->clearLearnedLiterals();
 
   Trace("userpushpop") << "SmtEngine: popped to level "

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -1047,7 +1047,10 @@ class CVC4_PUBLIC SmtEngine
   void setLogicInternal();
 
   /**
-   * Process the assertions that have been asserted.
+   * Process the assertions that have been asserted. This moves the set of
+   * assertions that have been buffered into the smt::Assertions object,
+   * preprocesses them, pushes them into the SMT solver, and clears the
+   * buffer.
    */
   void processAssertionsInternal();
 

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -1050,7 +1050,7 @@ class CVC4_PUBLIC SmtEngine
    * Process the assertions that have been asserted.
    */
   void processAssertionsInternal();
-  
+
   /**
    * Add to Model command.  This is used for recording a command
    * that should be reported during a get-model call.

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -1049,7 +1049,7 @@ class CVC4_PUBLIC SmtEngine
   /**
    * Process the assertions that have been asserted.
    */
-  void processAssertionsInternal(Assertions& as);
+  void processAssertionsInternal();
   
   /**
    * Add to Model command.  This is used for recording a command

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -99,6 +99,7 @@ class DumpManager;
 class ResourceOutListener;
 class SmtNodeManagerListener;
 class OptionsManager;
+class Preprocessor;
 /** Subsolvers */
 class AbductionSolver;
 /**
@@ -506,7 +507,7 @@ class CVC4_PUBLIC SmtEngine
    * @todo (design) is this meant to give an equivalent or an
    * equisatisfiable formula?
    */
-  Expr simplify(const Expr& e);
+  Node simplify(const Node& e);
 
   /**
    * Expand the definitions in a term or formula.  No other
@@ -524,7 +525,7 @@ class CVC4_PUBLIC SmtEngine
    * @throw ModalException, TypeCheckingException, LogicException,
    *        UnsafeInterruptException
    */
-  Expr getValue(const Expr& e) const;
+  Node getValue(const Node& e) const;
 
   /**
    * Same as getValue but for a vector of expressions
@@ -987,13 +988,6 @@ class CVC4_PUBLIC SmtEngine
   void checkAbduct(Node a);
 
   /**
-   * Postprocess a value for output to the user.  Involves doing things
-   * like turning datatypes back into tuples, length-1-bitvectors back
-   * into booleans, etc.
-   */
-  Node postprocess(TNode n, TypeNode expectedType) const;
-
-  /**
    * This is something of an "init" procedure, but is idempotent; call
    * as often as you like.  Should be called whenever the final options
    * and logic for the problem are set (at least, those options that are
@@ -1052,6 +1046,11 @@ class CVC4_PUBLIC SmtEngine
    */
   void setLogicInternal();
 
+  /**
+   * Process the assertions that have been asserted.
+   */
+  void processAssertionsInternal(Assertions& as);
+  
   /**
    * Add to Model command.  This is used for recording a command
    * that should be reported during a get-model call.
@@ -1197,12 +1196,6 @@ class CVC4_PUBLIC SmtEngine
    */
   bool d_needPostsolve;
 
-  /*
-   * Whether to call theory preprocessing during simplification - on
-   * by default* but gets turned off if arithRewriteEq is on
-   */
-  bool d_earlyTheoryPP;
-
   /**
    * Most recent result of last checkSatisfiability/checkEntailed or
    * (set-info :status).
@@ -1247,6 +1240,10 @@ class CVC4_PUBLIC SmtEngine
    * for set default options based on the logic.
    */
   std::unique_ptr<smt::OptionsManager> d_optm;
+  /**
+   * The preprocessor.
+   */
+  std::unique_ptr<smt::Preprocessor> d_pp;
   /**
    * The global scope object. Upon creation of this SmtEngine, it becomes the
    * SmtEngine in scope. It says the SmtEngine in scope until it is destructed,

--- a/src/theory/quantifiers/candidate_rewrite_database.cpp
+++ b/src/theory/quantifiers/candidate_rewrite_database.cpp
@@ -172,7 +172,7 @@ Node CandidateRewriteDatabase::addTerm(Node sol,
             if (val.isNull())
             {
               Assert(!refv.isNull() && refv.getKind() != BOUND_VARIABLE);
-              val = Node::fromExpr(rrChecker->getValue(refv.toExpr()));
+              val = rrChecker->getValue(refv);
             }
             Trace("rr-check") << "  " << v << " -> " << val << std::endl;
             pt.push_back(val);

--- a/src/theory/quantifiers/sygus/cegis_core_connective.cpp
+++ b/src/theory/quantifiers/sygus/cegis_core_connective.cpp
@@ -597,7 +597,7 @@ void CegisCoreConnective::getModel(SmtEngine& smt,
 {
   for (const Node& v : d_vars)
   {
-    Node mv = Node::fromExpr(smt.getValue(v.toExpr()));
+    Node mv = smt.getValue(v);
     Trace("sygus-ccore-model") << v << " -> " << mv << " ";
     vals.push_back(mv);
   }

--- a/src/theory/quantifiers/sygus/sygus_repair_const.cpp
+++ b/src/theory/quantifiers/sygus/sygus_repair_const.cpp
@@ -250,7 +250,7 @@ bool SygusRepairConst::repairSolution(Node sygusBody,
   {
     Assert(d_sk_to_fo.find(v) != d_sk_to_fo.end());
     Node fov = d_sk_to_fo[v];
-    Node fov_m = Node::fromExpr(repcChecker->getValue(fov.toExpr()));
+    Node fov_m = repcChecker->getValue(fov);
     Trace("sygus-repair-const") << "  " << fov << " = " << fov_m << std::endl;
     // convert to sygus
     Node fov_m_to_sygus = d_tds->getProxyVariable(v.getType(), fov_m);

--- a/src/theory/smt_engine_subsolver.cpp
+++ b/src/theory/smt_engine_subsolver.cpp
@@ -112,8 +112,8 @@ Result checkWithSubsolver(Node query,
   {
     for (const Node& v : vars)
     {
-      Expr val = smte->getValue(v.toExpr());
-      modelVals.push_back(Node::fromExpr(val));
+      Node val = smte->getValue(v);
+      modelVals.push_back(val);
     }
   }
   return r;

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -174,7 +174,7 @@ bool TheoryModel::isModelCoreSymbol(Expr sym) const
 Expr TheoryModel::getValue( Expr expr ) const{
   Node n = Node::fromExpr( expr );
   Node ret = getValue( n );
-  return d_smt.postprocess(ret, TypeNode::fromType(expr.getType())).toExpr();
+  return ret.toExpr();
 }
 
 /** get cardinality for sort */


### PR DESCRIPTION
This splits a collection of utilities from SmtEngine that work in cooperation to preprocess assertions (Boolean circuit propagator, preprocessing context, process assertions, term formula removal).

It updates various interfaces in SmtEngine from Expr -> Node and simplifies SmtEngine to use this utility.