### PR TITLE
(new theory) Update TheoryBV to new standard for collectModelValues

### DIFF
--- a/src/theory/bv/bitblast/lazy_bitblaster.cpp
+++ b/src/theory/bv/bitblast/lazy_bitblaster.cpp
@@ -531,7 +531,6 @@ Node TLazyBitblaster::getModelFromSatSolver(TNode a, bool fullModel) {
 }
 
 bool TLazyBitblaster::collectModelValues(TheoryModel* m,
-                                         bool fullModel,
                                          const std::set<Node>& termSet)
 {
   for (std::set<Node>::const_iterator it = termSet.begin(); it != termSet.end(); ++it) {

--- a/src/theory/bv/bitblast/lazy_bitblaster.cpp
+++ b/src/theory/bv/bitblast/lazy_bitblaster.cpp
@@ -530,9 +530,9 @@ Node TLazyBitblaster::getModelFromSatSolver(TNode a, bool fullModel) {
   return utils::mkConst(bits.size(), value);
 }
 
-bool TLazyBitblaster::collectModelInfo(TheoryModel* m,
-                                       bool fullModel,
-                                       const std::set<Node>& termSet)
+bool TLazyBitblaster::collectModelValues(TheoryModel* m,
+                                         bool fullModel,
+                                         const std::set<Node>& termSet)
 {
   for (std::set<Node>::const_iterator it = termSet.begin(); it != termSet.end(); ++it) {
     TNode var = *it;
@@ -547,9 +547,9 @@ bool TLazyBitblaster::collectModelInfo(TheoryModel* m,
     Node const_value = getModelFromSatSolver(var, true);
     Assert(const_value.isNull() || const_value.isConst());
     if(const_value != Node()) {
-      Debug("bitvector-model") << "TLazyBitblaster::collectModelInfo (assert (= "
-                               << var << " "
-                               << const_value << "))\n";
+      Debug("bitvector-model")
+          << "TLazyBitblaster::collectModelValues (assert (= " << var << " "
+          << const_value << "))\n";
       if (!m->assertEquality(var, const_value, true))
       {
         return false;

--- a/src/theory/bv/bitblast/lazy_bitblaster.cpp
+++ b/src/theory/bv/bitblast/lazy_bitblaster.cpp
@@ -530,12 +530,10 @@ Node TLazyBitblaster::getModelFromSatSolver(TNode a, bool fullModel) {
   return utils::mkConst(bits.size(), value);
 }
 
-bool TLazyBitblaster::collectModelInfo(TheoryModel* m, bool fullModel)
+bool TLazyBitblaster::collectModelInfo(TheoryModel* m,
+                                       bool fullModel,
+                                       const std::set<Node>& termSet)
 {
-  std::set<Node> termSet;
-  const std::set<Kind>& irrKinds = m->getIrrelevantKinds();
-  d_bv->computeAssertedTerms(termSet, irrKinds, true);
-
   for (std::set<Node>::const_iterator it = termSet.begin(); it != termSet.end(); ++it) {
     TNode var = *it;
     // not actually a leaf of the bit-vector theory

--- a/src/theory/bv/bitblast/lazy_bitblaster.h
+++ b/src/theory/bv/bitblast/lazy_bitblaster.h
@@ -76,9 +76,9 @@ class TLazyBitblaster : public TBitblaster<Node>
    * constants to equivalence classes that don't already have them
    * @param termSet the set of relevant terms
    */
-  bool collectModelInfo(TheoryModel* m,
-                        bool fullModel,
-                        const std::set<Node>& termSet);
+  bool collectModelValues(TheoryModel* m,
+                          bool fullModel,
+                          const std::set<Node>& termSet);
 
   typedef TNodeSet::const_iterator vars_iterator;
   vars_iterator beginVars() { return d_variables.begin(); }

--- a/src/theory/bv/bitblast/lazy_bitblaster.h
+++ b/src/theory/bv/bitblast/lazy_bitblaster.h
@@ -74,8 +74,11 @@ class TLazyBitblaster : public TBitblaster<Node>
    * @param m the model
    * @param fullModel whether to create a "full model," i.e., add
    * constants to equivalence classes that don't already have them
+   * @param termSet the set of relevant terms
    */
-  bool collectModelInfo(TheoryModel* m, bool fullModel);
+  bool collectModelInfo(TheoryModel* m,
+                        bool fullModel,
+                        const std::set<Node>& termSet);
 
   typedef TNodeSet::const_iterator vars_iterator;
   vars_iterator beginVars() { return d_variables.begin(); }

--- a/src/theory/bv/bitblast/lazy_bitblaster.h
+++ b/src/theory/bv/bitblast/lazy_bitblaster.h
@@ -72,12 +72,9 @@ class TLazyBitblaster : public TBitblaster<Node>
    * Adds a constant value for each bit-blasted variable in the model.
    *
    * @param m the model
-   * @param fullModel whether to create a "full model," i.e., add
-   * constants to equivalence classes that don't already have them
    * @param termSet the set of relevant terms
    */
   bool collectModelValues(TheoryModel* m,
-                          bool fullModel,
                           const std::set<Node>& termSet);
 
   typedef TNodeSet::const_iterator vars_iterator;

--- a/src/theory/bv/bv_quick_check.cpp
+++ b/src/theory/bv/bv_quick_check.cpp
@@ -140,11 +140,11 @@ void BVQuickCheck::popToZero() {
   }
 }
 
-bool BVQuickCheck::collectModelInfo(theory::TheoryModel* model,
-                                    bool fullModel,
-                                    const std::set<Node>& termSet)
+bool BVQuickCheck::collectModelValues(theory::TheoryModel* model,
+                                      bool fullModel,
+                                      const std::set<Node>& termSet)
 {
-  return d_bitblaster->collectModelInfo(model, fullModel, termSet);
+  return d_bitblaster->collectModelValues(model, fullModel, termSet);
 }
 
 BVQuickCheck::~BVQuickCheck() {

--- a/src/theory/bv/bv_quick_check.cpp
+++ b/src/theory/bv/bv_quick_check.cpp
@@ -140,9 +140,11 @@ void BVQuickCheck::popToZero() {
   }
 }
 
-bool BVQuickCheck::collectModelInfo(theory::TheoryModel* model, bool fullModel)
+bool BVQuickCheck::collectModelInfo(theory::TheoryModel* model,
+                                    bool fullModel,
+                                    const std::set<Node>& termSet)
 {
-  return d_bitblaster->collectModelInfo(model, fullModel);
+  return d_bitblaster->collectModelInfo(model, fullModel, termSet);
 }
 
 BVQuickCheck::~BVQuickCheck() {

--- a/src/theory/bv/bv_quick_check.cpp
+++ b/src/theory/bv/bv_quick_check.cpp
@@ -141,10 +141,9 @@ void BVQuickCheck::popToZero() {
 }
 
 bool BVQuickCheck::collectModelValues(theory::TheoryModel* model,
-                                      bool fullModel,
                                       const std::set<Node>& termSet)
 {
-  return d_bitblaster->collectModelValues(model, fullModel, termSet);
+  return d_bitblaster->collectModelValues(model, termSet);
 }
 
 BVQuickCheck::~BVQuickCheck() {

--- a/src/theory/bv/bv_quick_check.h
+++ b/src/theory/bv/bv_quick_check.h
@@ -98,9 +98,9 @@ class BVQuickCheck
    * @return
    */
   uint64_t computeAtomWeight(TNode atom, NodeSet& seen);
-  bool collectModelInfo(theory::TheoryModel* model,
-                        bool fullModel,
-                        const std::set<Node>& termSet);
+  bool collectModelValues(theory::TheoryModel* model,
+                          bool fullModel,
+                          const std::set<Node>& termSet);
 
   typedef std::unordered_set<TNode, TNodeHashFunction>::const_iterator
       vars_iterator;

--- a/src/theory/bv/bv_quick_check.h
+++ b/src/theory/bv/bv_quick_check.h
@@ -98,7 +98,9 @@ class BVQuickCheck
    * @return
    */
   uint64_t computeAtomWeight(TNode atom, NodeSet& seen);
-  bool collectModelInfo(theory::TheoryModel* model, bool fullModel);
+  bool collectModelInfo(theory::TheoryModel* model,
+                        bool fullModel,
+                        const std::set<Node>& termSet);
 
   typedef std::unordered_set<TNode, TNodeHashFunction>::const_iterator
       vars_iterator;

--- a/src/theory/bv/bv_quick_check.h
+++ b/src/theory/bv/bv_quick_check.h
@@ -99,7 +99,6 @@ class BVQuickCheck
    */
   uint64_t computeAtomWeight(TNode atom, NodeSet& seen);
   bool collectModelValues(theory::TheoryModel* model,
-                          bool fullModel,
                           const std::set<Node>& termSet);
 
   typedef std::unordered_set<TNode, TNodeHashFunction>::const_iterator

--- a/src/theory/bv/bv_solver.h
+++ b/src/theory/bv/bv_solver.h
@@ -78,11 +78,11 @@ class BVSolver
                        "BVSolver::explain() interface!";
     return TrustNode::null();
   }
-  
+
   /** Collect model values in m based on the relevant terms given by termSet */
   virtual bool collectModelValues(TheoryModel* m,
-                          const std::set<Node>& termSet) = 0;
-                          
+                                  const std::set<Node>& termSet) = 0;
+
   virtual std::string identify() const = 0;
 
   virtual Theory::PPAssertStatus ppAssert(

--- a/src/theory/bv/bv_solver.h
+++ b/src/theory/bv/bv_solver.h
@@ -77,14 +77,12 @@ class BVSolver
     Unimplemented() << "BVSolver propagated a node but doesn't implement the "
                        "BVSolver::explain() interface!";
     return TrustNode::null();
-  };
-
-  /**
-   * This is temporary only and will be deprecated soon in favor of
-   * Theory::collectModelValues.
-   */
-  virtual bool collectModelInfo(TheoryModel* m) = 0;
-
+  }
+  
+  /** Collect model values in m based on the relevant terms given by termSet */
+  virtual bool collectModelValues(TheoryModel* m,
+                          const std::set<Node>& termSet) = 0;
+                          
   virtual std::string identify() const = 0;
 
   virtual Theory::PPAssertStatus ppAssert(
@@ -96,7 +94,7 @@ class BVSolver
 
   virtual void presolve(){};
 
-  virtual void notifySharedTerm(TNode t) = 0;
+  virtual void notifySharedTerm(TNode t) {}
 
   virtual EqualityStatus getEqualityStatus(TNode a, TNode b)
   {

--- a/src/theory/bv/bv_solver_lazy.cpp
+++ b/src/theory/bv/bv_solver_lazy.cpp
@@ -368,7 +368,8 @@ bool BVSolverLazy::needsCheckLastEffort()
   return false;
 }
 
-bool BVSolverLazy::collectModelInfo(TheoryModel* m)
+bool BVSolverLazy::collectModelValues(TheoryModel* m,
+                          const std::set<Node>& termSet)
 {
   Assert(!inConflict());
   if (options::bitblastMode() == options::BitblastMode::EAGER)
@@ -382,7 +383,7 @@ bool BVSolverLazy::collectModelInfo(TheoryModel* m)
   {
     if (d_subtheories[i]->isComplete())
     {
-      return d_subtheories[i]->collectModelInfo(m, true);
+      return d_subtheories[i]->collectModelInfo(m, true, termSet);
     }
   }
   return true;
@@ -712,20 +713,6 @@ TrustNode BVSolverLazy::explain(TNode node)
                               << explanation << std::endl;
   Debug("bitvector::explain") << "BVSolverLazy::explain done. \n";
   return TrustNode::mkTrustPropExp(node, explanation, nullptr);
-}
-
-void BVSolverLazy::notifySharedTerm(TNode t)
-{
-  Debug("bitvector::sharing")
-      << indent() << "BVSolverLazy::notifySharedTerm(" << t << ")" << std::endl;
-  d_sharedTermsSet.insert(t);
-  if (options::bitvectorEqualitySolver())
-  {
-    for (unsigned i = 0; i < d_subtheories.size(); ++i)
-    {
-      d_subtheories[i]->addSharedTerm(t);
-    }
-  }
 }
 
 EqualityStatus BVSolverLazy::getEqualityStatus(TNode a, TNode b)

--- a/src/theory/bv/bv_solver_lazy.cpp
+++ b/src/theory/bv/bv_solver_lazy.cpp
@@ -383,7 +383,7 @@ bool BVSolverLazy::collectModelValues(TheoryModel* m,
   {
     if (d_subtheories[i]->isComplete())
     {
-      return d_subtheories[i]->collectModelValues(m, true, termSet);
+      return d_subtheories[i]->collectModelValues(m, termSet);
     }
   }
   return true;

--- a/src/theory/bv/bv_solver_lazy.cpp
+++ b/src/theory/bv/bv_solver_lazy.cpp
@@ -369,7 +369,7 @@ bool BVSolverLazy::needsCheckLastEffort()
 }
 
 bool BVSolverLazy::collectModelValues(TheoryModel* m,
-                          const std::set<Node>& termSet)
+                                      const std::set<Node>& termSet)
 {
   Assert(!inConflict());
   if (options::bitblastMode() == options::BitblastMode::EAGER)

--- a/src/theory/bv/bv_solver_lazy.cpp
+++ b/src/theory/bv/bv_solver_lazy.cpp
@@ -383,7 +383,7 @@ bool BVSolverLazy::collectModelValues(TheoryModel* m,
   {
     if (d_subtheories[i]->isComplete())
     {
-      return d_subtheories[i]->collectModelInfo(m, true, termSet);
+      return d_subtheories[i]->collectModelValues(m, true, termSet);
     }
   }
   return true;
@@ -713,6 +713,13 @@ TrustNode BVSolverLazy::explain(TNode node)
                               << explanation << std::endl;
   Debug("bitvector::explain") << "BVSolverLazy::explain done. \n";
   return TrustNode::mkTrustPropExp(node, explanation, nullptr);
+}
+
+void BVSolverLazy::notifySharedTerm(TNode t)
+{
+  Debug("bitvector::sharing")
+      << indent() << "BVSolverLazy::notifySharedTerm(" << t << ")" << std::endl;
+  d_sharedTermsSet.insert(t);
 }
 
 EqualityStatus BVSolverLazy::getEqualityStatus(TNode a, TNode b)

--- a/src/theory/bv/bv_solver_lazy.h
+++ b/src/theory/bv/bv_solver_lazy.h
@@ -87,7 +87,8 @@ class BVSolverLazy : public BVSolver
 
   TrustNode explain(TNode n) override;
 
-  bool collectModelInfo(TheoryModel* m) override;
+  bool collectModelValues(TheoryModel* m,
+                          const std::set<Node>& termSet) override;
 
   std::string identify() const override { return std::string("BVSolverLazy"); }
 
@@ -180,8 +181,6 @@ class BVSolverLazy : public BVSolver
    */
   void explain(TNode literal, std::vector<TNode>& assumptions);
 
-  void notifySharedTerm(TNode t) override;
-
   bool isSharedTerm(TNode t) { return d_sharedTermsSet.contains(t); }
 
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
@@ -207,13 +206,6 @@ class BVSolverLazy : public BVSolver
   }
 
   void checkForLemma(TNode node);
-
-  void computeAssertedTerms(std::set<Node>& termSet,
-                            const std::set<Kind>& irrKinds,
-                            bool includeShared) const
-  {
-    return d_bv.computeAssertedTerms(termSet, irrKinds, includeShared);
-  }
 
   size_t numAssertions() { return d_bv.numAssertions(); }
 

--- a/src/theory/bv/bv_solver_lazy.h
+++ b/src/theory/bv/bv_solver_lazy.h
@@ -181,6 +181,8 @@ class BVSolverLazy : public BVSolver
    */
   void explain(TNode literal, std::vector<TNode>& assumptions);
 
+  void notifySharedTerm(TNode t) override;
+
   bool isSharedTerm(TNode t) { return d_sharedTermsSet.contains(t); }
 
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;

--- a/src/theory/bv/bv_subtheory.h
+++ b/src/theory/bv/bv_subtheory.h
@@ -75,7 +75,6 @@ class SubtheorySolver {
   virtual void preRegister(TNode node) {}
   virtual void propagate(Theory::Effort e) {}
   virtual bool collectModelValues(TheoryModel* m,
-                                  bool fullModel,
                                   const std::set<Node>& termSet) = 0;
   virtual Node getModelValue(TNode var) = 0;
   virtual bool isComplete() = 0;

--- a/src/theory/bv/bv_subtheory.h
+++ b/src/theory/bv/bv_subtheory.h
@@ -74,11 +74,12 @@ class SubtheorySolver {
   virtual void explain(TNode literal, std::vector<TNode>& assumptions) = 0;
   virtual void preRegister(TNode node) {}
   virtual void propagate(Theory::Effort e) {}
-  virtual bool collectModelInfo(TheoryModel* m, bool fullModel) = 0;
+  virtual bool collectModelInfo(TheoryModel* m,
+                                bool fullModel,
+                                const std::set<Node>& termSet) = 0;
   virtual Node getModelValue(TNode var) = 0;
   virtual bool isComplete() = 0;
   virtual EqualityStatus getEqualityStatus(TNode a, TNode b) = 0;
-  virtual void addSharedTerm(TNode node) {}
   bool done() { return d_assertionQueue.size() == d_assertionIndex; }
   TNode get() {
     Assert(!done());

--- a/src/theory/bv/bv_subtheory.h
+++ b/src/theory/bv/bv_subtheory.h
@@ -74,9 +74,9 @@ class SubtheorySolver {
   virtual void explain(TNode literal, std::vector<TNode>& assumptions) = 0;
   virtual void preRegister(TNode node) {}
   virtual void propagate(Theory::Effort e) {}
-  virtual bool collectModelInfo(TheoryModel* m,
-                                bool fullModel,
-                                const std::set<Node>& termSet) = 0;
+  virtual bool collectModelValues(TheoryModel* m,
+                                  bool fullModel,
+                                  const std::set<Node>& termSet) = 0;
   virtual Node getModelValue(TNode var) = 0;
   virtual bool isComplete() = 0;
   virtual EqualityStatus getEqualityStatus(TNode a, TNode b) = 0;

--- a/src/theory/bv/bv_subtheory_algebraic.cpp
+++ b/src/theory/bv/bv_subtheory_algebraic.cpp
@@ -472,7 +472,8 @@ bool AlgebraicSolver::quickCheck(std::vector<Node>& facts) {
   return false;
 }
 
-void AlgebraicSolver::setConflict(TNode conflict) {
+void AlgebraicSolver::setConflict(TNode conflict)
+{
   Node final_conflict = conflict;
   if (options::bitvectorQuickXplain() &&
       conflict.getKind() == kind::AND &&
@@ -711,13 +712,12 @@ EqualityStatus AlgebraicSolver::getEqualityStatus(TNode a, TNode b) {
   return EQUALITY_UNKNOWN;
 }
 
-bool AlgebraicSolver::collectModelInfo(TheoryModel* model, bool fullModel)
+bool AlgebraicSolver::collectModelInfo(TheoryModel* model,
+                                       bool fullModel,
+                                       const std::set<Node>& termSet)
 {
   Debug("bitvector-model") << "AlgebraicSolver::collectModelInfo\n";
   AlwaysAssert(!d_quickSolver->inConflict());
-  set<Node> termSet;
-  const std::set<Kind>& irrKinds = model->getIrrelevantKinds();
-  d_bv->computeAssertedTerms(termSet, irrKinds, true);
 
   // collect relevant terms that the bv theory abstracts to variables
   // (variables and parametric terms such as select apply_uf)

--- a/src/theory/bv/bv_subtheory_algebraic.cpp
+++ b/src/theory/bv/bv_subtheory_algebraic.cpp
@@ -713,7 +713,6 @@ EqualityStatus AlgebraicSolver::getEqualityStatus(TNode a, TNode b) {
 }
 
 bool AlgebraicSolver::collectModelValues(TheoryModel* model,
-                                         bool fullModel,
                                          const std::set<Node>& termSet)
 {
   Debug("bitvector-model") << "AlgebraicSolver::collectModelValues\n";

--- a/src/theory/bv/bv_subtheory_algebraic.cpp
+++ b/src/theory/bv/bv_subtheory_algebraic.cpp
@@ -747,7 +747,7 @@ bool AlgebraicSolver::collectModelValues(TheoryModel* model,
   for (NodeSet::const_iterator it = leaf_vars.begin(); it != leaf_vars.end(); ++it) {
     TNode var = *it;
     Node value = d_quickSolver->getVarValue(var, true);
-    Assert(!value.isNull() || !fullModel);
+    Assert(!value.isNull());
 
     // may be a shared term that did not appear in the current assertions
     // AJR: need to check whether already in map for cases where collectModelInfo is called multiple times in the same context

--- a/src/theory/bv/bv_subtheory_algebraic.cpp
+++ b/src/theory/bv/bv_subtheory_algebraic.cpp
@@ -712,11 +712,11 @@ EqualityStatus AlgebraicSolver::getEqualityStatus(TNode a, TNode b) {
   return EQUALITY_UNKNOWN;
 }
 
-bool AlgebraicSolver::collectModelInfo(TheoryModel* model,
-                                       bool fullModel,
-                                       const std::set<Node>& termSet)
+bool AlgebraicSolver::collectModelValues(TheoryModel* model,
+                                         bool fullModel,
+                                         const std::set<Node>& termSet)
 {
-  Debug("bitvector-model") << "AlgebraicSolver::collectModelInfo\n";
+  Debug("bitvector-model") << "AlgebraicSolver::collectModelValues\n";
   AlwaysAssert(!d_quickSolver->inConflict());
 
   // collect relevant terms that the bv theory abstracts to variables

--- a/src/theory/bv/bv_subtheory_algebraic.h
+++ b/src/theory/bv/bv_subtheory_algebraic.h
@@ -236,7 +236,9 @@ class AlgebraicSolver : public SubtheorySolver
     Unreachable() << "AlgebraicSolver does not propagate.\n";
   }
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
-  bool collectModelInfo(TheoryModel* m, bool fullModel) override;
+  bool collectModelInfo(TheoryModel* m,
+                        bool fullModel,
+                        const std::set<Node>& termSet) override;
   Node getModelValue(TNode node) override;
   bool isComplete() override;
   void assertFact(TNode fact) override;

--- a/src/theory/bv/bv_subtheory_algebraic.h
+++ b/src/theory/bv/bv_subtheory_algebraic.h
@@ -236,9 +236,9 @@ class AlgebraicSolver : public SubtheorySolver
     Unreachable() << "AlgebraicSolver does not propagate.\n";
   }
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
-  bool collectModelInfo(TheoryModel* m,
-                        bool fullModel,
-                        const std::set<Node>& termSet) override;
+  bool collectModelValues(TheoryModel* m,
+                          bool fullModel,
+                          const std::set<Node>& termSet) override;
   Node getModelValue(TNode node) override;
   bool isComplete() override;
   void assertFact(TNode fact) override;

--- a/src/theory/bv/bv_subtheory_algebraic.h
+++ b/src/theory/bv/bv_subtheory_algebraic.h
@@ -237,7 +237,6 @@ class AlgebraicSolver : public SubtheorySolver
   }
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
   bool collectModelValues(TheoryModel* m,
-                          bool fullModel,
                           const std::set<Node>& termSet) override;
   Node getModelValue(TNode node) override;
   bool isComplete() override;

--- a/src/theory/bv/bv_subtheory_bitblast.cpp
+++ b/src/theory/bv/bv_subtheory_bitblast.cpp
@@ -248,9 +248,11 @@ EqualityStatus BitblastSolver::getEqualityStatus(TNode a, TNode b) {
   return d_bitblaster->getEqualityStatus(a, b);
 }
 
-bool BitblastSolver::collectModelInfo(TheoryModel* m, bool fullModel)
+bool BitblastSolver::collectModelInfo(TheoryModel* m,
+                                      bool fullModel,
+                                      const std::set<Node>& termSet)
 {
-  return d_bitblaster->collectModelInfo(m, fullModel);
+  return d_bitblaster->collectModelInfo(m, fullModel, termSet);
 }
 
 Node BitblastSolver::getModelValue(TNode node)
@@ -263,9 +265,8 @@ Node BitblastSolver::getModelValue(TNode node)
   return val;
 }
 
-
-
-void BitblastSolver::setConflict(TNode conflict) {
+void BitblastSolver::setConflict(TNode conflict)
+{
   Node final_conflict = conflict;
   if (options::bitvectorQuickXplain() &&
       conflict.getKind() == kind::AND) {

--- a/src/theory/bv/bv_subtheory_bitblast.cpp
+++ b/src/theory/bv/bv_subtheory_bitblast.cpp
@@ -248,11 +248,11 @@ EqualityStatus BitblastSolver::getEqualityStatus(TNode a, TNode b) {
   return d_bitblaster->getEqualityStatus(a, b);
 }
 
-bool BitblastSolver::collectModelInfo(TheoryModel* m,
-                                      bool fullModel,
-                                      const std::set<Node>& termSet)
+bool BitblastSolver::collectModelValues(TheoryModel* m,
+                                        bool fullModel,
+                                        const std::set<Node>& termSet)
 {
-  return d_bitblaster->collectModelInfo(m, fullModel, termSet);
+  return d_bitblaster->collectModelValues(m, fullModel, termSet);
 }
 
 Node BitblastSolver::getModelValue(TNode node)

--- a/src/theory/bv/bv_subtheory_bitblast.cpp
+++ b/src/theory/bv/bv_subtheory_bitblast.cpp
@@ -249,10 +249,9 @@ EqualityStatus BitblastSolver::getEqualityStatus(TNode a, TNode b) {
 }
 
 bool BitblastSolver::collectModelValues(TheoryModel* m,
-                                        bool fullModel,
                                         const std::set<Node>& termSet)
 {
-  return d_bitblaster->collectModelValues(m, fullModel, termSet);
+  return d_bitblaster->collectModelValues(m, termSet);
 }
 
 Node BitblastSolver::getModelValue(TNode node)

--- a/src/theory/bv/bv_subtheory_bitblast.h
+++ b/src/theory/bv/bv_subtheory_bitblast.h
@@ -72,9 +72,9 @@ class BitblastSolver : public SubtheorySolver
   bool check(Theory::Effort e) override;
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
-  bool collectModelInfo(TheoryModel* m,
-                        bool fullModel,
-                        const std::set<Node>& termSet) override;
+  bool collectModelValues(TheoryModel* m,
+                          bool fullModel,
+                          const std::set<Node>& termSet) override;
   Node getModelValue(TNode node) override;
   bool isComplete() override { return true; }
   void bitblastQueue();

--- a/src/theory/bv/bv_subtheory_bitblast.h
+++ b/src/theory/bv/bv_subtheory_bitblast.h
@@ -72,7 +72,9 @@ class BitblastSolver : public SubtheorySolver
   bool check(Theory::Effort e) override;
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
-  bool collectModelInfo(TheoryModel* m, bool fullModel) override;
+  bool collectModelInfo(TheoryModel* m,
+                        bool fullModel,
+                        const std::set<Node>& termSet) override;
   Node getModelValue(TNode node) override;
   bool isComplete() override { return true; }
   void bitblastQueue();

--- a/src/theory/bv/bv_subtheory_bitblast.h
+++ b/src/theory/bv/bv_subtheory_bitblast.h
@@ -73,7 +73,6 @@ class BitblastSolver : public SubtheorySolver
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
   bool collectModelValues(TheoryModel* m,
-                          bool fullModel,
                           const std::set<Node>& termSet) override;
   Node getModelValue(TNode node) override;
   bool isComplete() override { return true; }

--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -416,24 +416,24 @@ bool CoreSolver::isCompleteForTerm(TNode term, TNodeBoolMap& seen) {
   return utils::isEqualityTerm(term, seen); 
 }
 
-bool CoreSolver::collectModelInfo(TheoryModel* m,
-                                  bool fullModel,
-                                  const std::set<Node>& termSet)
+bool CoreSolver::collectModelValues(TheoryModel* m,
+                                    bool fullModel,
+                                    const std::set<Node>& termSet)
 {
   if (Debug.isOn("bitvector-model")) {
     context::CDQueue<Node>::const_iterator it = d_assertionQueue.begin();
     for (; it!= d_assertionQueue.end(); ++it) {
-      Debug("bitvector-model") << "CoreSolver::collectModelInfo (assert "
-                               << *it << ")\n";
+      Debug("bitvector-model")
+          << "CoreSolver::collectModelValues (assert " << *it << ")\n";
     }
   }
   if (isComplete()) {
-    Debug("bitvector-model") << "CoreSolver::collectModelInfo complete.";
+    Debug("bitvector-model") << "CoreSolver::collectModelValues complete.";
     for (ModelValue::const_iterator it = d_modelValues.begin(); it != d_modelValues.end(); ++it) {
       Node a = it->first;
       Node b = it->second;
-      Debug("bitvector-model") << "CoreSolver::collectModelInfo modelValues "
-                               << a << " => " << b <<")\n";
+      Debug("bitvector-model") << "CoreSolver::collectModelValues modelValues "
+                               << a << " => " << b << ")\n";
       if (!m->assertEquality(a, b, true))
       {
         return false;

--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -347,7 +347,10 @@ void CoreSolver::buildModel()
 
 bool CoreSolver::assertFactToEqualityEngine(TNode fact, TNode reason) {
   // Notify the equality engine
-  if (!d_bv->inConflict() && (!d_bv->wasPropagatedBySubtheory(fact) || d_bv->getPropagatingSubtheory(fact) != SUB_CORE)) {
+  if (!d_bv->inConflict()
+      && (!d_bv->wasPropagatedBySubtheory(fact)
+          || d_bv->getPropagatingSubtheory(fact) != SUB_CORE))
+  {
     Debug("bv-slicer-eq") << "CoreSolver::assertFactToEqualityEngine fact=" << fact << endl;
     // Debug("bv-slicer-eq") << "                     reason=" << reason << endl;
     bool negated = fact.getKind() == kind::NOT;
@@ -370,7 +373,8 @@ bool CoreSolver::assertFactToEqualityEngine(TNode fact, TNode reason) {
   }
 
   // checking for a conflict
-  if (d_bv->inConflict()) {
+  if (d_bv->inConflict())
+  {
     return false;
   }
   return true;
@@ -412,7 +416,9 @@ bool CoreSolver::isCompleteForTerm(TNode term, TNodeBoolMap& seen) {
   return utils::isEqualityTerm(term, seen); 
 }
 
-bool CoreSolver::collectModelInfo(TheoryModel* m, bool fullModel)
+bool CoreSolver::collectModelInfo(TheoryModel* m,
+                                  bool fullModel,
+                                  const std::set<Node>& termSet)
 {
   if (Debug.isOn("bitvector-model")) {
     context::CDQueue<Node>::const_iterator it = d_assertionQueue.begin();
@@ -420,13 +426,6 @@ bool CoreSolver::collectModelInfo(TheoryModel* m, bool fullModel)
       Debug("bitvector-model") << "CoreSolver::collectModelInfo (assert "
                                << *it << ")\n";
     }
-  }
-  set<Node> termSet;
-  const std::set<Kind>& irrKinds = m->getIrrelevantKinds();
-  d_bv->computeAssertedTerms(termSet, irrKinds, true);
-  if (!m->assertEqualityEngine(d_equalityEngine, &termSet))
-  {
-    return false;
   }
   if (isComplete()) {
     Debug("bitvector-model") << "CoreSolver::collectModelInfo complete.";
@@ -460,11 +459,6 @@ Node CoreSolver::getModelValue(TNode var) {
   }
   Debug("bitvector-model") << " => " << result <<"\n";
   return result;
-}
-
-void CoreSolver::addSharedTerm(TNode t)
-{
-  d_equalityEngine->addTriggerTerm(t, THEORY_BV);
 }
 
 EqualityStatus CoreSolver::getEqualityStatus(TNode a, TNode b)

--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -417,7 +417,6 @@ bool CoreSolver::isCompleteForTerm(TNode term, TNodeBoolMap& seen) {
 }
 
 bool CoreSolver::collectModelValues(TheoryModel* m,
-                                    bool fullModel,
                                     const std::set<Node>& termSet)
 {
   if (Debug.isOn("bitvector-model")) {

--- a/src/theory/bv/bv_subtheory_core.h
+++ b/src/theory/bv/bv_subtheory_core.h
@@ -110,8 +110,6 @@ class CoreSolver : public SubtheorySolver {
   ModelValue d_modelValues;
   void buildModel();
   bool assertFactToEqualityEngine(TNode fact, TNode reason);
-  bool decomposeFact(TNode fact);
-  Node getBaseDecomposition(TNode a);
   bool isCompleteForTerm(TNode term, TNodeBoolMap& seen);
   Statistics d_statistics;
 
@@ -154,9 +152,10 @@ class CoreSolver : public SubtheorySolver {
   void preRegister(TNode node) override;
   bool check(Theory::Effort e) override;
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
-  bool collectModelInfo(TheoryModel* m, bool fullModel) override;
+  bool collectModelInfo(TheoryModel* m,
+                        bool fullModel,
+                        const std::set<Node>& termSet) override;
   Node getModelValue(TNode var) override;
-  void addSharedTerm(TNode t) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
   bool hasTerm(TNode node) const;
   void addTermToEqualityEngine(TNode node);

--- a/src/theory/bv/bv_subtheory_core.h
+++ b/src/theory/bv/bv_subtheory_core.h
@@ -152,9 +152,9 @@ class CoreSolver : public SubtheorySolver {
   void preRegister(TNode node) override;
   bool check(Theory::Effort e) override;
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
-  bool collectModelInfo(TheoryModel* m,
-                        bool fullModel,
-                        const std::set<Node>& termSet) override;
+  bool collectModelValues(TheoryModel* m,
+                          bool fullModel,
+                          const std::set<Node>& termSet) override;
   Node getModelValue(TNode var) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
   bool hasTerm(TNode node) const;

--- a/src/theory/bv/bv_subtheory_core.h
+++ b/src/theory/bv/bv_subtheory_core.h
@@ -153,7 +153,6 @@ class CoreSolver : public SubtheorySolver {
   bool check(Theory::Effort e) override;
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
   bool collectModelValues(TheoryModel* m,
-                          bool fullModel,
                           const std::set<Node>& termSet) override;
   Node getModelValue(TNode var) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;

--- a/src/theory/bv/bv_subtheory_inequality.cpp
+++ b/src/theory/bv/bv_subtheory_inequality.cpp
@@ -190,7 +190,6 @@ void InequalitySolver::explain(TNode literal, std::vector<TNode>& assumptions) {
 
 void InequalitySolver::propagate(Theory::Effort e) { Assert(false); }
 bool InequalitySolver::collectModelValues(TheoryModel* m,
-                                          bool fullModel,
                                           const std::set<Node>& termSet)
 {
   Debug("bitvector-model") << "InequalitySolver::collectModelValues \n";

--- a/src/theory/bv/bv_subtheory_inequality.cpp
+++ b/src/theory/bv/bv_subtheory_inequality.cpp
@@ -189,11 +189,11 @@ void InequalitySolver::explain(TNode literal, std::vector<TNode>& assumptions) {
 }
 
 void InequalitySolver::propagate(Theory::Effort e) { Assert(false); }
-bool InequalitySolver::collectModelInfo(TheoryModel* m,
-                                        bool fullModel,
-                                        const std::set<Node>& termSet)
+bool InequalitySolver::collectModelValues(TheoryModel* m,
+                                          bool fullModel,
+                                          const std::set<Node>& termSet)
 {
-  Debug("bitvector-model") << "InequalitySolver::collectModelInfo \n";
+  Debug("bitvector-model") << "InequalitySolver::collectModelValues \n";
   std::vector<Node> model;
   d_inequalityGraph.getAllValuesInModel(model);
   for (unsigned i = 0; i < model.size(); ++i) {

--- a/src/theory/bv/bv_subtheory_inequality.cpp
+++ b/src/theory/bv/bv_subtheory_inequality.cpp
@@ -189,7 +189,9 @@ void InequalitySolver::explain(TNode literal, std::vector<TNode>& assumptions) {
 }
 
 void InequalitySolver::propagate(Theory::Effort e) { Assert(false); }
-bool InequalitySolver::collectModelInfo(TheoryModel* m, bool fullModel)
+bool InequalitySolver::collectModelInfo(TheoryModel* m,
+                                        bool fullModel,
+                                        const std::set<Node>& termSet)
 {
   Debug("bitvector-model") << "InequalitySolver::collectModelInfo \n";
   std::vector<Node> model;

--- a/src/theory/bv/bv_subtheory_inequality.h
+++ b/src/theory/bv/bv_subtheory_inequality.h
@@ -79,9 +79,9 @@ class InequalitySolver : public SubtheorySolver
   void propagate(Theory::Effort e) override;
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
   bool isComplete() override { return d_isComplete; }
-  bool collectModelInfo(TheoryModel* m,
-                        bool fullModel,
-                        const std::set<Node>& termSet) override;
+  bool collectModelValues(TheoryModel* m,
+                          bool fullModel,
+                          const std::set<Node>& termSet) override;
   Node getModelValue(TNode var) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
   void assertFact(TNode fact) override;

--- a/src/theory/bv/bv_subtheory_inequality.h
+++ b/src/theory/bv/bv_subtheory_inequality.h
@@ -79,7 +79,9 @@ class InequalitySolver : public SubtheorySolver
   void propagate(Theory::Effort e) override;
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
   bool isComplete() override { return d_isComplete; }
-  bool collectModelInfo(TheoryModel* m, bool fullModel) override;
+  bool collectModelInfo(TheoryModel* m,
+                        bool fullModel,
+                        const std::set<Node>& termSet) override;
   Node getModelValue(TNode var) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
   void assertFact(TNode fact) override;

--- a/src/theory/bv/bv_subtheory_inequality.h
+++ b/src/theory/bv/bv_subtheory_inequality.h
@@ -80,7 +80,6 @@ class InequalitySolver : public SubtheorySolver
   void explain(TNode literal, std::vector<TNode>& assumptions) override;
   bool isComplete() override { return d_isComplete; }
   bool collectModelValues(TheoryModel* m,
-                          bool fullModel,
                           const std::set<Node>& termSet) override;
   Node getModelValue(TNode var) override;
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -186,11 +186,6 @@ TrustNode TheoryBV::explain(TNode node) { return d_internal->explain(node); }
 void TheoryBV::notifySharedTerm(TNode t)
 {
   d_internal->notifySharedTerm(t);
-  // temporary, will be built into Theory::addSharedTerm
-  if (d_equalityEngine != nullptr)
-  {
-    d_equalityEngine->addTriggerTerm(t, THEORY_BV);
-  }
 }
 
 void TheoryBV::ppStaticLearn(TNode in, NodeBuilder<>& learned)

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -164,9 +164,11 @@ bool TheoryBV::needsCheckLastEffort()
   return d_internal->needsCheckLastEffort();
 }
 
-bool TheoryBV::collectModelInfo(TheoryModel* m)
+
+bool TheoryBV::collectModelValues(TheoryModel* m,
+                        const std::set<Node>& termSet)
 {
-  return d_internal->collectModelInfo(m);
+  return d_internal->collectModelValues(m, termSet);
 }
 
 void TheoryBV::propagate(Effort e) { return d_internal->propagate(e); }

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -164,9 +164,7 @@ bool TheoryBV::needsCheckLastEffort()
   return d_internal->needsCheckLastEffort();
 }
 
-
-bool TheoryBV::collectModelValues(TheoryModel* m,
-                        const std::set<Node>& termSet)
+bool TheoryBV::collectModelValues(TheoryModel* m, const std::set<Node>& termSet)
 {
   return d_internal->collectModelValues(m, termSet);
 }
@@ -185,13 +183,14 @@ void TheoryBV::presolve() { d_internal->presolve(); }
 
 TrustNode TheoryBV::explain(TNode node) { return d_internal->explain(node); }
 
-void TheoryBV::notifySharedTerm(TNode t) { d_internal->notifySharedTerm(t);
+void TheoryBV::notifySharedTerm(TNode t)
+{
+  d_internal->notifySharedTerm(t);
   // temporary, will be built into Theory::addSharedTerm
   if (d_equalityEngine != nullptr)
   {
     d_equalityEngine->addTriggerTerm(t, THEORY_BV);
   }
-  
 }
 
 void TheoryBV::ppStaticLearn(TNode in, NodeBuilder<>& learned)

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -186,6 +186,11 @@ TrustNode TheoryBV::explain(TNode node) { return d_internal->explain(node); }
 void TheoryBV::notifySharedTerm(TNode t)
 {
   d_internal->notifySharedTerm(t);
+  // temporary, will be built into Theory::addSharedTerm
+  if (d_equalityEngine != nullptr)
+  {
+    d_equalityEngine->addTriggerTerm(t, THEORY_BV);
+  }
 }
 
 void TheoryBV::ppStaticLearn(TNode in, NodeBuilder<>& learned)

--- a/src/theory/bv/theory_bv.cpp
+++ b/src/theory/bv/theory_bv.cpp
@@ -185,7 +185,14 @@ void TheoryBV::presolve() { d_internal->presolve(); }
 
 TrustNode TheoryBV::explain(TNode node) { return d_internal->explain(node); }
 
-void TheoryBV::notifySharedTerm(TNode t) { d_internal->notifySharedTerm(t); };
+void TheoryBV::notifySharedTerm(TNode t) { d_internal->notifySharedTerm(t);
+  // temporary, will be built into Theory::addSharedTerm
+  if (d_equalityEngine != nullptr)
+  {
+    d_equalityEngine->addTriggerTerm(t, THEORY_BV);
+  }
+  
+}
 
 void TheoryBV::ppStaticLearn(TNode in, NodeBuilder<>& learned)
 {

--- a/src/theory/bv/theory_bv.h
+++ b/src/theory/bv/theory_bv.h
@@ -71,7 +71,9 @@ class TheoryBV : public Theory
 
   TrustNode explain(TNode n) override;
 
-  bool collectModelInfo(TheoryModel* m) override;
+  /** Collect model values in m based on the relevant terms given by termSet */
+  bool collectModelValues(TheoryModel* m,
+                          const std::set<Node>& termSet) override;
 
   std::string identify() const override { return std::string("TheoryBV"); }
 


### PR DESCRIPTION
This makes collectModelValues the main model interface in BV instead of collectModelInfo.  BV is no longer responsible for asserting its equality engine or computing relevant/asserted terms.

This involved updating the interface on many subsolvers of BvSolverLazy.  This includes moving the responsibility of addSharedTerm (regarding trigger terms) from the subsolvers to TheoryBV, this eventually will be automatically handled in Theory once all theories are migrated to the new standard.

This ensures that TheoryBV is updated to the new standard (check was already migrated on https://github.com/CVC4/CVC4/commit/c9e23f66383a4d490aca6d082d40117fe799ee4b).