### PR TITLE
Fix type for Windows build

### DIFF
--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -877,7 +877,7 @@ Node BVToInt::reconstructNode(Node originalNode,
   {
     builder << originalNode.getOperator();
   }
-  for (uint i = 0; i < originalNode.getNumChildren(); i++)
+  for (size_t i = 0; i < originalNode.getNumChildren(); i++)
   {
     Node originalChild = originalNode[i];
     Node translatedChild = translated_children[i];


### PR DESCRIPTION
The `BVToInt` preprocessing pass was using `uint`, which appears to be
undefined when we cross-compile for Windows. This commit fixes the issue
by using `size_t`.