### PR TITLE
Simplify handling of subtypes in smt2 printer

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -5130,7 +5130,15 @@ Term Solver::getValue(Term term) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
   CVC4_API_SOLVER_CHECK_TERM(term);
-  return Term(this, d_smtEngine->getValue(*term.d_node));
+  Node value = d_smtEngine->getValue(*term.d_node);
+  Term res = Term(this, value);
+  // May need to wrap in real cast so that user know this is a real.
+  TypeNode tn = (*term.d_node).getType();
+  if (!tn.isInteger() && value.getType().isInteger())
+  {
+    return ensureRealSort(res);
+  }
+  return res;
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
 

--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -3187,6 +3187,19 @@ Term Solver::mkCharFromStrHelper(const std::string& s) const
   return mkValHelper<CVC4::String>(CVC4::String(cpts));
 }
 
+Term Solver::getValueHelper(Term term) const
+{
+  Node value = d_smtEngine->getValue(*term.d_node);
+  Term res = Term(this, value);
+  // May need to wrap in real cast so that user know this is a real.
+  TypeNode tn = (*term.d_node).getType();
+  if (!tn.isInteger() && value.getType().isInteger())
+  {
+    return ensureRealSort(res);
+  }
+  return res;
+}
+
 Term Solver::mkTermFromKind(Kind kind) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
@@ -5130,15 +5143,7 @@ Term Solver::getValue(Term term) const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;
   CVC4_API_SOLVER_CHECK_TERM(term);
-  Node value = d_smtEngine->getValue(*term.d_node);
-  Term res = Term(this, value);
-  // May need to wrap in real cast so that user know this is a real.
-  TypeNode tn = (*term.d_node).getType();
-  if (!tn.isInteger() && value.getType().isInteger())
-  {
-    return ensureRealSort(res);
-  }
-  return res;
+  return getValueHelper(term);
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
 
@@ -5161,7 +5166,7 @@ std::vector<Term> Solver::getValue(const std::vector<Term>& terms) const
         this == terms[i].d_solver, "term", terms[i], i)
         << "term associated to this solver object";
     /* Can not use emplace_back here since constructor is private. */
-    res.push_back(Term(this, d_smtEngine->getValue(terms[i].d_node->toExpr())));
+    res.push_back(getValueHelper(terms[i]));
   }
   return res;
   CVC4_API_SOLVER_TRY_CATCH_END;

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -3462,6 +3462,8 @@ class CVC4_PUBLIC Solver
   Term mkTermFromKind(Kind kind) const;
   /* Helper for mkChar functions that take a string as argument. */
   Term mkCharFromStrHelper(const std::string& s) const;
+  /** Get value helper, which accounts for subtyping */
+  Term getValueHelper(Term term) const;
 
   /**
    * Helper function that ensures that a given term is of sort real (as opposed

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -466,7 +466,7 @@ void Smt2Printer::toStream(std::ostream& out, TNode n, int toDepth) const
       // If constant rational, print as special case
       if (type_asc_arg.getKind() == kind::CONST_RATIONAL)
       {
-        const Rational& r = n.getConst<Rational>();
+        const Rational& r = type_asc_arg.getConst<Rational>();
         toStreamRational(out, r, !is_int, d_variant);
       }
       else

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -69,7 +69,7 @@ static void toStreamRational(std::ostream& out,
   {
     if (neg)
     {
-      out << (v == sygus_variant ? "-" : "(- ") << -r;
+      out << "(- " << -r;
     }
     else
     {
@@ -81,7 +81,7 @@ static void toStreamRational(std::ostream& out,
     }
     if (neg)
     {
-      out << (v == sygus_variant ? "" : ")");
+      out << ")";
     }
   }
   else
@@ -90,8 +90,8 @@ static void toStreamRational(std::ostream& out,
     if (neg)
     {
       Rational abs_r = (-r);
-      out << (v == sygus_variant ? "-" : "(- ") << abs_r.getNumerator();
-      out << (v == sygus_variant ? " " : ") ") << abs_r.getDenominator();
+      out << "(- ") << abs_r.getNumerator();
+      out << ") " << abs_r.getDenominator();
     }
     else
     {
@@ -179,11 +179,7 @@ void Smt2Printer::toStream(std::ostream& out, TNode n, int toDepth) const
       }
       break;
     case kind::BITVECTOR_TYPE:
-      if(d_variant == sygus_variant ){
-        out << "(BitVec " << n.getConst<BitVectorSize>().d_size << ")";
-      }else{
-        out << "(_ BitVec " << n.getConst<BitVectorSize>().d_size << ")";
-      }
+      out << "(_ BitVec " << n.getConst<BitVectorSize>().d_size << ")";
       break;
     case kind::FLOATINGPOINT_TYPE:
       out << "(_ FloatingPoint "

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1023,7 +1023,7 @@ void Smt2Printer::toStreamCastToType(std::ostream& out,
   {
     Assert (tn.isReal());
     // probably due to subtyping integers and reals, cast it
-    nasc = NodeManager::currentNM()->mkNode(kind::CAST_TO_REAL, tc, n);
+    nasc = NodeManager::currentNM()->mkNode(kind::CAST_TO_REAL, n);
   }
   else
   {

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -90,7 +90,7 @@ static void toStreamRational(std::ostream& out,
     if (neg)
     {
       Rational abs_r = (-r);
-      out << "(- ") << abs_r.getNumerator();
+      out << "(- " << abs_r.getNumerator();
       out << ") " << abs_r.getDenominator();
     }
     else

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1021,7 +1021,7 @@ void Smt2Printer::toStreamCastToType(std::ostream& out,
   Node nasc;
   if (n.getType().isInteger() && !tn.isInteger())
   {
-    Assert (tn.isReal());
+    Assert(tn.isReal());
     // probably due to subtyping integers and reals, cast it
     nasc = NodeManager::currentNM()->mkNode(kind::CAST_TO_REAL, n);
   }

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1019,13 +1019,11 @@ void Smt2Printer::toStreamCastToType(std::ostream& out,
                                      TypeNode tn) const
 {
   Node nasc;
-  if (n.getType() != tn)
+  if (n.getType().isInteger() && !tn.isInteger())
   {
-    // probably due to subtyping integers and reals, cast it using an apply
-    // type ascription.
-    NodeManager* nm = NodeManager::currentNM();
-    Node tc = nm->mkConst(AscriptionType(tn));
-    nasc = nm->mkNode(kind::APPLY_TYPE_ASCRIPTION, tc, n);
+    Assert (tn.isReal());
+    // probably due to subtyping integers and reals, cast it
+    nasc = NodeManager::currentNM()->mkNode(kind::CAST_TO_REAL, tc, n);
   }
   else
   {

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -403,14 +403,11 @@ void Smt2Printer::toStream(std::ostream& out,
   // determine if we are printing out a type ascription, store the argument of
   // the type ascription into type_asc_arg.
   Node type_asc_arg;
+  TypeNode force_nt;
   if (n.getKind() == kind::APPLY_TYPE_ASCRIPTION)
   {
     force_nt = n.getOperator().getConst<AscriptionType>().getType();
     type_asc_arg = n[0];
-  }
-  else if (!force_nt.isNull() && n.getType() != force_nt)
-  {
-    type_asc_arg = n;
   }
   if (!type_asc_arg.isNull())
   {

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1025,7 +1025,7 @@ void Smt2Printer::toStreamCastToType(std::ostream& out,
   {
     nasc = n;
   }
-  toStream(out, nasc, -1);
+  toStream(out, nasc, toDepth);
 }
 
 static string smtKindString(Kind k, Variant v)

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -65,7 +65,8 @@ static void toStreamRational(std::ostream& out,
   // Print the rational, possibly as decimal.
   // Notice that we print (/ (- 5) 3) instead of (- (/ 5 3)),
   // the former is compliant with real values in the smt lib standard.
-  if(r.isIntegral()) {
+  if (r.isIntegral())
+  {
     if (neg)
     {
       out << (v == sygus_variant ? "-" : "(- ") << -r;
@@ -74,18 +75,26 @@ static void toStreamRational(std::ostream& out,
     {
       out << r;
     }
-    if (decimal) { out << ".0"; }
+    if (decimal)
+    {
+      out << ".0";
+    }
     if (neg)
     {
       out << (v == sygus_variant ? "" : ")");
     }
-  }else{
+  }
+  else
+  {
     out << "(/ ";
-    if(neg) {
+    if (neg)
+    {
       Rational abs_r = (-r);
       out << (v == sygus_variant ? "-" : "(- ") << abs_r.getNumerator();
       out << (v == sygus_variant ? " " : ") ") << abs_r.getDenominator();
-    }else{
+    }
+    else
+    {
       out << r.getNumerator();
       out << ' ' << r.getDenominator();
     }
@@ -143,9 +152,7 @@ static bool stringifyRegexp(Node n, stringstream& ss) {
   return true;
 }
 
-void Smt2Printer::toStream(std::ostream& out,
-                           TNode n,
-                           int toDepth) const
+void Smt2Printer::toStream(std::ostream& out, TNode n, int toDepth) const
 {
   // null
   if(n.getKind() == kind::NULL_EXPR) {
@@ -153,7 +160,7 @@ void Smt2Printer::toStream(std::ostream& out,
     return;
   }
 
-  NodeManager * nm = NodeManager::currentNM();
+  NodeManager* nm = NodeManager::currentNM();
   // constant
   if(n.getMetaKind() == kind::metakind::CONSTANT) {
     switch(n.getKind()) {
@@ -457,7 +464,7 @@ void Smt2Printer::toStream(std::ostream& out,
       // the logic is mixed int/real. The former occurs more frequently.
       bool is_int = force_nt.isInteger();
       // If constant rational, print as special case
-      if (type_asc_arg.getKind()== kind::CONST_RATIONAL)
+      if (type_asc_arg.getKind() == kind::CONST_RATIONAL)
       {
         const Rational& r = n.getConst<Rational>();
         toStreamRational(out, r, !is_int, d_variant);
@@ -466,7 +473,7 @@ void Smt2Printer::toStream(std::ostream& out,
       {
         out << "("
             << smtKindString(is_int ? kind::TO_INTEGER : kind::DIVISION,
-                            d_variant)
+                             d_variant)
             << " ";
         toStream(out, type_asc_arg, toDepth);
         if (!is_int)
@@ -480,9 +487,7 @@ void Smt2Printer::toStream(std::ostream& out,
     {
       // use type ascription
       out << "(as ";
-      toStream(out,
-               type_asc_arg,
-               toDepth < 0 ? toDepth : toDepth - 1);
+      toStream(out, type_asc_arg, toDepth < 0 ? toDepth : toDepth - 1);
       out << " " << force_nt << ")";
     }
     return;
@@ -547,7 +552,7 @@ void Smt2Printer::toStream(std::ostream& out,
     break;
 
   // uf theory
-  case kind::APPLY_UF:  break;
+  case kind::APPLY_UF: break;
   // higher-order
   case kind::HO_APPLY:
     if (!options::flattenHOChains())
@@ -784,11 +789,12 @@ void Smt2Printer::toStream(std::ostream& out,
   {
     out << smtKindString(k, d_variant) << " ";
     TypeNode elemType = n.getType().getSetElementType();
-    toStreamCastToType(out, n[0], toDepth < 0 ? toDepth : toDepth - 1, elemType);
+    toStreamCastToType(
+        out, n[0], toDepth < 0 ? toDepth : toDepth - 1, elemType);
     out << ")";
     return;
   }
-    break;
+  break;
   case kind::MEMBER:
   case kind::INSERT:
   case kind::SET_TYPE:
@@ -972,9 +978,7 @@ void Smt2Printer::toStream(std::ostream& out,
                    toDepth < 0 ? toDepth : toDepth - 1);
         }
       }else{
-        toStream(out,
-                 n.getOperator(),
-                 toDepth < 0 ? toDepth : toDepth - 1);
+        toStream(out, n.getOperator(), toDepth < 0 ? toDepth : toDepth - 1);
       }
     } else {
       out << "(...)";
@@ -987,8 +991,7 @@ void Smt2Printer::toStream(std::ostream& out,
   
   for(size_t i = 0, c = 1; i < n.getNumChildren(); ) {
     if(toDepth != 0) {
-        toStream(
-            out, n[i], toDepth < 0 ? toDepth : toDepth - c);
+      toStream(out, n[i], toDepth < 0 ? toDepth : toDepth - c);
     } else {
       out << "(...)";
     }
@@ -1010,18 +1013,19 @@ void Smt2Printer::toStream(std::ostream& out,
   }
 }
 
-
-void Smt2Printer::toStreamCastToType(std::ostream& out, TNode n, int toDepth, TypeNode tn) const
+void Smt2Printer::toStreamCastToType(std::ostream& out,
+                                     TNode n,
+                                     int toDepth,
+                                     TypeNode tn) const
 {
   Node nasc;
-  if (n.getType()!=tn)
+  if (n.getType() != tn)
   {
     // probably due to subtyping integers and reals, cast it using an apply
     // type ascription.
-    NodeManager * nm = NodeManager::currentNM();
-        Node tc = nm->mkConst(
-            AscriptionType(tn));
-        nasc = nm->mkNode(kind::APPLY_TYPE_ASCRIPTION, tc, n);
+    NodeManager* nm = NodeManager::currentNM();
+    Node tc = nm->mkConst(AscriptionType(tn));
+    nasc = nm->mkNode(kind::APPLY_TYPE_ASCRIPTION, tc, n);
   }
   else
   {
@@ -1427,8 +1431,7 @@ void Smt2Printer::toStream(std::ostream& out,
     if (val.getKind() == kind::LAMBDA)
     {
       TypeNode rangeType = n.getType().getRangeType();
-      out << "(define-fun " << n << " " << val[0] << " "
-          << rangeType << " ";
+      out << "(define-fun " << n << " " << val[0] << " " << rangeType << " ";
       // call toStream and force its type to be proper
       toStreamCastToType(out, val[1], -1, rangeType);
       out << ")" << endl;

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -227,7 +227,7 @@ class Smt2Printer : public CVC4::Printer
       std::ostream& out, const std::vector<Command*>& sequence) const override;
 
  private:
-  void toStream(std::ostream& out, TNode n, int toDepth, TypeNode nt) const;
+  void toStream(std::ostream& out, TNode n, int toDepth) const;
   void toStream(std::ostream& out,
                 const smt::Model& m,
                 const NodeCommand* c) const override;

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -31,7 +31,6 @@ enum Variant
   smt2_0_variant,  // old-style 2.0 syntax, when it makes a difference
   smt2_6_variant,  // new-style 2.6 syntax, when it makes a difference, with
                    // support for the string standard
-  sygus_variant    // variant for sygus
 };                 /* enum Variant */
 
 class Smt2Printer : public CVC4::Printer

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -229,7 +229,10 @@ class Smt2Printer : public CVC4::Printer
  private:
   void toStream(std::ostream& out, TNode n, int toDepth) const;
   /** To stream, with a forced type */
-  void toStreamCastToType(std::ostream& out, TNode n, int toDepth, TypeNode tn) const;
+  void toStreamCastToType(std::ostream& out,
+                          TNode n,
+                          int toDepth,
+                          TypeNode tn) const;
   void toStream(std::ostream& out,
                 const smt::Model& m,
                 const NodeCommand* c) const override;

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -228,9 +228,9 @@ class Smt2Printer : public CVC4::Printer
 
  private:
   void toStream(std::ostream& out, TNode n, int toDepth) const;
-  /** 
+  /**
    * To stream, with a forced type. This method is used in some corner cases
-   * to force a node n to be printed as if it had type tn. This is used e.g. 
+   * to force a node n to be printed as if it had type tn. This is used e.g.
    * for the body of define-fun commands and arguments of singleton terms.
    */
   void toStreamCastToType(std::ostream& out,

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -228,7 +228,11 @@ class Smt2Printer : public CVC4::Printer
 
  private:
   void toStream(std::ostream& out, TNode n, int toDepth) const;
-  /** To stream, with a forced type */
+  /** 
+   * To stream, with a forced type. This method is used in some corner cases
+   * to force a node n to be printed as if it had type tn. This is used e.g. 
+   * for the body of define-fun commands and arguments of singleton terms.
+   */
   void toStreamCastToType(std::ostream& out,
                           TNode n,
                           int toDepth,

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -228,6 +228,8 @@ class Smt2Printer : public CVC4::Printer
 
  private:
   void toStream(std::ostream& out, TNode n, int toDepth) const;
+  /** To stream, with a forced type */
+  void toStreamCastToType(std::ostream& out, TNode n, int toDepth, TypeNode tn) const;
   void toStream(std::ostream& out,
                 const smt::Model& m,
                 const NodeCommand* c) const override;

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1584,14 +1584,6 @@ void GetValueCommand::invoke(api::Solver* solver)
     {
       api::Term request = d_terms[i];
       api::Term value = result[i];
-      if (value.getSort().isInteger()
-          && request.getSort() == solver->getRealSort())
-      {
-        // Need to wrap in division-by-one so that output printers know this
-        // is an integer-looking constant that really should be output as
-        // a rational.  Necessary for SMT-LIB standards compliance.
-        value = solver->mkTerm(api::DIVISION, value, solver->mkReal(1));
-      }
       result[i] = solver->mkTerm(api::SEXPR, request, value);
     }
     d_result = solver->mkTerm(api::SEXPR, result);

--- a/test/regress/regress0/get-value-reals-ints.smt2
+++ b/test/regress/regress0/get-value-reals-ints.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; EXPECT: ((pos_int 5) (pos_real_int_value (/ 3.0 1.0)) (pos_rat (/ 1 3)) (zero (/ 0.0 1.0)) (neg_rat (/ (- 2) 3)) (neg_real_int_value (/ (- 2.0) 1.0)) (neg_int (- 6)))
+; EXPECT: ((pos_int 5) (pos_real_int_value 3.0) (pos_rat (/ 1 3)) (zero 0.0) (neg_rat (/ (- 2) 3)) (neg_real_int_value (- 2.0)) (neg_int (- 6)))
 (set-info :smt-lib-version 2.0)
 (set-option :produce-models true)
 (set-logic QF_LIRA)

--- a/test/regress/regress0/get-value-reals.smt2
+++ b/test/regress/regress0/get-value-reals.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; EXPECT: ((pos_int (/ 3.0 1.0)) (pos_rat (/ 1 3)) (zero (/ 0.0 1.0)) (neg_rat (/ (- 2) 3)) (neg_int (/ (- 2.0) 1.0)))
+; EXPECT: ((pos_int 3.0) (pos_rat (/ 1 3)) (zero 0.0) (neg_rat (/ (- 2) 3)) (neg_int (- 2.0)))
 (set-info :smt-lib-version 2.0)
 (set-option :produce-models true)
 (set-logic QF_LRA)

--- a/test/regress/regress1/arith/mult.02.smt2
+++ b/test/regress/regress1/arith/mult.02.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: (error "A non-linear fact was asserted to arithmetic in a linear logic.
-; EXPECT: The fact in question: (>= (* (- 1.0) (* n n)) (- 1.0))
+; EXPECT: The fact in question: (>= (* (- 1) (* n n)) (- 1))
 ; EXPECT: ")
 ; EXIT: 1
 (set-logic QF_LRA)


### PR DESCRIPTION
This makes major simplifications to how subtypes are enforced in the smt2 printer. 

It is now the principle that the smt2 prints things faithfully to the AST, regardless of whether it conforms to the smt2 standard.

It also fixes the current smt2 printing of `to_real`.

Conversely, this removes a hack from GetValueCommand which forced casting via x -> (/ x 1).  This is now properly handled in Solver::getValue.

Some regressions change expected output as a result.  Notice that internally generated Node may not conform to the smt2 standard, but user-level terms will.