### PR TITLE
Use std::unique_ptr instead of std::shared_ptr for inference manager

### DIFF
--- a/src/theory/arith/inference_manager.cpp
+++ b/src/theory/arith/inference_manager.cpp
@@ -55,7 +55,7 @@ void InferenceManager::addPendingArithLemma(std::unique_ptr<ArithLemma> lemma,
   }
   else
   {
-    addPendingLemma(std::move(lemma));
+    d_pendingLem.emplace_back(std::move(lemma));
   }
 }
 void InferenceManager::addPendingArithLemma(const ArithLemma& lemma,
@@ -77,7 +77,7 @@ void InferenceManager::flushWaitingLemmas()
 {
   for (auto& lem : d_waitingLem)
   {
-    addPendingLemma(std::move(lem));
+    d_pendingLem.emplace_back(std::move(lem));
   }
   d_waitingLem.clear();
 }

--- a/src/theory/arith/inference_manager.cpp
+++ b/src/theory/arith/inference_manager.cpp
@@ -29,7 +29,7 @@ InferenceManager::InferenceManager(TheoryArith& ta,
 {
 }
 
-void InferenceManager::addPendingArithLemma(std::shared_ptr<ArithLemma> lemma,
+void InferenceManager::addPendingArithLemma(std::unique_ptr<ArithLemma> lemma,
                                             bool isWaiting)
 {
   lemma->d_node = Rewriter::rewrite(lemma->d_node);
@@ -61,14 +61,15 @@ void InferenceManager::addPendingArithLemma(std::shared_ptr<ArithLemma> lemma,
 void InferenceManager::addPendingArithLemma(const ArithLemma& lemma,
                                             bool isWaiting)
 {
-  addPendingArithLemma(std::make_shared<ArithLemma>(lemma), isWaiting);
+  addPendingArithLemma(std::unique_ptr<ArithLemma>(new ArithLemma(lemma)),
+                       isWaiting);
 }
 void InferenceManager::addPendingArithLemma(const Node& lemma,
                                             nl::Inference inftype,
                                             bool isWaiting)
 {
-  addPendingArithLemma(std::make_shared<ArithLemma>(
-                           lemma, LemmaProperty::NONE, nullptr, inftype),
+  addPendingArithLemma(std::unique_ptr<ArithLemma>(new ArithLemma(
+                           lemma, LemmaProperty::NONE, nullptr, inftype)),
                        isWaiting);
 }
 

--- a/src/theory/arith/inference_manager.h
+++ b/src/theory/arith/inference_manager.h
@@ -55,7 +55,7 @@ class InferenceManager : public InferenceManagerBuffered
    * If isWaiting is true, the lemma is first stored as waiting lemma and only
    * added as pending lemma when calling flushWaitingLemmas.
    */
-  void addPendingArithLemma(std::shared_ptr<ArithLemma> lemma,
+  void addPendingArithLemma(std::unique_ptr<ArithLemma> lemma,
                             bool isWaiting = false);
   /**
    * Add a lemma as pending lemma to the this inference manager.
@@ -102,7 +102,7 @@ class InferenceManager : public InferenceManagerBuffered
   bool isEntailedFalse(const ArithLemma& lem);
 
   /** The waiting lemmas. */
-  std::vector<std::shared_ptr<ArithLemma>> d_waitingLem;
+  std::vector<std::unique_ptr<ArithLemma>> d_waitingLem;
 
   /** cache of all preprocessed lemmas sent on the output channel
    * (user-context-dependent) */

--- a/src/theory/datatypes/inference_manager.cpp
+++ b/src/theory/datatypes/inference_manager.cpp
@@ -97,8 +97,7 @@ void InferenceManager::addPendingInference(Node conc,
                                            Node exp,
                                            ProofGenerator* pg)
 {
-  addPendingFact(std::unique_ptr<DatatypesInference>(
-      new DatatypesInference(conc, exp, pg)));
+  d_pendingFact.emplace_back(new DatatypesInference(conc, exp, pg));
 }
 
 void InferenceManager::process()

--- a/src/theory/datatypes/inference_manager.cpp
+++ b/src/theory/datatypes/inference_manager.cpp
@@ -97,7 +97,8 @@ void InferenceManager::addPendingInference(Node conc,
                                            Node exp,
                                            ProofGenerator* pg)
 {
-  d_pendingFact.push_back(std::make_shared<DatatypesInference>(conc, exp, pg));
+  addPendingFact(std::unique_ptr<DatatypesInference>(
+      new DatatypesInference(conc, exp, pg)));
 }
 
 void InferenceManager::process()

--- a/src/theory/inference_manager_buffered.cpp
+++ b/src/theory/inference_manager_buffered.cpp
@@ -50,11 +50,11 @@ void InferenceManagerBuffered::addPendingLemma(Node lem,
                                                ProofGenerator* pg)
 {
   // make the simple theory lemma
-  d_pendingLem.push_back(std::make_shared<SimpleTheoryLemma>(lem, p, pg));
+  d_pendingLem.emplace_back(new SimpleTheoryLemma(lem, p, pg));
 }
 
 void InferenceManagerBuffered::addPendingLemma(
-    std::shared_ptr<TheoryInference> lemma)
+    std::unique_ptr<TheoryInference> lemma)
 {
   d_pendingLem.emplace_back(std::move(lemma));
 }
@@ -65,12 +65,11 @@ void InferenceManagerBuffered::addPendingFact(Node conc,
 {
   // make a simple theory internal fact
   Assert(conc.getKind() != AND && conc.getKind() != OR);
-  d_pendingFact.push_back(
-      std::make_shared<SimpleTheoryInternalFact>(conc, exp, pg));
+  d_pendingFact.emplace_back(new SimpleTheoryInternalFact(conc, exp, pg));
 }
 
 void InferenceManagerBuffered::addPendingFact(
-    std::shared_ptr<TheoryInference> fact)
+    std::unique_ptr<TheoryInference> fact)
 {
   d_pendingFact.emplace_back(std::move(fact));
 }
@@ -97,7 +96,7 @@ void InferenceManagerBuffered::doPendingFacts()
 
 void InferenceManagerBuffered::doPendingLemmas()
 {
-  for (const std::shared_ptr<TheoryInference>& plem : d_pendingLem)
+  for (const std::unique_ptr<TheoryInference>& plem : d_pendingLem)
   {
     // process this lemma
     plem->process(this);

--- a/src/theory/inference_manager_buffered.h
+++ b/src/theory/inference_manager_buffered.h
@@ -62,7 +62,7 @@ class InferenceManagerBuffered : public TheoryInferenceManager
    * Add pending lemma, where lemma can be a (derived) class of the
    * theory inference base class.
    */
-  void addPendingLemma(std::shared_ptr<TheoryInference> lemma);
+  void addPendingLemma(std::unique_ptr<TheoryInference> lemma);
   /**
    * Add pending fact, which adds a fact on the pending fact queue. It must
    * be the case that:
@@ -78,7 +78,7 @@ class InferenceManagerBuffered : public TheoryInferenceManager
    * Add pending fact, where fact can be a (derived) class of the
    * theory inference base class.
    */
-  void addPendingFact(std::shared_ptr<TheoryInference> fact);
+  void addPendingFact(std::unique_ptr<TheoryInference> fact);
   /** Add pending phase requirement
    *
    * This method is called to indicate this class should send a phase
@@ -131,9 +131,9 @@ class InferenceManagerBuffered : public TheoryInferenceManager
 
  protected:
   /** A set of pending inferences to be processed as lemmas */
-  std::vector<std::shared_ptr<TheoryInference>> d_pendingLem;
+  std::vector<std::unique_ptr<TheoryInference>> d_pendingLem;
   /** A set of pending inferences to be processed as facts */
-  std::vector<std::shared_ptr<TheoryInference>> d_pendingFact;
+  std::vector<std::unique_ptr<TheoryInference>> d_pendingFact;
   /** A map from literals to their pending phase requirement */
   std::map<Node, bool> d_pendingReqPhase;
 };


### PR DESCRIPTION
We now use `std::unique_ptr` instead of `std::shared_ptr` when storing `TheoryInference` objects.