### PR TITLE
Standardize collectModelInfo and theory-specific collectRelevantTerms

### DIFF
--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -1101,7 +1101,7 @@ bool TheoryArrays::collectModelInfo(TheoryModel* m)
     return false;
   }
 
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   // Compute arrays that we need to produce representatives for
   std::vector<Node> arrays;
   eq::EqClassesIterator eqcs_i = eq::EqClassesIterator(d_equalityEngine);
@@ -2260,7 +2260,6 @@ TrustNode TheoryArrays::expandDefinition(Node node)
   }
   return TrustNode::null();
 }
-
 
 void TheoryArrays::computeRelevantTerms(std::set<Node>& termSet,
                                         bool includeShared)

--- a/src/theory/arrays/theory_arrays.cpp
+++ b/src/theory/arrays/theory_arrays.cpp
@@ -1101,6 +1101,7 @@ bool TheoryArrays::collectModelInfo(TheoryModel* m)
     return false;
   }
 
+  NodeManager * nm = NodeManager::currentNM();
   // Compute arrays that we need to produce representatives for
   std::vector<Node> arrays;
   eq::EqClassesIterator eqcs_i = eq::EqClassesIterator(d_equalityEngine);

--- a/src/theory/arrays/theory_arrays.h
+++ b/src/theory/arrays/theory_arrays.h
@@ -493,6 +493,12 @@ class TheoryArrays : public Theory {
    */
   Node getNextDecisionRequest();
 
+  /**
+   * Compute relevant terms. This includes additional select nodes for the
+   * RIntro1 and RIntro2 rules.
+   */
+  void computeRelevantTerms(std::set<Node>& termSet,
+                            bool includeShared = true) override;
  public:
   eq::EqualityEngine* getEqualityEngine() override { return &d_equalityEngine; }
 

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -1522,9 +1522,9 @@ bool TheoryDatatypes::collectModelInfo(TheoryModel* m)
   Trace("dt-model") << std::endl;
   printModelDebug( "dt-model" );
   Trace("dt-model") << std::endl;
-  
+
   std::set<Node> termSet;
-  
+
   // Compute terms appearing in assertions and shared terms, and in inferred equalities
   computeRelevantTerms(termSet);
 
@@ -2250,8 +2250,9 @@ Node TheoryDatatypes::mkAnd( std::vector< TNode >& assumptions ) {
   }
 }
 
-void TheoryDatatypes::computeRelevantTerms( std::set<Node>& termSet,
-                            bool includeShared ) {
+void TheoryDatatypes::computeRelevantTerms(std::set<Node>& termSet,
+                                           bool includeShared)
+{
   // Compute terms appearing in assertions and shared terms
   std::set<Kind> irrKinds;
   // testers are not relevant for model construction

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -2237,12 +2237,12 @@ Node TheoryDatatypes::mkAnd( std::vector< TNode >& assumptions ) {
   }
 }
 
-void TheoryDatatypes::getRelevantTerms( std::set<Node>& termSet ) {
+void TheoryDatatypes::computeRelevantTerms( std::set<Node>& termSet ) {
   // Compute terms appearing in assertions and shared terms
-  std::set<Kind> irr_kinds;
+  std::set<Kind> irrKinds;
   // testers are not relevant for model construction
-  irr_kinds.insert(APPLY_TESTER);
-  computeRelevantTerms(termSet, irr_kinds);
+  irrKinds.insert(APPLY_TESTER);
+  computeRelevantTermsInternal(termSet, irrKinds);
 
   Trace("dt-cmi") << "Have " << termSet.size() << " relevant terms..."
                   << std::endl;

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -1523,10 +1523,10 @@ bool TheoryDatatypes::collectModelInfo(TheoryModel* m)
   printModelDebug( "dt-model" );
   Trace("dt-model") << std::endl;
   
-  set<Node> termSet;
+  std::set<Node> termSet;
   
   // Compute terms appearing in assertions and shared terms, and in inferred equalities
-  getRelevantTerms(termSet);
+  computeRelevantTerms(termSet);
 
   //combine the equality engine
   if (!m->assertEqualityEngine(d_equalityEngine, &termSet))
@@ -2250,12 +2250,13 @@ Node TheoryDatatypes::mkAnd( std::vector< TNode >& assumptions ) {
   }
 }
 
-void TheoryDatatypes::computeRelevantTerms( std::set<Node>& termSet ) {
+void TheoryDatatypes::computeRelevantTerms( std::set<Node>& termSet,
+                            bool includeShared ) {
   // Compute terms appearing in assertions and shared terms
   std::set<Kind> irrKinds;
   // testers are not relevant for model construction
   irrKinds.insert(APPLY_TESTER);
-  computeRelevantTermsInternal(termSet, irrKinds);
+  computeRelevantTermsInternal(termSet, irrKinds, includeShared);
 
   Trace("dt-cmi") << "Have " << termSet.size() << " relevant terms..."
                   << std::endl;

--- a/src/theory/datatypes/theory_datatypes.h
+++ b/src/theory/datatypes/theory_datatypes.h
@@ -353,8 +353,6 @@ private:
   void instantiate( EqcInfo* eqc, Node n );
   /** must communicate fact */
   bool mustCommunicateFact( Node n, Node exp );
-  /** get relevant terms */
-  void getRelevantTerms( std::set<Node>& termSet );
 private:
   //equality queries
   bool hasTerm( TNode a );
@@ -363,7 +361,13 @@ private:
   bool areCareDisequal( TNode x, TNode y );
   TNode getRepresentative( TNode a );
 
- private:
+  /**
+   * Compute relevant terms. In addition to all terms in assertions and shared
+   * terms, this includes datatypes in non-singleton equivalence classes.
+   */
+  void computeRelevantTerms(std::set<Node>& termSet,
+                            bool includeShared = true) override;
+
   /** sygus symmetry breaking utility */
   std::unique_ptr<SygusExtension> d_sygusExtension;
 

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -327,15 +327,8 @@ void Theory::collectTerms(TNode n,
   }
 }
 
-
-void Theory::computeRelevantTerms(set<Node>& termSet, bool includeShared) const
-{
-  set<Kind> irrKinds;
-  computeRelevantTerms(termSet, irrKinds, includeShared);
-}
-
-void Theory::computeRelevantTerms(set<Node>& termSet,
-                                  set<Kind>& irrKinds,
+void Theory::computeRelevantTermsInternal(std::set<Node>& termSet,
+                                  std::set<Kind>& irrKinds,
                                   bool includeShared) const
 {
   // Collect all terms appearing in assertions
@@ -354,6 +347,12 @@ void Theory::computeRelevantTerms(set<Node>& termSet,
   for (; shared_it != shared_it_end; ++shared_it) {
     collectTerms(*shared_it, kempty, termSet);
   }
+}
+
+void Theory::computeRelevantTerms(std::set<Node>& termSet, bool includeShared) const
+{
+  std::set<Kind> irrKinds;
+  computeRelevantTermsInternal(termSet, irrKinds, includeShared);
 }
 
 Theory::PPAssertStatus Theory::ppAssert(TNode in,

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -383,8 +383,8 @@ void Theory::collectTerms(TNode n,
 }
 
 void Theory::computeRelevantTermsInternal(std::set<Node>& termSet,
-                                  std::set<Kind>& irrKinds,
-                                  bool includeShared) const
+                                          std::set<Kind>& irrKinds,
+                                          bool includeShared) const
 {
   // Collect all terms appearing in assertions
   irrKinds.insert(kind::EQUAL);

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -343,6 +343,23 @@ std::unordered_set<TNode, TNodeHashFunction> Theory::currentlySharedTerms() cons
   return currentlyShared;
 }
 
+bool Theory::collectModelInfo(TheoryModel* m)
+{
+  std::set<Node> termSet;
+  // Compute terms appearing in assertions and shared terms
+  computeRelevantTerms(termSet);
+  // if we are using an equality engine, assert it to the model
+  if (d_equalityEngine != nullptr)
+  {
+    if (!m->assertEqualityEngine(d_equalityEngine, &termSet))
+    {
+      return false;
+    }
+  }
+  // now, collect theory-specific value assigments
+  return collectModelValues(m, termSet);
+}
+
 void Theory::collectTerms(TNode n,
                           set<Kind>& irrKinds,
                           set<Node>& termSet) const
@@ -387,10 +404,15 @@ void Theory::computeRelevantTermsInternal(std::set<Node>& termSet,
   }
 }
 
-void Theory::computeRelevantTerms(std::set<Node>& termSet, bool includeShared) const
+void Theory::computeRelevantTerms(std::set<Node>& termSet, bool includeShared)
 {
   std::set<Kind> irrKinds;
   computeRelevantTermsInternal(termSet, irrKinds, includeShared);
+}
+
+bool Theory::collectModelValues(TheoryModel* m, std::set<Node>& termSet)
+{
+  return true;
 }
 
 Theory::PPAssertStatus Theory::ppAssert(TNode in,

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -183,7 +183,7 @@ class Theory {
    */
   context::CDList<TNode> d_sharedTerms;
 
-  //---------------------------------- computing relevant terms
+  //---------------------------------- collect model info
   /**
    * Scans the current set of assertions and shared terms top-down
    * until a theory-leaf is reached, and adds all terms found to
@@ -206,7 +206,6 @@ class Theory {
   void collectTerms(TNode n,
                     std::set<Kind>& irrKinds,
                     std::set<Node>& termSet) const;
-
   /**
    * Same as above, but with empty irrKinds. This version can be overridden
    * by the theory, e.g. by restricting or extended the set of terms returned
@@ -215,7 +214,13 @@ class Theory {
    */
   virtual void computeRelevantTerms(std::set<Node>& termSet,
                                     bool includeShared = true);
-  //---------------------------------- end computing relevant terms
+  /**
+   * Collect model values, after equality information is added to the model.
+   * The argument termSet is the set of relevant terms returned by
+   * computeRelevantTerms.
+   */
+  virtual bool collectModelValues(TheoryModel* m, std::set<Node>& termSet);
+  //---------------------------------- end collect model info
 
   /**
    * Construct a Theory.
@@ -627,7 +632,7 @@ class Theory {
    * This method returns true if and only if the equality engine of m is
    * consistent as a result of this call.
    */
-  virtual bool collectModelInfo(TheoryModel* m) { return true; }
+  virtual bool collectModelInfo(TheoryModel* m);
   /** if theories want to do something with model after building, do it here */
   virtual void postProcessModel( TheoryModel* m ){ }
   /**

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -160,13 +160,7 @@ class Theory {
    */
   context::CDList<TNode> d_sharedTerms;
 
-  /**
-   * Helper function for computeRelevantTerms
-   */
-  void collectTerms(TNode n,
-                    std::set<Kind>& irrKinds,
-                    std::set<Node>& termSet) const;
-
+  //---------------------------------- computing relevant terms
   /**
    * Scans the current set of assertions and shared terms top-down
    * until a theory-leaf is reached, and adds all terms found to
@@ -180,11 +174,25 @@ class Theory {
    * includeShared: Whether to include shared terms in termSet. Notice that
    * shared terms are not influenced by irrKinds.
    */
-  void computeRelevantTerms(std::set<Node>& termSet,
-                            std::set<Kind>& irrKinds,
-                            bool includeShared = true) const;
-  /** same as above, but with empty irrKinds */
-  void computeRelevantTerms(std::set<Node>& termSet, bool includeShared = true) const;
+  void computeRelevantTermsInternal(std::set<Node>& termSet,
+                                    std::set<Kind>& irrKinds,
+                                    bool includeShared = true) const;
+  /**
+   * Helper function for computeRelevantTerms
+   */
+  void collectTerms(TNode n,
+                    std::set<Kind>& irrKinds,
+                    std::set<Node>& termSet) const;
+
+  /**
+   * Same as above, but with empty irrKinds. This version can be overridden
+   * by the theory, e.g. by restricting or extended the set of terms returned
+   * by computeRelevantTermsInternal, which is called by default with no
+   * irrKinds.
+   */
+  virtual void computeRelevantTerms(std::set<Node>& termSet,
+                                    bool includeShared = true);
+  //---------------------------------- end computing relevant terms
 
   /**
    * Construct a Theory.

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -208,7 +208,7 @@ class Theory {
                     std::set<Node>& termSet) const;
   /**
    * Same as above, but with empty irrKinds. This version can be overridden
-   * by the theory, e.g. by restricting or extended the set of terms returned
+   * by the theory, e.g. by restricting or extending the set of terms returned
    * by computeRelevantTermsInternal, which is called by default with no
    * irrKinds.
    */


### PR DESCRIPTION
This is work towards a configurable approach to equality engine management.  This PR does not change any behavior, it only reorganizes the code.

This PR introduces the standard template for `collectModelInfo`, which isolates the usage of equality engine in relation to the model.  In the future, theories will be encouraged to use the standard template for `collectModelInfo` and override `collectRelevantTerms`/`collectModelValues` only.  This is to allow custom theory-independent modifications to building models (e.g. don't assert equality engine to model if we are using a centralized approach).

This PR standardizes TheoryArrays and TheoryDatatypes custom implementation of `collectRelevantTerms` as work towards using the standard template for `collectModelInfo`.  Notice this required separating two portions of a loop in TheoryArrays::collectModelInfo which was doing two different things (collecting arrays and relevant terms).