### PR TITLE
Move finite model minimization to UF last call effort

### DIFF
--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -87,12 +87,13 @@ void ModelEngine::check(Theory::Effort e, QEffort quant_e)
     }
     Trace("model-engine-debug") << "Check model..." << std::endl;
     d_incomplete_check = false;
-    //print debug
-    if( Trace.isOn("fmf-model-complete") ){
+    // print debug
+    if (Trace.isOn("fmf-model-complete"))
+    {
       Trace("fmf-model-complete") << std::endl;
       debugPrint("fmf-model-complete");
     }
-    //successfully built an acceptable model, now check it
+    // successfully built an acceptable model, now check it
     addedLemmas += checkModel();
 
     if( Trace.isOn("model-engine") ){

--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -77,7 +77,6 @@ void ModelEngine::check(Theory::Effort e, QEffort quant_e)
   if( doCheck ){
     Assert(!d_quantEngine->inConflict());
     int addedLemmas = 0;
-    FirstOrderModel* fm = d_quantEngine->getModel();
 
     //the following will test that the model satisfies all asserted universal quantifiers by
     // (model-based) exhaustive instantiation.

--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -24,9 +24,7 @@
 #include "theory/quantifiers/term_util.h"
 #include "theory/quantifiers_engine.h"
 #include "theory/theory_engine.h"
-#include "theory/uf/cardinality_extension.h"
 #include "theory/uf/equality_engine.h"
-#include "theory/uf/theory_uf.h"
 
 using namespace std;
 using namespace CVC4;

--- a/src/theory/quantifiers/fmf/model_engine.cpp
+++ b/src/theory/quantifiers/fmf/model_engine.cpp
@@ -88,28 +88,15 @@ void ModelEngine::check(Theory::Effort e, QEffort quant_e)
       Trace("model-engine") << "---Model Engine Round---" << std::endl;
       clSet = double(clock())/double(CLOCKS_PER_SEC);
     }
-
-    Trace("model-engine-debug") << "Verify uf ss is minimal..." << std::endl;
-    // Let the cardinality extension verify that the model is minimal.
-    // This will if there are terms in the model that the cardinality extension
-    // was not notified of.
-    uf::CardinalityExtension* ufss =
-        static_cast<uf::TheoryUF*>(
-            d_quantEngine->getTheoryEngine()->theoryOf(THEORY_UF))
-            ->getCardinalityExtension();
-    if( !ufss || ufss->debugModel( fm ) ){
-      Trace("model-engine-debug") << "Check model..." << std::endl;
-      d_incomplete_check = false;
-      //print debug
-      if( Trace.isOn("fmf-model-complete") ){
-        Trace("fmf-model-complete") << std::endl;
-        debugPrint("fmf-model-complete");
-      }
-      //successfully built an acceptable model, now check it
-      addedLemmas += checkModel();
-    }else{
-      addedLemmas++;
+    Trace("model-engine-debug") << "Check model..." << std::endl;
+    d_incomplete_check = false;
+    //print debug
+    if( Trace.isOn("fmf-model-complete") ){
+      Trace("fmf-model-complete") << std::endl;
+      debugPrint("fmf-model-complete");
     }
+    //successfully built an acceptable model, now check it
+    addedLemmas += checkModel();
 
     if( Trace.isOn("model-engine") ){
       double clSet2 = double(clock())/double(CLOCKS_PER_SEC);

--- a/src/theory/theory_state.cpp
+++ b/src/theory/theory_state.cpp
@@ -130,5 +130,10 @@ bool TheoryState::isSatLiteral(TNode lit) const
   return d_valuation.isSatLiteral(lit);
 }
 
+TheoryModel* TheoryState::getModel()
+{
+  return d_valuation.getModel();
+}
+
 }  // namespace theory
 }  // namespace CVC4

--- a/src/theory/theory_state.cpp
+++ b/src/theory/theory_state.cpp
@@ -130,10 +130,7 @@ bool TheoryState::isSatLiteral(TNode lit) const
   return d_valuation.isSatLiteral(lit);
 }
 
-TheoryModel* TheoryState::getModel()
-{
-  return d_valuation.getModel();
-}
+TheoryModel* TheoryState::getModel() { return d_valuation.getModel(); }
 
 }  // namespace theory
 }  // namespace CVC4

--- a/src/theory/theory_state.h
+++ b/src/theory/theory_state.h
@@ -79,7 +79,7 @@ class TheoryState
    * check.
    */
   TheoryModel* getModel();
-  
+
  protected:
   /** Pointer to the SAT context object used by the theory. */
   context::Context* d_context;

--- a/src/theory/theory_state.h
+++ b/src/theory/theory_state.h
@@ -74,7 +74,12 @@ class TheoryState
 
   /** Returns true if lit is a SAT literal. */
   virtual bool isSatLiteral(TNode lit) const;
-
+  /**
+   * Returns pointer to model. This model is only valid during last call effort
+   * check.
+   */
+  TheoryModel* getModel();
+  
  protected:
   /** Pointer to the SAT context object used by the theory. */
   context::Context* d_context;

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1183,6 +1183,7 @@ void SortModel::debugPrint( const char* c ){
 }
 
 bool SortModel::checkLastCall(){
+  TheoryModel * m = d_state.getModel();
   if( Trace.isOn("uf-ss-warn") ){
     std::vector< Node > eqcs;
     eq::EqClassesIterator eqcs_i =
@@ -1203,7 +1204,6 @@ bool SortModel::checkLastCall(){
       ++eqcs_i;
     }
   }
-  TheoryModel * m = d_state.getModel();
   RepSet* rs = m->getRepSetPtr();
   int nReps = (int)rs->getNumRepresentatives(d_type);
   if( nReps!=(d_maxNegCard+1) ){
@@ -1576,8 +1576,8 @@ void CardinalityExtension::check(Theory::Effort level)
   if (level==Theory::EFFORT_LAST_CALL)
   {
     // if last call, call last call check for each sort
-    for( std::pair< TypeNode, SortModel* >& r : d_rep_model ){
-      if( !r->checkLastCall() ){
+    for( std::pair< const TypeNode, SortModel* >& r : d_rep_model ){
+      if( !r.second->checkLastCall() ){
         break;
       }
     }

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1573,6 +1573,16 @@ bool CardinalityExtension::areDisequal(Node a, Node b)
 /** check */
 void CardinalityExtension::check(Theory::Effort level)
 {
+  if (level==Theory::EFFORT_LAST_CALL)
+  {
+    // if last call, call last call check for each sort
+    for( std::pair< TypeNode, SortModel* >& r : d_rep_model ){
+      if( !r->checkLastCall() ){
+        break;
+      }
+    }
+    return;
+  }
   if (!d_state.isInConflict())
   {
     if (options::ufssMode() == options::UfssMode::FULL)
@@ -1749,16 +1759,6 @@ void CardinalityExtension::debugPrint(const char* c)
     it->second->debugPrint( c );
     Debug( c ) << std::endl;
   }
-}
-
-bool CardinalityExtension::checkLastCall()
-{
-  for( std::pair< TypeNode, SortModel* >& r : d_rep_model ){
-    if( !r->checkLastCall() ){
-      return false;
-    }
-  }
-  return true;
 }
 
 /** initialize */

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1182,7 +1182,7 @@ void SortModel::debugPrint( const char* c ){
   }
 }
 
-bool SortModel::debugModel( TheoryModel* m ){
+bool SortModel::checkLastCall(){
   if( Trace.isOn("uf-ss-warn") ){
     std::vector< Node > eqcs;
     eq::EqClassesIterator eqcs_i =
@@ -1203,6 +1203,7 @@ bool SortModel::debugModel( TheoryModel* m ){
       ++eqcs_i;
     }
   }
+  TheoryModel * m = d_state.getModel();
   RepSet* rs = m->getRepSetPtr();
   int nReps = (int)rs->getNumRepresentatives(d_type);
   if( nReps!=(d_maxNegCard+1) ){
@@ -1750,10 +1751,10 @@ void CardinalityExtension::debugPrint(const char* c)
   }
 }
 
-bool CardinalityExtension::debugModel(TheoryModel* m)
+bool CardinalityExtension::checkLastCall()
 {
-  for( std::map< TypeNode, SortModel* >::iterator it = d_rep_model.begin(); it != d_rep_model.end(); ++it ){
-    if( !it->second->debugModel( m ) ){
+  for( std::pair< TypeNode, SortModel* >& r : d_rep_model ){
+    if( !r->checkLastCall() ){
       return false;
     }
   }

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1182,8 +1182,9 @@ void SortModel::debugPrint( const char* c ){
   }
 }
 
-bool SortModel::checkLastCall(){
-  TheoryModel * m = d_state.getModel();
+bool SortModel::checkLastCall()
+{
+  TheoryModel* m = d_state.getModel();
   if( Trace.isOn("uf-ss-warn") ){
     std::vector< Node > eqcs;
     eq::EqClassesIterator eqcs_i =
@@ -1573,11 +1574,13 @@ bool CardinalityExtension::areDisequal(Node a, Node b)
 /** check */
 void CardinalityExtension::check(Theory::Effort level)
 {
-  if (level==Theory::EFFORT_LAST_CALL)
+  if (level == Theory::EFFORT_LAST_CALL)
   {
     // if last call, call last call check for each sort
-    for( std::pair< const TypeNode, SortModel* >& r : d_rep_model ){
-      if( !r.second->checkLastCall() ){
+    for (std::pair<const TypeNode, SortModel*>& r : d_rep_model)
+    {
+      if (!r.second->checkLastCall())
+      {
         break;
       }
     }

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -327,8 +327,15 @@ class CardinalityExtension
     int getMaximumNegativeCardinality() { return d_maxNegCard.get(); }
     //print debug
     void debugPrint( const char* c );
-    /** debug a model */
-    bool debugModel( TheoryModel* m );
+    /** 
+    * Check at last call effort. This will verify that the model is minimal.
+    * This return lemmas if there are terms in the model that the cardinality
+    * extension was not notified of.
+    * 
+    * @return false if current model is not minimal. In this case, lemmas are
+    * sent on the output channel of the UF theory.
+    */
+    bool checkLastCall();
     /** get number of regions (for debugging) */
     int getNumRegions();
 
@@ -387,8 +394,6 @@ class CardinalityExtension
   std::string identify() const { return std::string("CardinalityExtension"); }
   //print debug
   void debugPrint( const char* c );
-  /** Check at last call effort */
-  bool checkLastCall();
   /** get cardinality for node */
   int getCardinality( Node n );
   /** get cardinality for type */

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -327,14 +327,14 @@ class CardinalityExtension
     int getMaximumNegativeCardinality() { return d_maxNegCard.get(); }
     //print debug
     void debugPrint( const char* c );
-    /** 
-    * Check at last call effort. This will verify that the model is minimal.
-    * This return lemmas if there are terms in the model that the cardinality
-    * extension was not notified of.
-    * 
-    * @return false if current model is not minimal. In this case, lemmas are
-    * sent on the output channel of the UF theory.
-    */
+    /**
+     * Check at last call effort. This will verify that the model is minimal.
+     * This return lemmas if there are terms in the model that the cardinality
+     * extension was not notified of.
+     *
+     * @return false if current model is not minimal. In this case, lemmas are
+     * sent on the output channel of the UF theory.
+     */
     bool checkLastCall();
     /** get number of regions (for debugging) */
     int getNumRegions();

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -387,8 +387,8 @@ class CardinalityExtension
   std::string identify() const { return std::string("CardinalityExtension"); }
   //print debug
   void debugPrint( const char* c );
-  /** debug a model */
-  bool debugModel( TheoryModel* m );
+  /** Check at last call effort */
+  bool checkLastCall();
   /** get cardinality for node */
   int getCardinality( Node n );
   /** get cardinality for type */

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -142,7 +142,7 @@ void TheoryUF::postCheck(Effort level)
   {
     d_thss->check(level);
   }
-  // check with the higher-order extension
+  // check with the higher-order extension at full effort
   if (!d_state.isInConflict() && fullEffort(level))
   {
     if (options::ufHo())

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -125,6 +125,12 @@ static Node mkAnd(const std::vector<TNode>& conjunctions) {
 
 //--------------------------------- standard check
 
+bool TheoryUF::needsCheckLastEffort()
+{
+  // last call effort needed if using finite model finding
+  return d_thss != nullptr;
+}
+
 void TheoryUF::postCheck(Effort level)
 {
   if (d_state.isInConflict())

--- a/src/theory/uf/theory_uf.h
+++ b/src/theory/uf/theory_uf.h
@@ -189,10 +189,6 @@ private:
   EqualityStatus getEqualityStatus(TNode a, TNode b) override;
 
   std::string identify() const override { return "THEORY_UF"; }
-
-  /** get a pointer to the uf with cardinality */
-  CardinalityExtension* getCardinalityExtension() const { return d_thss.get(); }
-
  private:
   /** Explain why this literal is true by building an explanation */
   void explain(TNode literal, Node& exp);

--- a/src/theory/uf/theory_uf.h
+++ b/src/theory/uf/theory_uf.h
@@ -158,6 +158,8 @@ private:
   //--------------------------------- end initialization
 
   //--------------------------------- standard check
+  /** Do we need a check call at last call effort? */
+  bool needsCheckLastEffort() override;
   /** Post-check, called after the fact queue of the theory is processed. */
   void postCheck(Effort level) override;
   /** Pre-notify fact, return true if processed. */

--- a/src/theory/valuation.h
+++ b/src/theory/valuation.h
@@ -107,7 +107,8 @@ public:
   Node getModelValue(TNode var);
 
   /**
-   * Returns pointer to model.
+   * Returns pointer to model. This model is only valid during last call effort
+   * check.
    */
   TheoryModel* getModel();
 

--- a/test/regress/regress0/fmf/issue4850-force-card.smt2
+++ b/test/regress/regress0/fmf/issue4850-force-card.smt2
@@ -1,0 +1,6 @@
+(set-logic UFC)
+(set-info :status sat)
+(declare-sort a 0)
+(declare-fun b () a)
+(assert (not (fmf.card b 1)))
+(check-sat)


### PR DESCRIPTION
This moves model minimization happen in TheoryUF's last call effort check instead of being a custom call in quantifiers finite model finding. This is both a better design and avoids bugs when quantifiers are not enabled (for `QF_UF`+cardinality constraints).

Fixes #4850.