### PR TITLE
Use theoryof-mode=type for QF_NRA

### DIFF
--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -604,7 +604,8 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
     if (logic.isSharingEnabled() && !logic.isTheoryEnabled(THEORY_BV)
         && !logic.isTheoryEnabled(THEORY_STRINGS)
         && !logic.isTheoryEnabled(THEORY_SETS)
-        && !logic.isTheoryEnabled(THEORY_BAGS))
+        && !logic.isTheoryEnabled(THEORY_BAGS)
+        && !(logic.isTheoryEnabled(THEORY_ARITH) && !logic.isLinear()))
     {
       Trace("smt") << "setting theoryof-mode to term-based" << std::endl;
       options::theoryOfMode.set(options::TheoryOfMode::THEORY_OF_TERM_BASED);

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -605,7 +605,8 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
         && !logic.isTheoryEnabled(THEORY_STRINGS)
         && !logic.isTheoryEnabled(THEORY_SETS)
         && !logic.isTheoryEnabled(THEORY_BAGS)
-        && !(logic.isTheoryEnabled(THEORY_ARITH) && !logic.isLinear()))
+        && !(logic.isTheoryEnabled(THEORY_ARITH) && !logic.isLinear()
+             && !logic.isQuantified()))
     {
       Trace("smt") << "setting theoryof-mode to term-based" << std::endl;
       options::theoryOfMode.set(options::TheoryOfMode::THEORY_OF_TERM_BASED);


### PR DESCRIPTION
We've observed that our QF_NRA solving benefits significantly from `--theoryof-mode=type` across the board (of other options that influence QF_NRA solving). This PR sets `type` as the new default for QF_NRA solving.