### PR TITLE
More basic fix for dumping synth-fun

### DIFF
--- a/src/smt/dump.h
+++ b/src/smt/dump.h
@@ -40,17 +40,6 @@ class CVC4_PUBLIC CVC4dumpstream
     return *this;
   }
 
-  // Note(abdoo8080): temporarily overloading operator<< for strings to allow us
-  // to print commands provided as strings
-  CVC4dumpstream& operator<<(const std::string& str)
-  {
-    if (d_os != nullptr)
-    {
-      (*d_os) << str << std::endl;
-    }
-    return *this;
-  }
-
  private:
   std::ostream* d_os;
 }; /* class CVC4dumpstream */

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1350,8 +1350,11 @@ void SmtEngine::declareSynthFun(const std::string& id,
                 : TypeNode::fromType(func.getType()),
             isInv,
             TypeNode::fromType(sygusType));
-
-    Dump("raw-benchmark") << ss.str();
+    
+    // must print it on the standard output channel since it is not possible
+    // to print anything except for commands with Dump.
+    std::ostream& out = d_options.getOut();
+    out << ss.str();
   }
 
   // sygus conjecture is now stale

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1353,8 +1353,8 @@ void SmtEngine::declareSynthFun(const std::string& id,
     
     // must print it on the standard output channel since it is not possible
     // to print anything except for commands with Dump.
-    std::ostream& out = d_options.getOut();
-    out << ss.str();
+    std::ostream& out = *d_options.getOut();
+    out << ss.str() << std::endl;
   }
 
   // sygus conjecture is now stale


### PR DESCRIPTION
The commit (https://github.com/CVC4/CVC4/commit/079a04b0b16f7caa31a15b97ddc9794ad0d8b862) appears to have broken the nightlies due to compile issues related a necessary addition to the Dump class (so that std::string could be printing on Dump streams). 

This changes the temporary solution so that we simply print a string on the standard output, when the Dump is enabled. This is required for temporarily keeping `dump=raw-benchmark` working for synth-fun commands.  