### PR TITLE
[CI] Fix Cython installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,12 @@ jobs:
         python3 -m pip install pexpect
         echo "::add-path::/usr/local/opt/ccache/libexec"
 
-    # Note: We install Cython with sudo since cmake can't find Cython otherwise.
     - name: Install Cython
       if: matrix.python-bindings && runner.os == 'Linux'
       run: |
-        sudo python3 -m pip install \
-          Cython==0.29 --install-option="--no-cython-compile"
+        python3 -m pip install \
+          Cython==0.29.* --install-option="--no-cython-compile"
+        echo "::add-path::$(python3 -m site --user-base)/bin"
 
     - name: Install Cython (macOS)
       if: matrix.python-bindings && runner.os == 'macOS'


### PR DESCRIPTION
Cython has been causing issues recently, see e.g.
https://github.com/CVC4/CVC4/pull/4982/checks?check_run_id=1052433862.
It looks like the issue is that globally installed packages can't be
found by Python (maybe the global site-package directories changed/are
not included in the search paths anymore?). This commit changes the
installation of Cython to install it locally to the user instead of
globally. It also adds `bin` in the user base directory to `PATH` s.t.
CMake is able to find the `cython` binary.