### PR TITLE
(proof-new) Indexed root predicates

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1158,6 +1158,7 @@ install(FILES
           ${CMAKE_INSTALL_INCLUDEDIR}/cvc4/theory)
 install(FILES
           util/abstract_value.h
+          util/arith.h
           util/bitvector.h
           util/bool.h
           util/cardinality.h

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -616,6 +616,12 @@ void Smt2Printer::toStream(std::ostream& out,
     out << "(_ divisible " << n.getOperator().getConst<Divisible>().k << ")";
     stillNeedToPrintParams = false;
     break;
+  case kind::INDEXED_ROOT_PREDICATE_OP:
+  {
+    const IndexedRootPredicate& irp = n.getConst<IndexedRootPredicate>();
+    out << "(_ root_predicate " << irp.d_index << ")";
+    break;
+  }
 
     // arrays theory
   case kind::SELECT:

--- a/src/theory/arith/kinds
+++ b/src/theory/arith/kinds
@@ -80,6 +80,13 @@ operator LEQ 2 "less than or equal, x <= y"
 operator GT 2 "greater than, x > y"
 operator GEQ 2 "greater than or equal, x >= y"
 
+constant INDEXED_ROOT_PREDICATE_OP \
+	::CVC4::IndexedRootPredicate \
+	::CVC4::IndexedRootPredicateHashFunction \
+	"util/arith.h" \
+	"operator for the indexed root predicate; payload is an instance of the CVC4::IndexedRootPredicate class"
+parameterized INDEXED_ROOT_PREDICATE INDEXED_ROOT_PREDICATE_OP 2 "indexed root predicate; first parameter is a INDEXED_ROOT_PREDICATE_OP, second is a real variable, third is a polynomial compared to zero"
+
 operator IS_INTEGER 1 "term-is-integer predicate (parameter is a real-sorted term)"
 operator TO_INTEGER 1 "convert term to integer by the floor function (parameter is a real-sorted term)"
 operator TO_REAL 1 "cast term to real (parameter is an integer-sorted term; this is a no-op in CVC4, as integer is a subtype of real)"
@@ -98,6 +105,9 @@ typerule LT "SimpleTypeRule<RBool, AReal, AReal>"
 typerule LEQ "SimpleTypeRule<RBool, AReal, AReal>"
 typerule GT "SimpleTypeRule<RBool, AReal, AReal>"
 typerule GEQ "SimpleTypeRule<RBool, AReal, AReal>"
+
+typerule INDEXED_ROOT_PREDICATE_OP "SimpleTypeRule<RBuiltinOperator>"
+typerule INDEXED_ROOT_PREDICATE ::CVC4::theory::arith::IndexedRootPredicateTypeRule
 
 typerule TO_REAL ::CVC4::theory::arith::ArithOperatorTypeRule
 typerule TO_INTEGER ::CVC4::theory::arith::ArithOperatorTypeRule

--- a/src/theory/arith/kinds
+++ b/src/theory/arith/kinds
@@ -85,7 +85,7 @@ constant INDEXED_ROOT_PREDICATE_OP \
 	::CVC4::IndexedRootPredicateHashFunction \
 	"util/arith.h" \
 	"operator for the indexed root predicate; payload is an instance of the CVC4::IndexedRootPredicate class"
-parameterized INDEXED_ROOT_PREDICATE INDEXED_ROOT_PREDICATE_OP 2 "indexed root predicate; first parameter is a INDEXED_ROOT_PREDICATE_OP, second is a real variable, third is a polynomial compared to zero"
+parameterized INDEXED_ROOT_PREDICATE INDEXED_ROOT_PREDICATE_OP 2 "indexed root predicate; first parameter is a INDEXED_ROOT_PREDICATE_OP, second is a real variable compared to zero, third is a polynomial"
 
 operator IS_INTEGER 1 "term-is-integer predicate (parameter is a real-sorted term)"
 operator TO_INTEGER 1 "convert term to integer by the floor function (parameter is a real-sorted term)"

--- a/src/theory/arith/theory_arith_type_rules.h
+++ b/src/theory/arith/theory_arith_type_rules.h
@@ -130,6 +130,34 @@ class IAndTypeRule
   }
 }; /* class BitVectorConversionTypeRule */
 
+
+class IndexedRootPredicateTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    IndexedRootPredicate info = n.getOperator().getConst<IndexedRootPredicate>();
+
+    if (check)
+    {
+      TypeNode t1 = n[0].getType(check);
+      if (!t1.isBoolean())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting boolean term as first argument");
+      }
+      TypeNode t2 = n[1].getType(check);
+      if (!t2.isReal())
+      {
+        throw TypeCheckingExceptionPrivate(n, "expecting polynomial as second argument");
+      }
+    }
+    return nodeManager->booleanType();
+  }
+}; /* class IndexedRootPredicateTypeRule */
+
+
 }/* CVC4::theory::arith namespace */
 }/* CVC4::theory namespace */
 }/* CVC4 namespace */

--- a/src/util/arith.h
+++ b/src/util/arith.h
@@ -1,0 +1,59 @@
+/*********************                                                        */
+/*! \file arith.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Aina Niemetz, Andres Noetzli, Dejan Jovanovic
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Utils for arithmetic kinds.
+ **
+ ** Some utils for arithmetic kinds, for example indexed root predicates.
+ **/
+
+
+
+#include "cvc4_public.h"
+
+#ifndef CVC4__UTIL__ARITH_H
+#define CVC4__UTIL__ARITH_H
+
+namespace CVC4 {
+
+/**
+ * The structure representing a root predicate.
+ */
+struct CVC4_PUBLIC IndexedRootPredicate
+{
+  /** The index of the root */
+  unsigned d_index;
+
+  IndexedRootPredicate(unsigned index) : d_index(index) {}
+
+  bool operator==(const IndexedRootPredicate& irp) const
+  {
+    return d_index == irp.d_index;
+  }
+}; /* struct IndexedRootPredicate */
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const IndexedRootPredicate& irp) CVC4_PUBLIC;
+inline std::ostream& operator<<(std::ostream& os, const IndexedRootPredicate& irp)
+{
+  return os << "k=" << irp.d_index;
+}
+
+struct CVC4_PUBLIC IndexedRootPredicateHashFunction
+{
+  std::size_t operator()(const IndexedRootPredicate& irp) const
+  {
+    return irp.d_index;
+  }
+}; /* struct IndexedRootPredicateHashFunction */
+
+}
+
+#endif


### PR DESCRIPTION
This PR adds a new node type called `INDEXED_ROOT_PREDICATE`.
It will be used for proofs generated by the cad subsolver. It roughly works as follows:

General structure: `(INDEXED_ROOT_PREDICATE k=unsigned var~0 poly)`

Example: `(INDEXED_ROOT_PREDICATE k=1 (>= y 0.0) (+ (* 1.0 (^ x 2.0)) (* 1.0 y)))`

It states that `y` should be `>=` than the first (k'th) root of the polynomial `x*x+y` (in `y`). Note that it can only be evaluated with respect to an assignment for all the remaining variables within the polynomial.