### PR TITLE
Eliminate uses of Expr in SmtEngine interface

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -5361,7 +5361,7 @@ void Solver::blockModelValues(const std::vector<Term>& terms) const
       << "Cannot get value when in unsat mode.";
   CVC4_API_ARG_SIZE_CHECK_EXPECTED(!terms.empty(), terms)
       << "a non-empty set of terms";
-  for (int i = 0; i < terms.size(); ++i)
+  for (size_t i = 0, tsize = terms.size(); i < tsize; ++i)
   {
     CVC4_API_ARG_AT_INDEX_CHECK_EXPECTED(
         !terms[i].isNull(), "term", terms[i], i)
@@ -5371,7 +5371,7 @@ void Solver::blockModelValues(const std::vector<Term>& terms) const
         << "a term associated to this solver object";
   }
   CVC4::ExprManagerScope exmgrs(*(d_exprMgr.get()));
-  d_smtEngine->blockModelValues(termVectorToExprs(terms));
+  d_smtEngine->blockModelValues(termVectorToNodes(terms));
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
 

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -4811,8 +4811,7 @@ Term Solver::defineFun(Term fun,
   CVC4_API_SOLVER_CHECK_TERM(term);
 
   std::vector<Node> ebound_vars = termVectorToNodes(bound_vars);
-  d_smtEngine->defineFunction(
-      *fun.d_node, ebound_vars, *term.d_node, global);
+  d_smtEngine->defineFunction(*fun.d_node, ebound_vars, *term.d_node, global);
   return fun;
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
@@ -4862,7 +4861,7 @@ Term Solver::defineFunRec(const std::string& symbol,
       << "Invalid sort of function body '" << term << "', expected '" << sort
       << "'";
   CVC4_API_SOLVER_CHECK_TERM(term);
-  NodeManager * nm = getNodeManager();
+  NodeManager* nm = getNodeManager();
   TypeNode type = TypeNode::fromType(*sort.d_type);
   if (!domain_types.empty())
   {

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -4557,7 +4557,7 @@ Result Solver::checkEntailed(Term term) const
   CVC4_API_ARG_CHECK_NOT_NULL(term);
   CVC4_API_SOLVER_CHECK_TERM(term);
 
-  CVC4::Result r = d_smtEngine->checkEntailed(term.d_node->toExpr());
+  CVC4::Result r = d_smtEngine->checkEntailed(*term.d_node);
   return Result(r);
 
   CVC4_API_SOLVER_TRY_CATCH_END;
@@ -4577,7 +4577,7 @@ Result Solver::checkEntailed(const std::vector<Term>& terms) const
     CVC4_API_ARG_CHECK_NOT_NULL(term);
   }
 
-  std::vector<Expr> exprs = termVectorToExprs(terms);
+  std::vector<Node> exprs = termVectorToNodes(terms);
   CVC4::Result r = d_smtEngine->checkEntailed(exprs);
   return Result(r);
 
@@ -4627,7 +4627,7 @@ Result Solver::checkSatAssuming(Term assumption) const
       << "Cannot make multiple queries unless incremental solving is enabled "
          "(try --incremental)";
   CVC4_API_SOLVER_CHECK_TERM(assumption);
-  CVC4::Result r = d_smtEngine->checkSat(assumption.d_node->toExpr());
+  CVC4::Result r = d_smtEngine->checkSat(*assumption.d_node);
   return Result(r);
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
@@ -4648,7 +4648,7 @@ Result Solver::checkSatAssuming(const std::vector<Term>& assumptions) const
     CVC4_API_SOLVER_CHECK_TERM(term);
     CVC4_API_ARG_CHECK_NOT_NULL(term);
   }
-  std::vector<Expr> eassumptions = termVectorToExprs(assumptions);
+  std::vector<Node> eassumptions = termVectorToNodes(assumptions);
   CVC4::Result r = d_smtEngine->checkSat(eassumptions);
   return Result(r);
   CVC4_API_SOLVER_TRY_CATCH_END;
@@ -4732,7 +4732,7 @@ Term Solver::defineFun(const std::string& symbol,
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
   CVC4_API_ARG_CHECK_EXPECTED(sort.isFirstClass(), sort)
       << "first-class sort as codomain sort for function sort";
-  std::vector<Type> domain_types;
+  std::vector<TypeNode> domain_types;
   for (size_t i = 0, size = bound_vars.size(); i < size; ++i)
   {
     CVC4_API_ARG_AT_INDEX_CHECK_EXPECTED(
@@ -4748,20 +4748,21 @@ Term Solver::defineFun(const std::string& symbol,
     CVC4_API_ARG_AT_INDEX_CHECK_EXPECTED(
         t.isFirstClass(), "sort of parameter", bound_vars[i], i)
         << "first-class sort of parameter of defined function";
-    domain_types.push_back(t);
+    domain_types.push_back(TypeNode::fromType(t));
   }
   CVC4_API_SOLVER_CHECK_SORT(sort);
   CVC4_API_CHECK(sort == term.getSort())
       << "Invalid sort of function body '" << term << "', expected '" << sort
       << "'";
-  Type type = *sort.d_type;
+  NodeManager* nm = getNodeManager();
+  TypeNode type = TypeNode::fromType(*sort.d_type);
   if (!domain_types.empty())
   {
-    type = d_exprMgr->mkFunctionType(domain_types, type);
+    type = nm->mkFunctionType(domain_types, type);
   }
-  Expr fun = d_exprMgr->mkVar(symbol, type);
-  std::vector<Expr> ebound_vars = termVectorToExprs(bound_vars);
-  d_smtEngine->defineFunction(fun, ebound_vars, term.d_node->toExpr(), global);
+  Node fun = Node::fromExpr(d_exprMgr->mkVar(symbol, type.toType()));
+  std::vector<Node> ebound_vars = termVectorToNodes(bound_vars);
+  d_smtEngine->defineFunction(fun, ebound_vars, *term.d_node, global);
   return Term(this, fun);
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
@@ -4810,9 +4811,9 @@ Term Solver::defineFun(Term fun,
 
   CVC4_API_SOLVER_CHECK_TERM(term);
 
-  std::vector<Expr> ebound_vars = termVectorToExprs(bound_vars);
+  std::vector<Node> ebound_vars = termVectorToNodes(bound_vars);
   d_smtEngine->defineFunction(
-      fun.d_node->toExpr(), ebound_vars, term.d_node->toExpr(), global);
+      *fun.d_node, ebound_vars, *term.d_node, global);
   return fun;
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
@@ -4839,7 +4840,7 @@ Term Solver::defineFunRec(const std::string& symbol,
   CVC4_API_ARG_CHECK_EXPECTED(sort.isFirstClass(), sort)
       << "first-class sort as function codomain sort";
   Assert(!sort.isFunction()); /* A function sort is not first-class. */
-  std::vector<Type> domain_types;
+  std::vector<TypeNode> domain_types;
   for (size_t i = 0, size = bound_vars.size(); i < size; ++i)
   {
     CVC4_API_ARG_AT_INDEX_CHECK_EXPECTED(
@@ -4851,7 +4852,7 @@ Term Solver::defineFunRec(const std::string& symbol,
         bound_vars[i],
         i)
         << "a bound variable";
-    CVC4::Type t = bound_vars[i].d_node->getType().toType();
+    CVC4::TypeNode t = bound_vars[i].d_node->getType();
     CVC4_API_ARG_AT_INDEX_CHECK_EXPECTED(
         t.isFirstClass(), "sort of parameter", bound_vars[i], i)
         << "first-class sort of parameter of defined function";
@@ -4862,13 +4863,14 @@ Term Solver::defineFunRec(const std::string& symbol,
       << "Invalid sort of function body '" << term << "', expected '" << sort
       << "'";
   CVC4_API_SOLVER_CHECK_TERM(term);
-  Type type = *sort.d_type;
+  NodeManager * nm = getNodeManager();
+  TypeNode type = TypeNode::fromType(*sort.d_type);
   if (!domain_types.empty())
   {
-    type = d_exprMgr->mkFunctionType(domain_types, type);
+    type = nm->mkFunctionType(domain_types, type);
   }
-  Expr fun = d_exprMgr->mkVar(symbol, type);
-  std::vector<Expr> ebound_vars = termVectorToExprs(bound_vars);
+  Node fun = Node::fromExpr(d_exprMgr->mkVar(symbol, type.toType()));
+  std::vector<Node> ebound_vars = termVectorToNodes(bound_vars);
   d_smtEngine->defineFunctionRec(
       fun, ebound_vars, term.d_node->toExpr(), global);
   return Term(this, fun);
@@ -4926,9 +4928,9 @@ Term Solver::defineFunRec(Term fun,
   }
 
   CVC4_API_SOLVER_CHECK_TERM(term);
-  std::vector<Expr> ebound_vars = termVectorToExprs(bound_vars);
+  std::vector<Node> ebound_vars = termVectorToNodes(bound_vars);
   d_smtEngine->defineFunctionRec(
-      fun.d_node->toExpr(), ebound_vars, term.d_node->toExpr(), global);
+      *fun.d_node, ebound_vars, *term.d_node, global);
   return fun;
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
@@ -5004,13 +5006,13 @@ void Solver::defineFunsRec(const std::vector<Term>& funs,
           << "function or nullary symbol";
     }
   }
-  std::vector<Expr> efuns = termVectorToExprs(funs);
-  std::vector<std::vector<Expr>> ebound_vars;
+  std::vector<Node> efuns = termVectorToNodes(funs);
+  std::vector<std::vector<Node>> ebound_vars;
   for (const auto& v : bound_vars)
   {
-    ebound_vars.push_back(termVectorToExprs(v));
+    ebound_vars.push_back(termVectorToNodes(v));
   }
-  std::vector<Expr> exprs = termVectorToExprs(terms);
+  std::vector<Node> exprs = termVectorToNodes(terms);
   d_smtEngine->defineFunctionsRec(efuns, ebound_vars, exprs, global);
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
@@ -5029,12 +5031,12 @@ void Solver::echo(std::ostream& out, const std::string& str) const
 std::vector<Term> Solver::getAssertions(void) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
-  std::vector<Expr> assertions = d_smtEngine->getAssertions();
+  std::vector<Node> assertions = d_smtEngine->getAssertions();
   /* Can not use
    *   return std::vector<Term>(assertions.begin(), assertions.end());
    * here since constructor is private */
   std::vector<Term> res;
-  for (const Expr& e : assertions)
+  for (const Node& e : assertions)
   {
     res.push_back(Term(this, e));
   }

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -817,7 +817,7 @@ void BVToInt::defineBVUFAsIntUF(Node bvUF, Node intUF)
   // The type of the resulting term
   TypeNode resultType;
   // symbolic arguments of original function
-  vector<Expr> args;
+  vector<Node> args;
   if (!bvUF.getType().isFunction()) {
     // bvUF is a variable.
     // in this case, the result is just the original term
@@ -839,7 +839,7 @@ void BVToInt::defineBVUFAsIntUF(Node bvUF, Node intUF)
       // Each bit-vector argument is casted to a natural number
       // Other arguments are left intact.
       Node fresh_bound_var = d_nm->mkBoundVar(d);
-      args.push_back(fresh_bound_var.toExpr());
+      args.push_back(fresh_bound_var);
       Node castedArg = args[i];
       if (d.isBitVector())
       {
@@ -853,8 +853,8 @@ void BVToInt::defineBVUFAsIntUF(Node bvUF, Node intUF)
   // If the result is BV, it needs to be casted back.
   result = castToType(result, resultType);
   // add the function definition to the smt engine.
-  smt::currentSmtEngine()->defineFunction(
-      bvUF.toExpr(), args, result.toExpr(), true);
+  d_preprocContext->getSmt()->defineFunction(
+      bvUF, args, result, true);
 }
 
 bool BVToInt::childrenTypesChanged(Node n)

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -851,8 +851,7 @@ void BVToInt::defineBVUFAsIntUF(Node bvUF, Node intUF)
   // If the result is BV, it needs to be casted back.
   result = castToType(result, resultType);
   // add the function definition to the smt engine.
-  d_preprocContext->getSmt()->defineFunction(
-      bvUF, args, result, true);
+  d_preprocContext->getSmt()->defineFunction(bvUF, args, result, true);
 }
 
 bool BVToInt::childrenTypesChanged(Node n)

--- a/src/preprocessing/passes/quantifier_macros.cpp
+++ b/src/preprocessing/passes/quantifier_macros.cpp
@@ -504,21 +504,21 @@ void QuantifierMacros::finalizeDefinitions() {
   if( options::incrementalSolving() || options::produceModels() || doDefs ){
     Trace("macros") << "Store as defined functions..." << std::endl;
     //also store as defined functions
-    SmtEngine * smt = d_preprocContext->getSmt();
+    SmtEngine* smt = d_preprocContext->getSmt();
     for( std::map< Node, Node >::iterator it = d_macro_defs.begin(); it != d_macro_defs.end(); ++it ){
       Trace("macros-def") << "Macro definition for " << it->first << " : " << it->second << std::endl;
       Trace("macros-def") << "  basis is : ";
       std::vector< Node > nargs;
-      std::vector< Node > args;
+      std::vector<Node> args;
       for( unsigned i=0; i<d_macro_basis[it->first].size(); i++ ){
         Node bv = NodeManager::currentNM()->mkBoundVar( d_macro_basis[it->first][i].getType() );
         Trace("macros-def") << d_macro_basis[it->first][i] << " ";
         nargs.push_back( bv );
-        args.push_back( bv );
+        args.push_back(bv);
       }
       Trace("macros-def") << std::endl;
       Node sbody = it->second.substitute( d_macro_basis[it->first].begin(), d_macro_basis[it->first].end(), nargs.begin(), nargs.end() );
-      smt->defineFunction( it->first, args, sbody );
+      smt->defineFunction(it->first, args, sbody);
 
       if( Trace.isOn("macros-warn") ){
         debugMacroDefinition( it->first, sbody );

--- a/src/preprocessing/passes/quantifier_macros.cpp
+++ b/src/preprocessing/passes/quantifier_macros.cpp
@@ -504,20 +504,21 @@ void QuantifierMacros::finalizeDefinitions() {
   if( options::incrementalSolving() || options::produceModels() || doDefs ){
     Trace("macros") << "Store as defined functions..." << std::endl;
     //also store as defined functions
+    SmtEngine * smt = d_preprocContext->getSmt();
     for( std::map< Node, Node >::iterator it = d_macro_defs.begin(); it != d_macro_defs.end(); ++it ){
       Trace("macros-def") << "Macro definition for " << it->first << " : " << it->second << std::endl;
       Trace("macros-def") << "  basis is : ";
       std::vector< Node > nargs;
-      std::vector< Expr > args;
+      std::vector< Node > args;
       for( unsigned i=0; i<d_macro_basis[it->first].size(); i++ ){
         Node bv = NodeManager::currentNM()->mkBoundVar( d_macro_basis[it->first][i].getType() );
         Trace("macros-def") << d_macro_basis[it->first][i] << " ";
         nargs.push_back( bv );
-        args.push_back( bv.toExpr() );
+        args.push_back( bv );
       }
       Trace("macros-def") << std::endl;
       Node sbody = it->second.substitute( d_macro_basis[it->first].begin(), d_macro_basis[it->first].end(), nargs.begin(), nargs.end() );
-      smt::currentSmtEngine()->defineFunction( it->first.toExpr(), args, sbody.toExpr() );
+      smt->defineFunction( it->first, args, sbody );
 
       if( Trace.isOn("macros-warn") ){
         debugMacroDefinition( it->first, sbody );

--- a/src/preprocessing/passes/real_to_int.cpp
+++ b/src/preprocessing/passes/real_to_int.cpp
@@ -182,8 +182,7 @@ Node RealToInt::realToIntInternal(TNode n, NodeMap& cache, std::vector<Node>& va
           // ensure that the original variable is defined to be the returned
           // one, which is important for models and for incremental solving.
           std::vector<Node> args;
-          d_preprocContext->getSmt()->defineFunction(
-              n, args, ret);
+          d_preprocContext->getSmt()->defineFunction(n, args, ret);
         }
       }
     }

--- a/src/preprocessing/passes/real_to_int.cpp
+++ b/src/preprocessing/passes/real_to_int.cpp
@@ -181,9 +181,9 @@ Node RealToInt::realToIntInternal(TNode n, NodeMap& cache, std::vector<Node>& va
           var_eq.push_back(n.eqNode(ret));
           // ensure that the original variable is defined to be the returned
           // one, which is important for models and for incremental solving.
-          std::vector<Expr> args;
-          smt::currentSmtEngine()->defineFunction(
-              n.toExpr(), args, ret.toExpr());
+          std::vector<Node> args;
+          d_preprocContext->getSmt()->defineFunction(
+              n, args, ret);
         }
       }
     }

--- a/src/preprocessing/passes/sygus_inference.cpp
+++ b/src/preprocessing/passes/sygus_inference.cpp
@@ -44,21 +44,21 @@ PreprocessingPassResult SygusInference::applyInternal(
   {
     Assert(funs.size() == sols.size());
     // if so, sygus gives us function definitions
-    SmtEngine* master_smte = smt::currentSmtEngine();
+    SmtEngine* master_smte = d_preprocContext->getSmt();
     for (unsigned i = 0, size = funs.size(); i < size; i++)
     {
-      std::vector<Expr> args;
+      std::vector<Node> args;
       Node sol = sols[i];
       // if it is a non-constant function
       if (sol.getKind() == LAMBDA)
       {
         for (const Node& v : sol[0])
         {
-          args.push_back(v.toExpr());
+          args.push_back(v);
         }
         sol = sol[1];
       }
-      master_smte->defineFunction(funs[i].toExpr(), args, sol.toExpr());
+      master_smte->defineFunction(funs[i], args, sol);
     }
 
     // apply substitution to everything, should result in SAT

--- a/src/smt/abduction_solver.cpp
+++ b/src/smt/abduction_solver.cpp
@@ -139,8 +139,8 @@ void AbductionSolver::checkAbduct(Node a)
   Trace("check-abduct") << "SmtEngine::checkAbduct: get expanded assertions"
                         << std::endl;
 
-  std::vector<Expr> asserts = d_parent->getExpandedAssertions();
-  asserts.push_back(a.toExpr());
+  std::vector<Node> asserts = d_parent->getExpandedAssertions();
+  asserts.push_back(a);
 
   // two checks: first, consistent with assertions, second, implies negated goal
   // is unsatisfiable.
@@ -153,7 +153,7 @@ void AbductionSolver::checkAbduct(Node a)
     initializeSubsolver(abdChecker);
     Trace("check-abduct") << "SmtEngine::checkAbduct: phase " << j
                           << ": asserting formulas" << std::endl;
-    for (const Expr& e : asserts)
+    for (const Node& e : asserts)
     {
       abdChecker->assertFormula(e);
     }
@@ -177,7 +177,7 @@ void AbductionSolver::checkAbduct(Node a)
           << "SmtEngine::checkAbduct: goal is " << d_abdConj << std::endl;
       // add the goal to the set of assertions
       Assert(!d_abdConj.isNull());
-      asserts.push_back(d_abdConj.toExpr());
+      asserts.push_back(d_abdConj);
     }
     else
     {

--- a/src/smt/abduction_solver.cpp
+++ b/src/smt/abduction_solver.cpp
@@ -39,12 +39,7 @@ bool AbductionSolver::getAbduct(const Node& goal,
     throw ModalException(msg);
   }
   Trace("sygus-abduct") << "SmtEngine::getAbduct: goal " << goal << std::endl;
-  std::vector<Expr> easserts = d_parent->getExpandedAssertions();
-  std::vector<Node> axioms;
-  for (unsigned i = 0, size = easserts.size(); i < size; i++)
-  {
-    axioms.push_back(Node::fromExpr(easserts[i]));
-  }
+  std::vector<Node> axioms = d_parent->getExpandedAssertions();
   std::vector<Node> asserts(axioms.begin(), axioms.end());
   // must expand definitions
   Node conjn = d_parent->expandDefinitions(goal);

--- a/src/smt/defined_function.h
+++ b/src/smt/defined_function.h
@@ -34,7 +34,7 @@ class DefinedFunction
 {
  public:
   DefinedFunction() {}
-  DefinedFunction(Node func, std::vector<Node>& formals, Node formula)
+  DefinedFunction(Node func, const std::vector<Node>& formals, Node formula)
       : d_func(func), d_formals(formals), d_formula(formula)
   {
   }

--- a/src/smt/interpolation_solver.cpp
+++ b/src/smt/interpolation_solver.cpp
@@ -44,12 +44,7 @@ bool InterpolationSolver::getInterpol(const Node& conj,
   }
   Trace("sygus-interpol") << "SmtEngine::getInterpol: conjecture " << conj
                           << std::endl;
-  std::vector<Expr> easserts = d_parent->getExpandedAssertions();
-  std::vector<Node> axioms;
-  for (unsigned i = 0, size = easserts.size(); i < size; i++)
-  {
-    axioms.push_back(Node::fromExpr(easserts[i]));
-  }
+  std::vector<Node> axioms = d_parent->getExpandedAssertions();
   // must expand definitions
   Node conjn = d_parent->expandDefinitions(conj);
   std::string name("A");
@@ -60,7 +55,7 @@ bool InterpolationSolver::getInterpol(const Node& conj,
   {
     if (options::checkInterpols())
     {
-      checkInterpol(interpol.toExpr(), easserts, conj);
+      checkInterpol(interpol.toExpr(), axioms, conj);
     }
     return true;
   }
@@ -73,8 +68,8 @@ bool InterpolationSolver::getInterpol(const Node& conj, Node& interpol)
   return getInterpol(conj, grammarType, interpol);
 }
 
-void InterpolationSolver::checkInterpol(Expr interpol,
-                                        const std::vector<Expr>& easserts,
+void InterpolationSolver::checkInterpol(Node interpol,
+                                        const std::vector<Node>& easserts,
                                         const Node& conj)
 {
   Assert(interpol.getType().isBoolean());
@@ -98,18 +93,18 @@ void InterpolationSolver::checkInterpol(Expr interpol,
                             << ": asserting formulas" << std::endl;
     if (j == 0)
     {
-      for (const Expr& e : easserts)
+      for (const Node& e : easserts)
       {
         itpChecker->assertFormula(e);
       }
-      Expr negitp = interpol.notExpr();
+      Node negitp = interpol.notNode();
       itpChecker->assertFormula(negitp);
     }
     else
     {
       itpChecker->assertFormula(interpol);
       Assert(!conj.isNull());
-      itpChecker->assertFormula(conj.toExpr().notExpr());
+      itpChecker->assertFormula(conj.notNode());
     }
     Trace("check-interpol") << "SmtEngine::checkInterpol: phase " << j
                             << ": check the assertions" << std::endl;

--- a/src/smt/interpolation_solver.h
+++ b/src/smt/interpolation_solver.h
@@ -71,8 +71,8 @@ class InterpolationSolver
    * the interpolation problem (interpol), and the solution implies the goal
    * (conj). If these criteria are not met, an internal error is thrown.
    */
-  void checkInterpol(Expr interpol,
-                     const std::vector<Expr>& easserts,
+  void checkInterpol(Node interpol,
+                     const std::vector<Node>& easserts,
                      const Node& conj);
 
  private:

--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -23,24 +23,15 @@ using namespace CVC4::kind;
 
 namespace CVC4 {
 
-Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
+Node ModelBlocker::getModelBlocker(const std::vector<Node>& assertions,
                                    theory::TheoryModel* m,
                                    options::BlockModelsMode mode,
-                                   const std::vector<Expr>& exprToBlock)
+                                   const std::vector<Node>& exprToBlock)
 {
   NodeManager* nm = NodeManager::currentNM();
   // convert to nodes
-  std::vector<Node> tlAsserts;
-  for (const Expr& a : assertions)
-  {
-    Node an = Node::fromExpr(a);
-    tlAsserts.push_back(an);
-  }
-  std::vector<Node> nodesToBlock;
-  for (const Expr& eb : exprToBlock)
-  {
-    nodesToBlock.push_back(Node::fromExpr(eb));
-  }
+  std::vector<Node> tlAsserts = assertions;
+  std::vector<Node> nodesToBlock = exprToBlock;
   Trace("model-blocker") << "Compute model blocker, assertions:" << std::endl;
   Node blocker;
   if (mode == options::BlockModelsMode::LITERALS)
@@ -117,7 +108,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
               // rewrite, this ensures that e.g. the propositional value of
               // quantified formulas can be queried
               n = theory::Rewriter::rewrite(n);
-              Node vn = Node::fromExpr(m->getValue(n.toExpr()));
+              Node vn = m->getValue(n);
               Assert(vn.isConst());
               if (vn.getConst<bool>() == cpol)
               {
@@ -139,7 +130,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
         }
         else if (catom.getKind() == ITE)
         {
-          Node vcond = Node::fromExpr(m->getValue(cur[0].toExpr()));
+          Node vcond = m->getValue(cur[0]);
           Assert(vcond.isConst());
           Node cond = cur[0];
           Node branch;
@@ -282,7 +273,7 @@ Expr ModelBlocker::getModelBlocker(const std::vector<Expr>& assertions,
     }
   }
   Trace("model-blocker") << "...model blocker is " << blocker << std::endl;
-  return blocker.toExpr();
+  return blocker;
 }
 
 } /* namespace CVC4 */

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -59,11 +59,11 @@ class ModelBlocker
    * our input. In other words, we do not return ~(x < 0) V ~(w < 0) since the
    * left disjunct is always false.
    */
-  static Expr getModelBlocker(
-      const std::vector<Expr>& assertions,
+  static Node getModelBlocker(
+      const std::vector<Node>& assertions,
       theory::TheoryModel* m,
       options::BlockModelsMode mode,
-      const std::vector<Expr>& exprToBlock = std::vector<Expr>());
+      const std::vector<Node>& exprToBlock = std::vector<Node>());
 }; /* class TheoryModelCoreBuilder */
 
 }  // namespace CVC4

--- a/src/smt/model_core_builder.cpp
+++ b/src/smt/model_core_builder.cpp
@@ -20,7 +20,7 @@ using namespace CVC4::kind;
 
 namespace CVC4 {
 
-bool ModelCoreBuilder::setModelCore(const std::vector<Expr>& assertions,
+bool ModelCoreBuilder::setModelCore(const std::vector<Node>& assertions,
                                     Model* m,
                                     options::ModelCoresMode mode)
 {
@@ -34,14 +34,9 @@ bool ModelCoreBuilder::setModelCore(const std::vector<Expr>& assertions,
   }
 
   // convert to nodes
-  std::vector<Node> asserts;
-  for (unsigned i = 0, size = assertions.size(); i < size; i++)
-  {
-    asserts.push_back(Node::fromExpr(assertions[i]));
-  }
   NodeManager* nm = NodeManager::currentNM();
 
-  Node formula = asserts.size() > 1? nm->mkNode(AND, asserts) : asserts[0];
+  Node formula = nm->mkAnd(assertions);
   std::vector<Node> vars;
   std::vector<Node> subs;
   Trace("model-core") << "Assignments: " << std::endl;

--- a/src/smt/model_core_builder.h
+++ b/src/smt/model_core_builder.h
@@ -54,7 +54,7 @@ class ModelCoreBuilder
    * If m is not a model for assertions, this method returns false and m is
    * left unchanged.
    */
-  static bool setModelCore(const std::vector<Expr>& assertions,
+  static bool setModelCore(const std::vector<Node>& assertions,
                            Model* m,
                            options::ModelCoresMode mode);
 }; /* class TheoryModelCoreBuilder */

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -71,7 +71,6 @@
 #include "smt/abduction_solver.h"
 #include "smt/abstract_values.h"
 #include "smt/assertions.h"
-#include "smt/node_command.h"
 #include "smt/defined_function.h"
 #include "smt/dump_manager.h"
 #include "smt/expr_names.h"
@@ -80,6 +79,7 @@
 #include "smt/logic_request.h"
 #include "smt/model_blocker.h"
 #include "smt/model_core_builder.h"
+#include "smt/node_command.h"
 #include "smt/options_manager.h"
 #include "smt/preprocessor.h"
 #include "smt/proof_manager.h"
@@ -94,12 +94,12 @@
 #include "smt_util/boolean_simplification.h"
 #include "smt_util/nary_builder.h"
 #include "theory/logic_info.h"
+#include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/rewriter.h"
 #include "theory/sort_inference.h"
 #include "theory/substitutions.h"
 #include "theory/theory_engine.h"
 #include "theory/theory_model.h"
-#include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/theory_traits.h"
 #include "util/hash.h"
 #include "util/random.h"
@@ -653,7 +653,10 @@ CVC4::SExpr SmtEngine::getInfo(const std::string& key) const
 
 void SmtEngine::debugCheckFormals(const std::vector<Node>& formals, Node func)
 {
-  for(std::vector<Node>::const_iterator i = formals.begin(); i != formals.end(); ++i) {
+  for (std::vector<Node>::const_iterator i = formals.begin();
+       i != formals.end();
+       ++i)
+  {
     if((*i).getKind() != kind::BOUND_VARIABLE) {
       stringstream ss;
       ss << "All formal arguments to defined functions must be BOUND_VARIABLEs, but in the\n"
@@ -723,8 +726,7 @@ void SmtEngine::defineFunction(Node func,
     nFormals.push_back(formal);
   }
 
-  DefineFunctionNodeCommand nc(
-      ss.str(), func, nFormals, formula);
+  DefineFunctionNodeCommand nc(ss.str(), func, nFormals, formula);
   d_dumpm->addToModelCommandAndDump(
       nc, ExprManager::VAR_FLAG_DEFINED, true, "declarations");
 
@@ -830,14 +832,15 @@ void SmtEngine::defineFunctionRec(Node func,
 {
   std::vector<Node> funcs;
   funcs.push_back(func);
-  std::vector<std::vector<Node> > formals_multi;
+  std::vector<std::vector<Node>> formals_multi;
   formals_multi.push_back(formals);
   std::vector<Node> formulas;
   formulas.push_back(formula);
   defineFunctionsRec(funcs, formals_multi, formulas, global);
 }
 
-bool SmtEngine::isDefinedFunction( Node func ){
+bool SmtEngine::isDefinedFunction(Node func)
+{
   Debug("smt") << "isDefined function " << func << "?" << std::endl;
   return d_definedFunctions->find(func) != d_definedFunctions->end();
 }
@@ -944,7 +947,8 @@ Result SmtEngine::checkSat(const Node& assumption, bool inUnsatCore)
   return checkSatInternal(assump, inUnsatCore, false);
 }
 
-Result SmtEngine::checkSat(const std::vector<Node>& assumptions, bool inUnsatCore)
+Result SmtEngine::checkSat(const std::vector<Node>& assumptions,
+                           bool inUnsatCore)
 {
   if (Dump.isOn("benchmark"))
   {
@@ -969,15 +973,15 @@ Result SmtEngine::checkEntailed(const Node& node, bool inUnsatCore)
     getOutputManager().getPrinter().toStreamCmdQuery(
         getOutputManager().getDumpOut(), node);
   }
-  return checkSatInternal(node.isNull()
-                              ? std::vector<Node>()
-                              : std::vector<Node>{node},
-                          inUnsatCore,
-                          true)
+  return checkSatInternal(
+             node.isNull() ? std::vector<Node>() : std::vector<Node>{node},
+             inUnsatCore,
+             true)
       .asEntailmentResult();
 }
 
-Result SmtEngine::checkEntailed(const std::vector<Node>& nodes, bool inUnsatCore)
+Result SmtEngine::checkEntailed(const std::vector<Node>& nodes,
+                                bool inUnsatCore)
 {
   return checkSatInternal(nodes, inUnsatCore, true).asEntailmentResult();
 }
@@ -1610,7 +1614,8 @@ void SmtEngine::checkModel(bool hardFailure) {
         // [func->func2] and checking equality of the Nodes.
         // (this just a way to check if func is in n.)
         SubstitutionMap subs(&fakeContext);
-        Node func2 = NodeManager::currentNM()->mkSkolem("", func.getType(), "", NodeManager::SKOLEM_NO_NOTIFY);
+        Node func2 = NodeManager::currentNM()->mkSkolem(
+            "", func.getType(), "", NodeManager::SKOLEM_NO_NOTIFY);
         subs.addSubstitution(func, func2);
         if(subs.apply(n) != n) {
           Notice() << "SmtEngine::checkModel(): *** PROBLEM: MODEL VALUE DEFINED IN TERMS OF ITSELF ***" << endl;
@@ -1861,21 +1866,25 @@ bool SmtEngine::getAbduct(const Node& conj, Node& abd)
   return getAbduct(conj, grammarType, abd);
 }
 
-void SmtEngine::getInstantiatedQuantifiedFormulas( std::vector< Node >& qs ) {
+void SmtEngine::getInstantiatedQuantifiedFormulas(std::vector<Node>& qs)
+{
   SmtScope smts(this);
   TheoryEngine* te = getTheoryEngine();
   Assert(te != nullptr);
   te->getInstantiatedQuantifiedFormulas(qs);
 }
 
-void SmtEngine::getInstantiations( Node q, std::vector< Node >& insts ) {
+void SmtEngine::getInstantiations(Node q, std::vector<Node>& insts)
+{
   SmtScope smts(this);
   TheoryEngine* te = getTheoryEngine();
   Assert(te != nullptr);
   te->getInstantiations(q, insts);
 }
 
-void SmtEngine::getInstantiationTermVectors( Node q, std::vector< std::vector< Node > >& tvecs ) {
+void SmtEngine::getInstantiationTermVectors(
+    Node q, std::vector<std::vector<Node>>& tvecs)
+{
   SmtScope smts(this);
   Assert(options::trackInstLemmas());
   TheoryEngine* te = getTheoryEngine();

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1377,7 +1377,7 @@ Model* SmtEngine::getModel() {
   {
     // If we enabled model cores, we compute a model core for m based on our
     // (expanded) assertions using the model core builder utility
-    std::vector<Expr> eassertsProc = getExpandedAssertions();
+    std::vector<Node> eassertsProc = getExpandedAssertions();
     ModelCoreBuilder::setModelCore(eassertsProc, m, options::modelCoresMode());
   }
   m->d_inputName = d_state->getFilename();
@@ -1424,7 +1424,7 @@ Result SmtEngine::blockModelValues(const std::vector<Node>& exprs)
   if (Dump.isOn("benchmark"))
   {
     getOutputManager().getPrinter().toStreamCmdBlockModelValues(
-        getOutputManager().getDumpOut(), exprVectorToNodes(exprs));
+        getOutputManager().getDumpOut(), exprs);
   }
 
   TheoryModel* m = getAvailableModel("block model values");

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -115,20 +115,6 @@ using namespace CVC4::theory;
 
 namespace CVC4 {
 
-// !!! Temporary until commands are migrated to the new API !!!
-std::vector<Node> exprVectorToNodes(const std::vector<Expr>& exprs)
-{
-  std::vector<Node> nodes;
-  nodes.reserve(exprs.size());
-
-  for (Expr e : exprs)
-  {
-    nodes.push_back(Node::fromExpr(e));
-  }
-
-  return nodes;
-}
-
 SmtEngine::SmtEngine(ExprManager* em, Options* optr)
     : d_state(new SmtEngineState(*this)),
       d_exprManager(em),

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1447,8 +1447,8 @@ std::pair<Node, Node> SmtEngine::getSepHeapAndNilExpr(void)
     throw RecoverableModalException(msg);
   }
   NodeManagerScope nms(d_nodeManager);
-  Node heap;
-  Node nil;
+  Expr heap;
+  Expr nil;
   Model* m = getAvailableModel("get separation logic heap and nil");
   if (!m->getHeapModel(heap, nil))
   {
@@ -1456,7 +1456,7 @@ std::pair<Node, Node> SmtEngine::getSepHeapAndNilExpr(void)
         << "SmtEngine::getSepHeapAndNilExpr(): failed to obtain heap/nil "
            "expressions from theory model.";
   }
-  return std::make_pair(heap, nil);
+  return std::make_pair(Node::fromExpr(heap), Node::fromExpr(nil));
 }
 
 std::vector<Node> SmtEngine::getExpandedAssertions()
@@ -1610,7 +1610,7 @@ void SmtEngine::checkModel(bool hardFailure) {
         // [func->func2] and checking equality of the Nodes.
         // (this just a way to check if func is in n.)
         SubstitutionMap subs(&fakeContext);
-        Node func2 = NodeManager::currentNM()->mkSkolem("", TypeNode::fromType(func.getType()), "", NodeManager::SKOLEM_NO_NOTIFY);
+        Node func2 = NodeManager::currentNM()->mkSkolem("", func.getType(), "", NodeManager::SKOLEM_NO_NOTIFY);
         subs.addSubstitution(func, func2);
         if(subs.apply(n) != n) {
           Notice() << "SmtEngine::checkModel(): *** PROBLEM: MODEL VALUE DEFINED IN TERMS OF ITSELF ***" << endl;
@@ -1861,28 +1861,18 @@ bool SmtEngine::getAbduct(const Node& conj, Node& abd)
   return getAbduct(conj, grammarType, abd);
 }
 
-void SmtEngine::getInstantiatedQuantifiedFormulas( std::vector< Expr >& qs ) {
+void SmtEngine::getInstantiatedQuantifiedFormulas( std::vector< Node >& qs ) {
   SmtScope smts(this);
   TheoryEngine* te = getTheoryEngine();
   Assert(te != nullptr);
-  std::vector<Node> qs_n;
-  te->getInstantiatedQuantifiedFormulas(qs_n);
-  for (std::size_t i = 0, n = qs_n.size(); i < n; i++)
-  {
-    qs.push_back(qs_n[i].toExpr());
-  }
+  te->getInstantiatedQuantifiedFormulas(qs);
 }
 
 void SmtEngine::getInstantiations( Node q, std::vector< Node >& insts ) {
   SmtScope smts(this);
   TheoryEngine* te = getTheoryEngine();
   Assert(te != nullptr);
-  std::vector<Node> insts_n;
-  te->getInstantiations(q, insts_n);
-  for (std::size_t i = 0, n = insts_n.size(); i < n; i++)
-  {
-    insts.push_back(insts_n[i].toExpr());
-  }
+  te->getInstantiations(q, insts);
 }
 
 void SmtEngine::getInstantiationTermVectors( Node q, std::vector< std::vector< Node > >& tvecs ) {

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -941,7 +941,13 @@ void SmtEngine::notifyPostSolvePost()
   te->postsolve();
 }
 
-Result SmtEngine::checkSat(const Expr& assumption, bool inUnsatCore)
+Result SmtEngine::checkSat()
+{
+  Node nullNode;
+  return checkSat(nullNode);
+}
+
+Result SmtEngine::checkSat(const Node& assumption, bool inUnsatCore)
 {
   if (Dump.isOn("benchmark"))
   {
@@ -951,12 +957,12 @@ Result SmtEngine::checkSat(const Expr& assumption, bool inUnsatCore)
   std::vector<Node> assump;
   if (!assumption.isNull())
   {
-    assump.push_back(Node::fromExpr(assumption));
+    assump.push_back(assumption);
   }
   return checkSatInternal(assump, inUnsatCore, false);
 }
 
-Result SmtEngine::checkSat(const vector<Expr>& assumptions, bool inUnsatCore)
+Result SmtEngine::checkSat(const std::vector<Node>& assumptions, bool inUnsatCore)
 {
   if (Dump.isOn("benchmark"))
   {
@@ -971,15 +977,10 @@ Result SmtEngine::checkSat(const vector<Expr>& assumptions, bool inUnsatCore)
           getOutputManager().getDumpOut(), exprVectorToNodes(assumptions));
     }
   }
-  std::vector<Node> assumps;
-  for (const Expr& e : assumptions)
-  {
-    assumps.push_back(Node::fromExpr(e));
-  }
-  return checkSatInternal(assumps, inUnsatCore, false);
+  return checkSatInternal(assumptions, inUnsatCore, false);
 }
 
-Result SmtEngine::checkEntailed(const Expr& node, bool inUnsatCore)
+Result SmtEngine::checkEntailed(const Node& node, bool inUnsatCore)
 {
   if (Dump.isOn("benchmark"))
   {
@@ -988,23 +989,18 @@ Result SmtEngine::checkEntailed(const Expr& node, bool inUnsatCore)
   }
   return checkSatInternal(node.isNull()
                               ? std::vector<Node>()
-                              : std::vector<Node>{Node::fromExpr(node)},
+                              : std::vector<Node>{node},
                           inUnsatCore,
                           true)
       .asEntailmentResult();
 }
 
-Result SmtEngine::checkEntailed(const vector<Expr>& nodes, bool inUnsatCore)
+Result SmtEngine::checkEntailed(const std::vector<Node>& nodes, bool inUnsatCore)
 {
-  std::vector<Node> ns;
-  for (const Expr& e : nodes)
-  {
-    ns.push_back(Node::fromExpr(e));
-  }
-  return checkSatInternal(ns, inUnsatCore, true).asEntailmentResult();
+  return checkSatInternal(nodes, inUnsatCore, true).asEntailmentResult();
 }
 
-Result SmtEngine::checkSatInternal(const vector<Node>& assumptions,
+Result SmtEngine::checkSatInternal(const std::vector<Node>& assumptions,
                                    bool inUnsatCore,
                                    bool isEntailmentCheck)
 {

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -540,7 +540,7 @@ class CVC4_PUBLIC SmtEngine
    * this function returns true if the expression was added and false
    * if this request was ignored.
    */
-  bool addToAssignment(const Node& e);
+  bool addToAssignment(const Expr& e);
 
   /**
    * Get the assignment (only if immediately preceded by a SAT or

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -391,8 +391,7 @@ class CVC4_PUBLIC SmtEngine
    *
    * @throw Exception
    */
-  Result checkEntailed(const Node& assumption,
-                       bool inUnsatCore = true);
+  Result checkEntailed(const Node& assumption, bool inUnsatCore = true);
   Result checkEntailed(const std::vector<Node>& assumptions,
                        bool inUnsatCore = true);
 
@@ -691,7 +690,7 @@ class CVC4_PUBLIC SmtEngine
    * instantiation lemmas above.
    */
   void getInstantiationTermVectors(Node q,
-                                   std::vector<std::vector<Node> >& tvecs);
+                                   std::vector<std::vector<Node>>& tvecs);
 
   /**
    * Get an unsatisfiable core (only if immediately preceded by an UNSAT or

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -391,7 +391,7 @@ class CVC4_PUBLIC SmtEngine
    *
    * @throw Exception
    */
-  Result checkEntailed(const Node& assumption = Node(),
+  Result checkEntailed(const Node& assumption,
                        bool inUnsatCore = true);
   Result checkEntailed(const std::vector<Node>& assumptions,
                        bool inUnsatCore = true);
@@ -402,7 +402,8 @@ class CVC4_PUBLIC SmtEngine
    *
    * @throw Exception
    */
-  Result checkSat(const Node& assumption = Node(), bool inUnsatCore = true);
+  Result checkSat();
+  Result checkSat(const Node& assumption, bool inUnsatCore = true);
   Result checkSat(const std::vector<Node>& assumptions,
                   bool inUnsatCore = true);
 

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -306,13 +306,13 @@ class CVC4_PUBLIC SmtEngine
    *
    * The return value has the same meaning as that of assertFormula.
    */
-  Result blockModelValues(const std::vector<Expr>& exprs);
+  Result blockModelValues(const std::vector<Node>& exprs);
 
   /** When using separation logic, obtain the expression for the heap.  */
-  Expr getSepHeapExpr();
+  Node getSepHeapExpr();
 
   /** When using separation logic, obtain the expression for nil.  */
-  Expr getSepNilExpr();
+  Node getSepNilExpr();
 
   /**
    * Get an aspect of the current SMT execution environment.
@@ -333,13 +333,13 @@ class CVC4_PUBLIC SmtEngine
    * @param global True if this definition is global (i.e. should persist when
    *               popping the user context)
    */
-  void defineFunction(Expr func,
-                      const std::vector<Expr>& formals,
-                      Expr formula,
+  void defineFunction(Node func,
+                      const std::vector<Node>& formals,
+                      Node formula,
                       bool global = false);
 
   /** Return true if given expression is a defined function. */
-  bool isDefinedFunction(Expr func);
+  bool isDefinedFunction(Node func);
 
   /**
    * Define functions recursive
@@ -359,17 +359,17 @@ class CVC4_PUBLIC SmtEngine
    * @param global True if this definition is global (i.e. should persist when
    *               popping the user context)
    */
-  void defineFunctionsRec(const std::vector<Expr>& funcs,
-                          const std::vector<std::vector<Expr>>& formals,
-                          const std::vector<Expr>& formulas,
+  void defineFunctionsRec(const std::vector<Node>& funcs,
+                          const std::vector<std::vector<Node>>& formals,
+                          const std::vector<Node>& formulas,
                           bool global = false);
   /**
    * Define function recursive
    * Same as above, but for a single function.
    */
-  void defineFunctionRec(Expr func,
-                         const std::vector<Expr>& formals,
-                         Expr formula,
+  void defineFunctionRec(Node func,
+                         const std::vector<Node>& formals,
+                         Node formula,
                          bool global = false);
   /**
    * Add a formula to the current context: preprocess, do per-theory
@@ -391,9 +391,9 @@ class CVC4_PUBLIC SmtEngine
    *
    * @throw Exception
    */
-  Result checkEntailed(const Expr& assumption = Expr(),
+  Result checkEntailed(const Node& assumption = Node(),
                        bool inUnsatCore = true);
-  Result checkEntailed(const std::vector<Expr>& assumptions,
+  Result checkEntailed(const std::vector<Node>& assumptions,
                        bool inUnsatCore = true);
 
   /**
@@ -402,8 +402,8 @@ class CVC4_PUBLIC SmtEngine
    *
    * @throw Exception
    */
-  Result checkSat(const Expr& assumption = Expr(), bool inUnsatCore = true);
-  Result checkSat(const std::vector<Expr>& assumptions,
+  Result checkSat(const Node& assumption = Node(), bool inUnsatCore = true);
+  Result checkSat(const std::vector<Node>& assumptions,
                   bool inUnsatCore = true);
 
   /**
@@ -528,7 +528,7 @@ class CVC4_PUBLIC SmtEngine
   /**
    * Same as getValue but for a vector of expressions
    */
-  std::vector<Expr> getValues(const std::vector<Expr>& exprs);
+  std::vector<Node> getValues(const std::vector<Node>& exprs);
 
   /**
    * Add a function to the set of expressions whose value is to be
@@ -539,7 +539,7 @@ class CVC4_PUBLIC SmtEngine
    * this function returns true if the expression was added and false
    * if this request was ignored.
    */
-  bool addToAssignment(const Expr& e);
+  bool addToAssignment(const Node& e);
 
   /**
    * Get the assignment (only if immediately preceded by a SAT or
@@ -666,7 +666,7 @@ class CVC4_PUBLIC SmtEngine
    * Get list of quantified formulas that were instantiated on the last call
    * to check-sat.
    */
-  void getInstantiatedQuantifiedFormulas(std::vector<Expr>& qs);
+  void getInstantiatedQuantifiedFormulas(std::vector<Node>& qs);
 
   /**
    * Get instantiations for quantified formula q.
@@ -679,7 +679,7 @@ class CVC4_PUBLIC SmtEngine
    * In particular, if q is of the form forall x. P(x), then insts is a list
    * of formulas of the form P(t1), ..., P(tn).
    */
-  void getInstantiations(Expr q, std::vector<Expr>& insts);
+  void getInstantiations(Node q, std::vector<Node>& insts);
   /**
    * Get instantiation term vectors for quantified formula q.
    *
@@ -689,8 +689,8 @@ class CVC4_PUBLIC SmtEngine
    * Notice that these are not guaranteed to come in the same order as the
    * instantiation lemmas above.
    */
-  void getInstantiationTermVectors(Expr q,
-                                   std::vector<std::vector<Expr> >& tvecs);
+  void getInstantiationTermVectors(Node q,
+                                   std::vector<std::vector<Node> >& tvecs);
 
   /**
    * Get an unsatisfiable core (only if immediately preceded by an UNSAT or
@@ -703,7 +703,7 @@ class CVC4_PUBLIC SmtEngine
    * Get the current set of assertions.  Only permitted if the
    * SmtEngine is set to operate interactively.
    */
-  std::vector<Expr> getAssertions();
+  std::vector<Node> getAssertions();
 
   /**
    * Push a user-level context.
@@ -879,7 +879,7 @@ class CVC4_PUBLIC SmtEngine
    *
    * Return the set of assertions, after expanding definitions.
    */
-  std::vector<Expr> getExpandedAssertions();
+  std::vector<Node> getExpandedAssertions();
   /* .......................................................................  */
  private:
   /* .......................................................................  */
@@ -949,8 +949,8 @@ class CVC4_PUBLIC SmtEngine
    * the interpolation problem (interpol), and the solution implies the goal
    * (conj). If these criteria are not met, an internal error is thrown.
    */
-  void checkInterpol(Expr interpol,
-                     const std::vector<Expr>& easserts,
+  void checkInterpol(Node interpol,
+                     const std::vector<Node>& easserts,
                      const Node& conj);
 
   /**
@@ -1037,23 +1037,23 @@ class CVC4_PUBLIC SmtEngine
    * the function that the formal argument list is for. This method is used
    * as a helper function when defining (recursive) functions.
    */
-  void debugCheckFormals(const std::vector<Expr>& formals, Expr func);
+  void debugCheckFormals(const std::vector<Node>& formals, Node func);
 
   /**
    * Checks whether formula is a valid function body for func whose formal
    * argument list is stored in formals. This method is
    * used as a helper function when defining (recursive) functions.
    */
-  void debugCheckFunctionBody(Expr formula,
-                              const std::vector<Expr>& formals,
-                              Expr func);
+  void debugCheckFunctionBody(Node formula,
+                              const std::vector<Node>& formals,
+                              Node func);
 
   /**
    * Helper method to obtain both the heap and nil from the solver. Returns a
    * std::pair where the first element is the heap expression and the second
    * element is the nil expression.
    */
-  std::pair<Expr, Expr> getSepHeapAndNilExpr();
+  std::pair<Node, Node> getSepHeapAndNilExpr();
 
   /* Members -------------------------------------------------------------- */
 

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -386,7 +386,7 @@ bool CegSingleInv::solve()
     return false;
   }
   // now, get the instantiations
-  std::vector<Expr> qs;
+  std::vector<Node> qs;
   siSmt->getInstantiatedQuantifiedFormulas(qs);
   Assert(qs.size() <= 1);
   // track the instantiations, as solution construction is based on this
@@ -394,15 +394,13 @@ bool CegSingleInv::solve()
                     << std::endl;
   d_inst.clear();
   d_instConds.clear();
-  for (const Expr& q : qs)
+  for (const Node& q : qs)
   {
-    TNode qn = Node::fromExpr(q);
-    Assert(qn.getKind() == FORALL);
-    std::vector<std::vector<Expr> > tvecs;
-    siSmt->getInstantiationTermVectors(q, tvecs);
-    Trace("sygus-si") << "#instantiations of " << q << "=" << tvecs.size()
+    Assert(q.getKind() == FORALL);
+    siSmt->getInstantiationTermVectors(q, d_inst);
+    Trace("sygus-si") << "#instantiations of " << q << "=" << d_inst.size()
                       << std::endl;
-    // We use the original synthesis conjecture siq, since qn may contain
+    // We use the original synthesis conjecture siq, since q may contain
     // internal symbols e.g. termITE skolem after preprocessing.
     std::vector<Node> vars;
     for (const Node& v : siq[0])
@@ -410,14 +408,9 @@ bool CegSingleInv::solve()
       vars.push_back(v);
     }
     Node body = siq[1];
-    for (unsigned i = 0, ninsts = tvecs.size(); i < ninsts; i++)
+    for (unsigned i = 0, ninsts = d_inst.size(); i < ninsts; i++)
     {
-      std::vector<Expr>& tvi = tvecs[i];
-      std::vector<Node> inst;
-      for (const Expr& t : tvi)
-      {
-        inst.push_back(Node::fromExpr(t));
-      }
+      std::vector<Node>& inst = d_inst[i];
       Trace("sygus-si") << "  Instantiation: " << inst << std::endl;
       d_inst.push_back(inst);
       // instantiation should have same arity since we are not allowed to

--- a/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
+++ b/src/theory/quantifiers/sygus/ce_guided_single_inv.cpp
@@ -412,7 +412,6 @@ bool CegSingleInv::solve()
     {
       std::vector<Node>& inst = d_inst[i];
       Trace("sygus-si") << "  Instantiation: " << inst << std::endl;
-      d_inst.push_back(inst);
       // instantiation should have same arity since we are not allowed to
       // eliminate variables from quantifiers marked with QuantElimAttribute.
       Assert(inst.size() == vars.size());

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -98,8 +98,10 @@ void TheoryModel::setHeapModel( Node h, Node neq ) {
   d_sep_nil_eq = neq;
 }
 
-bool TheoryModel::getHeapModel( Node& h, Node& neq ) const {
-  if( d_sep_heap.isNull() || d_sep_nil_eq.isNull() ){
+bool TheoryModel::getHeapModel(Node& h, Node& neq) const
+{
+  if (d_sep_heap.isNull() || d_sep_nil_eq.isNull())
+  {
     return false;
   }
   h = d_sep_heap;

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -98,6 +98,15 @@ void TheoryModel::setHeapModel( Node h, Node neq ) {
   d_sep_nil_eq = neq;
 }
 
+bool TheoryModel::getHeapModel( Node& h, Node& neq ) const {
+  if( d_sep_heap.isNull() || d_sep_nil_eq.isNull() ){
+    return false;
+  }
+  h = d_sep_heap;
+  neq = d_sep_nil_eq;
+  return true;
+}
+
 bool TheoryModel::getHeapModel( Expr& h, Expr& neq ) const {
   if( d_sep_heap.isNull() || d_sep_nil_eq.isNull() ){
     return false;

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -301,6 +301,8 @@ public:
   /** set the heap and value sep.nil is equal to */
   void setHeapModel(Node h, Node neq);
   /** get the heap and value sep.nil is equal to */
+  bool getHeapModel(Node& h, Node& neq) const;
+  /** get the heap and value sep.nil is equal to */
   bool getHeapModel(Expr& h, Expr& neq) const override;
   //---------------------------- end separation logic
 

--- a/test/unit/expr/type_node_white.h
+++ b/test/unit/expr/type_node_white.h
@@ -64,9 +64,9 @@ class TypeNodeWhite : public CxxTest::TestSuite {
     Node xPos = d_nm->mkNode(GT, x, d_nm->mkConst(Rational(0)));
     TypeNode funtype = d_nm->mkFunctionType(integerType, booleanType);
     Node lambda = d_nm->mkVar("lambda", funtype);
-    vector<Expr> formals;
-    formals.push_back(x.toExpr());
-    d_smt->defineFunction(lambda.toExpr(), formals, xPos.toExpr());
+    vector<Node> formals;
+    formals.push_back(x);
+    d_smt->defineFunction(lambda, formals, xPos);
 
     TS_ASSERT( not realType.isComparableTo(booleanType) );
     TS_ASSERT( realType.isComparableTo(integerType) );


### PR DESCRIPTION
This eliminates all use of Expr in the SmtEngine except in a few interfaces (setUserAttribute, getAssignment) whose signature is currently in question.

The next steps will be to (1) eliminate Expr from the smt/model.h interface, (2) replace Type by TypeNode in Sort.