### PR TITLE
Remove uf-ss-totality option

### DIFF
--- a/src/options/uf_options.toml
+++ b/src/options/uf_options.toml
@@ -12,15 +12,6 @@ header = "options/uf_options.h"
   help       = "use UF symmetry breaker (Deharbe et al., CADE 2011)"
 
 [[option]]
-  name       = "ufssTotality"
-  category   = "regular"
-  long       = "uf-ss-totality"
-  type       = "bool"
-  default    = "false"
-  read_only  = true
-  help       = "always use totality axioms for enforcing cardinality constraints"
-
-[[option]]
   name       = "ufssTotalityLimited"
   category   = "regular"
   long       = "uf-ss-totality-limited=N"

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -685,10 +685,6 @@ void SortModel::check(Theory::Effort level)
     if( level==Theory::EFFORT_FULL ){
       Debug("uf-ss-sat") << "We have " << d_reps << " representatives for type "
                          << d_type << ", <= " << d_cardinality << std::endl;
-      // Notice() << "We have " << d_reps << " representatives for type " <<
-      // d_type << ", <= " << cardinality << std::endl; Notice() << "Model size
-      // for " << d_type << " is " << cardinality << std::endl; Notice() <<
-      // cardinality << " ";
     }
     return;
   }

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1304,7 +1304,7 @@ Node SortModel::getCardinalityLiteral(unsigned c)
     d_totalityTerms.push_back(var);
   }
   // must be distinct from all other cardinality terms
-  for (unsigned i = 1, size = d_totalityTerms.size(); i < size; i++)
+  for (size_t i = 1, size = d_totalityTerms.size(); i < size; i++)
   {
     Node lem = var.eqNode(d_totalityTerms[i - 1]).notNode();
     Trace("uf-ss-lemma") << "Totality distinctness lemma : " << lem

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1298,14 +1298,14 @@ Node SortModel::getCardinalityLiteral(unsigned c)
       var = nm->mkSkolem(ss.str(), d_type, "is a cardinality lemma term");
     }
     d_totalityTerms.push_back(var);
-  }
-  // must be distinct from all other cardinality terms
-  for (size_t i = 1, size = d_totalityTerms.size(); i < size; i++)
-  {
-    Node lem = var.eqNode(d_totalityTerms[i - 1]).notNode();
-    Trace("uf-ss-lemma") << "Totality distinctness lemma : " << lem
-                         << std::endl;
-    d_im.lemma(lem, LemmaProperty::NONE, false);
+    // must be distinct from all other cardinality terms
+    for (size_t i = 1, size = d_totalityTerms.size(); i < size; i++)
+    {
+      Node lem = var.eqNode(d_totalityTerms[i - 1]).notNode();
+      Trace("uf-ss-lemma") << "Totality distinctness lemma : " << lem
+                          << std::endl;
+      d_im.lemma(lem, LemmaProperty::NONE, false);
+    }
   }
   // must send totality axioms for each existing term
   for (NodeIntMap::iterator it = d_regions_map.begin();

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1105,7 +1105,7 @@ void SortModel::addTotalityAxiom(Node n, size_t cardinality)
           Trace("uf-ss-totality") << "Allocate symmetry breaking term " << n << ", index = " << use_cardinality << std::endl;
           if( sbts.size()>1 ){
             //enforce canonicity
-            for( int i=2; i<use_cardinality; i++ ){
+            for( size_t i=2; i<use_cardinality; i++ ){
               //can only be assigned to domain constant d if someone has been assigned domain constant d-1
               Node eq = n.eqNode( getTotalityLemmaTerm(i ) );
               std::vector< Node > eqs;
@@ -1122,7 +1122,7 @@ void SortModel::addTotalityAxiom(Node n, size_t cardinality)
       }
 
       std::vector< Node > eqs;
-      for( int i=0; i<use_cardinality; i++ ){
+      for( size_t i=0; i<use_cardinality; i++ ){
         eqs.push_back( n.eqNode( getTotalityLemmaTerm(i ) ) );
       }
       Node ax = eqs.size() == 1 ? eqs[0] : nm->mkNode(OR, eqs);

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1154,7 +1154,7 @@ bool SortModel::applyTotality( int cardinality ){
 Node SortModel::getTotalityLemmaTerm(size_t i)
 {
   NodeManager* nm = NodeManager::currentNM();
-  while (d_totalityTerms.size()<=i)
+  while (d_totalityTerms.size() <= i)
   {
     Node var;
     if (i == 0 && !options::ufssTotalitySymBreak())
@@ -1173,7 +1173,7 @@ Node SortModel::getTotalityLemmaTerm(size_t i)
     {
       Node lem = var.eqNode(d_totalityTerms[i]).notNode();
       Trace("uf-ss-lemma") << "Totality distinctness lemma : " << lem
-                          << std::endl;
+                           << std::endl;
       d_im.lemma(lem, LemmaProperty::NONE, false);
     }
     d_totalityTerms.push_back(var);

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -538,46 +538,56 @@ void SortModel::merge( Node a, Node b ){
   {
     return;
   }
-  Debug("uf-ss") << "CardinalityExtension: Merging " << a << " = " << b
-                  << "..." << std::endl;
-  if( a!=b ){
+  Debug("uf-ss") << "CardinalityExtension: Merging " << a << " = " << b << "..."
+                 << std::endl;
+  if (a != b)
+  {
     Assert(d_regions_map.find(a) != d_regions_map.end());
     Assert(d_regions_map.find(b) != d_regions_map.end());
     int ai = d_regions_map[a];
     int bi = d_regions_map[b];
     Debug("uf-ss") << "   regions: " << ai << " " << bi << std::endl;
-    if( ai!=bi ){
-      if( d_regions[ai]->getNumReps()==1  ){
-        int ri = combineRegions( bi, ai );
-        d_regions[ri]->setEqual( a, b );
-        checkRegion( ri );
-      }else if( d_regions[bi]->getNumReps()==1 ){
-        int ri = combineRegions( ai, bi );
-        d_regions[ri]->setEqual( a, b );
-        checkRegion( ri );
-      }else{
+    if (ai != bi)
+    {
+      if (d_regions[ai]->getNumReps() == 1)
+      {
+        int ri = combineRegions(bi, ai);
+        d_regions[ri]->setEqual(a, b);
+        checkRegion(ri);
+      }
+      else if (d_regions[bi]->getNumReps() == 1)
+      {
+        int ri = combineRegions(ai, bi);
+        d_regions[ri]->setEqual(a, b);
+        checkRegion(ri);
+      }
+      else
+      {
         // Either move a to d_regions[bi], or b to d_regions[ai].
         RegionNodeInfo* a_region_info = d_regions[ai]->getRegionInfo(a);
         RegionNodeInfo* b_region_info = d_regions[bi]->getRegionInfo(b);
-        int aex = ( a_region_info->getNumInternalDisequalities() -
-                    getNumDisequalitiesToRegion( a, bi ) );
-        int bex = ( b_region_info->getNumInternalDisequalities() -
-                    getNumDisequalitiesToRegion( b, ai ) );
+        int aex = (a_region_info->getNumInternalDisequalities()
+                   - getNumDisequalitiesToRegion(a, bi));
+        int bex = (b_region_info->getNumInternalDisequalities()
+                   - getNumDisequalitiesToRegion(b, ai));
         // Based on which would produce the fewest number of
         // external disequalities.
-        if( aex<bex ){
-          moveNode( a, bi );
-          d_regions[bi]->setEqual( a, b );
+        if (aex < bex)
+        {
+          moveNode(a, bi);
+          d_regions[bi]->setEqual(a, b);
         }else{
-          moveNode( b, ai );
+          moveNode(b, ai);
           d_regions[ai]->setEqual( a, b );
         }
-        checkRegion( ai );
-        checkRegion( bi );
+        checkRegion(ai);
+        checkRegion(bi);
       }
-    }else{
-      d_regions[ai]->setEqual( a, b );
-      checkRegion( ai );
+    }
+    else
+    {
+      d_regions[ai]->setEqual(a, b);
+      checkRegion(ai);
     }
     d_regions_map[b] = -1;
   }
@@ -590,43 +600,51 @@ void SortModel::assertDisequal( Node a, Node b, Node reason ){
   {
     return;
   }
-  //if they are not already disequal
+  // if they are not already disequal
   eq::EqualityEngine* ee = d_thss->getTheory()->getEqualityEngine();
   a = ee->getRepresentative(a);
   b = ee->getRepresentative(b);
   int ai = d_regions_map[a];
   int bi = d_regions_map[b];
-  if( d_regions[ai]->isDisequal( a, b, ai==bi ) ){
+  if (d_regions[ai]->isDisequal(a, b, ai == bi))
+  {
     // already disequal
     return;
   }
-  Debug("uf-ss") << "Assert disequal " << a << " != " << b << "..." << std::endl;
-  Debug("uf-ss-disequal") << "Assert disequal " << a << " != " << b << "..." << std::endl;
-  //add to list of disequalities
-  if( d_disequalities_index<d_disequalities.size() ){
+  Debug("uf-ss") << "Assert disequal " << a << " != " << b << "..."
+                 << std::endl;
+  Debug("uf-ss-disequal") << "Assert disequal " << a << " != " << b << "..."
+                          << std::endl;
+  // add to list of disequalities
+  if (d_disequalities_index < d_disequalities.size())
+  {
     d_disequalities[d_disequalities_index] = reason;
-  }else{
-    d_disequalities.push_back( reason );
+  }
+  else
+  {
+    d_disequalities.push_back(reason);
   }
   d_disequalities_index = d_disequalities_index + 1;
-  //now, add disequalities to regions
+  // now, add disequalities to regions
   Assert(d_regions_map.find(a) != d_regions_map.end());
   Assert(d_regions_map.find(b) != d_regions_map.end());
   Debug("uf-ss") << "   regions: " << ai << " " << bi << std::endl;
-  if( ai==bi ){
-    //internal disequality
-    d_regions[ai]->setDisequal( a, b, 1, true );
-    d_regions[ai]->setDisequal( b, a, 1, true );
-    //do not need to check if it needs to combine (no new ext. disequalities)
-    checkRegion( ai, false );  
-  }else{
-    //external disequality
-    d_regions[ai]->setDisequal( a, b, 0, true );
-    d_regions[bi]->setDisequal( b, a, 0, true );
-    checkRegion( ai );
-    checkRegion( bi );
+  if (ai == bi)
+  {
+    // internal disequality
+    d_regions[ai]->setDisequal(a, b, 1, true);
+    d_regions[ai]->setDisequal(b, a, 1, true);
+    // do not need to check if it needs to combine (no new ext. disequalities)
+    checkRegion(ai, false);
   }
-
+  else
+  {
+    // external disequality
+    d_regions[ai]->setDisequal(a, b, 0, true);
+    d_regions[bi]->setDisequal(b, a, 0, true);
+    checkRegion(ai);
+    checkRegion(bi);
+  }
 }
 
 bool SortModel::areDisequal( Node a, Node b ) {
@@ -651,34 +669,44 @@ void SortModel::check(Theory::Effort level)
     return;
   }
   Debug("uf-ss") << "CardinalityExtension: Check " << level << " " << d_type
-                  << std::endl;
-  if( level==Theory::EFFORT_FULL ){
+                 << std::endl;
+  if (level == Theory::EFFORT_FULL)
+  {
     Debug("fmf-full-check") << std::endl;
-    Debug("fmf-full-check") << "Full check for SortModel " << d_type << ", status : " << std::endl;
+    Debug("fmf-full-check")
+        << "Full check for SortModel " << d_type << ", status : " << std::endl;
     debugPrint("fmf-full-check");
     Debug("fmf-full-check") << std::endl;
   }
-  if( d_reps<=(unsigned)d_cardinality ){
-    Debug("uf-ss-debug") << "We have " << d_reps << " representatives for type " << d_type << ", <= " << d_cardinality << std::endl;
+  if (d_reps <= (unsigned)d_cardinality)
+  {
+    Debug("uf-ss-debug") << "We have " << d_reps << " representatives for type "
+                         << d_type << ", <= " << d_cardinality << std::endl;
     if( level==Theory::EFFORT_FULL ){
-      Debug("uf-ss-sat") << "We have " << d_reps << " representatives for type " << d_type << ", <= " << d_cardinality << std::endl;
-      //Notice() << "We have " << d_reps << " representatives for type " << d_type << ", <= " << cardinality << std::endl;
-      //Notice() << "Model size for " << d_type << " is " << cardinality << std::endl;
-      //Notice() << cardinality << " ";
+      Debug("uf-ss-sat") << "We have " << d_reps << " representatives for type "
+                         << d_type << ", <= " << d_cardinality << std::endl;
+      // Notice() << "We have " << d_reps << " representatives for type " <<
+      // d_type << ", <= " << cardinality << std::endl; Notice() << "Model size
+      // for " << d_type << " is " << cardinality << std::endl; Notice() <<
+      // cardinality << " ";
     }
     return;
   }
-  //first check if we can generate a clique conflict
-  //do a check within each region
+  // first check if we can generate a clique conflict
+  // do a check within each region
   for (size_t i = 0; i < d_regions_index; i++)
   {
-    if( d_regions[i]->valid() ){
-      std::vector< Node > clique;
-      if( d_regions[i]->check( level, d_cardinality, clique ) ){
-        //add clique lemma
+    if (d_regions[i]->valid())
+    {
+      std::vector<Node> clique;
+      if (d_regions[i]->check(level, d_cardinality, clique))
+      {
+        // add clique lemma
         addCliqueLemma(clique);
         return;
-      }else{
+      }
+      else
+      {
         Trace("uf-ss-debug") << "No clique in Region #" << i << std::endl;
       }
     }
@@ -691,8 +719,7 @@ void SortModel::check(Theory::Effort level)
     // see if we have any recommended splits from large regions
     for (size_t i = 0; i < d_regions_index; i++)
     {
-      if (d_regions[i]->valid()
-          && d_regions[i]->getNumReps() > d_cardinality)
+      if (d_regions[i]->valid() && d_regions[i]->getNumReps() > d_cardinality)
       {
         int sp = addSplit(d_regions[i]);
         if (sp == 1)
@@ -713,8 +740,7 @@ void SortModel::check(Theory::Effort level)
     return;
   }
   // check at full effort
-  Trace("uf-ss-debug")
-      << "No splits added. " << d_cardinality << std::endl;
+  Trace("uf-ss-debug") << "No splits added. " << d_cardinality << std::endl;
   Trace("uf-ss-si") << "Must combine region" << std::endl;
   bool recheck = false;
   SortInference* si = d_thss->getSortInference();

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1283,24 +1283,20 @@ Node SortModel::getCardinalityLiteral(unsigned c)
   }
 
   NodeManager* nm = NodeManager::currentNM();
-  Node var;
-  if (c == 1 && !options::ufssTotalitySymBreak())
+  while (d_totalityTerms.size()<c)
   {
-    // get arbitrary ground term
-    var = d_cardinality_term;
-  }
-  else
-  {
-    std::stringstream ss;
-    ss << "_c_" << c;
-    var = nm->mkSkolem(ss.str(), d_type, "is a cardinality lemma term");
-  }
-  if ((c - 1) < d_totalityTerms.size())
-  {
-    d_totalityTerms[c - 1] = var;
-  }
-  else
-  {
+    Node var;
+    if (c == 1 && !options::ufssTotalitySymBreak())
+    {
+      // get arbitrary ground term
+      var = d_cardinality_term;
+    }
+    else
+    {
+      std::stringstream ss;
+      ss << "_c_" << c;
+      var = nm->mkSkolem(ss.str(), d_type, "is a cardinality lemma term");
+    }
     d_totalityTerms.push_back(var);
   }
   // must be distinct from all other cardinality terms

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -528,7 +528,9 @@ void SortModel::newEqClass( Node n ){
       if( options::ufssTotality() ){
         // Regions map will store whether we need to equate this term
         // with a constant equivalence class.
-        if( std::find( d_totalityTerms.begin(), d_totalityTerms.end(), n )==d_totalityTerms.end() ){
+        if (std::find(d_totalityTerms.begin(), d_totalityTerms.end(), n)
+            == d_totalityTerms.end())
+        {
           d_regions_map[n] = 0;
         }else{
           d_regions_map[n] = -1;
@@ -1080,7 +1082,9 @@ void SortModel::addCliqueLemma(std::vector<Node>& clique)
 
 void SortModel::addTotalityAxiom(Node n, size_t cardinality)
 {
-  if( std::find( d_totalityTerms.begin(), d_totalityTerms.end(), n )==d_totalityTerms.end() ){
+  if (std::find(d_totalityTerms.begin(), d_totalityTerms.end(), n)
+      == d_totalityTerms.end())
+  {
     if( std::find( d_totality_lems[n].begin(), d_totality_lems[n].end(), cardinality ) == d_totality_lems[n].end() ){
       NodeManager* nm = NodeManager::currentNM();
       d_totality_lems[n].push_back( cardinality );
@@ -1095,22 +1099,27 @@ void SortModel::addTotalityAxiom(Node n, size_t cardinality)
       size_t use_cardinality = cardinality;
       if( options::ufssTotalitySymBreak() ){
         TypeNode tn = n.getType();
-        std::vector< Node >& sbts = d_sym_break_terms[tn][sort_id];
+        std::vector<Node>& sbts = d_sym_break_terms[tn][sort_id];
         if( d_sym_break_index.find(n)!=d_sym_break_index.end() ){
           use_cardinality = d_sym_break_index[n];
-        }else if( sbts.size()+1<cardinality ){
+        }
+        else if (sbts.size() + 1 < cardinality)
+        {
           use_cardinality = sbts.size() + 1;
-          sbts.push_back( n );
+          sbts.push_back(n);
           d_sym_break_index[n] = use_cardinality;
           Trace("uf-ss-totality") << "Allocate symmetry breaking term " << n << ", index = " << use_cardinality << std::endl;
-          if( sbts.size()>1 ){
+          if (sbts.size() > 1)
+          {
             //enforce canonicity
-            for( size_t i=2; i<use_cardinality; i++ ){
+            for (size_t i = 2; i < use_cardinality; i++)
+            {
               //can only be assigned to domain constant d if someone has been assigned domain constant d-1
-              Node eq = n.eqNode( getTotalityLemmaTerm(i ) );
+              Node eq = n.eqNode(getTotalityLemmaTerm(i));
               std::vector< Node > eqs;
-              for( size_t j=0; j<(sbts.size()-1); j++ ){
-                eqs.push_back( sbts[j].eqNode( getTotalityLemmaTerm(i-1 ) ) );
+              for (size_t j = 0; j < (sbts.size() - 1); j++)
+              {
+                eqs.push_back(sbts[j].eqNode(getTotalityLemmaTerm(i - 1)));
               }
               Node ax = eqs.size()==1 ? eqs[0] : NodeManager::currentNM()->mkNode( OR, eqs );
               Node lem = NodeManager::currentNM()->mkNode( IMPLIES, eq, ax );
@@ -1122,8 +1131,9 @@ void SortModel::addTotalityAxiom(Node n, size_t cardinality)
       }
 
       std::vector< Node > eqs;
-      for( size_t i=0; i<use_cardinality; i++ ){
-        eqs.push_back( n.eqNode( getTotalityLemmaTerm(i ) ) );
+      for (size_t i = 0; i < use_cardinality; i++)
+      {
+        eqs.push_back(n.eqNode(getTotalityLemmaTerm(i)));
       }
       Node ax = eqs.size() == 1 ? eqs[0] : nm->mkNode(OR, eqs);
       Node lem = NodeManager::currentNM()->mkNode( IMPLIES, cardLit, ax );
@@ -1141,8 +1151,9 @@ bool SortModel::applyTotality( int cardinality ){
 }
 
 /** get totality lemma terms */
-Node SortModel::getTotalityLemmaTerm( size_t i ){
-  Assert (i<d_totalityTerms.size());
+Node SortModel::getTotalityLemmaTerm(size_t i)
+{
+  Assert(i < d_totalityTerms.size());
   return d_totalityTerms[i];
 }
 

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -266,7 +266,7 @@ class CardinalityExtension
     /** add clique lemma */
     void addCliqueLemma(std::vector<Node>& clique);
     /** add totality axiom */
-    void addTotalityAxiom(Node n, int cardinality);
+    void addTotalityAxiom(Node n, size_t cardinality);
     /** cardinality */
     context::CDO< int > d_cardinality;
     /** cardinality lemma term */
@@ -289,7 +289,7 @@ class CardinalityExtension
     /** apply totality */
     bool applyTotality( int cardinality );
     /** get totality lemma terms */
-    Node getTotalityLemmaTerm( int cardinality, int i );
+    Node getTotalityLemmaTerm( size_t i );
     /** simple check cardinality */
     void simpleCheckCardinality();
 

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -272,7 +272,7 @@ class CardinalityExtension
     /** cardinality lemma term */
     Node d_cardinality_term;
     /** cardinality totality terms */
-    std::map< int, std::vector< Node > > d_totality_terms;
+    std::vector< Node > d_totalityTerms;
     /** cardinality literals */
     std::map< int, Node > d_cardinality_literal;
     /** whether a positive cardinality constraint has been asserted */

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -272,7 +272,7 @@ class CardinalityExtension
     /** cardinality lemma term */
     Node d_cardinality_term;
     /** cardinality totality terms */
-    std::vector< Node > d_totalityTerms;
+    std::vector<Node> d_totalityTerms;
     /** cardinality literals */
     std::map< int, Node > d_cardinality_literal;
     /** whether a positive cardinality constraint has been asserted */

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -222,7 +222,7 @@ class CardinalityExtension
     /** Pointer to the cardinality extension that owns this. */
     CardinalityExtension* d_thss;
     /** regions used to d_region_index */
-    context::CDO< unsigned > d_regions_index;
+    context::CDO< size_t > d_regions_index;
     /** vector of regions */
     std::vector< Region* > d_regions;
     /** map from Nodes to index of d_regions they exist in, -1 means invalid */
@@ -265,31 +265,22 @@ class CardinalityExtension
     int addSplit(Region* r);
     /** add clique lemma */
     void addCliqueLemma(std::vector<Node>& clique);
-    /** add totality axiom */
-    void addTotalityAxiom(Node n, size_t cardinality);
     /** cardinality */
-    context::CDO< int > d_cardinality;
+    context::CDO< size_t > d_cardinality;
     /** cardinality lemma term */
     Node d_cardinality_term;
-    /** cardinality totality terms */
-    std::vector<Node> d_totalityTerms;
     /** cardinality literals */
-    std::map< int, Node > d_cardinality_literal;
+    std::map< size_t, Node > d_cardinality_literal;
     /** whether a positive cardinality constraint has been asserted */
     context::CDO< bool > d_hasCard;
     /** clique lemmas that have been asserted */
     std::map< int, std::vector< std::vector< Node > > > d_cliques;
     /** maximum negatively asserted cardinality */
-    context::CDO< int > d_maxNegCard;
+    context::CDO< size_t > d_maxNegCard;
     /** list of fresh representatives allocated */
     std::vector< Node > d_fresh_aloc_reps;
     /** whether we are initialized */
     context::CDO< bool > d_initialized;
-
-    /** apply totality */
-    bool applyTotality( int cardinality );
-    /** get totality lemma terms */
-    Node getTotalityLemmaTerm(size_t i);
     /** simple check cardinality */
     void simpleCheckCardinality();
 
@@ -322,7 +313,7 @@ class CardinalityExtension
     /** get cardinality term */
     Node getCardinalityTerm() { return d_cardinality_term; }
     /** get cardinality literal */
-    Node getCardinalityLiteral(unsigned c);
+    Node getCardinalityLiteral(size_t c);
     /** get maximum negative cardinality */
     int getMaximumNegativeCardinality() { return d_maxNegCard.get(); }
     //print debug
@@ -406,8 +397,6 @@ class CardinalityExtension
     IntStat d_clique_conflicts;
     IntStat d_clique_lemmas;
     IntStat d_split_lemmas;
-    IntStat d_disamb_term_lemmas;
-    IntStat d_totality_lemmas;
     IntStat d_max_model_size;
     Statistics();
     ~Statistics();

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -222,7 +222,7 @@ class CardinalityExtension
     /** Pointer to the cardinality extension that owns this. */
     CardinalityExtension* d_thss;
     /** regions used to d_region_index */
-    context::CDO< size_t > d_regions_index;
+    context::CDO<size_t> d_regions_index;
     /** vector of regions */
     std::vector< Region* > d_regions;
     /** map from Nodes to index of d_regions they exist in, -1 means invalid */
@@ -266,17 +266,17 @@ class CardinalityExtension
     /** add clique lemma */
     void addCliqueLemma(std::vector<Node>& clique);
     /** cardinality */
-    context::CDO< size_t > d_cardinality;
+    context::CDO<size_t> d_cardinality;
     /** cardinality lemma term */
     Node d_cardinality_term;
     /** cardinality literals */
-    std::map< size_t, Node > d_cardinality_literal;
+    std::map<size_t, Node> d_cardinality_literal;
     /** whether a positive cardinality constraint has been asserted */
     context::CDO< bool > d_hasCard;
     /** clique lemmas that have been asserted */
     std::map< int, std::vector< std::vector< Node > > > d_cliques;
     /** maximum negatively asserted cardinality */
-    context::CDO< size_t > d_maxNegCard;
+    context::CDO<size_t> d_maxNegCard;
     /** list of fresh representatives allocated */
     std::vector< Node > d_fresh_aloc_reps;
     /** whether we are initialized */

--- a/src/theory/uf/cardinality_extension.h
+++ b/src/theory/uf/cardinality_extension.h
@@ -289,7 +289,7 @@ class CardinalityExtension
     /** apply totality */
     bool applyTotality( int cardinality );
     /** get totality lemma terms */
-    Node getTotalityLemmaTerm( size_t i );
+    Node getTotalityLemmaTerm(size_t i);
     /** simple check cardinality */
     void simpleCheckCardinality();
 

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -509,6 +509,8 @@ set(regress_0_tests
   regress0/fmf/fmf-strange-bounds-2.smt2
   regress0/fmf/forall_unit_data2.smt2
   regress0/fmf/issue3661-ccard-dec.smt2
+  regress0/fmf/issue4872-qf_ufc.smt2
+  regress0/fmf/issue5239-uf-ss-tot.smt2
   regress0/fmf/krs-sat.smt2
   regress0/fmf/no-minimal-sat.smt2
   regress0/fmf/quant_real_univ.cvc

--- a/test/regress/regress0/fmf/issue4872-qf_ufc.smt2
+++ b/test/regress/regress0/fmf/issue4872-qf_ufc.smt2
@@ -1,0 +1,8 @@
+(set-logic QF_UFC)
+(set-option :uf-ss-totality true)
+(set-info :status sat)
+(declare-sort S0 0)
+(declare-const S0-0 S0)
+(assert (fmf.card S0-0 1))
+(assert (fmf.card S0-0 4))
+(check-sat)

--- a/test/regress/regress0/fmf/issue4872-qf_ufc.smt2
+++ b/test/regress/regress0/fmf/issue4872-qf_ufc.smt2
@@ -1,5 +1,4 @@
 (set-logic QF_UFC)
-(set-option :uf-ss-totality true)
 (set-info :status sat)
 (declare-sort S0 0)
 (declare-const S0-0 S0)

--- a/test/regress/regress0/fmf/issue5239-uf-ss-tot.smt2
+++ b/test/regress/regress0/fmf/issue5239-uf-ss-tot.smt2
@@ -1,0 +1,7 @@
+(set-logic UFC)
+(set-option :uf-ss-totality true)
+(set-info :status sat)
+(declare-sort a 0)
+(declare-fun b () a)
+(assert (fmf.card b 2))
+(check-sat)

--- a/test/regress/regress0/fmf/issue5239-uf-ss-tot.smt2
+++ b/test/regress/regress0/fmf/issue5239-uf-ss-tot.smt2
@@ -1,5 +1,4 @@
 (set-logic UFC)
-(set-option :uf-ss-totality true)
 (set-info :status sat)
 (declare-sort a 0)
 (declare-fun b () a)

--- a/test/regress/regress1/fmf/issue4068-si-qf.smt2
+++ b/test/regress/regress1/fmf/issue4068-si-qf.smt2
@@ -1,4 +1,4 @@
-; COMMAND-LINE: --uf-ss-totality --fmf-fun --sort-inference --no-check-models
+; COMMAND-LINE: --fmf-fun --sort-inference --no-check-models
 ; EXPECT: sat
 (set-logic QF_UFNIA)
 (set-info :status sat)


### PR DESCRIPTION
This option has a number of subtle bugs, it should be reimplemented if/when finite-model-find is refactored.  It is not high priority enough to maintain.

This does some additional cleaning of the uf cardinality extension, some methods changed indentation.

Fixes #5239, fixes #4872, fixes #4865.