### PR TITLE
Add strings-exp to regression

### DIFF
--- a/test/regress/regress0/strings/unsound-0908.smt2
+++ b/test/regress/regress0/strings/unsound-0908.smt2
@@ -1,3 +1,5 @@
+; COMMAND-LINE: --strings-exp
+; EXPECT: sat
 (set-logic QF_SLIA)
 (set-info :status sat)
 (declare-const x String)


### PR DESCRIPTION
`str.at` expands to `str.substr`, thus this benchmark (may) require strings-exp if things do not rewrite/preprocess. This triggers a regress0 failure on `proof-new` currently.