### PR TITLE
Reset assertions on resetAssertions

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -2028,6 +2028,7 @@ void SmtEngine::resetAssertions()
         getOutputManager().getDumpOut());
   }
 
+  d_asserts->clearCurrent();
   d_state->notifyResetAssertions();
   d_dumpm->resetAssertions();
   // push the state to maintain global context around everything

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -576,6 +576,7 @@ set(regress_0_tests
   regress0/issue2832-qualId.smt2
   regress0/issue4010-sort-inf-var.smt2
   regress0/issue4469-unc-no-reuse-var.smt2
+  regress0/issue5144-resetAssertions.smt2
   regress0/ite.cvc
   regress0/ite2.smt2
   regress0/ite3.smt2

--- a/test/regress/regress0/issue5144-resetAssertions.smt2
+++ b/test/regress/regress0/issue5144-resetAssertions.smt2
@@ -1,4 +1,5 @@
 (set-logic QF_LIA)
+(set-info :status sat)
 (assert (= 0 1))
 (reset-assertions)
 (check-sat)

--- a/test/regress/regress0/issue5144-resetAssertions.smt2
+++ b/test/regress/regress0/issue5144-resetAssertions.smt2
@@ -1,0 +1,4 @@
+(set-logic QF_LIA)
+(assert (= 0 1))
+(reset-assertions)
+(check-sat)


### PR DESCRIPTION
The assertions object is currently not cleared on resetAssertions, only the prop engine is reset. This means that if a user added assertion, did not use them in a check-sat, and then called reset-assertions, they would not be removed from the assertions pipeline (storing the pending assertions before they are sent to the prop engine).

This fixes #5144.