### PR TITLE
Dumping internal define-funs with no arguments

### DIFF
--- a/src/smt/node_command.cpp
+++ b/src/smt/node_command.cpp
@@ -166,7 +166,7 @@ void DefineFunctionNodeCommand::toStream(std::ostream& out,
 {
   TypeNode tn = d_fun.getType();
   bool hasRange =
-      ((tn.isFunction()) || (tn.isConstructor()) || (tn.isSelector()));
+      (tn.isFunction() || tn.isConstructor() || tn.isSelector());
   Printer::getPrinter(language)->toStreamCmdDefineFunction(
       out,
       d_fun.toString(),

--- a/src/smt/node_command.cpp
+++ b/src/smt/node_command.cpp
@@ -164,11 +164,14 @@ void DefineFunctionNodeCommand::toStream(std::ostream& out,
                                          size_t dag,
                                          OutputLanguage language) const
 {
+  TypeNode tn = d_fun.getType();
+  bool hasRange =
+      ((tn.isFunction()) || (tn.isConstructor()) || (tn.isSelector()));
   Printer::getPrinter(language)->toStreamCmdDefineFunction(
       out,
       d_fun.toString(),
       d_formals,
-      d_fun.getType().getRangeType(),
+      (hasRange ? d_fun.getType().getRangeType() : tn),
       d_formula);
 }
 

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -673,6 +673,7 @@ set(regress_0_tests
   regress0/preprocess/preprocess_13.cvc
   regress0/preprocess/preprocess_14.cvc
   regress0/preprocess/preprocess_15.cvc
+  regress0/print_define_fun_internal.smt2
   regress0/print_lambda.cvc
   regress0/print_model.cvc
   regress0/printer/bv_consts_bin.smt2

--- a/test/regress/regress0/print_define_fun_internal.smt2
+++ b/test/regress/regress0/print_define_fun_internal.smt2
@@ -1,0 +1,10 @@
+; COMMAND-LINE: --solve-real-as-int --dump=assertions:post-real-to-int
+; EXIT: 0
+; SCRUBBER: grep -v -E '.*'
+(set-logic QF_NRA)
+(declare-fun a () Real)
+(declare-fun b () Real)
+(assert (= (* a a) 4))
+(assert (= (* b b) 0))
+(assert (= (+ (* a a) (* b b)) 4))
+(check-sat)


### PR DESCRIPTION
Currently, `--dump=assertions:...` fails if a `define-fun` command is executed internally (an example for this can be found [here](https://github.com/CVC4/CVC4/blob/bcaebfa163bb27e1cf14c0f763afb47b185a5f99/src/preprocessing/passes/real_to_int.cpp#L177).

The failure occurs because the printer expects a range type whenever a `define-fun` command is executed. However, when this command is used for 0-ary functions (variables), the getter for the range fails.

This PR fixes this by asking for a range only if the type is indeed a function. Otherwise, the original type is printed.

A test that currently fails but passes with this PR is included.