### PR TITLE
[CI] Update package list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
           libcln-dev \
           libgmp-dev \
           libedit-dev \
-          swig3.0
+          flex \
+          libfl-dev \
+          flexc++
         python3 -m pip install toml
         python3 -m pip install setuptools
         python3 -m pip install pexpect
@@ -78,7 +80,7 @@ jobs:
           cln \
           gmp \
           pkgconfig \
-          swig
+          flex
         python3 -m pip install toml
         python3 -m pip install setuptools
         python3 -m pip install pexpect


### PR DESCRIPTION
Since
https://github.com/CVC4/LFSC/commit/1d1c55fa17b08e2bc8cb686b9d07ec63bf0dd4a2
LFSC requires Flex, so we need to install the corresponding packages in
our CI environment. This commit also removes SWIG from the list of
packages to install since we do not use it anymore.