### PR TITLE
Restrict bvxnor to only allow two operands (was n-ary).

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,11 @@ Changes:
   SMT-LIB 2.6 semantics.
 * The `competition` build type includes the dependencies used for SMT-COMP by
   default. Note that this makes this build type produce GPL-licensed binaries.
+* Bit-vector operator bvxnor was previously mistakenly marked as
+  left-assoicative in SMT-LIB. This has recently been corrected in SMT-LIB. We
+  now restrict bvxnor to only allow two operands in order to avoid confusion
+  about the semantics, since the behavior of n-ary operands to bvxnor is now
+  undefined in SMT-LIB.
 
 
 Changes since 1.7

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -3145,7 +3145,7 @@ Term Solver::mkTermHelper(Kind kind, const std::vector<Term>& children) const
   if (echildren.size() > 2)
   {
     if (kind == INTS_DIVISION || kind == XOR || kind == MINUS
-        || kind == DIVISION || kind == BITVECTOR_XNOR || kind == HO_APPLY)
+        || kind == DIVISION || kind == HO_APPLY)
     {
       // left-associative, but CVC4 internally only supports 2 args
       res = d_exprMgr->mkLeftAssociative(k, echildren);

--- a/test/regress/regress0/parser/bv_arity_smt2.6.smt2
+++ b/test/regress/regress0/parser/bv_arity_smt2.6.smt2
@@ -8,6 +8,5 @@
             (not (= (bvmul x y z) (bvmul (bvmul x y) z)))
             (not (= (bvand x y z) (bvand (bvand x y) z)))
             (not (= (bvor x y z) (bvor (bvor x y) z)))
-            (not (= (bvxor x y z) (bvxor (bvxor x y) z)))
-            (not (= (bvxnor x y z) (bvxnor (bvxnor x y) z)))))
+            (not (= (bvxor x y z) (bvxor (bvxor x y) z)))))
 (check-sat)


### PR DESCRIPTION
Bit-vector operator bvxnor was previously mistakenly marked as
left-assoicative in SMT-LIB. This has recently been corrected in
SMT-LIB. We  now restrict bvxnor to only allow two operands in order to
avoid confusion about the semantics, since the behavior of n-ary
operands to bvxnor is now undefined in SMT-LIB.