### PR TITLE
Minor cleanup related to notifications

### DIFF
--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -102,8 +102,11 @@ void CoreSolver::preRegister(TNode node) {
       }
   } else {
     d_equalityEngine.addTerm(node);
-    // register with the extended theory
-    d_extTheory->registerTerm(t);
+    // Register with the extended theory, for context-dependent simplification.
+    // Notice we do this for registered terms not internally generated
+    // equivalence classes. The two should roughly cooincide. Since ExtTheory is
+    // being used as a heuristic, it is good enough to be registered here.
+    d_extTheory->registerTerm(node);
   }
 }
 

--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -103,7 +103,7 @@ void CoreSolver::preRegister(TNode node) {
   } else {
     d_equalityEngine.addTerm(node);
     // Register with the extended theory, for context-dependent simplification.
-    // Notice we do this for registered terms not internally generated
+    // Notice we do this for registered terms but not internally generated
     // equivalence classes. The two should roughly cooincide. Since ExtTheory is
     // being used as a heuristic, it is good enough to be registered here.
     d_extTheory->registerTerm(node);

--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -102,6 +102,8 @@ void CoreSolver::preRegister(TNode node) {
       }
   } else {
     d_equalityEngine.addTerm(node);
+    // register with the extended theory
+    d_extTheory->registerTerm(t);
   }
 }
 
@@ -397,10 +399,6 @@ void CoreSolver::NotifyClass::eqNotifyConstantTermMerge(TNode t1, TNode t2) {
   d_solver.conflict(t1, t2);
 }
 
-void CoreSolver::NotifyClass::eqNotifyNewClass(TNode t) {
-  d_solver.eqNotifyNewClass( t );
-}
-
 bool CoreSolver::storePropagation(TNode literal) {
   return d_bv->storePropagation(literal, SUB_CORE);
 }
@@ -411,8 +409,6 @@ void CoreSolver::conflict(TNode a, TNode b) {
   Node conflict = flattenAnd(assumptions);
   d_bv->setConflict(conflict);
 }
-
-void CoreSolver::eqNotifyNewClass(TNode t) { d_extTheory->registerTerm(t); }
 
 bool CoreSolver::isCompleteForTerm(TNode term, TNodeBoolMap& seen) {
   if (d_useSlicer)

--- a/src/theory/bv/bv_subtheory_core.h
+++ b/src/theory/bv/bv_subtheory_core.h
@@ -61,7 +61,7 @@ class CoreSolver : public SubtheorySolver {
                                      TNode t2,
                                      bool value) override;
     void eqNotifyConstantTermMerge(TNode t1, TNode t2) override;
-    void eqNotifyNewClass(TNode t) override;
+    void eqNotifyNewClass(TNode t) override {}
     void eqNotifyMerge(TNode t1, TNode t2) override {}
     void eqNotifyDisequal(TNode t1, TNode t2, TNode reason) override {}
   };
@@ -78,9 +78,6 @@ class CoreSolver : public SubtheorySolver {
 
   /** Store a conflict from merging two constants */
   void conflict(TNode a, TNode b);
-
-  /** new equivalence class */
-  void eqNotifyNewClass(TNode t);
 
   std::unique_ptr<Slicer> d_slicer;
   context::CDO<bool> d_isComplete;

--- a/src/theory/strings/solver_state.cpp
+++ b/src/theory/strings/solver_state.cpp
@@ -136,7 +136,7 @@ void SolverState::eqNotifyMerge(TNode t1, TNode t2)
   EqcInfo* e2 = getOrMakeEqcInfo(t2, false);
   if (e2)
   {
-    Assert (t1.getType().isStringLike());
+    Assert(t1.getType().isStringLike());
     EqcInfo* e1 = getOrMakeEqcInfo(t1);
     // add information from e2 to e1
     if (!e2->d_lengthTerm.get().isNull())

--- a/src/theory/strings/solver_state.cpp
+++ b/src/theory/strings/solver_state.cpp
@@ -118,10 +118,12 @@ void SolverState::eqNotifyNewClass(TNode t)
   }
   else if (t.isConst())
   {
-    EqcInfo* ei = getOrMakeEqcInfo(t);
-    ei->d_prefixC = t;
-    ei->d_suffixC = t;
-    return;
+    if (t.getType().isStringLike())
+    {
+      EqcInfo* ei = getOrMakeEqcInfo(t);
+      ei->d_prefixC = t;
+      ei->d_suffixC = t;
+    }
   }
   else if (k == STRING_CONCAT)
   {
@@ -134,6 +136,7 @@ void SolverState::eqNotifyMerge(TNode t1, TNode t2)
   EqcInfo* e2 = getOrMakeEqcInfo(t2, false);
   if (e2)
   {
+    Assert (t1.getType().isStringLike());
     EqcInfo* e1 = getOrMakeEqcInfo(t1);
     // add information from e2 to e1
     if (!e2->d_lengthTerm.get().isNull())

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -413,6 +413,13 @@ class Theory {
   }
 
   /**
+   * Set the output channel associated to this theory.
+   */
+  void setOutputChannel(OutputChannel& out) {
+    d_out = &out;
+  }
+
+  /**
    * Get the output channel associated to this theory.
    */
   OutputChannel& getOutputChannel() {

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -413,13 +413,6 @@ class Theory {
   }
 
   /**
-   * Set the output channel associated to this theory.
-   */
-  void setOutputChannel(OutputChannel& out) {
-    d_out = &out;
-  }
-
-  /**
    * Get the output channel associated to this theory.
    */
   OutputChannel& getOutputChannel() {
@@ -521,9 +514,6 @@ class Theory {
   void setQuantifiersEngine(QuantifiersEngine* qe);
   /** Called to set the decision manager. */
   void setDecisionManager(DecisionManager* dm);
-
-  /** Setup an ExtTheory module for this Theory. Can only be called once. */
-  void setupExtTheory();
 
   /**
    * Return the current theory care graph. Theories should overload


### PR DESCRIPTION
This includes eliminating TheoryBV's call to eqNotifyNewEqClass and fixing an issue with string's eqNotifyNewEqClass method, which was registering constant integers. 

It also removes some unnecessary methods in Theory. 