### PR TITLE
Catch more cases of nested recursion in datatypes

### DIFF
--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -431,6 +431,7 @@ set(regress_0_tests
   regress0/datatypes/is_test.smt2
   regress0/datatypes/issue1433.smt2
   regress0/datatypes/issue2838.cvc
+  regress0/datatypes/issue5280-no-nrec.smt2
   regress0/datatypes/jsat-2.6.smt2
   regress0/datatypes/list-bool.smt2
   regress0/datatypes/model-subterms-min.smt2

--- a/test/regress/regress0/datatypes/issue5280-no-nrec.smt2
+++ b/test/regress/regress0/datatypes/issue5280-no-nrec.smt2
@@ -1,0 +1,7 @@
+; EXPECT: (error "")
+(set-logic ALL)
+(declare-datatype ty0 ((Emp) (Container (v2 (Set ty0)))))
+(declare-fun v1 () ty0)
+(assert (not ((_ is Emp) v1)))
+(assert (= (v2 v1) (singleton v1)))
+(check-sat)

--- a/test/regress/regress0/datatypes/issue5280-no-nrec.smt2
+++ b/test/regress/regress0/datatypes/issue5280-no-nrec.smt2
@@ -1,4 +1,5 @@
-; EXPECT: (error "")
+; EXPECT: (error "Cannot handle nested-recursive datatype ty0")
+; EXIT: 1
 (set-logic ALL)
 (declare-datatype ty0 ((Emp) (Container (v2 (Set ty0)))))
 (declare-fun v1 () ty0)


### PR DESCRIPTION
Fixes #5280. 

Previously we were checking for nested recursive datatypes in expandDefinitions.  This does not catch cases where the only terms of a malformed nested recursive datatype are variables.  The proper place to check is in preRegisterTerm.  The benchmark from that issue now gives an error.