### PR TITLE
Fix SmtEngine::reset()

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2101,10 +2101,13 @@ void SmtEngine::reset()
   if(Dump.isOn("benchmark")) {
     Dump("benchmark") << ResetCommand();
   }
+  std::string filename = d_state->getFilename();
   Options opts;
   opts.copyValues(d_originalOptions);
   this->~SmtEngine();
   new (this) SmtEngine(em, &opts);
+  // Restore data set after creation
+  notifyStartParsing(filename);
 }
 
 void SmtEngine::resetAssertions()

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -946,6 +946,7 @@ set(regress_0_tests
   regress0/smtlib/issue4077.smt2
   regress0/smtlib/issue4151.smt2
   regress0/smtlib/issue4552.smt2
+  regress0/smtlib/issue4866.smt2
   regress0/smtlib/reason-unknown.smt2
   regress0/smtlib/reset.smt2
   regress0/smtlib/reset-assertions1.smt2

--- a/test/regress/regress0/smtlib/issue4866.smt2
+++ b/test/regress/regress0/smtlib/issue4866.smt2
@@ -1,0 +1,6 @@
+; EXIT: 0
+; EXPECT: 
+; Test triple reset. There was a bug with restoring options on reset.
+(reset)
+(reset)
+(reset)


### PR DESCRIPTION
Calling `(reset)` multiple times produced parsing problems (#4866) and could probably lead to all kinds of interesting issues.
In a nutshell, `reset()` failed to properly reset `d_initialOptions` (which is used to properly reset `d_options`) so that all options defaulted after the second call to `reset()`.
This PR properly sets `d_initialOptions` after a reset (and the `filename` as well).

Fixes #4866.