### PR TITLE
fixes a typo in help output and removes unsupported option

### DIFF
--- a/src/options/language.cpp
+++ b/src/options/language.cpp
@@ -181,9 +181,8 @@ InputLanguage toInputLanguage(std::string language) {
     return input::LANG_SMTLIB_V2_6;
   } else if(language == "tptp" || language == "LANG_TPTP") {
     return input::LANG_TPTP;
-  }
-  else if (language == "sygus2" || language == "LANG_SYGUS_V2")
-  {
+  } else if(language == "sygus" || language == "sygus2" ||
+          language == "LANG_SYGUS" || language == "LANG_SYGUS_V2") {
     return input::LANG_SYGUS_V2;
   }
   else if (language == "auto" || language == "LANG_AUTO")

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -538,7 +538,7 @@ InputLanguage OptionsHandler::stringToInputLanguage(std::string option,
   try {
     return language::toInputLanguage(optarg);
   } catch(OptionException& oe) {
-    throw OptionException("Error in " + option + ": " + oe.getMessage() + "\nTry --language help");
+    throw OptionException("Error in " + option + ": " + oe.getMessage() + "\nTry --lang help");
   }
 
   Unreachable();


### PR DESCRIPTION
This PR fixes a typo in an error message and also removes the option `--lang sygus` from the help output. 

Currently `--lang sygus` throws a parsing error and CVC4 doesn't support sygus 1.0 anymore, so I took a guess that this should be removed from the help file?

~~~
$ cvc4 --lang sygus
(error "Error in option parsing: Error in --lang: Error in option parsing: unknown input language `sygus'
Try --language help")

~~~