### PR TITLE
bv2int: improving bvand tables

### DIFF
--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -42,10 +42,6 @@ Rational intpow2(uint64_t b)
   return Rational(Integer(2).pow(b), Integer(1));
 }
 
-/**
- * Helper functions for createBitwiseNode
- */
-
 } //end empty namespace
 
 Node BVToInt::mkRangeConstraint(Node newVar, uint64_t k)

--- a/src/theory/arith/nl/iand_table.cpp
+++ b/src/theory/arith/nl/iand_table.cpp
@@ -154,8 +154,6 @@ std::map<std::pair<int64_t, int64_t>, uint64_t> IAndTable::getAndTable(
   std::map<std::pair<int64_t, int64_t>, uint64_t> table;
   uint64_t num_of_values = ((uint64_t)pow(2, granularity));
   // populate the table with all the values
-  // at this point we do not take into account the most common value,
-  // but instead just put all values in the table.
   for (uint64_t i = 0; i < num_of_values; i++)
   {
     for (uint64_t j = 0; j < num_of_values; j++)

--- a/src/theory/arith/nl/iand_table.cpp
+++ b/src/theory/arith/nl/iand_table.cpp
@@ -60,9 +60,10 @@ Node IAndTable::createITEFromTable(
 {
   NodeManager* nm = NodeManager::currentNM();
   Assert(granularity <= 8);
-  uint64_t num_of_values = ((int64_t)pow(2, granularity));
+  uint64_t num_of_values = ((uint64_t)pow(2, granularity));
   // The table represents a function from pairs of integers to integers, where
   // all integers are between 0 (inclusive) and num_of_values (exclusive).
+  // additionally, there is a default value (-1, -1).
   Assert(table.size() == 1 + ((uint64_t)(num_of_values * num_of_values)));
   // start with the default, most common value.
   // this value is represented in the table by (-1, -1).
@@ -151,13 +152,13 @@ std::map<std::pair<int64_t, int64_t>, uint64_t> IAndTable::getAndTable(
   }
   // the table was not yet computed
   std::map<std::pair<int64_t, int64_t>, uint64_t> table;
-  int64_t num_of_values = ((int64_t)pow(2, granularity));
+  uint64_t num_of_values = ((uint64_t)pow(2, granularity));
   // populate the table with all the values
   // at this point we do not take into account the most common value,
   // but instead just put all values in the table.
-  for (int64_t i = 0; i < num_of_values; i++)
+  for (uint64_t i = 0; i < num_of_values; i++)
   {
-    for (int64_t j = 0; j < num_of_values; j++)
+    for (uint64_t j = 0; j < num_of_values; j++)
     {
       // compute
       // (bv_to_int (bvand ((int_to_bv granularity) i) ((int_to_bv granularity)

--- a/src/theory/arith/nl/iand_table.cpp
+++ b/src/theory/arith/nl/iand_table.cpp
@@ -123,9 +123,13 @@ Node IAndTable::createBitwiseNode(Node x,
   uint64_t sumSize = bvsize / granularity;
   // initialize the sum
   Node sumNode = nm->mkConst<Rational>(0);
-  // get the table for the current granularity
-  std::map<std::pair<int64_t, int64_t>, uint64_t> table =
-      getAndTable(granularity);
+  // compute the table for the current granularity if needed
+  if (d_bvandTable.find(granularity) == d_bvandTable.end())
+  {
+    computeAndTable(granularity);
+  }
+  const std::map<std::pair<int64_t, int64_t>, uint64_t>& table =
+      d_bvandTable[granularity];
   for (uint64_t i = 0; i < sumSize; i++)
   {
     // compute the current blocks of x and y
@@ -142,14 +146,9 @@ Node IAndTable::createBitwiseNode(Node x,
   return sumNode;
 }
 
-std::map<std::pair<int64_t, int64_t>, uint64_t> IAndTable::getAndTable(
-    uint64_t granularity)
+void IAndTable::computeAndTable(uint64_t granularity)
 {
-  if (d_bvandTable.find(granularity) != d_bvandTable.end())
-  {
-    // the table was already computed
-    return d_bvandTable[granularity];
-  }
+  Assert(d_bvandTable.find(granularity) == d_bvandTable.end());
   // the table was not yet computed
   std::map<std::pair<int64_t, int64_t>, uint64_t> table;
   uint64_t num_of_values = ((uint64_t)pow(2, granularity));
@@ -180,7 +179,6 @@ std::map<std::pair<int64_t, int64_t>, uint64_t> IAndTable::getAndTable(
   Assert(table.size() == 1 + (static_cast<uint64_t>(num_of_values * num_of_values)));
   // store the table in the cache and return it
   d_bvandTable[granularity] = table;
-  return table;
 }
 
 void IAndTable::addDefaultValue(

--- a/src/theory/arith/nl/iand_table.cpp
+++ b/src/theory/arith/nl/iand_table.cpp
@@ -38,6 +38,7 @@ Node pow2(uint64_t k)
 
 bool oneBitAnd(bool a, bool b) { return (a && b); }
 
+// computes (bv_to_int ((_ extract i+size-1 i) (int_to_bv x))))
 Node intExtract(Node x, uint64_t i, uint64_t size)
 {
   Assert(size > 0);

--- a/src/theory/arith/nl/iand_table.cpp
+++ b/src/theory/arith/nl/iand_table.cpp
@@ -165,7 +165,7 @@ std::map<std::pair<int64_t, int64_t>, uint64_t> IAndTable::getAndTable(
       for (uint64_t n = 0; n < granularity; n++)
       {
         // b is the result of f on the current bit
-        bool b = (oneBitAnd)((((i >> n) & 1) == 1), (((j >> n) & 1) == 1));
+        bool b = oneBitAnd((((i >> n) & 1) == 1), (((j >> n) & 1) == 1));
         // add the corresponding power of 2 only if the result is 1
         if (b)
         {
@@ -177,7 +177,7 @@ std::map<std::pair<int64_t, int64_t>, uint64_t> IAndTable::getAndTable(
   }
   // optimize the table by identifying and adding the default value
   addDefaultValue(table, num_of_values);
-  Assert(table.size() == 1 + ((uint64_t)(num_of_values * num_of_values)));
+  Assert(table.size() == 1 + (static_cast<uint64_t>(num_of_values * num_of_values)));
   // store the table in the cache and return it
   d_bvandTable[granularity] = table;
   return table;
@@ -193,7 +193,7 @@ void IAndTable::addDefaultValue(
   {
     counters[i] = 0;
   }
-  for (std::pair<std::pair<int64_t, int64_t>, uint64_t> element : table)
+  for (const std::pair<std::pair<int64_t, int64_t>, uint64_t>& element : table)
   {
     uint64_t result = element.second;
     counters[result]++;

--- a/src/theory/arith/nl/iand_table.cpp
+++ b/src/theory/arith/nl/iand_table.cpp
@@ -60,16 +60,16 @@ Node IAndTable::createITEFromTable(
 {
   NodeManager* nm = NodeManager::currentNM();
   Assert(granularity <= 8);
-  int64_t num_of_values = ((int64_t)pow(2, granularity));
+  uint64_t num_of_values = ((int64_t)pow(2, granularity));
   // The table represents a function from pairs of integers to integers, where
   // all integers are between 0 (inclusive) and num_of_values (exclusive).
   Assert(table.size() == 1 + ((uint64_t)(num_of_values * num_of_values)));
   // start with the default, most common value.
   // this value is represented in the table by (-1, -1).
   Node ite = nm->mkConst<Rational>(table.at(std::make_pair(-1, -1)));
-  for (int64_t i = 0; i < num_of_values; i++)
+  for (uint64_t i = 0; i < num_of_values; i++)
   {
-    for (int64_t j = 0; j < num_of_values; j++)
+    for (uint64_t j = 0; j < num_of_values; j++)
     {
       // skip the most common value, as it was already stored.
       if (table.at(std::make_pair(i, j)) == table.at(std::make_pair(-1, -1)))

--- a/src/theory/arith/nl/iand_table.h
+++ b/src/theory/arith/nl/iand_table.h
@@ -104,11 +104,9 @@ class IAndTable
       const std::map<std::pair<int64_t, int64_t>, uint64_t>& table);
 
   /**
-   * Returns d_bvandTable[granularity] if it was already computed.
-   * Otherwise, computes it and then returns it.
+   * updates  d_bvandTable[granularity] if it wasn't already computed.
    */
-  std::map<std::pair<int64_t, int64_t>, uint64_t> getAndTable(
-      uint64_t granularity);
+  void computeAndTable(uint64_t granularity);
 
   /**
    * @param table a table that represents integer conjunction

--- a/src/theory/arith/nl/iand_table.h
+++ b/src/theory/arith/nl/iand_table.h
@@ -33,10 +33,10 @@ class IAndTable
 {
  public:
   /**
-   * A generic function that creates a node that represents a bitwise
+   * A generic function that creates a node that represents a bvand
    * operation.
    *
-   * For example: Suppose bvsize is 4, granularity is 1, and f(x,y) = x && y.
+   * For example: Suppose bvsize is 4, granularity is 1.
    * Denote by ITE(a,b) the term: ite(a==0, 0, ite(b==1, 1, 0)).
    * The result of this function would be:
    * ITE(x[0], y[0])*2^0 + ... + ITE(x[3], y[3])*2^3
@@ -68,6 +68,9 @@ class IAndTable
    * The result of this function would be:
    * ITE(x[1:0], y[1:0])*2^0 + ITE(x[3:2], y[3:2])*2^2
    *
+   * More precisely, the ITE term is optimized so that the most common
+   * result is in the final "else" branch.
+   * Hence in practice, the generated ITEs will be shorter.
    *
    * @param x is an integer operand that correspond to the first original
    *        bit-vector operand.
@@ -76,8 +79,6 @@ class IAndTable
    * @param bvsize is the bit width of the original bit-vector variables.
    * @param granularity is specified in the options for this preprocessing
    *        pass.
-   * @param f is a pointer to a boolean function that corresponds
-   *        to the original bitwise operation.
    * @return A node that represents the operation, as described above.
    */
   Node createBitwiseNode(Node x, Node y, uint64_t bvsize, uint64_t granularity);
@@ -92,21 +93,40 @@ class IAndTable
    * @param table a function from pairs of integers to integers.
    *        The domain of this function consists of pairs of
    *        integers between 0 (inclusive) and 2^{bitwidth} (exclusive).
+   *        The domain also includes one additional pair (-1, -1), that
+   *        represents the default (most common) value.
    * @return An ite term that represents this table.
    */
   Node createITEFromTable(
       Node x,
       Node y,
       uint64_t granularity,
-      const std::map<std::pair<int64_t, int64_t>, int64_t>& table);
+      const std::map<std::pair<int64_t, int64_t>, uint64_t>& table);
 
-  Node createPart(Node x, Node y, uint64_t granularity);
-  std::map<std::pair<int64_t, int64_t>, int64_t> getAndTable(
+  /**
+   * Returns d_bvandTable[granularity] if it was already computed.
+   * Otherwise, computes it and then returns it.
+   */
+  std::map<std::pair<int64_t, int64_t>, uint64_t> getAndTable(
       uint64_t granularity);
-  void addDefaultValue(std::map<std::pair<int64_t, int64_t>, int64_t>& table,
-                       int64_t num_of_values);
 
-  std::map<int64_t, std::map<std::pair<int64_t, int64_t>, int64_t>>
+  /**
+   * @param table a table that represents integer conjunction
+   * @param num_of_values the number of rows in the table
+   * The function will add a single row to the table.
+   * the key will be (-1, -1) and the value will be the most common
+   * value of the original table.
+   */
+  void addDefaultValue(std::map<std::pair<int64_t, int64_t>, uint64_t>& table,
+                       uint64_t num_of_values);
+
+  /**
+   * For each granularity between 1 and 8, we store a separate table
+   * in d_bvandTable[granularity].
+   * The definition of these tables is given in the description of
+   * createBitwiseNode.
+   */
+  std::map<uint64_t, std::map<std::pair<int64_t, int64_t>, uint64_t>>
       d_bvandTable;
 };
 

--- a/src/theory/arith/nl/iand_table.h
+++ b/src/theory/arith/nl/iand_table.h
@@ -18,7 +18,6 @@
 
 #include <tuple>
 #include <vector>
-
 #include "expr/node.h"
 
 namespace CVC4 {
@@ -99,7 +98,16 @@ class IAndTable
       Node x,
       Node y,
       uint64_t granularity,
-      const std::map<std::pair<uint64_t, uint64_t>, uint64_t>& table);
+      const std::map<std::pair<int64_t, int64_t>, int64_t>& table);
+
+  Node createPart(Node x, Node y, uint64_t granularity);
+  std::map<std::pair<int64_t, int64_t>, int64_t> getAndTable(
+      uint64_t granularity);
+  void addDefaultValue(std::map<std::pair<int64_t, int64_t>, int64_t>& table,
+                       int64_t num_of_values);
+
+  std::map<int64_t, std::map<std::pair<int64_t, int64_t>, int64_t>>
+      d_bvandTable;
 };
 
 }  // namespace nl


### PR DESCRIPTION
The bv-to-int preprocessing pass introduces large `ite` terms that correspond to truth tables of `bvand` for various bit-widths.
Previously there were two inefficiencies in those tables:
1. They weren't being cached
2. The `ite` was not optimized

This PR adds a cache for the tables that induce the `ite` terms.
In addition, it computes smaller `ite` terms by computing the most common value of each table and using it as the default value of the `ite`.