### PR TITLE
Update theory of arithmetic to standard check

### DIFF
--- a/src/theory/arith/nl/nl_solver.h
+++ b/src/theory/arith/nl/nl_solver.h
@@ -31,7 +31,7 @@
 #include "theory/arith/nl/nl_lemma_utils.h"
 #include "theory/arith/nl/nl_model.h"
 #include "theory/arith/nl/nl_monomial.h"
-#include "theory/arith/theory_arith.h"
+#include "theory/arith/inference_manager.h"
 
 namespace CVC4 {
 namespace theory {

--- a/src/theory/arith/nl/nonlinear_extension.h
+++ b/src/theory/arith/nl/nonlinear_extension.h
@@ -37,7 +37,6 @@
 #include "theory/arith/nl/stats.h"
 #include "theory/arith/nl/strategy.h"
 #include "theory/arith/nl/transcendental_solver.h"
-#include "theory/arith/theory_arith.h"
 #include "theory/ext_theory.h"
 #include "theory/uf/equality_engine.h"
 

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -140,7 +140,9 @@ void TheoryArith::postCheck(Effort level)
 bool TheoryArith::preNotifyFact(
     TNode atom, bool pol, TNode fact, bool isPrereg, bool isInternal)
 {
-  d_internal->notifyFact(atom, pol, fact);
+  d_internal->preNotifyFact(atom, pol, fact);
+  // We do not assert to the equality engine of arithmetic in the standard way,
+  // hence we return "true" to indicate we are finished with this fact.
   return true;
 }
 

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -128,7 +128,10 @@ bool TheoryArith::needsCheckLastEffort() {
   return d_internal->needsCheckLastEffort();
 }
 
-TrustNode TheoryArith::explain(TNode n) { return d_aim.explainLit(n); }
+TrustNode TheoryArith::explain(TNode n) {   
+  Node exp = d_internal->explain(n);	
+  return TrustNode::mkTrustPropExp(n, exp, nullptr); 
+}
 
 void TheoryArith::propagate(Effort e) {
   d_internal->propagate(e);
@@ -159,7 +162,6 @@ bool TheoryArith::collectModelValues(TheoryModel* m,
   {
     // maps to constant of comparable type
     Assert(p.first.getType().isComparableTo(p.second.getType()));
-    Assert(p.second.isConst());
     if (m->assertEquality(p.first, p.second, true))
     {
       continue;

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -170,7 +170,7 @@ bool TheoryArith::collectModelInfo(TheoryModel* m)
   // Work out which variables are needed
   const std::set<Kind>& irrKinds = m->getIrrelevantKinds();
   computeAssertedTerms(termSet, irrKinds);
-  // this override behavior to not assert equality engine
+  // this overrides behavior to not assert equality engine
   return collectModelValues(m, termSet);
 }
 

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -90,12 +90,13 @@ void TheoryArith::finishInit()
   d_internal->finishInit();
 }
 
-void TheoryArith::preRegisterTerm(TNode n) { 
+void TheoryArith::preRegisterTerm(TNode n)
+{
   if (d_nonlinearExtension != nullptr)
   {
     d_nonlinearExtension->preRegisterTerm(n);
   }
-  d_internal->preRegisterTerm(n); 
+  d_internal->preRegisterTerm(n);
 }
 
 TrustNode TheoryArith::expandDefinition(Node node)
@@ -121,7 +122,8 @@ void TheoryArith::ppStaticLearn(TNode n, NodeBuilder<>& learned) {
 
 bool TheoryArith::preCheck(Effort level) { return d_internal->preCheck(level); }
 
-void TheoryArith::postCheck(Effort level) { 
+void TheoryArith::postCheck(Effort level)
+{
   // check with the non-linear solver at last call
   if (level == Theory::EFFORT_LAST_CALL)
   {
@@ -132,7 +134,7 @@ void TheoryArith::postCheck(Effort level) {
     return;
   }
   // otherwise, check with the linear solver
-  d_internal->postCheck(level); 
+  d_internal->postCheck(level);
 }
 
 bool TheoryArith::preNotifyFact(
@@ -150,9 +152,10 @@ bool TheoryArith::needsCheckLastEffort() {
   return false;
 }
 
-TrustNode TheoryArith::explain(TNode n) {   
-  Node exp = d_internal->explain(n);	
-  return TrustNode::mkTrustPropExp(n, exp, nullptr); 
+TrustNode TheoryArith::explain(TNode n)
+{
+  Node exp = d_internal->explain(n);
+  return TrustNode::mkTrustPropExp(n, exp, nullptr);
 }
 
 void TheoryArith::propagate(Effort e) {

--- a/src/theory/arith/theory_arith.cpp
+++ b/src/theory/arith/theory_arith.cpp
@@ -159,10 +159,13 @@ void TheoryArith::propagate(Effort e) {
   d_internal->propagate(e);
 }
 
-bool TheoryArith::collectModelInfo(TheoryModel* m,
-                                   const std::set<Node>& termSet)
+bool TheoryArith::collectModelInfo(TheoryModel* m)
 {
-  // overrides behavior to not assert the equality engine
+  std::set<Node> termSet;
+  // Work out which variables are needed
+  const std::set<Kind>& irrKinds = m->getIrrelevantKinds();
+  computeAssertedTerms(termSet, irrKinds);
+  // this override behavior to not assert equality engine
   return collectModelValues(m, termSet);
 }
 

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -20,6 +20,7 @@
 #include "expr/node.h"
 #include "theory/arith/arith_state.h"
 #include "theory/arith/inference_manager.h"
+#include "theory/arith/nl/nonlinear_extension.h"
 #include "theory/arith/theory_arith_private_forward.h"
 #include "theory/theory.h"
 

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -19,7 +19,6 @@
 
 #include "expr/node.h"
 #include "theory/arith/arith_state.h"
-#include "theory/arith/equality_solver.h"
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/theory_arith_private_forward.h"
 #include "theory/theory.h"

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -28,8 +28,6 @@ namespace CVC4 {
 namespace theory {
 namespace arith {
 
-class EqualitySolver;
-
 /**
  * Implementation of linear and non-linear integer and real arithmetic.
  * The linear arithmetic solver is based upon:

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -19,6 +19,7 @@
 
 #include "expr/node.h"
 #include "theory/arith/arith_state.h"
+#include "theory/arith/equality_solver.h"
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/theory_arith_private_forward.h"
 #include "theory/theory.h"
@@ -27,9 +28,7 @@ namespace CVC4 {
 namespace theory {
 namespace arith {
 
-namespace nl {
-class NonlinearExtension;
-}
+class EqualitySolver;
 
 /**
  * Implementation of linear and non-linear integer and real arithmetic.
@@ -75,12 +74,23 @@ class TheoryArith : public Theory {
 
   TrustNode expandDefinition(Node node) override;
 
-  void check(Effort e) override;
+  //--------------------------------- standard check
+  /** Pre-check, called before the fact queue of the theory is processed. */
+  bool preCheck(Effort level) override;
+  /** Post-check, called after the fact queue of the theory is processed. */
+  void postCheck(Effort level) override;
+  /** Pre-notify fact, return true if processed. */
+  bool preNotifyFact(TNode atom,
+                     bool pol,
+                     TNode fact,
+                     bool isPrereg,
+                     bool isInternal) override;
+  //--------------------------------- end standard check
   bool needsCheckLastEffort() override;
   void propagate(Effort e) override;
   TrustNode explain(TNode n) override;
 
-  bool collectModelInfo(TheoryModel* m) override;
+  bool collectModelInfo(TheoryModel* m, const std::set<Node>& termSet) override;
   /**
    * Collect model values in m based on the relevant terms given by termSet.
    */
@@ -116,7 +126,6 @@ class TheoryArith : public Theory {
   eq::ProofEqEngine* getProofEqEngine();
   /** The state object wrapping TheoryArithPrivate  */
   ArithState d_astate;
-
   /** The arith::InferenceManager. */
   InferenceManager d_inferenceManager;
 

--- a/src/theory/arith/theory_arith.h
+++ b/src/theory/arith/theory_arith.h
@@ -87,7 +87,7 @@ class TheoryArith : public Theory {
   void propagate(Effort e) override;
   TrustNode explain(TNode n) override;
 
-  bool collectModelInfo(TheoryModel* m, const std::set<Node>& termSet) override;
+  bool collectModelInfo(TheoryModel* m) override;
   /**
    * Collect model values in m based on the relevant terms given by termSet.
    */

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -3305,6 +3305,7 @@ bool TheoryArithPrivate::hasFreshArithLiteral(Node n) const{
 
 bool TheoryArithPrivate::preCheck(Theory::Effort level)
 {
+  Assert(d_currentPropagationList.empty());
   if(Debug.isOn("arith::consistency")){
     Assert(unenqueuedVariablesAreConsistent());
   }

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -1479,11 +1479,6 @@ void TheoryArithPrivate::setupAtom(TNode atom) {
 void TheoryArithPrivate::preRegisterTerm(TNode n) {
   Debug("arith::preregister") <<"begin arith::preRegisterTerm("<< n <<")"<< endl;
 
-  if (d_nonlinearExtension != nullptr)
-  {
-    d_nonlinearExtension->preRegisterTerm(n);
-  }
-
   try {
     if(isRelationOperator(n.getKind())){
       if(!isSetup(n)){
@@ -3338,14 +3333,6 @@ void TheoryArithPrivate::notifyFact(TNode atom, bool pol, TNode fact)
 
 void TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
 {
-  if (effortLevel == Theory::EFFORT_LAST_CALL)
-  {
-    if (d_nonlinearExtension != nullptr)
-    {
-      d_nonlinearExtension->check(effortLevel);
-    }
-    return;
-  }
   if(!anyConflict()){
     while(!d_learnedBounds.empty()){
       // we may attempt some constraints twice.  this is okay!
@@ -3857,15 +3844,6 @@ void TheoryArithPrivate::debugPrintModel(std::ostream& out) const{
   }
 }
 
-bool TheoryArithPrivate::needsCheckLastEffort() {
-  if (d_nonlinearExtension != nullptr)
-  {
-    return d_nonlinearExtension->needsCheckLastEffort();
-  }else{
-    return false;
-  }
-}
-
 Node TheoryArithPrivate::explain(TNode n)
 {
   Debug("arith::explain") << "explain @" << getSatContext()->getLevel() << ": " << n << endl;
@@ -4256,11 +4234,6 @@ void TheoryArithPrivate::presolve(){
     Node lem = *i;
     Debug("arith::oldprop") << " lemma lemma duck " <<lem << endl;
     outputLemma(lem);
-  }
-
-  if (d_nonlinearExtension != nullptr)
-  {
-    d_nonlinearExtension->presolve();
   }
 }
 

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -3321,7 +3321,7 @@ bool TheoryArithPrivate::preCheck(Theory::Effort level)
   return false;
 }
 
-void TheoryArithPrivate::notifyFact(TNode atom, bool pol, TNode fact)
+void TheoryArithPrivate::preNotifyFact(TNode atom, bool pol, TNode fact)
 {
   ConstraintP curr = constraintFromFactQueue(fact);
   if (curr != NullConstraint)

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -1080,7 +1080,7 @@ void TheoryArithPrivate::notifySharedTerm(TNode n)
   if(n.isConst()){
     d_partialModel.invalidateDelta();
   }
-
+  d_congruenceManager.addSharedTerm(n);
   if(!n.isConst() && !isSetup(n)){
     Polynomial poly = Polynomial::parsePolynomial(n);
     Polynomial::iterator it = poly.begin();

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -169,8 +169,11 @@ TheoryArithPrivate::TheoryArithPrivate(TheoryArith& containing,
       d_dioSolveResources(0),
       d_solveIntMaybeHelp(0u),
       d_solveIntAttempts(0u),
+      d_newFacts(false),
+      d_previousStatus(Result::SAT_UNKNOWN),
       d_statistics(),
-      d_opElim(pnm, logicInfo)
+      d_opElim(pnm, logicInfo),
+      d_arithStateConflict(c, false)
 {
   ProofChecker* pc = pnm != nullptr ? pnm->getChecker() : nullptr;
   if (pc != nullptr)
@@ -543,6 +546,13 @@ void TheoryArithPrivate::raiseBlackBoxConflict(Node bb){
     d_blackBoxConflict = bb;
   }
 }
+
+bool TheoryArithPrivate::anyConflict() const
+{
+  return !conflictQueueEmpty() || !d_blackBoxConflict.get().isNull();
+}
+
+void TheoryArithPrivate::notifyInConflict() { d_arithStateConflict = true; }
 
 void TheoryArithPrivate::revertOutOfConflict(){
   d_partialModel.revertAssignmentChanges();
@@ -1067,13 +1077,13 @@ bool TheoryArithPrivate::AssertDisequality(ConstraintP constraint){
   return false;
 }
 
-void TheoryArithPrivate::addSharedTerm(TNode n){
-  Debug("arith::addSharedTerm") << "addSharedTerm: " << n << endl;
+void TheoryArithPrivate::notifySharedTerm(TNode n)
+{
+  Debug("arith::notifySharedTerm") << "notifySharedTerm: " << n << endl;
   if(n.isConst()){
     d_partialModel.invalidateDelta();
   }
 
-  d_congruenceManager.addSharedTerm(n);
   if(!n.isConst() && !isSetup(n)){
     Polynomial poly = Polynomial::parsePolynomial(n);
     Polynomial::iterator it = poly.begin();
@@ -1701,10 +1711,8 @@ Node TheoryArithPrivate::callDioSolver(){
   return d_diosolver.processEquationsForConflict();
 }
 
-ConstraintP TheoryArithPrivate::constraintFromFactQueue(){
-  Assert(!done());
-  TNode assertion = get();
-
+ConstraintP TheoryArithPrivate::constraintFromFactQueue(TNode assertion)
+{
   Kind simpleKind = Comparison::comparisonKind(assertion);
   ConstraintP constraint = d_constraintDatabase.lookup(assertion);
   if(constraint == NullConstraint){
@@ -1962,37 +1970,24 @@ void TheoryArithPrivate::outputConflicts(){
 
 void TheoryArithPrivate::outputLemma(TNode lem) {
   Debug("arith::channel") << "Arith lemma: " << lem << std::endl;
-  (d_containing.d_out)->lemma(lem);
+  d_containing.d_out.lemma(lem);
 }
 
 void TheoryArithPrivate::outputConflict(TNode lit) {
   Debug("arith::channel") << "Arith conflict: " << lit << std::endl;
-  (d_containing.d_out)->conflict(lit);
+  d_containing.d_out.conflict(lit);
 }
 
 void TheoryArithPrivate::outputPropagate(TNode lit) {
   Debug("arith::channel") << "Arith propagation: " << lit << std::endl;
-  (d_containing.d_out)->propagate(lit);
+  // call the propagate lit method of the
+  d_containing.d_out.propagate(lit);
 }
 
 void TheoryArithPrivate::outputRestart() {
   Debug("arith::channel") << "Arith restart!" << std::endl;
   (d_containing.d_out)->demandRestart();
 }
-
-// void TheoryArithPrivate::branchVector(const std::vector<ArithVar>& lemmas){
-//   //output the lemmas
-//   for(vector<ArithVar>::const_iterator i = lemmas.begin(); i != lemmas.end();
-//   ++i){
-//     ArithVar v = *i;
-//     Assert(!d_cutInContext.contains(v));
-//     d_cutInContext.insert(v);
-//     d_cutCount = d_cutCount + 1;
-//     Node lem = branchIntegerVariable(v);
-//     outputLemma(lem);
-//     ++(d_statistics.d_externalBranchAndBounds);
-//   }
-// }
 
 bool TheoryArithPrivate::attemptSolveInteger(Theory::Effort effortLevel, bool emmmittedLemmaOrSplit){
   int level = getSatContext()->getLevel();
@@ -3316,46 +3311,43 @@ bool TheoryArithPrivate::hasFreshArithLiteral(Node n) const{
   }
 }
 
-void TheoryArithPrivate::check(Theory::Effort effortLevel){
-  Assert(d_currentPropagationList.empty());
-
-  if(done() && effortLevel < Theory::EFFORT_FULL && ( d_qflraStatus == Result::SAT) ){
-    return;
+bool TheoryArithPrivate::preCheck(Theory::Effort level)
+{
+  if(Debug.isOn("arith::consistency")){
+    Assert(unenqueuedVariablesAreConsistent());
   }
 
-  if(effortLevel == Theory::EFFORT_LAST_CALL){
+  d_newFacts = !done();
+  // If d_previousStatus == SAT, then reverts on conflicts are safe
+  // Otherwise, they are not and must be committed.
+  d_previousStatus = d_qflraStatus;
+  if (d_newFacts)
+  {
+    d_qflraStatus = Result::SAT_UNKNOWN;
+    d_hasDoneWorkSinceCut = true;
+  }
+  return false;
+}
+
+void TheoryArithPrivate::notifyFact(TNode atom, bool pol, TNode fact)
+{
+  ConstraintP curr = constraintFromFactQueue(fact);
+  if (curr != NullConstraint)
+  {
+    bool res CVC4_UNUSED = assertionCases(curr);
+    Assert(!res || anyConflict());
+  }
+}
+
+void TheoryArithPrivate::postCheck(Theory::Effort effortLevel)
+{
+  if (effortLevel == Theory::EFFORT_LAST_CALL)
+  {
     if (d_nonlinearExtension != nullptr)
     {
       d_nonlinearExtension->check(effortLevel);
     }
     return;
-  }
-
-  TimerStat::CodeTimer checkTimer(d_containing.d_checkTime);
-  //cout << "TheoryArithPrivate::check " << effortLevel << std::endl;
-  Debug("effortlevel") << "TheoryArithPrivate::check " << effortLevel << std::endl;
-  Debug("arith") << "TheoryArithPrivate::check begun " << effortLevel << std::endl;
-
-  if(Debug.isOn("arith::consistency")){
-    Assert(unenqueuedVariablesAreConsistent());
-  }
-
-  bool newFacts = !done();
-  //If previous == SAT, then reverts on conflicts are safe
-  //Otherwise, they are not and must be committed.
-  Result::Sat previous = d_qflraStatus;
-  if(newFacts){
-    d_qflraStatus = Result::SAT_UNKNOWN;
-    d_hasDoneWorkSinceCut = true;
-  }
-
-  while(!done()){
-    ConstraintP curr = constraintFromFactQueue();
-    if(curr != NullConstraint){
-      bool res CVC4_UNUSED = assertionCases(curr);
-      Assert(!res || anyConflict());
-    }
-    if(anyConflict()){ break; }
   }
   if(!anyConflict()){
     while(!d_learnedBounds.empty()){
@@ -3373,14 +3365,19 @@ void TheoryArithPrivate::check(Theory::Effort effortLevel){
 
   if(anyConflict()){
     d_qflraStatus = Result::UNSAT;
-    if(options::revertArithModels() && previous == Result::SAT){
+    if (options::revertArithModels() && d_previousStatus == Result::SAT)
+    {
       ++d_statistics.d_revertsOnConflicts;
-      Debug("arith::bt") << "clearing here " << " " << newFacts << " " << previous << " " << d_qflraStatus  << endl;
+      Debug("arith::bt") << "clearing here "
+                         << " " << d_newFacts << " " << d_previousStatus << " "
+                         << d_qflraStatus << endl;
       revertOutOfConflict();
       d_errorSet.clear();
     }else{
       ++d_statistics.d_commitsOnConflicts;
-      Debug("arith::bt") << "committing here " << " " << newFacts << " " << previous << " " << d_qflraStatus  << endl;
+      Debug("arith::bt") << "committing here "
+                         << " " << d_newFacts << " " << d_previousStatus << " "
+                         << d_qflraStatus << endl;
       d_partialModel.commitAssignmentChanges();
       revertOutOfConflict();
     }
@@ -3415,7 +3412,9 @@ void TheoryArithPrivate::check(Theory::Effort effortLevel){
     solveInteger(effortLevel);
     if(anyConflict()){
       ++d_statistics.d_commitsOnConflicts;
-      Debug("arith::bt") << "committing here " << " " << newFacts << " " << previous << " " << d_qflraStatus  << endl;
+      Debug("arith::bt") << "committing here "
+                         << " " << d_newFacts << " " << d_previousStatus << " "
+                         << d_qflraStatus << endl;
       revertOutOfConflict();
       d_errorSet.clear();
       outputConflicts();
@@ -3428,11 +3427,14 @@ void TheoryArithPrivate::check(Theory::Effort effortLevel){
 
   switch(d_qflraStatus){
   case Result::SAT:
-    if(newFacts){
+    if (d_newFacts)
+    {
       ++d_statistics.d_nontrivialSatChecks;
     }
 
-    Debug("arith::bt") << "committing sap inConflit"  << " " << newFacts << " " << previous << " " << d_qflraStatus  << endl;
+    Debug("arith::bt") << "committing sap inConflit"
+                       << " " << d_newFacts << " " << d_previousStatus << " "
+                       << d_qflraStatus << endl;
     d_partialModel.commitAssignmentChanges();
     d_unknownsInARow = 0;
     if(Debug.isOn("arith::consistency")){
@@ -3450,7 +3452,9 @@ void TheoryArithPrivate::check(Theory::Effort effortLevel){
     ++d_unknownsInARow;
     ++(d_statistics.d_unknownChecks);
     Assert(!Theory::fullEffort(effortLevel));
-    Debug("arith::bt") << "committing unknown"  << " " << newFacts << " " << previous << " " << d_qflraStatus  << endl;
+    Debug("arith::bt") << "committing unknown"
+                       << " " << d_newFacts << " " << d_previousStatus << " "
+                       << d_qflraStatus << endl;
     d_partialModel.commitAssignmentChanges();
     d_statistics.d_maxUnknownsInARow.maxAssign(d_unknownsInARow);
 
@@ -3467,7 +3471,9 @@ void TheoryArithPrivate::check(Theory::Effort effortLevel){
 
     ++d_statistics.d_commitsOnConflicts;
 
-    Debug("arith::bt") << "committing on conflict" << " " << newFacts << " " << previous << " " << d_qflraStatus  << endl;
+    Debug("arith::bt") << "committing on conflict"
+                       << " " << d_newFacts << " " << d_previousStatus << " "
+                       << d_qflraStatus << endl;
     d_partialModel.commitAssignmentChanges();
     revertOutOfConflict();
 
@@ -3564,7 +3570,9 @@ void TheoryArithPrivate::check(Theory::Effort effortLevel){
       outputConflicts();
       emmittedConflictOrSplit = true;
       //cout << "unate conflict " << endl;
-      Debug("arith::bt") << "committing on unate conflict" << " " << newFacts << " " << previous << " " << d_qflraStatus  << endl;
+      Debug("arith::bt") << "committing on unate conflict"
+                         << " " << d_newFacts << " " << d_previousStatus << " "
+                         << d_qflraStatus << endl;
 
       Debug("arith::conflict") << "unate arith conflict" << endl;
     }
@@ -3884,7 +3892,7 @@ Node TheoryArithPrivate::explain(TNode n)
       return d_congruenceManager.explain(n);
     }
   }else{
-    Assert(d_congruenceManager.canExplain(n));
+    // Assert(d_congruenceManager.canExplain(n));
     Debug("arith::explain") << "dm explanation" << n << endl;
     return d_congruenceManager.explain(n);
   }

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -172,8 +172,7 @@ TheoryArithPrivate::TheoryArithPrivate(TheoryArith& containing,
       d_newFacts(false),
       d_previousStatus(Result::SAT_UNKNOWN),
       d_statistics(),
-      d_opElim(pnm, logicInfo),
-      d_arithStateConflict(c, false)
+      d_opElim(pnm, logicInfo)
 {
   ProofChecker* pc = pnm != nullptr ? pnm->getChecker() : nullptr;
   if (pc != nullptr)
@@ -551,8 +550,6 @@ bool TheoryArithPrivate::anyConflict() const
 {
   return !conflictQueueEmpty() || !d_blackBoxConflict.get().isNull();
 }
-
-void TheoryArithPrivate::notifyInConflict() { d_arithStateConflict = true; }
 
 void TheoryArithPrivate::revertOutOfConflict(){
   d_partialModel.revertAssignmentChanges();
@@ -1970,18 +1967,18 @@ void TheoryArithPrivate::outputConflicts(){
 
 void TheoryArithPrivate::outputLemma(TNode lem) {
   Debug("arith::channel") << "Arith lemma: " << lem << std::endl;
-  d_containing.d_out.lemma(lem);
+  (d_containing.d_out)->lemma(lem);
 }
 
 void TheoryArithPrivate::outputConflict(TNode lit) {
   Debug("arith::channel") << "Arith conflict: " << lit << std::endl;
-  d_containing.d_out.conflict(lit);
+  (d_containing.d_out)->conflict(lit);
 }
 
 void TheoryArithPrivate::outputPropagate(TNode lit) {
   Debug("arith::channel") << "Arith propagation: " << lit << std::endl;
   // call the propagate lit method of the
-  d_containing.d_out.propagate(lit);
+  (d_containing.d_out)->propagate(lit);
 }
 
 void TheoryArithPrivate::outputRestart() {
@@ -3892,7 +3889,7 @@ Node TheoryArithPrivate::explain(TNode n)
       return d_congruenceManager.explain(n);
     }
   }else{
-    // Assert(d_congruenceManager.canExplain(n));
+    Assert(d_congruenceManager.canExplain(n));
     Debug("arith::explain") << "dm explanation" << n << endl;
     return d_congruenceManager.explain(n);
   }

--- a/src/theory/arith/theory_arith_private.h
+++ b/src/theory/arith/theory_arith_private.h
@@ -343,9 +343,6 @@ private:
    */
   bool anyConflict() const;
 
-  /** External notification (e.g. from ArithState) that we are in conflict */
-  void notifyInConflict();
-
  private:
   inline bool conflictQueueEmpty() const {
     return d_conflicts.empty();
@@ -492,6 +489,7 @@ private:
 
   EqualityStatus getEqualityStatus(TNode a, TNode b);
 
+  /** Called when n is notified as being a shared term with TheoryArith. */
   void notifySharedTerm(TNode n);
 
   Node getModelValue(TNode var);

--- a/src/theory/arith/theory_arith_private.h
+++ b/src/theory/arith/theory_arith_private.h
@@ -502,8 +502,8 @@ private:
   //--------------------------------- standard check
   /** Pre-check, called before the fact queue of the theory is processed. */
   bool preCheck(Theory::Effort level);
-  /** Notify fact. */
-  void notifyFact(TNode atom, bool pol, TNode fact);
+  /** Pre-notify fact. */
+  void preNotifyFact(TNode atom, bool pol, TNode fact);
   /** Post-check, called after the fact queue of the theory is processed. */
   void postCheck(Theory::Effort level);
   //--------------------------------- end standard check
@@ -652,6 +652,9 @@ private:
    * Handles the case splitting for check() for a new assertion.
    * Returns a conflict if one was found.
    * Returns Node::null if no conflict was found.
+   * 
+   * @param assertion The assertion that was just popped from the fact queue
+   * of TheoryArith and given to this class via preNotifyFact.
    */
   ConstraintP constraintFromFactQueue(TNode assertion);
   bool assertionCases(ConstraintP c);

--- a/src/theory/arith/theory_arith_private.h
+++ b/src/theory/arith/theory_arith_private.h
@@ -652,7 +652,7 @@ private:
    * Handles the case splitting for check() for a new assertion.
    * Returns a conflict if one was found.
    * Returns Node::null if no conflict was found.
-   * 
+   *
    * @param assertion The assertion that was just popped from the fact queue
    * of TheoryArith and given to this class via preNotifyFact.
    */

--- a/src/theory/arith/theory_arith_private.h
+++ b/src/theory/arith/theory_arith_private.h
@@ -769,7 +769,9 @@ private:
   RationalVector d_farkasBuffer;
 
   //---------------- during check
+  /** Whether there were new facts during preCheck */
   bool d_newFacts;
+  /** The previous status, computed during preCheck */
   Result::Sat d_previousStatus;
   //---------------- end during check
 
@@ -880,8 +882,6 @@ private:
   ArithRewriter d_rewriter;
   /** The operator elimination utility */
   OperatorElim d_opElim;
-  /** Are we in conflict? */
-  context::CDO<bool> d_arithStateConflict;
 };/* class TheoryArithPrivate */
 
 }/* CVC4::theory::arith namespace */

--- a/src/theory/arith/theory_arith_private.h
+++ b/src/theory/arith/theory_arith_private.h
@@ -461,7 +461,6 @@ private:
   void preRegisterTerm(TNode n);
   TrustNode expandDefinition(Node node);
 
-  bool needsCheckLastEffort();
   void propagate(Theory::Effort e);
   Node explain(TNode n);
 


### PR DESCRIPTION
This updates the theory of arithmetic to use the standard check callbacks (preCheck, postCheck, preNotifyFact, notifyFact). It also refactors some use of the non-linear solver which will solely live in TheoryArith.

The longer term goal is to have TheoryArithPrivate be responsible for linear arithmetic solving only, and to be treated as a black box. Eventually, the non-linear solver will be removed from this class.

This PR is required for several things, including refactoring of preprocessing and expand definitions for arithmetic (div/mod will not be eliminated eagerly). It is also required for fixing issues related to div/mod appearing in instantiations.

This is the last class to have a custom check method.  Followup PR will make Theory::check non-virtual.