### PR TITLE
Set strings pending conflict flag

### DIFF
--- a/src/theory/strings/solver_state.cpp
+++ b/src/theory/strings/solver_state.cpp
@@ -246,6 +246,7 @@ void SolverState::setPendingConflict(InferInfo& ii)
   if (!d_pendingConflictSet.get())
   {
     d_pendingConflict = ii;
+    d_pendingConflictSet.set(true);
   }
 }
 


### PR DESCRIPTION
While addressing the review on https://github.com/CVC4/CVC4/commit/6898ab93a3858e78b20af38e537fe48ee9140c58, strings eager conflicts were accidentally disabled, this reenables them.