### PR TITLE
Basic proof support in inference manager

### DIFF
--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -1381,7 +1381,7 @@ Node NodeManager::mkAnd(const std::vector<NodeTemplate<ref_count> >& children)
   {
     return children[0];
   }
-  return mkNode(AND, a);
+  return mkNode(kind::AND, children);
 }
 
 template <bool ref_count>

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -473,6 +473,17 @@ class NodeManager {
   template <bool ref_count>
   Node* mkNodePtr(Kind kind, const std::vector<NodeTemplate<ref_count> >& children);
 
+  /** 
+   * Create an AND node with arbitrary number of children. This returns the
+   * true node if children is empty, or the single node in children if
+   * it contains only one node.
+   *
+   * We define construction of AND as a special case here since it is widely
+   * used for e.g. constructing explanations.
+   */
+  template <bool ref_count>
+  Node mkAnd(const std::vector<NodeTemplate<ref_count> >& children);
+  
   /** Create a node (with no children) by operator. */
   Node mkNode(TNode opNode);
   Node* mkNodePtr(TNode opNode);
@@ -1357,6 +1368,20 @@ inline Node NodeManager::mkNode(Kind kind,
   NodeBuilder<> nb(this, kind);
   nb.append(children);
   return nb.constructNode();
+}
+  
+template <bool ref_count>
+Node NodeManager::mkAnd(const std::vector<NodeTemplate<ref_count> >& children)
+{
+  if (children.empty())
+  {
+    return mkConst(true);
+  }
+  else if (children.size() == 1)
+  {
+    return children[0];
+  }
+  return mkNode(AND, a);
 }
 
 template <bool ref_count>

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -473,7 +473,7 @@ class NodeManager {
   template <bool ref_count>
   Node* mkNodePtr(Kind kind, const std::vector<NodeTemplate<ref_count> >& children);
 
-  /** 
+  /**
    * Create an AND node with arbitrary number of children. This returns the
    * true node if children is empty, or the single node in children if
    * it contains only one node.
@@ -483,7 +483,7 @@ class NodeManager {
    */
   template <bool ref_count>
   Node mkAnd(const std::vector<NodeTemplate<ref_count> >& children);
-  
+
   /** Create a node (with no children) by operator. */
   Node mkNode(TNode opNode);
   Node* mkNodePtr(TNode opNode);
@@ -1369,7 +1369,7 @@ inline Node NodeManager::mkNode(Kind kind,
   nb.append(children);
   return nb.constructNode();
 }
-  
+
 template <bool ref_count>
 Node NodeManager::mkAnd(const std::vector<NodeTemplate<ref_count> >& children)
 {

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -142,11 +142,12 @@ void TheoryInferenceManager::assertInternalFact(TNode atom, bool pol, TNode exp)
   processInternalFact(atom, pol, PfRule::UNKNOWN, {exp}, {});
 }
 
-void TheoryInferenceManager::assertInternalFact(TNode atom, bool pol,
+void TheoryInferenceManager::assertInternalFact(TNode atom,
+                                                bool pol,
                                                 PfRule id,
                                                 const std::vector<Node>& exp,
                                                 const std::vector<Node>& args)
-{  
+{
   processInternalFact(atom, pol, id, exp, args);
 }
 
@@ -167,7 +168,7 @@ void TheoryInferenceManager::processInternalFact(TNode atom,
   Trace("infer-manager") << "TheoryInferenceManager::assertInternalFact: "
                          << expn << std::endl;
   // if no proof production, or no proof rule was given
-  if (d_pfee==nullptr || id==PfRule::UNKNOWN)
+  if (d_pfee == nullptr || id == PfRule::UNKNOWN)
   {
     if (atom.getKind() == kind::EQUAL)
     {
@@ -196,7 +197,6 @@ void TheoryInferenceManager::processInternalFact(TNode atom,
   Trace("infer-manager")
       << "TheoryInferenceManager::finished assertInternalFact" << std::endl;
 }
-
 
 void TheoryInferenceManager::explain(TNode n, std::vector<TNode>& assumptions)
 {

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -32,7 +32,6 @@ TheoryInferenceManager::TheoryInferenceManager(Theory& t,
       d_pnm(pnm),
       d_keep(t.getSatContext())
 {
-  d_true = NodeManager::currentNM()->mkConst(true);
 }
 
 void TheoryInferenceManager::setEqualityEngine(eq::EqualityEngine* ee)
@@ -154,10 +153,11 @@ void TheoryInferenceManager::assertInternalFact(TNode atom,
 
 void TheoryInferenceManager::assertInternalFact(TNode atom,
                                                 bool pol,
+                          const std::vector<Node>& exp,
                                                 ProofGenerator* pg)
 {
   Assert(pg != nullptr);
-  processInternalFact(atom, pol, PfRule::ASSUME, {}, {}, pg);
+  processInternalFact(atom, pol, PfRule::ASSUME, exp, {}, pg);
 }
 
 void TheoryInferenceManager::processInternalFact(TNode atom,

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -153,7 +153,7 @@ void TheoryInferenceManager::assertInternalFact(TNode atom,
 
 void TheoryInferenceManager::assertInternalFact(TNode atom,
                                                 bool pol,
-                          const std::vector<Node>& exp,
+                                                const std::vector<Node>& exp,
                                                 ProofGenerator* pg)
 {
   Assert(pg != nullptr);

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -38,10 +38,12 @@ void TheoryInferenceManager::setEqualityEngine(eq::EqualityEngine* ee)
 {
   d_ee = ee;
   // if proofs are enabled, also make a proof equality engine to wrap ee
-  if (d_pnm!=nullptr)
+  if (d_pnm != nullptr)
   {
-    d_pfee.reset(new eq::ProofEqEngine(
-        d_theoryState.getSatContext(), d_theoryState.getUserContext(), *d_ee, d_pnm));
+    d_pfee.reset(new eq::ProofEqEngine(d_theoryState.getSatContext(),
+                                       d_theoryState.getUserContext(),
+                                       *d_ee,
+                                       d_pnm));
   }
 }
 
@@ -91,7 +93,7 @@ bool TheoryInferenceManager::propagateLit(TNode lit)
 
 TrustNode TheoryInferenceManager::explainLit(TNode lit)
 {
-  if (d_pfee!=nullptr)
+  if (d_pfee != nullptr)
   {
     return d_pfee->explain(lit);
   }
@@ -110,7 +112,7 @@ TrustNode TheoryInferenceManager::explainConflictEqConstantMerge(TNode a,
                                                                  TNode b)
 {
   Node lit = a.eqNode(b);
-  if (d_pfee!=nullptr)
+  if (d_pfee != nullptr)
   {
     return d_pfee->explain(lit);
   }
@@ -134,27 +136,25 @@ LemmaStatus TheoryInferenceManager::trustedLemma(const TrustNode& tlem,
   return d_out.trustedLemma(tlem, p);
 }
 
-void TheoryInferenceManager::assertInternalFact(TNode atom,
-                                                bool pol,
-                                                TNode exp)
+void TheoryInferenceManager::assertInternalFact(TNode atom, bool pol, TNode exp)
 {
   processInternalFact(atom, pol, PfRule::ASSUME, {exp}, {});
 }
 
 void TheoryInferenceManager::assertInternalFact(TNode atom,
                                                 bool pol,
-                PfRule id,
-                const std::vector<Node>& exp,
-                const std::vector<Node>& args)
+                                                PfRule id,
+                                                const std::vector<Node>& exp,
+                                                const std::vector<Node>& args)
 {
   processInternalFact(atom, pol, id, exp, args);
 }
 
 void TheoryInferenceManager::processInternalFact(TNode atom,
-                                                bool pol,
-                PfRule id,
-                const std::vector<Node>& exp,
-                const std::vector<Node>& args)
+                                                 bool pol,
+                                                 PfRule id,
+                                                 const std::vector<Node>& exp,
+                                                 const std::vector<Node>& args)
 {
   // call the pre-notify fact method with preReg = false, isInternal = true
   if (d_theory.preNotifyFact(atom, pol, fact, false, true))

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -148,15 +148,15 @@ void TheoryInferenceManager::assertInternalFact(TNode atom,
                                                 const std::vector<Node>& exp,
                                                 const std::vector<Node>& args)
 {
-  Assert (id!=PfRule::UNKNOWN);
+  Assert(id != PfRule::UNKNOWN);
   processInternalFact(atom, pol, id, exp, args, nullptr);
 }
 
 void TheoryInferenceManager::assertInternalFact(TNode atom,
-                            bool pol,
-                            ProofGenerator * pg)
+                                                bool pol,
+                                                ProofGenerator* pg)
 {
-  Assert (pg!=nullptr);
+  Assert(pg != nullptr);
   processInternalFact(atom, pol, PfRule::ASSUME, {}, {}, pg);
 }
 
@@ -165,7 +165,7 @@ void TheoryInferenceManager::processInternalFact(TNode atom,
                                                  PfRule id,
                                                  const std::vector<Node>& exp,
                                                  const std::vector<Node>& args,
-                            ProofGenerator * pg)
+                                                 ProofGenerator* pg)
 {
   // make the node corresponding to the explanation
   Node expn = NodeManager::currentNM()->mkAnd(exp);
@@ -205,7 +205,7 @@ void TheoryInferenceManager::processInternalFact(TNode atom,
     // optimize this so that a few less nodes are created, but at the cost
     // of a more verbose interface to proof equality engine.
     Node lit = pol ? Node(atom) : atom.notNode();
-    if (pg!=nullptr)
+    if (pg != nullptr)
     {
       // use the proof generator interface
       d_pfee->assertFact(lit, expn, pg);

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -130,16 +130,24 @@ class TheoryInferenceManager
                           PfRule id,
                           const std::vector<Node>& exp,
                           const std::vector<Node>& args);
+  /**
+   * Assert internal fact, with a proof generator justification.
+   */
+  void assertInternalFact(TNode atom,
+                          bool pol,
+                          ProofGenerator * pg);
 
  protected:
   /**
    * Process internal fact. This is a common helper method for the
    * assertInternalFact variants above.
    */
-  void processInternalFact(Node fact,
+  void processInternalFact(TNode atom,
+                                                 bool pol,
                            PfRule id,
                            const std::vector<Node>& exp,
-                           const std::vector<Node>& args);
+                           const std::vector<Node>& args,
+                          ProofGenerator * pg);
   /**
    * Explain conflict from constants merging in the equality engine. This
    * method is called by conflictEqConstantMerge. By default, it returns

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -120,7 +120,7 @@ class TheoryInferenceManager
    * output channel as a propagation or lemma. This method ensures that the
    * Theory's preNotifyFact and notifyFact method have been called with
    * isInternal = true.
-   * 
+   *
    * @param atom The atom of the fact to assert
    * @param pol Its polarity
    * @param exp Its explanation, i.e. ( exp => (~) atom ) is valid.
@@ -130,7 +130,7 @@ class TheoryInferenceManager
    * Assert internal fact, with a proof step justification. Notice that if
    * proofs are not enabled in this inference manager, then this asserts
    * a fact to the equality engine in the normal way.
-   * 
+   *
    * @param atom The atom of the fact to assert
    * @param pol Its polarity
    * @param id The proof rule identifier of the proof step
@@ -145,7 +145,7 @@ class TheoryInferenceManager
   /**
    * Assert internal fact, with a proof generator justification. Same as above,
    * but with a proof generator instead of an explicit step.
-   * 
+   *
    * @param atom The atom of the fact to assert
    * @param pol Its polarity
    * @param exp Its explanation, interpreted as a conjunction
@@ -153,7 +153,8 @@ class TheoryInferenceManager
    * can provide a proof concluding (~) atom from free asumptions in exp in
    * the remainder of the current SAT context.
    */
-  void assertInternalFact(TNode atom, bool pol, 
+  void assertInternalFact(TNode atom,
+                          bool pol,
                           const std::vector<Node>& exp,
                           ProofGenerator* pg);
 

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -169,6 +169,8 @@ class TheoryInferenceManager
   std::unique_ptr<eq::ProofEqEngine> d_pfee;
   /** The proof node manager of the theory */
   ProofNodeManager* d_pnm;
+  /** Common nodes */
+  Node d_true;
   /**
    * The keep set of this class. This set is maintained to ensure that
    * facts and their explanations are ref-counted. Since facts and their

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -54,6 +54,12 @@ class EqualityEngine;
  * (with isInternal = true) whenever we assert internal facts using
  * assertFactInernal below, mirroring what is done for facts from the fact
  * queue (where isInternal = false).
+ *
+ * (3) The proof equality engine is used whenever proofs are enabled (when
+ * the proof node manager provided to this class is non-null). Notice this
+ * class automatically will construct a proof equality engine during
+ * setEqualityEngine, and use it for handling variants of assertInternalFact
+ * below that involve proofs.
  */
 class TheoryInferenceManager
 {

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -126,10 +126,10 @@ class TheoryInferenceManager
    * Assert internal fact, with a proof step justification.
    */
   void assertInternalFact(TNode atom,
-                                                bool pol,
-                  PfRule id,
-                  const std::vector<Node>& exp,
-                  const std::vector<Node>& args);
+                          bool pol,
+                          PfRule id,
+                          const std::vector<Node>& exp,
+                          const std::vector<Node>& args);
 
  protected:
   /**
@@ -137,9 +137,9 @@ class TheoryInferenceManager
    * assertInternalFact variants above.
    */
   void processInternalFact(Node fact,
-                  PfRule id,
-                  const std::vector<Node>& exp,
-                  const std::vector<Node>& args);
+                           PfRule id,
+                           const std::vector<Node>& exp,
+                           const std::vector<Node>& args);
   /**
    * Explain conflict from constants merging in the equality engine. This
    * method is called by conflictEqConstantMerge. By default, it returns

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -120,10 +120,22 @@ class TheoryInferenceManager
    * output channel as a propagation or lemma. This method ensures that the
    * Theory's preNotifyFact and notifyFact method have been called with
    * isInternal = true.
+   * 
+   * @param atom The atom of the fact to assert
+   * @param pol Its polarity
+   * @param exp Its explanation, i.e. ( exp => (~) atom ) is valid.
    */
   void assertInternalFact(TNode atom, bool pol, TNode exp);
   /**
-   * Assert internal fact, with a proof step justification.
+   * Assert internal fact, with a proof step justification. Notice that if
+   * proofs are not enabled in this inference manager, then this asserts
+   * a fact to the equality engine in the normal way.
+   * 
+   * @param atom The atom of the fact to assert
+   * @param pol Its polarity
+   * @param id The proof rule identifier of the proof step
+   * @param exp Its explanation, interpreted as a conjunction
+   * @param args The arguments of the proof step
    */
   void assertInternalFact(TNode atom,
                           bool pol,
@@ -131,9 +143,19 @@ class TheoryInferenceManager
                           const std::vector<Node>& exp,
                           const std::vector<Node>& args);
   /**
-   * Assert internal fact, with a proof generator justification.
+   * Assert internal fact, with a proof generator justification. Same as above,
+   * but with a proof generator instead of an explicit step.
+   * 
+   * @param atom The atom of the fact to assert
+   * @param pol Its polarity
+   * @param exp Its explanation, interpreted as a conjunction
+   * @param pg The proof generator for this step. It must be the case that pf
+   * can provide a proof concluding (~) atom from free asumptions in exp in
+   * the remainder of the current SAT context.
    */
-  void assertInternalFact(TNode atom, bool pol, ProofGenerator* pg);
+  void assertInternalFact(TNode atom, bool pol, 
+                          const std::vector<Node>& exp,
+                          ProofGenerator* pg);
 
  protected:
   /**
@@ -175,8 +197,6 @@ class TheoryInferenceManager
   std::unique_ptr<eq::ProofEqEngine> d_pfee;
   /** The proof node manager of the theory */
   ProofNodeManager* d_pnm;
-  /** Common nodes */
-  Node d_true;
   /**
    * The keep set of this class. This set is maintained to ensure that
    * facts and their explanations are ref-counted. Since facts and their

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -133,9 +133,7 @@ class TheoryInferenceManager
   /**
    * Assert internal fact, with a proof generator justification.
    */
-  void assertInternalFact(TNode atom,
-                          bool pol,
-                          ProofGenerator * pg);
+  void assertInternalFact(TNode atom, bool pol, ProofGenerator* pg);
 
  protected:
   /**
@@ -143,11 +141,11 @@ class TheoryInferenceManager
    * assertInternalFact variants above.
    */
   void processInternalFact(TNode atom,
-                                                 bool pol,
+                           bool pol,
                            PfRule id,
                            const std::vector<Node>& exp,
                            const std::vector<Node>& args,
-                          ProofGenerator * pg);
+                           ProofGenerator* pg);
   /**
    * Explain conflict from constants merging in the equality engine. This
    * method is called by conflictEqConstantMerge. By default, it returns

--- a/src/theory/uf/proof_equality_engine.cpp
+++ b/src/theory/uf/proof_equality_engine.cpp
@@ -126,7 +126,7 @@ bool ProofEqEngine::assertFact(Node lit,
     d_proof.addLazyStep(lit, &d_factPg, false);
   }
   // second, assert it to the equality engine
-  Node reason = mkAnd(exp);
+  Node reason = NodeManager::currentNM()->mkAnd(exp);
   return assertFactInternal(atom, polarity, reason);
 }
 
@@ -494,11 +494,11 @@ TrustNode ProofEqEngine::ensureProofForFact(Node conc,
     // scope the proof constructed above, and connect the formula with the proof
     // minimize the assumptions
     pf = d_pnm->mkScope(pfBody, scopeAssumps, true, true);
-    exp = mkAnd(scopeAssumps);
+    exp = nm->mkAnd(scopeAssumps);
   }
   else
   {
-    exp = mkAnd(assumps);
+    exp = nm->mkAnd(assumps);
   }
   // Make the lemma or conflict node. This must exactly match the conclusion
   // of SCOPE below.
@@ -666,32 +666,6 @@ void ProofEqEngine::explainWithProof(Node lit,
     pf->addToProof(curr);
   }
   Trace("pfee-proof") << "pfee::explainWithProof: finished" << std::endl;
-}
-
-Node ProofEqEngine::mkAnd(const std::vector<Node>& a)
-{
-  if (a.empty())
-  {
-    return d_true;
-  }
-  else if (a.size() == 1)
-  {
-    return a[0];
-  }
-  return NodeManager::currentNM()->mkNode(AND, a);
-}
-
-Node ProofEqEngine::mkAnd(const std::vector<TNode>& a)
-{
-  if (a.empty())
-  {
-    return d_true;
-  }
-  else if (a.size() == 1)
-  {
-    return a[0];
-  }
-  return NodeManager::currentNM()->mkNode(AND, a);
 }
 
 ProofEqEngine::FactProofGenerator::FactProofGenerator(context::Context* c,

--- a/src/theory/uf/proof_equality_engine.h
+++ b/src/theory/uf/proof_equality_engine.h
@@ -307,12 +307,6 @@ class ProofEqEngine : public EagerProofGenerator
                                const std::vector<TNode>& assumps,
                                TrustNodeKind tnk,
                                LazyCDProof* curr);
-  /**
-   * Make the conjunction of nodes in a. Returns true if a is empty, and a
-   * single literal if a has size 1.
-   */
-  Node mkAnd(const std::vector<Node>& a);
-  Node mkAnd(const std::vector<TNode>& a);
   /** Reference to the equality engine */
   eq::EqualityEngine& d_ee;
   /** The default proof generator (for simple facts) */


### PR DESCRIPTION
This adds basic support for asserting internal facts with proofs in the inference manager class.

The purpose of this PR is twofold:
(1) From the point of view of proofs, this PR standardizes the management of proof equality engine within inference manager. Theories no longer have to manually construct proof equality engines, and instead are recommended to create inference managers.
(2) From the point of view of the new approach to theory combination, this PR ensures standard theory callbacks (preNotifyFact / notifyFact) are used for internal facts, regardless of whether proofs are enabled.

This will simplify several of the current (unmerged) changes for proof production in theory solvers on `proof-new`.

Notice this PR adds the utility method NodeManager::mkAnd, which is arguably long overdue.

Also notice this code is not yet active, but will be used on proof-new after this PR is merged.