### PR TITLE
Replace calls to SmtEngine with calls to Solver.

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -752,9 +752,34 @@ class CVC4ApiExceptionStream
   std::stringstream d_stream;
 };
 
+class CVC4ApiRecoverableExceptionStream
+{
+ public:
+  CVC4ApiRecoverableExceptionStream() {}
+  /* Note: This needs to be explicitly set to 'noexcept(false)' since it is
+   * a destructor that throws an exception and in C++11 all destructors
+   * default to noexcept(true) (else this triggers a call to std::terminate). */
+  ~CVC4ApiRecoverableExceptionStream() noexcept(false)
+  {
+    if (!std::uncaught_exception())
+    {
+      throw CVC4ApiRecoverableException(d_stream.str());
+    }
+  }
+
+  std::ostream& ostream() { return d_stream; }
+
+ private:
+  std::stringstream d_stream;
+};
+
 #define CVC4_API_CHECK(cond) \
   CVC4_PREDICT_TRUE(cond)    \
   ? (void)0 : OstreamVoider() & CVC4ApiExceptionStream().ostream()
+
+#define CVC4_API_RECOVERABLE_CHECK(cond) \
+  CVC4_PREDICT_TRUE(cond)                \
+  ? (void)0 : OstreamVoider() & CVC4ApiRecoverableExceptionStream().ostream()
 
 #define CVC4_API_CHECK_NOT_NULL                     \
   CVC4_API_CHECK(!isNullHelper())                   \
@@ -5075,7 +5100,7 @@ std::vector<Term> Solver::getUnsatCore(void) const
   CVC4_API_CHECK(d_smtEngine->getOptions()[options::unsatCores])
       << "Cannot get unsat core unless explicitly enabled "
          "(try --produce-unsat-cores)";
-  CVC4_API_CHECK(d_smtEngine->getSmtMode() == SmtMode::UNSAT)
+  CVC4_API_RECOVERABLE_CHECK(d_smtEngine->getSmtMode() == SmtMode::UNSAT)
       << "Cannot get unsat core unless in unsat mode.";
   UnsatCore core = d_smtEngine->getUnsatCore();
   /* Can not use

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -996,7 +996,6 @@ class CVC4_PUBLIC GetModelCommand : public Command
 
  protected:
   Model* d_result;
-  SmtEngine* d_smtEngine;
 }; /* class GetModelCommand */
 
 /** The command to block models. */
@@ -1091,7 +1090,7 @@ class CVC4_PUBLIC GetSynthSolutionCommand : public Command
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
  protected:
-  SmtEngine* d_smtEngine;
+  api::Solver* d_solver;
 }; /* class GetSynthSolutionCommand */
 
 /** The command (get-interpol s B (G)?)

--- a/test/regress/regress0/smtlib/set-info-status.smt2
+++ b/test/regress/regress0/smtlib/set-info-status.smt2
@@ -1,4 +1,4 @@
-; EXPECT: (error "Cannot get an unsat core unless immediately preceded by UNSAT/ENTAILED response.")
+; EXPECT: (error "Cannot get unsat core unless in unsat mode.")
 ; EXPECT: sat
 ; EXPECT: sat
 ; EXPECT: unsat


### PR DESCRIPTION
This PR replaces more calls to SmtEngine functions with calls to corresponding Solver functions in `command.cpp`. The PR also adds `CVC4_API_RECOVERABLE_CHECK` macro to use for recoverable exceptions.