### PR TITLE
Dynamic allocation of model equality engine

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -480,6 +480,8 @@ libcvc4_add_sources(
   theory/decision_strategy.h
   theory/eager_proof_generator.cpp
   theory/eager_proof_generator.h
+  theory/ee_manager.cpp
+  theory/ee_manager.h
   theory/ee_manager_distributed.cpp
   theory/ee_manager_distributed.h
   theory/ee_setup_info.h

--- a/src/theory/ee_manager.cpp
+++ b/src/theory/ee_manager.cpp
@@ -1,0 +1,31 @@
+/*********************                                                        */
+/*! \file ee_manager.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Utilities for management of equality engines.
+ **/
+
+#include "theory/ee_manager.h"
+
+namespace CVC4 {
+namespace theory {
+
+const EeTheoryInfo* EqEngineManager::getEeTheoryInfo(TheoryId tid) const
+{
+  std::map<TheoryId, EeTheoryInfo>::const_iterator it = d_einfo.find(tid);
+  if (it != d_einfo.end())
+  {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+}  // namespace theory
+}  // namespace CVC4

--- a/src/theory/ee_manager.h
+++ b/src/theory/ee_manager.h
@@ -59,6 +59,15 @@ class EqEngineManager
    */
   virtual void initializeTheories() = 0;
   /**
+   * Finish initialize, called by TheoryEngine::finishInit after theory
+   * objects have been created but prior to their final initialization. This
+   * sets up equality engines for all theories.
+   *
+   * This method is context-independent, and is applied once during
+   * the lifetime of TheoryEngine (during finishInit).
+   */
+  virtual void initializeModel(TheoryModel* m) = 0;
+  /**
    * Get the equality engine theory information for theory with the given id.
    */
   const EeTheoryInfo* getEeTheoryInfo(TheoryId tid) const;

--- a/src/theory/ee_manager.h
+++ b/src/theory/ee_manager.h
@@ -1,0 +1,81 @@
+/*********************                                                        */
+/*! \file ee_manager.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Andrew Reynolds
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Utilities for management of equality engines.
+ **/
+
+#include "cvc4_private.h"
+
+#ifndef CVC4__THEORY__EE_MANAGER__H
+#define CVC4__THEORY__EE_MANAGER__H
+
+#include <map>
+#include <memory>
+
+#include "theory/ee_setup_info.h"
+#include "theory/theory.h"
+#include "theory/uf/equality_engine.h"
+
+namespace CVC4 {
+namespace theory {
+
+/**
+ * This is (theory-agnostic) information associated with the management of
+ * an equality engine for a single theory. This information is maintained
+ * by the manager class below.
+ *
+ * Currently, this simply is the equality engine itself, for memory
+ * management purposes.
+ */
+struct EeTheoryInfo
+{
+  EeTheoryInfo() : d_usedEe(nullptr) {}
+  /** Equality engine that is used (if it exists) */
+  eq::EqualityEngine* d_usedEe;
+  /** Equality engine allocated specifically for this theory (if it exists) */
+  std::unique_ptr<eq::EqualityEngine> d_allocEe;
+};
+
+/** Virtual base class for equality engine managers */
+class EqEngineManager
+{
+ public:
+  virtual ~EqEngineManager() {}
+  /**
+   * Finish initialize, called by TheoryEngine::finishInit after theory
+   * objects have been created but prior to their final initialization. This
+   * sets up equality engines for all theories.
+   *
+   * This method is context-independent, and is applied once during
+   * the lifetime of TheoryEngine (during finishInit).
+   */
+  virtual void initializeTheories() = 0;
+  /**
+   * Get the equality engine theory information for theory with the given id.
+   */
+  const EeTheoryInfo* getEeTheoryInfo(TheoryId tid) const;
+  /**
+   * Get the core equality engine, which is the equality engine that the
+   * quantifiers engine should use. This corresponds to the master equality
+   * engine if eeMode is distributed, or the central equality engine if eeMode
+   * is central.
+   */
+  virtual eq::EqualityEngine* getCoreEqualityEngine() = 0;
+
+ protected:
+  /** Information related to the equality engine, per theory. */
+  std::map<TheoryId, EeTheoryInfo> d_einfo;
+};
+
+}  // namespace theory
+}  // namespace CVC4
+
+#endif /* CVC4__THEORY__EE_MANAGER__H */

--- a/src/theory/ee_manager_distributed.cpp
+++ b/src/theory/ee_manager_distributed.cpp
@@ -15,7 +15,6 @@
 #include "theory/ee_manager_distributed.h"
 
 #include "theory/quantifiers_engine.h"
-#include "theory/shared_terms_database.h"
 #include "theory/theory_engine.h"
 
 namespace CVC4 {

--- a/src/theory/ee_manager_distributed.cpp
+++ b/src/theory/ee_manager_distributed.cpp
@@ -21,9 +21,8 @@
 namespace CVC4 {
 namespace theory {
 
-EqEngineManagerDistributed::EqEngineManagerDistributed(TheoryEngine& te,
-                                                       SharedTermsDatabase* sdb)
-    : d_te(te), d_sdb(sdb), d_masterEENotify(nullptr)
+EqEngineManagerDistributed::EqEngineManagerDistributed(TheoryEngine& te)
+    : d_te(te), d_masterEENotify(nullptr)
 {
 }
 
@@ -35,21 +34,6 @@ EqEngineManagerDistributed::~EqEngineManagerDistributed()
 void EqEngineManagerDistributed::initializeTheories()
 {
   context::Context* c = d_te.getSatContext();
-  // initialize the shared terms database
-  if (d_sdb != nullptr)
-  {
-    EeSetupInfo esis;
-    if (d_sdb->needsEqualityEngine(esis))
-    {
-      d_stbEqualityEngine.reset(allocateEqualityEngine(esis, c));
-      d_sdb->setEqualityEngine(d_stbEqualityEngine.get());
-    }
-    else
-    {
-      AlwaysAssert(false)
-          << "Expected shared terms database to use equality engine";
-    }
-  }
 
   // allocate equality engines per theory
   for (TheoryId theoryId = theory::THEORY_FIRST;
@@ -70,6 +54,7 @@ void EqEngineManagerDistributed::initializeTheories()
       // theory said it doesn't need an equality engine, skip
       continue;
     }
+    // allocate the equality engine
     eet.d_allocEe.reset(allocateEqualityEngine(esi, c));
     // the theory uses the equality engine
     eet.d_usedEe = eet.d_allocEe.get();

--- a/src/theory/ee_manager_distributed.h
+++ b/src/theory/ee_manager_distributed.h
@@ -49,7 +49,7 @@ namespace theory {
 class EqEngineManagerDistributed : public EqEngineManager
 {
  public:
-  EqEngineManagerDistributed(TheoryEngine& te, SharedTermsDatabase* sdb);
+  EqEngineManagerDistributed(TheoryEngine& te);
   ~EqEngineManagerDistributed();
   /**
    * Finish initialize, called by TheoryEngine::finishInit after theory
@@ -116,16 +116,10 @@ class EqEngineManagerDistributed : public EqEngineManager
   };
   /** Reference to the theory engine */
   TheoryEngine& d_te;
-  /** Pointer to shared terms database (if it exists) */
-  SharedTermsDatabase* d_sdb;
   /** The master equality engine notify class */
   std::unique_ptr<MasterNotifyClass> d_masterEENotify;
   /** The master equality engine. */
   std::unique_ptr<eq::EqualityEngine> d_masterEqualityEngine;
-  /**
-   * The equality engine of the shared terms database.
-   */
-  std::unique_ptr<eq::EqualityEngine> d_stbEqualityEngine;
   /**
    * A dummy context for the model equality engine, so we can clear it
    * independently of search context.

--- a/src/theory/ee_manager_distributed.h
+++ b/src/theory/ee_manager_distributed.h
@@ -49,7 +49,7 @@ namespace theory {
 class EqEngineManagerDistributed : public EqEngineManager
 {
  public:
-  EqEngineManagerDistributed(TheoryEngine& te);
+  EqEngineManagerDistributed(TheoryEngine& te, SharedTermsDatabase* sdb);
   ~EqEngineManagerDistributed();
   /**
    * Finish initialize, called by TheoryEngine::finishInit after theory
@@ -60,6 +60,15 @@ class EqEngineManagerDistributed : public EqEngineManager
    * the lifetime of TheoryEngine (during finishInit).
    */
   void initializeTheories() override;
+  /**
+   * Finish initialize, called by TheoryEngine::finishInit after theory
+   * objects have been created but prior to their final initialization. This
+   * sets up equality engines for all theories.
+   *
+   * This method is context-independent, and is applied once during
+   * the lifetime of TheoryEngine (during finishInit).
+   */
+  void initializeModel(TheoryModel* m) override;
   /** get the model equality engine context */
   context::Context* getModelEqualityEngineContext();
   /** get the model equality engine */
@@ -107,10 +116,16 @@ class EqEngineManagerDistributed : public EqEngineManager
   };
   /** Reference to the theory engine */
   TheoryEngine& d_te;
+  /** Pointer to shared terms database (if it exists) */
+  SharedTermsDatabase* d_sdb;
   /** The master equality engine notify class */
   std::unique_ptr<MasterNotifyClass> d_masterEENotify;
   /** The master equality engine. */
   std::unique_ptr<eq::EqualityEngine> d_masterEqualityEngine;
+  /**
+   * The equality engine of the shared terms database.
+   */
+  std::unique_ptr<eq::EqualityEngine> d_stbEqualityEngine;
   /**
    * A dummy context for the model equality engine, so we can clear it
    * independently of search context.

--- a/src/theory/ee_manager_distributed.h
+++ b/src/theory/ee_manager_distributed.h
@@ -51,21 +51,13 @@ class EqEngineManagerDistributed : public EqEngineManager
   EqEngineManagerDistributed(TheoryEngine& te);
   ~EqEngineManagerDistributed();
   /**
-   * Finish initialize, called by TheoryEngine::finishInit after theory
-   * objects have been created but prior to their final initialization. This
-   * sets up equality engines for all theories.
-   *
-   * This method is context-independent, and is applied once during
-   * the lifetime of TheoryEngine (during finishInit).
+   * Initialize theories. This method allocates unique equality engines
+   * per theories and connects them to a master equality engine.
    */
   void initializeTheories() override;
   /**
-   * Finish initialize, called by TheoryEngine::finishInit after theory
-   * objects have been created but prior to their final initialization. This
-   * sets up equality engines for all theories.
-   *
-   * This method is context-independent, and is applied once during
-   * the lifetime of TheoryEngine (during finishInit).
+   * Initialize model. This method allocates a new equality engine for the
+   * model.
    */
   void initializeModel(TheoryModel* m) override;
   /** get the model equality engine context */

--- a/src/theory/ee_manager_distributed.h
+++ b/src/theory/ee_manager_distributed.h
@@ -27,7 +27,6 @@
 namespace CVC4 {
 
 class TheoryEngine;
-class SharedTermsDatabase;
 
 namespace theory {
 

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -140,7 +140,7 @@ void TheoryEngine::finishInit() {
   // Initialize the equality engine architecture for all theories, which
   // includes the master equality engine.
   d_eeDistributed.reset(new EqEngineManagerDistributed(*this));
-  d_eeDistributed->finishInit();
+  d_eeDistributed->initializeTheories();
 
   // Initialize the model and model builder.
   if (d_logicInfo.isQuantified())

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -161,7 +161,7 @@ void TheoryEngine::finishInit() {
 
   // Initialize the model
   d_eeDistributed->initializeModel(d_curr_model);
-  
+
   // finish initializing the theories
   for(TheoryId theoryId = theory::THEORY_FIRST; theoryId != theory::THEORY_LAST; ++ theoryId) {
     Theory* t = d_theoryTable[theoryId];

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -159,6 +159,9 @@ void TheoryEngine::finishInit() {
     d_aloc_curr_model_builder = true;
   }
 
+  // Initialize the model
+  d_eeDistributed->initializeModel(d_curr_model);
+  
   // finish initializing the theories
   for(TheoryId theoryId = theory::THEORY_FIRST; theoryId != theory::THEORY_LAST; ++ theoryId) {
     Theory* t = d_theoryTable[theoryId];
@@ -504,6 +507,10 @@ void TheoryEngine::check(Theory::Effort effort) {
       }
       //checks for theories requiring the model go at last call
       d_curr_model->reset();
+      // !!! temporary, will be part of distributed model manager
+      context::Context* meec = d_eeDistributed->getModelEqualityEngineContext();
+      meec->pop();
+      meec->push();
       for (TheoryId theoryId = THEORY_FIRST; theoryId < THEORY_LAST; ++theoryId) {
         if( theoryId!=THEORY_QUANTIFIERS ){
           Theory* theory = d_theoryTable[theoryId];
@@ -1810,7 +1817,7 @@ SharedTermsDatabase* TheoryEngine::getSharedTermsDatabase()
 theory::eq::EqualityEngine* TheoryEngine::getMasterEqualityEngine()
 {
   Assert(d_eeDistributed != nullptr);
-  return d_eeDistributed->getMasterEqualityEngine();
+  return d_eeDistributed->getCoreEqualityEngine();
 }
 
 void TheoryEngine::getExplanation(std::vector<NodeTheoryPair>& explanationVector, LemmaProofRecipe* proofRecipe) {

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -33,8 +33,7 @@ TheoryModel::TheoryModel(context::Context* c,
       d_substitutions(c, false),
       d_equalityEngine(nullptr),
       d_using_model_core(false),
-      d_enableFuncModels(enableFuncModels),
-      d_usingRelevantTerms(false)
+      d_enableFuncModels(enableFuncModels)
 {
   // must use function models when ufHo is enabled
   Assert(d_enableFuncModels || !options::ufHo());

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -81,6 +81,17 @@ class TheoryModel : public Model
 public:
   TheoryModel(context::Context* c, std::string name, bool enableFuncModels);
   ~TheoryModel() override;
+  //---------------------------- initialization
+  /** Called to set the equality engine. */
+  void setEqualityEngine(eq::EqualityEngine* ee);
+  /**
+   * Returns true if we need an equality engine, this has the same contract
+   * as Theory::needsEqualityEngine.
+   */
+  bool needsEqualityEngine(EeSetupInfo& esi);
+  /** Finish init */
+  void finishInit();
+  //---------------------------- end initialization
 
   /** reset the model */
   virtual void reset();
@@ -348,15 +359,14 @@ public:
   std::vector< Node > getFunctionsToAssign();
   //---------------------------- end function values
  protected:
+  /** Unique name of this model */
+  std::string d_name;
   /** substitution map for this model */
   SubstitutionMap d_substitutions;
   /** whether we have tried to build this model in the current context */
   bool d_modelBuilt;
   /** whether this model has been built successfully */
   bool d_modelBuiltSuccess;
-  /** special local context for our equalityEngine so we can clear it
-   * independently of search context */
-  context::Context* d_eeContext;
   /** equality engine containing all known equalities/disequalities */
   eq::EqualityEngine* d_equalityEngine;
   /** approximations (see recordApproximation) */


### PR DESCRIPTION
This makes the equality engine manager responsible for initializing the equality engine of the model.

It also moves the base equality engine manager class to its own file.

Notice the code in TheoryEngine will undergo significant cleaning in forthcoming PRs when the "ModelManagerDistributed" is added.  This PR adds temporary calls there to preserve the current behavior.