### PR TITLE
(proof-new) Make CombinationEngine proof producing

### DIFF
--- a/src/theory/combination_care_graph.cpp
+++ b/src/theory/combination_care_graph.cpp
@@ -22,8 +22,10 @@ namespace CVC4 {
 namespace theory {
 
 CombinationCareGraph::CombinationCareGraph(
-    TheoryEngine& te, const std::vector<Theory*>& paraTheories)
-    : CombinationEngine(te, paraTheories)
+    TheoryEngine& te,
+    const std::vector<Theory*>& paraTheories,
+    ProofNodeManager* pnm)
+    : CombinationEngine(te, paraTheories, pnm)
 {
 }
 
@@ -62,7 +64,19 @@ void CombinationCareGraph::combineTheories()
         << "TheoryEngine::combineTheories(): requesting a split " << std::endl;
 
     Node split = equality.orNode(equality.notNode());
-    sendLemma(split, carePair.d_theory);
+    TrustNode tsplit;
+    if (isProofEnabled())
+    {
+      // make proof of splitting lemma
+      std::vector<Node> pfArgs;
+      pfArgs.push_back(equality);
+      tsplit = d_cmbsPg->mkTrustNode(split, PfRule::SPLIT, pfArgs);
+    }
+    else
+    {
+      tsplit = TrustNode::mkTrustLemma(split, nullptr);
+    }
+    sendLemma(tsplit, carePair.d_theory);
 
     // Could check the equality status here:
     //   EqualityStatus es = getEqualityStatus(carePair.d_a, carePair.d_b);

--- a/src/theory/combination_care_graph.cpp
+++ b/src/theory/combination_care_graph.cpp
@@ -68,9 +68,7 @@ void CombinationCareGraph::combineTheories()
     if (isProofEnabled())
     {
       // make proof of splitting lemma
-      std::vector<Node> pfArgs;
-      pfArgs.push_back(equality);
-      tsplit = d_cmbsPg->mkTrustNode(split, PfRule::SPLIT, pfArgs);
+      tsplit = d_cmbsPg->mkTrustNode(split, PfRule::SPLIT, {equality});
     }
     else
     {

--- a/src/theory/combination_care_graph.h
+++ b/src/theory/combination_care_graph.h
@@ -35,7 +35,8 @@ class CombinationCareGraph : public CombinationEngine
 {
  public:
   CombinationCareGraph(TheoryEngine& te,
-                       const std::vector<Theory*>& paraTheories);
+                       const std::vector<Theory*>& paraTheories,
+                       ProofNodeManager* pnm);
   ~CombinationCareGraph();
 
   bool buildModel() override;

--- a/src/theory/combination_engine.cpp
+++ b/src/theory/combination_engine.cpp
@@ -111,9 +111,9 @@ eq::EqualityEngineNotify* CombinationEngine::getModelEqualityEngineNotify()
   return nullptr;
 }
 
-void CombinationEngine::sendLemma(TrustNode node, TheoryId atomsTo)
+void CombinationEngine::sendLemma(TrustNode trn, TheoryId atomsTo)
 {
-  d_te.lemma(node, RULE_INVALID, LemmaProperty::NONE, atomsTo);
+  d_te.lemma(trn.getNode(), RULE_INVALID, LemmaProperty::NONE, atomsTo);
 }
 
 void CombinationEngine::resetRound()

--- a/src/theory/combination_engine.cpp
+++ b/src/theory/combination_engine.cpp
@@ -26,12 +26,15 @@ namespace CVC4 {
 namespace theory {
 
 CombinationEngine::CombinationEngine(TheoryEngine& te,
-                                     const std::vector<Theory*>& paraTheories)
+                                     const std::vector<Theory*>& paraTheories,
+                                     ProofNodeManager* pnm)
     : d_te(te),
       d_logicInfo(te.getLogicInfo()),
       d_paraTheories(paraTheories),
       d_eemanager(nullptr),
-      d_mmanager(nullptr)
+      d_mmanager(nullptr),
+      d_cmbsPg(pnm ? new EagerProofGenerator(pnm, te.getUserContext())
+                   : nullptr)
 {
 }
 
@@ -100,15 +103,17 @@ theory::TheoryModel* CombinationEngine::getModel()
   return d_mmanager->getModel();
 }
 
+bool CombinationEngine::isProofEnabled() const { return d_cmbsPg != nullptr; }
+
 eq::EqualityEngineNotify* CombinationEngine::getModelEqualityEngineNotify()
 {
   // by default, no notifications from model's equality engine
   return nullptr;
 }
 
-void CombinationEngine::sendLemma(TNode node, TheoryId atomsTo)
+void CombinationEngine::sendLemma(TrustNode node, TheoryId atomsTo)
 {
-  d_te.lemma(node, RULE_INVALID, false, LemmaProperty::NONE, atomsTo);
+  d_te.lemma(node, RULE_INVALID, LemmaProperty::NONE, atomsTo);
 }
 
 void CombinationEngine::resetRound()

--- a/src/theory/combination_engine.cpp
+++ b/src/theory/combination_engine.cpp
@@ -113,7 +113,7 @@ eq::EqualityEngineNotify* CombinationEngine::getModelEqualityEngineNotify()
 
 void CombinationEngine::sendLemma(TrustNode trn, TheoryId atomsTo)
 {
-  d_te.lemma(trn.getNode(), RULE_INVALID, LemmaProperty::NONE, atomsTo);
+  d_te.lemma(trn.getNode(), RULE_INVALID, false, LemmaProperty::NONE, atomsTo);
 }
 
 void CombinationEngine::resetRound()

--- a/src/theory/combination_engine.h
+++ b/src/theory/combination_engine.h
@@ -102,7 +102,7 @@ class CombinationEngine
    */
   virtual eq::EqualityEngineNotify* getModelEqualityEngineNotify();
   /** Send lemma to the theory engine, atomsTo is the theory to send atoms to */
-  void sendLemma(TrustNode node, TheoryId atomsTo);
+  void sendLemma(TrustNode trn, TheoryId atomsTo);
   /** Reference to the theory engine */
   TheoryEngine& d_te;
   /** Logic info of theory engine (cached) */

--- a/src/theory/combination_engine.h
+++ b/src/theory/combination_engine.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <memory>
 
+#include "theory/eager_proof_generator.h"
 #include "theory/ee_manager.h"
 #include "theory/model_manager.h"
 
@@ -39,7 +40,9 @@ namespace theory {
 class CombinationEngine
 {
  public:
-  CombinationEngine(TheoryEngine& te, const std::vector<Theory*>& paraTheories);
+  CombinationEngine(TheoryEngine& te,
+                    const std::vector<Theory*>& paraTheories,
+                    ProofNodeManager* pnm);
   virtual ~CombinationEngine();
 
   /** Finish initialization */
@@ -91,13 +94,15 @@ class CombinationEngine
   virtual void combineTheories() = 0;
 
  protected:
+  /** Is proof enabled? */
+  bool isProofEnabled() const;
   /**
    * Get model equality engine notify. Return the notification object for
    * who listens to the model's equality engine (if any).
    */
   virtual eq::EqualityEngineNotify* getModelEqualityEngineNotify();
   /** Send lemma to the theory engine, atomsTo is the theory to send atoms to */
-  void sendLemma(TNode node, TheoryId atomsTo);
+  void sendLemma(TrustNode node, TheoryId atomsTo);
   /** Reference to the theory engine */
   TheoryEngine& d_te;
   /** Logic info of theory engine (cached) */
@@ -114,6 +119,11 @@ class CombinationEngine
    * model.
    */
   std::unique_ptr<ModelManager> d_mmanager;
+  /**
+   * An eager proof generator, if proofs are enabled. This proof generator is
+   * responsible for proofs of splitting lemmas generated in combineTheories.
+   */
+  std::unique_ptr<EagerProofGenerator> d_cmbsPg;
 };
 
 }  // namespace theory

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -151,7 +151,7 @@ void TheoryEngine::finishInit() {
   // Initialize the theory combination architecture
   if (options::tcMode() == options::TcMode::CARE_GRAPH)
   {
-    d_tc.reset(new CombinationCareGraph(*this, paraTheories));
+    d_tc.reset(new CombinationCareGraph(*this, paraTheories, d_pnm));
   }
   else
   {
@@ -213,6 +213,7 @@ TheoryEngine::TheoryEngine(context::Context* context,
       d_context(context),
       d_userContext(userContext),
       d_logicInfo(logicInfo),
+      d_pnm(nullptr),
       d_sharedTerms(this, context),
       d_tc(nullptr),
       d_quantEngine(nullptr),

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -143,7 +143,12 @@ class TheoryEngine {
    * the cost of walking the DAG on registration, etc.
    */
   const LogicInfo& d_logicInfo;
-
+  
+  //--------------------------------- new proofs
+  /** Proof node manager used by this theory engine, if proofs are enabled */
+  ProofNodeManager* d_pnm;
+  //--------------------------------- end new proofs
+  
   /**
    * The database of shared terms.
    */

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -143,12 +143,12 @@ class TheoryEngine {
    * the cost of walking the DAG on registration, etc.
    */
   const LogicInfo& d_logicInfo;
-  
+
   //--------------------------------- new proofs
   /** Proof node manager used by this theory engine, if proofs are enabled */
   ProofNodeManager* d_pnm;
   //--------------------------------- end new proofs
-  
+
   /**
    * The database of shared terms.
    */


### PR DESCRIPTION
Makes combination engine proof producing (for Boolean splits). Followup PRs will start to add proof production in TheoryEngine.