### PR TITLE
Fix connection to master equality engine in sets

### DIFF
--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -203,7 +203,8 @@ eq::EqualityEngine* TheorySets::getEqualityEngine()
   return &d_equalityEngine;
 }
 
-void TheorySets::setMasterEqualityEngine(eq::EqualityEngine* eq) {
+void TheorySets::setMasterEqualityEngine(eq::EqualityEngine* eq)
+{
   d_equalityEngine.setMasterEqualityEngine(eq);
 }
 

--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -203,6 +203,10 @@ eq::EqualityEngine* TheorySets::getEqualityEngine()
   return &d_equalityEngine;
 }
 
+void TheorySets::setMasterEqualityEngine(eq::EqualityEngine* eq) {
+  d_equalityEngine.setMasterEqualityEngine(eq);
+}
+
 /**************************** eq::NotifyClass *****************************/
 
 bool TheorySets::NotifyClass::eqNotifyTriggerEquality(TNode equality,

--- a/src/theory/sets/theory_sets.h
+++ b/src/theory/sets/theory_sets.h
@@ -65,6 +65,7 @@ class TheorySets : public Theory
   PPAssertStatus ppAssert(TNode in, SubstitutionMap& outSubstitutions) override;
   void presolve() override;
   void propagate(Effort) override;
+  void setMasterEqualityEngine(eq::EqualityEngine* eq) override;
   bool isEntailed(Node n, bool pol);
   /* equality engine */
   virtual eq::EqualityEngine* getEqualityEngine() override;


### PR DESCRIPTION
This corrects an issue introduced by a merge of a previous commit (https://github.com/CVC4/CVC4/commit/b5b2858807d48136807aba29bb53a1e91cfacc6e) which dropped the connection from sets to its master equality engine.

Fixes several issues in sets regressions, including a timeout in regress0.