### PR TITLE
(proof-new) Added addTrustedConflict() for arithmetic inference manager

### DIFF
--- a/src/theory/arith/inference_manager.cpp
+++ b/src/theory/arith/inference_manager.cpp
@@ -98,6 +98,14 @@ void InferenceManager::addConflict(const Node& conf, InferenceId inftype)
   conflict(conf);
 }
 
+void InferenceManager::addTrustedConflict(const TrustNode& tconf,
+                                          InferenceId inftype)
+{
+  Trace("arith::infman") << "Adding conflict: " << inftype << " " << tconf
+                         << std::endl;
+  trustedConflict(tconf);
+}
+
 bool InferenceManager::hasUsed() const
 {
   return hasSent() || hasPending();

--- a/src/theory/arith/inference_manager.h
+++ b/src/theory/arith/inference_manager.h
@@ -87,12 +87,7 @@ class InferenceManager : public InferenceManagerBuffered
   void addConflict(const Node& conf, InferenceId inftype);
 
   /** Add a conflict with a proof to this inference manager. */
-  void addTrustedConflict(const TrustNode& tconf, InferenceId inftype)
-  {
-    Trace("arith::infman") << "Adding conflict: " << inftype << " " << tconf
-                           << std::endl;
-    trustedConflict(tconf);
-  }
+  void addTrustedConflict(const TrustNode& tconf, InferenceId inftype);
 
   /**
    * Checks whether we have made any progress, that is whether a conflict,

--- a/src/theory/arith/inference_manager.h
+++ b/src/theory/arith/inference_manager.h
@@ -37,7 +37,7 @@ class TheoryArith;
  * arithmetic theory.
  *
  * It adds some convenience methods to send ArithLemma and adds a mechanism for
- * waiting lemmas that can be flushed into the pending lemmas of the this
+ * waiting lemmas that can be flushed into the pending lemmas of this
  * buffered inference manager.
  * It also extends the caching mechanism of TheoryInferenceManager to cache
  * preprocessing lemmas and non-preprocessing lemmas separately. For the former,
@@ -51,20 +51,20 @@ class InferenceManager : public InferenceManagerBuffered
   InferenceManager(TheoryArith& ta, ArithState& astate, ProofNodeManager* pnm);
 
   /**
-   * Add a lemma as pending lemma to the this inference manager.
+   * Add a lemma as pending lemma to this inference manager.
    * If isWaiting is true, the lemma is first stored as waiting lemma and only
    * added as pending lemma when calling flushWaitingLemmas.
    */
   void addPendingArithLemma(std::unique_ptr<ArithLemma> lemma,
                             bool isWaiting = false);
   /**
-   * Add a lemma as pending lemma to the this inference manager.
+   * Add a lemma as pending lemma to this inference manager.
    * If isWaiting is true, the lemma is first stored as waiting lemma and only
    * added as pending lemma when calling flushWaitingLemmas.
    */
   void addPendingArithLemma(const ArithLemma& lemma, bool isWaiting = false);
   /**
-   * Add a lemma as pending lemma to the this inference manager.
+   * Add a lemma as pending lemma to this inference manager.
    * If isWaiting is true, the lemma is first stored as waiting lemma and only
    * added as pending lemma when calling flushWaitingLemmas.
    */
@@ -73,7 +73,7 @@ class InferenceManager : public InferenceManagerBuffered
                             bool isWaiting = false);
 
   /**
-   * Flush all waiting lemmas to the this inference manager (as pending
+   * Flush all waiting lemmas to this inference manager (as pending
    * lemmas). To actually send them, call doPendingLemmas() afterwards.
    */
   void flushWaitingLemmas();
@@ -83,12 +83,20 @@ class InferenceManager : public InferenceManagerBuffered
    */
   void clearWaitingLemmas();
 
-  /** Add a conflict to the this inference manager. */
+  /** Add a conflict to this inference manager. */
   void addConflict(const Node& conf, InferenceId inftype);
 
+  /** Add a conflict with a proof to this inference manager. */
+  void addTrustedConflict(const TrustNode& tconf, InferenceId inftype)
+  {
+    Trace("arith::infman") << "Adding conflict: " << inftype << " " << tconf
+                           << std::endl;
+    trustedConflict(tconf);
+  }
+
   /**
-   * Checks whether we have made any progress, that is whether a conflict, lemma
-   * or fact was added or whether a lemma or fact is pending.
+   * Checks whether we have made any progress, that is whether a conflict,
+   * lemma or fact was added or whether a lemma or fact is pending.
    */
   bool hasUsed() const;
 


### PR DESCRIPTION
This PR adds a new method `addTrustedConflict` for the arithmetic inference manager.