### PR TITLE
Use Result::Sat instead of BenchmarkStatus in printers.

### DIFF
--- a/src/printer/ast/ast_printer.cpp
+++ b/src/printer/ast/ast_printer.cpp
@@ -341,7 +341,7 @@ void AstPrinter::toStreamCmdGetUnsatCore(std::ostream& out) const
 }
 
 void AstPrinter::toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                               BenchmarkStatus status) const
+                                               Result::Sat status) const
 {
   out << "SetBenchmarkStatus(" << status << ')';
 }

--- a/src/printer/ast/ast_printer.h
+++ b/src/printer/ast/ast_printer.h
@@ -122,7 +122,7 @@ class AstPrinter : public CVC4::Printer
 
   /** Print set-info :status command */
   void toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                     BenchmarkStatus status) const override;
+                                     Result::Sat status) const override;
 
   /** Print set-logic command */
   void toStreamCmdSetBenchmarkLogic(std::ostream& out,

--- a/src/printer/cvc/cvc_printer.cpp
+++ b/src/printer/cvc/cvc_printer.cpp
@@ -1436,7 +1436,7 @@ void CvcPrinter::toStreamCmdGetUnsatCore(std::ostream& out) const
 }
 
 void CvcPrinter::toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                               BenchmarkStatus status) const
+                                               Result::Sat status) const
 {
   out << "% (set-info :status " << status << ')';
 }

--- a/src/printer/cvc/cvc_printer.h
+++ b/src/printer/cvc/cvc_printer.h
@@ -123,7 +123,7 @@ class CvcPrinter : public CVC4::Printer
 
   /** Print set-info :status command */
   void toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                     BenchmarkStatus status) const override;
+                                     Result::Sat status) const override;
 
   /** Print set-logic command */
   void toStreamCmdSetBenchmarkLogic(std::ostream& out,

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -23,6 +23,7 @@
 #include "printer/cvc/cvc_printer.h"
 #include "printer/smt2/smt2_printer.h"
 #include "printer/tptp/tptp_printer.h"
+#include "smt/command.h"
 #include "smt/node_command.h"
 
 using namespace std;
@@ -346,7 +347,7 @@ void Printer::toStreamCmdGetAssertions(std::ostream& out) const
 }
 
 void Printer::toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                            BenchmarkStatus status) const
+                                            Result::Sat status) const
 {
   printUnknownCommand(out, "set-info");
 }

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -24,13 +24,16 @@
 
 #include "expr/node.h"
 #include "options/language.h"
-#include "smt/command.h"
 #include "smt/model.h"
+#include "util/result.h"
 #include "util/sexpr.h"
 
 namespace CVC4 {
 
+class Command;
+class CommandStatus;
 class NodeCommand;
+class UnsatCore;
 
 class Printer
 {
@@ -212,7 +215,7 @@ class Printer
 
   /** Print set-info :status command */
   virtual void toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                             BenchmarkStatus status) const;
+                                             Result::Sat status) const;
 
   /** Print set-logic command */
   virtual void toStreamCmdSetBenchmarkLogic(std::ostream& out,

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -31,6 +31,7 @@
 #include "options/printer_options.h"
 #include "options/smt_options.h"
 #include "printer/dagification_visitor.h"
+#include "smt/command.h"
 #include "smt/node_command.h"
 #include "smt/smt_engine.h"
 #include "smt_util/boolean_simplification.h"
@@ -1775,7 +1776,7 @@ void Smt2Printer::toStreamCmdGetUnsatCore(std::ostream& out) const
 }
 
 void Smt2Printer::toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                                BenchmarkStatus status) const
+                                                Result::Sat status) const
 {
   out << "(set-info :status " << status << ')';
 }

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -178,7 +178,7 @@ class Smt2Printer : public CVC4::Printer
 
   /** Print set-info :status command */
   void toStreamCmdSetBenchmarkStatus(std::ostream& out,
-                                     BenchmarkStatus status) const override;
+                                     Result::Sat status) const override;
 
   /** Print set-logic command */
   void toStreamCmdSetBenchmarkLogic(std::ostream& out,

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -2981,10 +2981,8 @@ void SetBenchmarkStatusCommand::toStream(std::ostream& out,
   switch (d_status)
   {
     case BenchmarkStatus::SMT_SATISFIABLE: status = Result::SAT; break;
-    case BenchmarkStatus::SMT_UNSATISFIABLE:
-      status = Result::SAT_UNKNOWN;
-      break;
-    case BenchmarkStatus::SMT_UNKNOWN: status = Result::UNSAT; break;
+    case BenchmarkStatus::SMT_UNSATISFIABLE: status = Result::UNSAT; break;
+    case BenchmarkStatus::SMT_UNKNOWN: status = Result::SAT_UNKNOWN; break;
   }
 
   Printer::getPrinter(language)->toStreamCmdSetBenchmarkStatus(out, status);

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -2977,7 +2977,17 @@ void SetBenchmarkStatusCommand::toStream(std::ostream& out,
                                          size_t dag,
                                          OutputLanguage language) const
 {
-  Printer::getPrinter(language)->toStreamCmdSetBenchmarkStatus(out, d_status);
+  Result::Sat status;
+  switch (d_status)
+  {
+    case BenchmarkStatus::SMT_SATISFIABLE: status = Result::SAT; break;
+    case BenchmarkStatus::SMT_UNSATISFIABLE:
+      status = Result::SAT_UNKNOWN;
+      break;
+    case BenchmarkStatus::SMT_UNKNOWN: status = Result::UNSAT; break;
+  }
+
+  Printer::getPrinter(language)->toStreamCmdSetBenchmarkStatus(out, status);
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This PR modifies the printers to use `Result::Sat`, "internal" version of `BenchmarkStatus`, for printing benchmark status commands.