### PR TITLE
Add missing includes.

### DIFF
--- a/src/theory/arith/nl/strategy.cpp
+++ b/src/theory/arith/nl/strategy.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/arith/nl/strategy.h"
 
+#include <iostream>
+
 #include "base/check.h"
 #include "options/arith_options.h"
 

--- a/src/theory/arith/nl/strategy.h
+++ b/src/theory/arith/nl/strategy.h
@@ -15,6 +15,7 @@
 #ifndef CVC4__THEORY__ARITH__NL__STRATEGY_H
 #define CVC4__THEORY__ARITH__NL__STRATEGY_H
 
+#include <iosfwd>
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
The strategy class added in #5160 was missing the proper includes for `std::ostream`. For some reason it works for most configurations, but triggers compilation errors in certain cases.