### PR TITLE
Fix compilation without LibPoly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
         include:
           - name: production
-            config: production --all-bindings --lfsc --editline
+            config: production --all-bindings --lfsc --editline --poly
             cache-key: production
             python-bindings: true
             check-examples: true
@@ -44,7 +44,7 @@ jobs:
             exclude_regress: 1-4
 
           - name: debug-cln
-            config: debug --symfpu --cln --gpl --no-debug-symbols --no-proofs
+            config: debug --symfpu --cln --gpl --no-debug-symbols --no-proofs --poly
             cache-key: debug-cln
             os: ubuntu-latest
             exclude_regress: 1-4
@@ -158,7 +158,6 @@ jobs:
       run: |
         ${{ matrix.env }} ./configure.sh ${{ matrix.config }} \
           --python3 \
-          --poly \
           --prefix=$(pwd)/build/install \
           --unit-testing
 

--- a/src/theory/arith/nl/icp/icp_solver.cpp
+++ b/src/theory/arith/nl/icp/icp_solver.cpp
@@ -14,8 +14,6 @@
 
 #include "theory/arith/nl/icp/icp_solver.h"
 
-#ifdef CVC4_POLY_IMP
-
 #include <iostream>
 
 #include "base/check.h"
@@ -32,6 +30,8 @@ namespace theory {
 namespace arith {
 namespace nl {
 namespace icp {
+
+#ifdef CVC4_POLY_IMP
 
 namespace {
 /** A simple wrapper to nicely print an interval assignment. */
@@ -355,10 +355,22 @@ void ICPSolver::check()
   }
 }
 
+#else /* CVC4_POLY_IMP */
+
+void ICPSolver::reset(const std::vector<Node>& assertions)
+{
+  Unimplemented() << "ICPSolver requires CVC4 to be configured with LibPoly";
+}
+
+void ICPSolver::check()
+{
+  Unimplemented() << "ICPSolver requires CVC4 to be configured with LibPoly";
+}
+
+#endif /* CVC4_POLY_IMP */
+
 }  // namespace icp
 }  // namespace nl
 }  // namespace arith
 }  // namespace theory
 }  // namespace CVC4
-
-#endif

--- a/src/theory/arith/nl/icp/icp_solver.h
+++ b/src/theory/arith/nl/icp/icp_solver.h
@@ -19,6 +19,7 @@
 
 #ifdef CVC4_POLY_IMP
 #include <poly/polyxx.h>
+#endif /* CVC4_POLY_IMP */
 
 #include "expr/node.h"
 #include "theory/arith/inference_manager.h"
@@ -33,6 +34,8 @@ namespace theory {
 namespace arith {
 namespace nl {
 namespace icp {
+
+#ifdef CVC4_POLY_IMP
 
 /**
  * This class implements an ICP-based solver. As it is intended to be used in
@@ -132,11 +135,22 @@ class ICPSolver
   void check();
 };
 
+#else /* CVC4_POLY_IMP */
+
+class ICPSolver
+{
+ public:
+  ICPSolver(InferenceManager& im) {}
+  void reset(const std::vector<Node>& assertions);
+  void check();
+};
+
+#endif /* CVC4_POLY_IMP */
+
 }  // namespace icp
 }  // namespace nl
 }  // namespace arith
 }  // namespace theory
 }  // namespace CVC4
 
-#endif
 #endif


### PR DESCRIPTION
Commit e969318f12d4e8ee01b12933e9e60fafafd96963 introduced the ICP-based
solver for nonlinear arithmetic. That code, however, depends on LibPoly.
When configuring CVC4 without LibPoly, the code doesn't compile because
the class `ICPSolver` is missing. This commit adds a dummy version if
`ICPSolver` to remedy the issue.