### PR TITLE
Fixes for corner case of decision tree learning with different types

### DIFF
--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -1431,9 +1431,12 @@ Node SygusUnifIo::constructSol(
           }
           else
           {
-            // if the child types are different, it could still make a
-            // difference to recurse, for instance see issue #4790.
-            bool childTypesEqual = ce.getType() == etn;
+            // if the branch types are different, it could still make a
+            // difference to recurse, for instance see issue #4790. We do this
+            // if either branch is a different type from the current type.
+            TypeNode branchType1 = etis->d_cenum[1].first.getType();
+            TypeNode branchType2 = etis->d_cenum[2].first.getType();
+            bool childTypesEqual = branchType1 == etn && branchType2 == etn;
             if (!childTypesEqual)
             {
               if (!ecache_child.d_enum_vals.empty())

--- a/src/theory/quantifiers/sygus/sygus_unif_io.cpp
+++ b/src/theory/quantifiers/sygus/sygus_unif_io.cpp
@@ -58,7 +58,7 @@ bool UnifContextIo::updateContext(SygusUnifIo* sui,
     }
     if (v != poln)
     {
-      if (v == d_true)
+      if (d_vals[i] == d_true)
       {
         d_vals[i] = d_false;
         changed = true;


### PR DESCRIPTION
There was a last minute change was a typo when merging https://github.com/CVC4/CVC4/commit/103b5ea715e532e021e91f9b03ea7d7876a3ccbf .
Also the fix in that commit needed to be slightly more robust to the case when either branch of an ITE had a different sygus type.

Fixes regress1.