### PR TITLE
(proof-new) Update add lazy step interface in LazyCDProof

### DIFF
--- a/src/expr/lazy_proof.cpp
+++ b/src/expr/lazy_proof.cpp
@@ -133,10 +133,10 @@ std::shared_ptr<ProofNode> LazyCDProof::getProofFor(Node fact)
 
 void LazyCDProof::addLazyStep(Node expected,
                               ProofGenerator* pg,
+                              PfRule idNull,
                               bool isClosed,
                               const char* ctx,
-                              bool forceOverwrite,
-                              PfRule idNull)
+                              bool forceOverwrite)
 {
   if (pg == nullptr)
   {

--- a/src/expr/lazy_proof.h
+++ b/src/expr/lazy_proof.h
@@ -67,23 +67,23 @@ class LazyCDProof : public CDProof
    *
    * @param expected The fact that can be proven.
    * @param pg The generator that can proof expected.
+   * @param trustId If a null proof generator is provided, we add a step to
+   * the proof that has trustId as the rule and expected as the sole argument.
+   * We do this only if trustId is not PfRule::ASSUME. This is primarily used
+   * for identifying the kind of hole when a proof generator is not given.
    * @param isClosed Whether to expect that pg can provide a closed proof for
    * this fact.
    * @param ctx The context we are in (for debugging).
    * @param forceOverwrite If this flag is true, then this call overwrites
    * an existing proof generator provided for expected, if one was provided
    * via a previous call to addLazyStep in the current context.
-   * @param trustId If a null proof generator is provided, we add a step to
-   * the proof that has trustId as the rule and expected as the sole argument.
-   * We do this only if trustId is not PfRule::ASSUME. This is primarily used
-   * for identifying the kind of hole when a proof generator is not given.
    */
   void addLazyStep(Node expected,
                    ProofGenerator* pg,
-                   bool isClosed = true,
+                   PfRule trustId = PfRule::ASSUME,
+                   bool isClosed = false,
                    const char* ctx = "LazyCDProof::addLazyStep",
-                   bool forceOverwrite = false,
-                   PfRule trustId = PfRule::ASSUME);
+                   bool forceOverwrite = false);
   /**
    * Does this have any proof generators? This method always returns true
    * if the default is non-null.

--- a/src/expr/term_conversion_proof_generator.cpp
+++ b/src/expr/term_conversion_proof_generator.cpp
@@ -62,13 +62,17 @@ TConvProofGenerator::TConvProofGenerator(ProofNodeManager* pnm,
 
 TConvProofGenerator::~TConvProofGenerator() {}
 
-void TConvProofGenerator::addRewriteStep(
-    Node t, Node s, ProofGenerator* pg, bool isClosed, uint32_t tctx)
+void TConvProofGenerator::addRewriteStep(Node t,
+                                         Node s,
+                                         ProofGenerator* pg,
+                                         PfRule trustId,
+                                         bool isClosed,
+                                         uint32_t tctx)
 {
   Node eq = registerRewriteStep(t, s, tctx);
   if (!eq.isNull())
   {
-    d_proof.addLazyStep(eq, pg, isClosed);
+    d_proof.addLazyStep(eq, pg, trustId, isClosed);
   }
 }
 

--- a/src/expr/term_conversion_proof_generator.h
+++ b/src/expr/term_conversion_proof_generator.h
@@ -144,6 +144,8 @@ class TConvProofGenerator : public ProofGenerator
   /**
    * Add rewrite step t --> s based on proof generator.
    *
+   * @param trustId If a null proof generator is provided, we add a step to
+   * the proof that has trustId as the rule and expected as the sole argument.
    * @param isClosed whether to expect that pg can provide a closed proof for
    * this fact.
    * @param tctx The term context identifier for the rewrite step. This
@@ -154,7 +156,8 @@ class TConvProofGenerator : public ProofGenerator
   void addRewriteStep(Node t,
                       Node s,
                       ProofGenerator* pg,
-                      bool isClosed = true,
+                      PfRule trustId = PfRule::ASSUME,
+                      bool isClosed = false,
                       uint32_t tctx = 0);
   /** Same as above, for a single step */
   void addRewriteStep(Node t, Node s, ProofStep ps, uint32_t tctx = 0);

--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -155,9 +155,8 @@ void AssertionPipeline::conjoin(size_t i, Node n, ProofGenerator* pg)
     //   rewrite( d_nodes[i] ^ n )
     // allocate a fresh proof which will act as the proof generator
     LazyCDProof* lcp = d_pppg->allocateHelperProof();
-    lcp->addLazyStep(d_nodes[i], d_pppg, false);
-    lcp->addLazyStep(
-        n, pg, false, "AssertionPipeline::conjoin", false, PfRule::PREPROCESS);
+    lcp->addLazyStep(d_nodes[i], d_pppg);
+    lcp->addLazyStep(n, pg, PfRule::PREPROCESS);
     lcp->addStep(newConj, PfRule::AND_INTRO, {d_nodes[i], n}, {});
     if (newConjr != newConj)
     {

--- a/src/prop/proof_cnf_stream.cpp
+++ b/src/prop/proof_cnf_stream.cpp
@@ -81,8 +81,11 @@ void ProofCnfStream::convertAndAssert(TNode node,
     Trace("cnf") << "ProofCnfStream::convertAndAssert: pg: " << pg->identify()
                  << "\n";
     Node toJustify = negated ? node.notNode() : static_cast<Node>(node);
-    d_proof.addLazyStep(
-        toJustify, pg, true, "ProofCnfStream::convertAndAssert:cnf");
+    d_proof.addLazyStep(toJustify,
+                        pg,
+                        PfRule::ASSUME,
+                        true,
+                        "ProofCnfStream::convertAndAssert:cnf");
   }
   convertAndAssert(node, negated);
   // process saved steps in buffer
@@ -519,8 +522,11 @@ void ProofCnfStream::convertPropagation(theory::TrustNode trn)
   Assert(trn.getGenerator()->getProofFor(proven)->isClosed());
   Trace("cnf-steps") << proven << " by explainPropagation "
                      << trn.identifyGenerator() << std::endl;
-  d_proof.addLazyStep(
-      proven, trn.getGenerator(), true, "ProofCnfStream::convertPropagation");
+  d_proof.addLazyStep(proven,
+                      trn.getGenerator(),
+                      PfRule::ASSUME,
+                      true,
+                      "ProofCnfStream::convertPropagation");
   // since the propagation is added directly to the SAT solver via theoryProxy,
   // do the transformation of the lemma E1 ^ ... ^ En => P into CNF here
   NodeManager* nm = NodeManager::currentNM();
@@ -548,7 +554,7 @@ void ProofCnfStream::convertPropagation(theory::TrustNode trn)
     d_proof.addStep(clauseExp,
                     PfRule::RESOLUTION,
                     {clauseAndNeg, clauseImpliesElim},
-                    {proven[0]});
+                    {nm->mkConst(true), proven[0]});
   }
   else
   {

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -542,10 +542,10 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
     Node ret = builtinPfC->applyRewrite(args[0], idr);
     Node eq = args[0].eqNode(ret);
     if (idr == MethodId::RW_REWRITE || idr == MethodId::RW_REWRITE_EQ_EXT)
-    {    
+    {
       // automatically expand THEORY_REWRITE as well here if set
       bool elimTR =
-(d_elimRules.find(PfRule::THEORY_REWRITE) != d_elimRules.end());
+          (d_elimRules.find(PfRule::THEORY_REWRITE) != d_elimRules.end());
       // rewrites from theory::Rewriter
       bool isExtEq = (idr == MethodId::RW_REWRITE_EQ_EXT);
       // use rewrite with proof interface

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -460,8 +460,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
           // add previous rewrite steps
           for (unsigned j = 0, nvars = vvec.size(); j < nvars; j++)
           {
-            // not necessarily closed, so we pass false to addRewriteStep.
-            tcg.addRewriteStep(vvec[j], svec[j], pgs[j], false);
+            tcg.addRewriteStep(vvec[j], svec[j], pgs[j]);
           }
           // get the proof for the update to the current substitution
           Node seqss = subs.eqNode(ss);
@@ -506,8 +505,7 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
                                true);
       for (unsigned j = 0, nvars = vvec.size(); j < nvars; j++)
       {
-        // not necessarily closed, so we pass false to addRewriteStep.
-        tcpg.addRewriteStep(vvec[j], svec[j], pgs[j], false);
+        tcpg.addRewriteStep(vvec[j], svec[j], pgs[j]);
       }
       // add the proof constructed by the term conversion utility
       std::shared_ptr<ProofNode> pfn = tcpg.getProofFor(eq);
@@ -544,11 +542,11 @@ Node ProofPostprocessCallback::expandMacros(PfRule id,
     Node ret = builtinPfC->applyRewrite(args[0], idr);
     Node eq = args[0].eqNode(ret);
     if (idr == MethodId::RW_REWRITE || idr == MethodId::RW_REWRITE_EQ_EXT)
-    {
-      // rewrites from theory::Rewriter
+    {    
       // automatically expand THEORY_REWRITE as well here if set
       bool elimTR =
-          (d_elimRules.find(PfRule::THEORY_REWRITE) != d_elimRules.end());
+(d_elimRules.find(PfRule::THEORY_REWRITE) != d_elimRules.end());
+      // rewrites from theory::Rewriter
       bool isExtEq = (idr == MethodId::RW_REWRITE_EQ_EXT);
       // use rewrite with proof interface
       Rewriter* rr = d_smte->getRewriter();

--- a/src/smt/term_formula_removal.cpp
+++ b/src/smt/term_formula_removal.cpp
@@ -334,10 +334,9 @@ Node RemoveTermFormulas::runCurrent(std::pair<Node, uint32_t>& curr,
           ProofGenerator* expg = sm->getProofGenerator(existsAssertion);
           d_lp->addLazyStep(existsAssertion,
                             expg,
+                            PfRule::WITNESS_AXIOM,
                             true,
-                            "RemoveTermFormulas::run:skolem_pf",
-                            false,
-                            PfRule::WITNESS_AXIOM);
+                            "RemoveTermFormulas::run:skolem_pf");
           d_lp->addStep(newAssertion, PfRule::SKOLEMIZE, {existsAssertion}, {});
           newAssertionPg = d_lp.get();
         }

--- a/src/smt/witness_form.cpp
+++ b/src/smt/witness_form.cpp
@@ -114,12 +114,11 @@ Node WitnessFormGenerator::convertToWitnessForm(Node t)
           d_wintroPf.addLazyStep(
               exists,
               pg,
+              PfRule::WITNESS_AXIOM,
               true,
-              "WitnessFormGenerator::convertToWitnessForm:witness_axiom",
-              false,
-              PfRule::WITNESS_AXIOM);
+              "WitnessFormGenerator::convertToWitnessForm:witness_axiom");
           d_wintroPf.addStep(eq, PfRule::WITNESS_INTRO, {exists}, {});
-          d_tcpg.addRewriteStep(cur, curw, &d_wintroPf);
+          d_tcpg.addRewriteStep(cur, curw, &d_wintroPf, PfRule::ASSUME, true);
         }
         else
         {

--- a/src/theory/quantifiers/instantiate.cpp
+++ b/src/theory/quantifiers/instantiate.cpp
@@ -268,10 +268,9 @@ bool Instantiate::addInstantiation(
       // add the transformation proof, or THEORY_PREPROCESS if none provided
       pfTmp->addLazyStep(proven,
                          tpBody.getGenerator(),
+                         PfRule::THEORY_PREPROCESS,
                          true,
-                         "Instantiate::getInstantiation:qpreprocess",
-                         false,
-                         PfRule::THEORY_PREPROCESS);
+                         "Instantiate::getInstantiation:qpreprocess");
       pfTmp->addStep(body, PfRule::EQ_RESOLVE, {orig_body, proven}, {});
     }
   }
@@ -477,10 +476,9 @@ Node Instantiate::getInstantiation(Node q,
         Node proven = trn.getProven();
         pf->addLazyStep(proven,
                         trn.getGenerator(),
+                        PfRule::THEORY_PREPROCESS,
                         true,
-                        "Instantiate::getInstantiation:rewrite_inst",
-                        false,
-                        PfRule::THEORY_PREPROCESS);
+                        "Instantiate::getInstantiation:rewrite_inst");
         pf->addStep(newBody, PfRule::EQ_RESOLVE, {body, proven}, {});
       }
       body = newBody;

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1462,10 +1462,9 @@ theory::LemmaStatus TheoryEngine::lemma(theory::TrustNode tlemma,
         {
           d_lazyProof->addLazyStep(tplemma.getProven(),
                                    tplemma.getGenerator(),
+                                   PfRule::PREPROCESS_LEMMA,
                                    true,
-                                   "TheoryEngine::lemma_pp",
-                                   false,
-                                   PfRule::PREPROCESS_LEMMA);
+                                   "TheoryEngine::lemma_pp");
           // ---------- from d_lazyProof -------------- from theory preprocess
           // lemma                       lemma = lemmap
           // ------------------------------------------ EQ_RESOLVE

--- a/src/theory/theory_preprocessor.cpp
+++ b/src/theory/theory_preprocessor.cpp
@@ -213,10 +213,9 @@ TrustNode TheoryPreprocessor::preprocess(TNode node,
         // store in the lazy proof
         d_lp->addLazyStep(assertion,
                           trn.getGenerator(),
+                          PfRule::THEORY_PREPROCESS_LEMMA,
                           true,
-                          "TheoryPreprocessor::rewrite_lemma_new",
-                          false,
-                          PfRule::THEORY_PREPROCESS_LEMMA);
+                          "TheoryPreprocessor::rewrite_lemma_new");
         d_lp->addStep(rewritten,
                       PfRule::MACRO_SR_PRED_TRANSFORM,
                       {assertion},

--- a/src/theory/theory_preprocessor.cpp
+++ b/src/theory/theory_preprocessor.cpp
@@ -433,7 +433,8 @@ Node TheoryPreprocessor::preprocessWithProof(Node term)
       trn.debugCheckClosed("tpp-proof-debug",
                            "TheoryPreprocessor::preprocessWithProof");
       // always use term context hash 0 (default)
-      d_tpg->addRewriteStep(term, termr, trn.getGenerator(), PfRule::ASSUME, true);
+      d_tpg->addRewriteStep(
+          term, termr, trn.getGenerator(), PfRule::ASSUME, true);
     }
     else
     {

--- a/src/theory/theory_preprocessor.cpp
+++ b/src/theory/theory_preprocessor.cpp
@@ -433,7 +433,7 @@ Node TheoryPreprocessor::preprocessWithProof(Node term)
       trn.debugCheckClosed("tpp-proof-debug",
                            "TheoryPreprocessor::preprocessWithProof");
       // always use term context hash 0 (default)
-      d_tpg->addRewriteStep(term, termr, trn.getGenerator());
+      d_tpg->addRewriteStep(term, termr, trn.getGenerator(), PfRule::ASSUME, true);
     }
     else
     {

--- a/src/theory/trust_substitutions.h
+++ b/src/theory/trust_substitutions.h
@@ -74,7 +74,7 @@ class TrustSubstitutionMap
   ProofGenerator* addSubstitutionSolved(TNode x, TNode t, TrustNode tn);
   /**
    * Add substitutions from trust substitution map t. This adds all
-   * substitutions for t and carries over its information about proofs.
+   * substitutions from the map t and carries over its information about proofs.
    */
   void addSubstitutions(TrustSubstitutionMap& t);
   /**

--- a/src/theory/trust_substitutions.h
+++ b/src/theory/trust_substitutions.h
@@ -68,11 +68,13 @@ class TrustSubstitutionMap
    * based on transforming the tn.getProven() to (= x t) if tn has a
    * non-null proof generator; otherwise if tn has no proof generator
    * we simply add the substitution.
+   *
+   * @return The proof generator that can prove (= x t).
    */
-  void addSubstitutionSolved(TNode x, TNode t, TrustNode tn);
+  ProofGenerator* addSubstitutionSolved(TNode x, TNode t, TrustNode tn);
   /**
    * Add substitutions from trust substitution map t. This adds all
-   * substitutions from the map t and carries over its information about proofs.
+   * substitutions for t and carries over its information about proofs.
    */
   void addSubstitutions(TrustSubstitutionMap& t);
   /**

--- a/src/theory/uf/proof_equality_engine.cpp
+++ b/src/theory/uf/proof_equality_engine.cpp
@@ -68,7 +68,7 @@ bool ProofEqEngine::assertFact(Node lit,
   ps.d_args = args;
   d_factPg.addStep(lit, ps);
   // add lazy step to proof
-  d_proof.addLazyStep(lit, &d_factPg, false);
+  d_proof.addLazyStep(lit, &d_factPg);
   // second, assert it to the equality engine
   Node reason = NodeManager::currentNM()->mkAnd(exp);
   return assertFactInternal(atom, polarity, reason);
@@ -116,7 +116,7 @@ bool ProofEqEngine::assertFact(Node lit,
   ps.d_args = args;
   d_factPg.addStep(lit, ps);
   // add lazy step to proof
-  d_proof.addLazyStep(lit, &d_factPg, false);
+  d_proof.addLazyStep(lit, &d_factPg);
   // second, assert it to the equality engine
   return assertFactInternal(atom, polarity, exp);
 }
@@ -140,7 +140,7 @@ bool ProofEqEngine::assertFact(Node lit, Node exp, ProofStepBuffer& psb)
     d_factPg.addStep(step.first, step.second);
   }
   // add lazy step to proof
-  d_proof.addLazyStep(lit, &d_factPg, false);
+  d_proof.addLazyStep(lit, &d_factPg);
   // second, assert it to the equality engine
   return assertFactInternal(atom, polarity, exp);
 }
@@ -157,7 +157,7 @@ bool ProofEqEngine::assertFact(Node lit, Node exp, ProofGenerator* pg)
     return false;
   }
   // note the proof generator is responsible for remembering the explanation
-  d_proof.addLazyStep(lit, pg, false);
+  d_proof.addLazyStep(lit, pg);
   // second, assert it to the equality engine
   return assertFactInternal(atom, polarity, exp);
 }


### PR DESCRIPTION
Ensuring closed proofs should not be enabled by default, it is actually not used very often as a whole.  Moreover, the "trust id" argument is the most useful argument and hence should come as the 3rd argument.  This updates all uses of addLazyStep for the change in interface, also changes term conversion generator which had a similar issue with default arguments.

Notice that some calls to addLazyStep were checking closed but without providing a debug string, these I've left alone (they no longer check closed).