### PR TITLE
Eliminating spurious replay of define funs expansion when checking unsat cores

### DIFF
--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -1115,12 +1115,6 @@ class CVC4_PUBLIC SmtEngine
   AssignmentSet* d_assignments;
 
   /**
-   * A vector of command definitions to be imported in the new
-   * SmtEngine when checking unsat-cores.
-   */
-  std::vector<Command*> d_defineCommands;
-
-  /**
    * The logic we're in. This logic may be an extension of the logic set by the
    * user.
    */


### PR DESCRIPTION
Doing it via commands being added to the `coreChecker` SMT engine is not necessary since we can directly added assertions after expansion from the original SMT engine.