### PR TITLE
Simplify and fix care graph for ufHo

### DIFF
--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -611,20 +611,21 @@ void TheoryUF::addCarePairs(TNodeTrie* t1,
 }
 
 void TheoryUF::computeCareGraph() {
-
-  if (d_sharedTerms.empty()) {
+  if (d_sharedTerms.empty())
+  {
     return;
   }
   // Use term indexing. We build separate indices for APPLY_UF and HO_APPLY.
   // We maintain indices per operator for the former, and indices per
   // function type for the latter.
-  Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Build term indices..." << std::endl;
+  Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Build term indices..."
+                       << std::endl;
   std::map<Node, TNodeTrie> index;
   std::map<TypeNode, TNodeTrie> hoIndex;
   std::map<Node, size_t> arity;
   for (TNode app : d_functionsTerms)
   {
-    std::vector< TNode > reps;
+    std::vector<TNode> reps;
     bool has_trigger_arg = false;
     for (const Node& j : app)
     {
@@ -634,7 +635,8 @@ void TheoryUF::computeCareGraph() {
         has_trigger_arg = true;
       }
     }
-    if( has_trigger_arg ){
+    if (has_trigger_arg)
+    {
       if (app.getKind() == kind::APPLY_UF)
       {
         Node op = app.getOperator();
@@ -649,22 +651,23 @@ void TheoryUF::computeCareGraph() {
       }
     }
   }
-  //for each index
+  // for each index
   for (std::pair<const Node, TNodeTrie>& tt : index)
   {
     Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Process index "
-                          << tt.first << "..." << std::endl;
+                         << tt.first << "..." << std::endl;
     Assert(arity.find(tt.first) != arity.end());
     addCarePairs(&tt.second, nullptr, arity[tt.first], 0);
   }
   for (std::pair<const TypeNode, TNodeTrie>& tt : hoIndex)
   {
     Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Process ho index "
-                          << tt.first << "..." << std::endl;
+                         << tt.first << "..." << std::endl;
     // the arity of HO_APPLY is always two
     addCarePairs(&tt.second, nullptr, 2, 0);
   }
-  Debug("uf::sharing") << "TheoryUf::computeCareGraph(): finished." << std::endl;
+  Debug("uf::sharing") << "TheoryUf::computeCareGraph(): finished."
+                       << std::endl;
 }/* TheoryUF::computeCareGraph() */
 
 void TheoryUF::conflict(TNode a, TNode b) {

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -616,6 +616,7 @@ void TheoryUF::computeCareGraph() {
     Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Build term indices..." << std::endl;
     std::map<Node, TNodeTrie> index;
     std::map<TypeNode, TNodeTrie> hoIndex;
+    std::map<Node, size_t> arity;
     for (TNode app : d_functionsTerms){
       std::vector< TNode > reps;
       bool has_trigger_arg = false;
@@ -645,6 +646,7 @@ void TheoryUF::computeCareGraph() {
     {
       Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Process index "
                            << tt.first << "..." << std::endl;
+                           Assert(arity.find(tt.first)!=arity.end());
       addCarePairs(&tt.second, nullptr, arity[tt.first], 0);
     }
     for (std::pair<const TypeNode, TNodeTrie>& tt : index)

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -652,7 +652,7 @@ void TheoryUF::computeCareGraph() {
       Assert(arity.find(tt.first) != arity.end());
       addCarePairs(&tt.second, nullptr, arity[tt.first], 0);
     }
-    for (std::pair<const TypeNode, TNodeTrie>& tt : index)
+    for (std::pair<const TypeNode, TNodeTrie>& tt : hoIndex)
     {
       Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Process ho index "
                            << tt.first << "..." << std::endl;

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -539,7 +539,7 @@ void TheoryUF::addCarePairs(TNodeTrie* t1,
       {
         Debug("uf::sharing") << "TheoryUf::computeCareGraph(): checking function " << f1 << " and " << f2 << std::endl;
         vector< pair<TNode, TNode> > currentPairs;
-        for (unsigned k = 0; k < f1.getNumChildren(); ++k)
+        for (size_t k = 0, nchildren=f1.getNumChildren(); k < nchildren; ++k)
         {
           TNode x = f1[k];
           TNode y = f2[k];

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -539,7 +539,8 @@ void TheoryUF::addCarePairs(TNodeTrie* t1,
       {
         Debug("uf::sharing") << "TheoryUf::computeCareGraph(): checking function " << f1 << " and " << f2 << std::endl;
         vector< pair<TNode, TNode> > currentPairs;
-        for (unsigned k = 0; k < f1.getNumChildren(); ++ k) {
+        for (unsigned k = 0; k < f1.getNumChildren(); ++k)
+        {
           TNode x = f1[k];
           TNode y = f2[k];
           Assert(d_equalityEngine->hasTerm(x));
@@ -617,10 +618,12 @@ void TheoryUF::computeCareGraph() {
     std::map<Node, TNodeTrie> index;
     std::map<TypeNode, TNodeTrie> hoIndex;
     std::map<Node, size_t> arity;
-    for (TNode app : d_functionsTerms){
+    for (TNode app : d_functionsTerms)
+    {
       std::vector< TNode > reps;
       bool has_trigger_arg = false;
-      for (const Node& j : app){
+      for (const Node& j : app)
+      {
         reps.push_back(d_equalityEngine->getRepresentative(j));
         if (d_equalityEngine->isTriggerTerm(j, THEORY_UF))
         {
@@ -628,7 +631,7 @@ void TheoryUF::computeCareGraph() {
         }
       }
       if( has_trigger_arg ){
-        if (app.getKind()==kind::APPLY_UF)
+        if (app.getKind() == kind::APPLY_UF)
         {
           Node op = app.getOperator();
           index[op].addTerm(app, reps);
@@ -636,7 +639,7 @@ void TheoryUF::computeCareGraph() {
         }
         else
         {
-          Assert (app.getKind()==kind::HO_APPLY);
+          Assert(app.getKind() == kind::HO_APPLY);
           hoIndex[app[0].getType()].addTerm(app, reps);
         }
       }
@@ -646,7 +649,7 @@ void TheoryUF::computeCareGraph() {
     {
       Debug("uf::sharing") << "TheoryUf::computeCareGraph(): Process index "
                            << tt.first << "..." << std::endl;
-                           Assert(arity.find(tt.first)!=arity.end());
+      Assert(arity.find(tt.first) != arity.end());
       addCarePairs(&tt.second, nullptr, arity[tt.first], 0);
     }
     for (std::pair<const TypeNode, TNodeTrie>& tt : index)

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -629,6 +629,7 @@ void TheoryUF::computeCareGraph() {
       if( has_trigger_arg ){
         if (app.getKind()==kind::APPLY_UF)
         {
+          Node op = app.getOperator();
           index[op].addTerm(app, reps);
           arity[op] = reps.size();
         }

--- a/src/theory/uf/theory_uf.h
+++ b/src/theory/uf/theory_uf.h
@@ -150,15 +150,6 @@ private:
   /** called when two equivalence classes are made disequal */
   void eqNotifyDisequal(TNode t1, TNode t2, TNode reason);
 
- private:
-  /** get the operator for this node (node should be either APPLY_UF or
-   * HO_APPLY)
-   */
-  Node getOperatorForApplyTerm(TNode node);
-  /** get the starting index of the arguments for node (node should be either
-   * APPLY_UF or HO_APPLY) */
-  unsigned getArgumentStartIndexForApplyTerm(TNode node);
-
  public:
 
   /** Constructs a new instance of TheoryUF w.r.t. the provided context.*/

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -545,6 +545,7 @@ set(regress_0_tests
   regress0/ho/ho-std-fmf.smt2
   regress0/ho/hoa0008.smt2
   regress0/ho/issue4477.smt2
+  regress0/ho/issue4990-care-graph.smt2
   regress0/ho/ite-apply-eq.smt2
   regress0/ho/lambda-equality-non-canon.smt2
   regress0/ho/match-middle.smt2

--- a/test/regress/regress0/ho/issue4990-care-graph.smt2
+++ b/test/regress/regress0/ho/issue4990-care-graph.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --uf-ho
+; EXPECT: sat
+(set-logic QF_AUFBVLIA)
+(set-option :uf-ho true)
+(declare-fun a () Int)
+(declare-fun b () Int)
+(declare-fun c (Int) Int)
+(declare-fun d (Int Int) Int)
+(assert (xor (= c (d a)) (= c (d b))))
+(check-sat)


### PR DESCRIPTION
We now separate APPLY_UF and HO_APPLY.  We do not generate care pairs based on comparing APPLY_UF terms with HO_APPLY terms, which led to type errors previously.  
Fixes #4990.