### PR TITLE
Eliminate a custom use of TheorySep in quantifiers engine for EPR

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -911,6 +911,10 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
     {
       options::preSkolemQuant.set(true);
     }
+    // must have separation logic
+    logic = logic.getUnlockedCopy();
+    logic.enableTheory(THEORY_SEP);
+    logic.lock();
   }
 
   // now, have determined whether finite model find is on/off

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -498,19 +498,6 @@ void QuantifiersEngine::ppNotifyAssertions(
       quantifiers::QuantAttributes::setInstantiationLevelAttr(a, 0);
     }
   }
-  if (d_qepr != NULL)
-  {
-    for (const Node& a : assertions)
-    {
-      d_qepr->registerAssertion(a);
-    }
-    // must handle sources of other new constants e.g. separation logic
-    // FIXME (as part of project 3) : cleanup
-    sep::TheorySep* theory_sep =
-        static_cast<sep::TheorySep*>(getTheoryEngine()->theoryOf(THEORY_SEP));
-    theory_sep->initializeBounds();
-    d_qepr->finishInit();
-  }
   if (options::sygus())
   {
     quantifiers::SynthEngine* sye = d_private->d_synth_e.get();

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1002,8 +1002,8 @@ void TheorySep::ppNotifyAssertions(const std::vector<Node>& assertions) {
     }
   }
   // initialize the EPR utility
-  QuantifiersEngine * qe = getQuantifiersEngine();
-  if (qe!=nullptr)
+  QuantifiersEngine* qe = getQuantifiersEngine();
+  if (qe != nullptr)
   {
     quantifiers::QuantEPR* qepr = qe->getQuantEPR();
     if (qepr != nullptr)

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1002,9 +1002,10 @@ void TheorySep::ppNotifyAssertions(const std::vector<Node>& assertions) {
     }
   }
   // initialize the EPR utility
-  if (d_quantEngine!=nullptr)
+  QuantifiersEngine * qe = getQuantifiersEngine();
+  if (qe!=nullptr)
   {
-    quantifiers::QuantEPR* qepr = d_quantEngine->getQuantEPR();
+    quantifiers::QuantEPR* qepr = qe->getQuantEPR();
     if (qepr != nullptr)
     {
       for (const Node& a : assertions)

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1001,6 +1001,21 @@ void TheorySep::ppNotifyAssertions(const std::vector<Node>& assertions) {
       d_loc_to_data_type[d_type_ref] = d_type_data;
     }
   }
+  // initialize the EPR utility
+  if (d_quantEngine!=nullptr)
+  {
+    quantifiers::QuantEPR* qepr = d_quantEngine->getQuantEPR();
+    if (qepr != nullptr)
+    {
+      for (const Node& a : assertions)
+      {
+        qepr->registerAssertion(a);
+      }
+      // must handle sources of other new constants e.g. separation logic
+      initializeBounds();
+      qepr->finishInit();
+    }
+  }
 }
 
 //return cardinality


### PR DESCRIPTION
This moves the initialization of the connection between separation logic and EPR to the separation logic theory, which is a more logical place for this.  This eliminates a backwards reference to theory engine from quantifiers engine.