### PR TITLE
Handle rewrite to bool in BoundInference

### DIFF
--- a/src/theory/arith/bound_inference.cpp
+++ b/src/theory/arith/bound_inference.cpp
@@ -95,8 +95,13 @@ Bounds BoundInference::get(const Node& v) const
 const std::map<Node, Bounds>& BoundInference::get() const { return d_bounds; }
 bool BoundInference::add(const Node& n)
 {
+  Node tmp = Rewriter::rewrite(n);
+  if (tmp.getKind() == Kind::CONST_BOOLEAN)
+  {
+    return false;
+  }
   // Parse the node as a comparison
-  auto comp = Comparison::parseNormalForm(Rewriter::rewrite(n));
+  auto comp = Comparison::parseNormalForm(tmp);
   auto dec = comp.decompose(true);
   if (std::get<0>(dec).isVariable())
   {

--- a/src/theory/arith/nl/icp/icp_solver.cpp
+++ b/src/theory/arith/nl/icp/icp_solver.cpp
@@ -306,13 +306,12 @@ void ICPSolver::reset(const std::vector<Node>& assertions)
   d_state.reset();
   for (const auto& n : assertions)
   {
-    Node tmp = Rewriter::rewrite(n);
     Trace("nl-icp") << "Adding " << n << std::endl;
-    if (tmp.getKind() != Kind::CONST_BOOLEAN)
+    if (n.getKind() != Kind::CONST_BOOLEAN)
     {
-      if (!d_state.d_bounds.add(tmp))
+      if (!d_state.d_bounds.add(n))
       {
-        addCandidate(tmp);
+        addCandidate(n);
       }
     }
   }

--- a/src/theory/arith/nl/icp/icp_solver.cpp
+++ b/src/theory/arith/nl/icp/icp_solver.cpp
@@ -306,12 +306,13 @@ void ICPSolver::reset(const std::vector<Node>& assertions)
   d_state.reset();
   for (const auto& n : assertions)
   {
+    Node tmp = Rewriter::rewrite(n);
     Trace("nl-icp") << "Adding " << n << std::endl;
-    if (n.getKind() != Kind::CONST_BOOLEAN)
+    if (tmp.getKind() != Kind::CONST_BOOLEAN)
     {
-      if (!d_state.d_bounds.add(n))
+      if (!d_state.d_bounds.add(tmp))
       {
-        addCandidate(n);
+        addCandidate(tmp);
       }
     }
   }

--- a/src/theory/arith/nl/icp/icp_solver.cpp
+++ b/src/theory/arith/nl/icp/icp_solver.cpp
@@ -77,8 +77,12 @@ std::vector<Node> ICPSolver::collectVariables(const Node& n) const
 
 std::vector<Candidate> ICPSolver::constructCandidates(const Node& n)
 {
-  auto comp =
-      Comparison::parseNormalForm(Rewriter::rewrite(n)).decompose(false);
+  Node tmp = Rewriter::rewrite(n);
+  if (tmp.isConst())
+  {
+    return {};
+  }
+  auto comp = Comparison::parseNormalForm(tmp).decompose(false);
   Kind k = std::get<1>(comp);
   if (k == Kind::DISTINCT)
   {


### PR DESCRIPTION
The BoundInference class did not properly handle rewrites that yield constant Booleans. This PR fixes this issue by explicitly checking for this case.