### PR TITLE
cmake: Add warning when unit testing is disabled due to assertions being disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ endif()
 # Only enable unit testing if assertions are enabled. Otherwise, unit tests
 # that expect AssertionException to be thrown will fail.
 if(NOT ENABLE_ASSERTIONS)
+  message(WARNING "Disabling unit tests since assertions are disabled.")
   set(ENABLE_UNIT_TESTING OFF)
 endif()
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -229,8 +229,8 @@ We have 4 categories of tests:
   (label: **example**)
 - **regression tests** (5 levels) in directory `test/regress`
   (label: **regressN** with N the regression level)
-- **system tests** in directory `test/system`
-  (label: **system**)
+- **api tests** in directory `test/api`
+  (label: **api**)
 - **unit tests** in directory `test/unit`
   (label: **unit**)
 
@@ -238,25 +238,28 @@ We have 4 categories of tests:
 
 The system tests are not built by default.
 
-    make systemtests                      # build and run all system tests
-    make <system_test>                    # build test/system/<system_test>.<ext>
-    ctest system/<system_test>            # run test/system/<system_test>.<ext>
+    make apitests                         # build and run all system tests
+    make <api_test>                       # build test/system/<system_test>.<ext>
+    ctest api/<api_test>                  # run test/system/<system_test>.<ext>
 
 All system test binaries are built into `<build_dir>/bin/test/system`.
 
-We use prefix `system/` + `<system_test>` (for `<system_test>` in `test/system`)
+We use prefix `api/` + `<api_test>` (for `<api_test>` in `test/api`)
 as test target name.  
 
-    make ouroborous                       # build test/system/ouroborous.cpp
+    make ouroborous                       # build test/api/ouroborous.cpp
     ctest -R ouroborous                   # run all tests that match '*ouroborous*'
-                                          # > runs system/ouroborous
+                                          # > runs api/ouroborous
     ctest -R ouroborous$                  # run all tests that match '*ouroborous'
-                                          # > runs system/ouroborous
-    ctest -R system/ouroborous$           # run all tests that match '*system/ouroborous'
-                                          # > runs system/ouroborous
+                                          # > runs api/ouroborous
+    ctest -R api/ouroborous$              # run all tests that match '*api/ouroborous'
+                                          # > runs api/ouroborous
 ### Testing Unit Tests
 
 The unit tests are not built by default.
+
+To configure CVC4 with unit tests, assertions must be enabled, and building a
+non-static binary must be configured.
 
     make units                            # build and run all unit tests
     make <unit_test>                      # build test/unit/<subdir>/<unit_test>.<ext>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -258,8 +258,8 @@ as test target name.
 
 The unit tests are not built by default.
 
-To configure CVC4 with unit tests, assertions must be enabled, and building a
-non-static binary must be configured.
+Note that CVC4 can only be configured with unit tests in non-static builds with
+assertions enabled.
 
     make units                            # build and run all unit tests
     make <unit_test>                      # build test/unit/<subdir>/<unit_test>.<ext>


### PR DESCRIPTION
This further fixes the testing instructions for API tests (formerly known as `system tests`)
in INSTALL.md.