### PR TITLE
Require dumping in a dumping test

### DIFF
--- a/test/regress/regress0/print_define_fun_internal.smt2
+++ b/test/regress/regress0/print_define_fun_internal.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: dumping
 ; COMMAND-LINE: --solve-real-as-int --dump=assertions:post-real-to-int
 ; EXIT: 0
 ; SCRUBBER: grep -v -E '.*'


### PR DESCRIPTION
Add `; REQUIRES: dumping` to a dumping test.
Fixes nightlies.