### PR TITLE
Add proper support for the declare-heap command for separation logic

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -5181,6 +5181,17 @@ Term Solver::getQuantifierEliminationDisjunct(api::Term q) const
   CVC4_API_SOLVER_TRY_CATCH_END;
 }
 
+void Solver::declareSeparationHeap(api::Sort locSort, api::Sort dataSort) const
+{
+  CVC4_API_SOLVER_TRY_CATCH_BEGIN;
+  CVC4_API_CHECK(
+      d_smtEngine->getLogicInfo().isTheoryEnabled(theory::THEORY_SEP))
+      << "Cannot obtain separation logic expressions if not using the "
+         "separation logic theory.";
+  d_smtEngine->declareSepHeap(locSort.getTypeNode(), dataSort.getTypeNode());
+  CVC4_API_SOLVER_TRY_CATCH_END;
+}
+
 Term Solver::getSeparationHeap() const
 {
   CVC4_API_SOLVER_TRY_CATCH_BEGIN;

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -3165,7 +3165,7 @@ class CVC4_PUBLIC Solver
    * @param dataSort The data sort of the heap
    */
   void declareSeparationHeap(api::Sort locSort, api::Sort dataSort) const;
-  
+
   /**
    * When using separation logic, obtain the term for the heap.
    * @return The term for the heap

--- a/src/api/cvc4cpp.h
+++ b/src/api/cvc4cpp.h
@@ -3158,6 +3158,15 @@ class CVC4_PUBLIC Solver
   Term getQuantifierEliminationDisjunct(api::Term q) const;
 
   /**
+   * When using separation logic, this sets the location sort and the
+   * datatype sort to the given ones. This method should be invoked exactly
+   * once, before any separation logic constraints are provided.
+   * @param locSort The location sort of the heap
+   * @param dataSort The data sort of the heap
+   */
+  void declareSeparationHeap(api::Sort locSort, api::Sort dataSort) const;
+  
+  /**
    * When using separation logic, obtain the term for the heap.
    * @return The term for the heap
    */

--- a/src/api/python/cvc4.pxd
+++ b/src/api/python/cvc4.pxd
@@ -235,6 +235,7 @@ cdef extern from "api/cvc4cpp.h" namespace "CVC4::api":
         vector[Term] getUnsatCore() except +
         Term getValue(Term term) except +
         vector[Term] getValue(const vector[Term]& terms) except +
+        void declareSeparationHeap(Sort locSort, Sort dataSort) except +
         Term getSeparationHeap() except +
         Term getSeparationNilTerm() except +
         void pop(uint32_t nscopes) except +

--- a/src/api/python/cvc4.pxi
+++ b/src/api/python/cvc4.pxi
@@ -1123,7 +1123,7 @@ cdef class Solver:
         return term
 
     def declareSeparationHeap(self, Sort locType, Sort dataType):
-        self.declareSeparationHeap(locType.csort, dataType.csort)
+        self.csolver.declareSeparationHeap(locType.csort, dataType.csort)
 
     def getSeparationNilTerm(self):
         cdef Term term = Term(self)

--- a/src/api/python/cvc4.pxi
+++ b/src/api/python/cvc4.pxi
@@ -1122,6 +1122,9 @@ cdef class Solver:
         term.cterm = self.csolver.getSeparationHeap()
         return term
 
+    def declareSeparationHeap(self, Sort locType, Sort dataType):
+        self.declareSeparationHeap(locType.csort, dataType.csort)
+
     def getSeparationNilTerm(self):
         cdef Term term = Term(self)
         term.cterm = self.csolver.getSeparationNilTerm()

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -2260,7 +2260,6 @@ DECLARE_DATATYPES_2_5_TOK : { !( PARSER_STATE->v2_6() || PARSER_STATE->sygus() )
 DECLARE_DATATYPES_TOK : { PARSER_STATE->v2_6() || PARSER_STATE->sygus() }?'declare-datatypes';
 DECLARE_CODATATYPES_2_5_TOK : { !( PARSER_STATE->v2_6() || PARSER_STATE->sygus() ) }?'declare-codatatypes';
 DECLARE_CODATATYPES_TOK : { PARSER_STATE->v2_6() || PARSER_STATE->sygus() }?'declare-codatatypes';
-DECLARE_HEAP_TOK : 'declare-heap';
 PAR_TOK : { PARSER_STATE->v2_6() }?'par';
 COMPREHENSION_TOK : { PARSER_STATE->isTheoryEnabled(theory::THEORY_SETS) }?'comprehension';
 TESTER_TOK : { ( PARSER_STATE->v2_6() || PARSER_STATE->sygus() ) && PARSER_STATE->isTheoryEnabled(theory::THEORY_DATATYPES) }?'is';

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -910,11 +910,6 @@ extendedCommand[std::unique_ptr<CVC4::Command>* cmd]
   | DECLARE_CODATATYPES_2_5_TOK datatypes_2_5_DefCommand[true, cmd]
   | DECLARE_CODATATYPE_TOK datatypeDefCommand[true, cmd]
   | DECLARE_CODATATYPES_TOK datatypesDefCommand[true, cmd]
-  | DECLARE_HEAP_TOK LPAREN_TOK sortSymbol[t,CHECK_DECLARED]
-    sortSymbol[s,CHECK_DECLARED] RPAREN_TOK
-    {
-      seq->addCommand(new DeclareHeapCommand(t, s));
-    }
 
     /* Support some of Z3's extended SMT-LIB commands */
 
@@ -1078,9 +1073,8 @@ extendedCommand[std::unique_ptr<CVC4::Command>* cmd]
     }
   | DECLARE_HEAP LPAREN_TOK
     sortSymbol[t, CHECK_DECLARED]
-    sortSymbol[t, CHECK_DECLARED]
-    // We currently do nothing with the type information declared for the heap.
-    { cmd->reset(new EmptyCommand()); }
+    sortSymbol[s, CHECK_DECLARED]
+    { cmd->reset(new DeclareHeapCommand(t, s)); }
     RPAREN_TOK
   | BLOCK_MODEL_TOK { PARSER_STATE->checkThatLogicIsSet(); }
     { cmd->reset(new BlockModelCommand()); }

--- a/src/parser/smt2/Smt2.g
+++ b/src/parser/smt2/Smt2.g
@@ -895,7 +895,7 @@ extendedCommand[std::unique_ptr<CVC4::Command>* cmd]
 @declarations {
   std::vector<api::DatatypeDecl> dts;
   CVC4::api::Term e, e2;
-  CVC4::api::Sort t;
+  CVC4::api::Sort t, s;
   std::string name;
   std::vector<std::string> names;
   std::vector<CVC4::api::Term> terms;
@@ -910,6 +910,11 @@ extendedCommand[std::unique_ptr<CVC4::Command>* cmd]
   | DECLARE_CODATATYPES_2_5_TOK datatypes_2_5_DefCommand[true, cmd]
   | DECLARE_CODATATYPE_TOK datatypeDefCommand[true, cmd]
   | DECLARE_CODATATYPES_TOK datatypesDefCommand[true, cmd]
+  | DECLARE_HEAP_TOK LPAREN_TOK sortSymbol[t,CHECK_DECLARED]
+    sortSymbol[s,CHECK_DECLARED] RPAREN_TOK
+    {
+      seq->addCommand(new DeclareHeapCommand(t, s));
+    }
 
     /* Support some of Z3's extended SMT-LIB commands */
 
@@ -2261,6 +2266,7 @@ DECLARE_DATATYPES_2_5_TOK : { !( PARSER_STATE->v2_6() || PARSER_STATE->sygus() )
 DECLARE_DATATYPES_TOK : { PARSER_STATE->v2_6() || PARSER_STATE->sygus() }?'declare-datatypes';
 DECLARE_CODATATYPES_2_5_TOK : { !( PARSER_STATE->v2_6() || PARSER_STATE->sygus() ) }?'declare-codatatypes';
 DECLARE_CODATATYPES_TOK : { PARSER_STATE->v2_6() || PARSER_STATE->sygus() }?'declare-codatatypes';
+DECLARE_HEAP_TOK : 'declare-heap';
 PAR_TOK : { PARSER_STATE->v2_6() }?'par';
 COMPREHENSION_TOK : { PARSER_STATE->isTheoryEnabled(theory::THEORY_SETS) }?'comprehension';
 TESTER_TOK : { ( PARSER_STATE->v2_6() || PARSER_STATE->sygus() ) && PARSER_STATE->isTheoryEnabled(theory::THEORY_DATATYPES) }?'is';

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -416,11 +416,11 @@ void Printer::toStreamCmdComment(std::ostream& out,
 }
 
 void Printer::toStreamCmdDeclareHeap(std::ostream& out,
-                             TypeNode locType,
-                             TypeNode dataType) const
-                             {
+                                     TypeNode locType,
+                                     TypeNode dataType) const
+{
   printUnknownCommand(out, "declare-heap");
-                             }
+}
 
 void Printer::toStreamCmdCommandSequence(
     std::ostream& out, const std::vector<Command*>& sequence) const

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -415,6 +415,13 @@ void Printer::toStreamCmdComment(std::ostream& out,
   printUnknownCommand(out, "comment");
 }
 
+void Printer::toStreamCmdDeclareHeap(std::ostream& out,
+                             TypeNode locType,
+                             TypeNode dataType) const
+                             {
+  printUnknownCommand(out, "declare-heap");
+                             }
+
 void Printer::toStreamCmdCommandSequence(
     std::ostream& out, const std::vector<Command*>& sequence) const
 {

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -258,8 +258,8 @@ class Printer
                                   const std::string& comment) const;
   /** Declare heap command */
   virtual void toStreamCmdDeclareHeap(std::ostream& out,
-                             TypeNode locType,
-                             TypeNode dataType) const;
+                                      TypeNode locType,
+                                      TypeNode dataType) const;
 
   /** Print command sequence command */
   virtual void toStreamCmdCommandSequence(

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -256,6 +256,10 @@ class Printer
   /** Print comment command */
   virtual void toStreamCmdComment(std::ostream& out,
                                   const std::string& comment) const;
+  /** Declare heap command */
+  virtual void toStreamCmdDeclareHeap(std::ostream& out,
+                             TypeNode locType,
+                             TypeNode dataType) const;
 
   /** Print command sequence command */
   virtual void toStreamCmdCommandSequence(

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1995,12 +1995,12 @@ void Smt2Printer::toStreamCmdComment(std::ostream& out,
   out << "(set-info :notes \"" << s << "\")" << std::endl;
 }
 
-  void Smt2Printer::toStreamCmdDeclareHeap(std::ostream& out,
-                             TypeNode locType,
-                             TypeNode dataType) const
-                             {
-                               out << "(declare-heap (" << locType << " " << dataType << "))" << std::endl;
-                             }
+void Smt2Printer::toStreamCmdDeclareHeap(std::ostream& out,
+                                         TypeNode locType,
+                                         TypeNode dataType) const
+{
+  out << "(declare-heap (" << locType << " " << dataType << "))" << std::endl;
+}
 
 void Smt2Printer::toStreamCmdEmpty(std::ostream& out,
                                    const std::string& name) const

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1995,6 +1995,13 @@ void Smt2Printer::toStreamCmdComment(std::ostream& out,
   out << "(set-info :notes \"" << s << "\")" << std::endl;
 }
 
+  void Smt2Printer::toStreamCmdDeclareHeap(std::ostream& out,
+                             TypeNode locType,
+                             TypeNode dataType) const
+                             {
+                               out << "(declare-heap (" << locType << " " << dataType << "))" << std::endl;
+                             }
+
 void Smt2Printer::toStreamCmdEmpty(std::ostream& out,
                                    const std::string& name) const
 {

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -218,6 +218,11 @@ class Smt2Printer : public CVC4::Printer
   void toStreamCmdComment(std::ostream& out,
                           const std::string& comment) const override;
 
+  /** Print declare-heap command */
+  void toStreamCmdDeclareHeap(std::ostream& out,
+                             TypeNode locType,
+                             TypeNode dataType) const override;
+                             
   /** Print command sequence command */
   void toStreamCmdCommandSequence(
       std::ostream& out, const std::vector<Command*>& sequence) const override;

--- a/src/printer/smt2/smt2_printer.h
+++ b/src/printer/smt2/smt2_printer.h
@@ -220,9 +220,9 @@ class Smt2Printer : public CVC4::Printer
 
   /** Print declare-heap command */
   void toStreamCmdDeclareHeap(std::ostream& out,
-                             TypeNode locType,
-                             TypeNode dataType) const override;
-                             
+                              TypeNode locType,
+                              TypeNode dataType) const override;
+
   /** Print command sequence command */
   void toStreamCmdCommandSequence(
       std::ostream& out, const std::vector<Command*>& sequence) const override;

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1425,9 +1425,48 @@ void DefineFunctionRecCommand::toStream(std::ostream& out,
       formals,
       api::termVectorToNodes(d_formulas));
 }
+/* -------------------------------------------------------------------------- */
+/* class DeclareHeapCommand                                                   */
+/* -------------------------------------------------------------------------- */
+DeclareHeapCommand::DeclareHeapCommand(api::Sort locSort, api::Sort dataSort)
+    : d_locSort(locSort), d_dataSort(dataSort)
+{
+}
+
+api::Sort DeclareHeapCommand::getLocationSort() const
+{
+  return d_locSort;
+}
+api::Sort DeclareHeapCommand::getDataSort() const
+{
+  return d_dataSort;
+}
+
+void DeclareHeapCommand::invoke(api::Solver* solver)
+{
+  solver->declareSepHeap(d_locSort, d_dataSort);
+}
+
+Command* DeclareHeapCommand::clone() const
+{
+  return new DeclareHeapCommand(d_locSort, d_dataSort);
+}
+
+std::string DeclareHeapCommand::getCommandName() const { return "declare-heap"; }
+
+void DeclareHeapCommand::toStream(std::ostream& out,
+                                 int toDepth,
+                                 size_t dag,
+                                 OutputLanguage language) const
+{
+  Printer::getPrinter(language)->toStreamCmdDeclareHeap(
+      out,
+      d_locSort,
+      d_dataSort);
+}
 
 /* -------------------------------------------------------------------------- */
-/* class SetUserAttribute                                                     */
+/* class SetUserAttributeCommand                                              */
 /* -------------------------------------------------------------------------- */
 
 SetUserAttributeCommand::SetUserAttributeCommand(

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1438,7 +1438,7 @@ api::Sort DeclareHeapCommand::getDataSort() const { return d_dataSort; }
 
 void DeclareHeapCommand::invoke(api::Solver* solver)
 {
-  solver->declareSepHeap(d_locSort, d_dataSort);
+  solver->declareSeparationHeap(d_locSort, d_dataSort);
 }
 
 Command* DeclareHeapCommand::clone() const

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1433,14 +1433,8 @@ DeclareHeapCommand::DeclareHeapCommand(api::Sort locSort, api::Sort dataSort)
 {
 }
 
-api::Sort DeclareHeapCommand::getLocationSort() const
-{
-  return d_locSort;
-}
-api::Sort DeclareHeapCommand::getDataSort() const
-{
-  return d_dataSort;
-}
+api::Sort DeclareHeapCommand::getLocationSort() const { return d_locSort; }
+api::Sort DeclareHeapCommand::getDataSort() const { return d_dataSort; }
 
 void DeclareHeapCommand::invoke(api::Solver* solver)
 {
@@ -1452,17 +1446,18 @@ Command* DeclareHeapCommand::clone() const
   return new DeclareHeapCommand(d_locSort, d_dataSort);
 }
 
-std::string DeclareHeapCommand::getCommandName() const { return "declare-heap"; }
+std::string DeclareHeapCommand::getCommandName() const
+{
+  return "declare-heap";
+}
 
 void DeclareHeapCommand::toStream(std::ostream& out,
-                                 int toDepth,
-                                 size_t dag,
-                                 OutputLanguage language) const
+                                  int toDepth,
+                                  size_t dag,
+                                  OutputLanguage language) const
 {
   Printer::getPrinter(language)->toStreamCmdDeclareHeap(
-      out,
-      d_locSort,
-      d_dataSort);
+      out, d_locSort, d_dataSort);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1457,7 +1457,7 @@ void DeclareHeapCommand::toStream(std::ostream& out,
                                   OutputLanguage language) const
 {
   Printer::getPrinter(language)->toStreamCmdDeclareHeap(
-      out, d_locSort, d_dataSort);
+      out, d_locSort.getTypeNode(), d_dataSort.getTypeNode());
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -566,7 +566,7 @@ class CVC4_PUBLIC DefineFunctionRecCommand : public Command
  *   (declare-heap (T U))
  * where T is the location sort and U is the data sort.
  */
-class CVC4_PUBLIC DeclareHeapCommand
+class CVC4_PUBLIC DeclareHeapCommand : public Command
 {
  public:
   DeclareHeapCommand(api::Sort locSort, api::Sort dataSort);
@@ -586,7 +586,7 @@ class CVC4_PUBLIC DeclareHeapCommand
   api::Sort d_locSort;
   /** The data sort */
   api::Sort d_dataSort;
-}; /* class DeclareHeapCommand */
+};
 
 /**
  * The command when an attribute is set by a user.  In SMT-LIBv2 this is done

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -560,7 +560,6 @@ class CVC4_PUBLIC DefineFunctionRecCommand : public Command
   bool d_global;
 }; /* class DefineFunctionRecCommand */
 
-
 /**
  * In separation logic inputs, which is an extension of smt2 inputs, this
  * corresponds to the command:
@@ -569,7 +568,6 @@ class CVC4_PUBLIC DefineFunctionRecCommand : public Command
  */
 class CVC4_PUBLIC DeclareHeapCommand
 {
-
  public:
   DeclareHeapCommand(api::Sort locSort, api::Sort dataSort);
   api::Sort getLocationSort() const;
@@ -582,10 +580,11 @@ class CVC4_PUBLIC DeclareHeapCommand
       int toDepth = -1,
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
+
  protected:
-   /** The location sort */
+  /** The location sort */
   api::Sort d_locSort;
-   /** The data sort */
+  /** The data sort */
   api::Sort d_dataSort;
 }; /* class DeclareHeapCommand */
 

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -511,7 +511,6 @@ class CVC4_PUBLIC DefineNamedFunctionCommand : public DefineFunctionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class DefineNamedFunctionCommand */
@@ -560,6 +559,35 @@ class CVC4_PUBLIC DefineFunctionRecCommand : public Command
    */
   bool d_global;
 }; /* class DefineFunctionRecCommand */
+
+
+/**
+ * In separation logic inputs, which is an extension of smt2 inputs, this
+ * corresponds to the command:
+ *   (declare-heap (T U))
+ * where T is the location sort and U is the data sort.
+ */
+class CVC4_PUBLIC DeclareHeapCommand
+{
+
+ public:
+  DeclareHeapCommand(api::Sort locSort, api::Sort dataSort);
+  api::Sort getLocationSort() const;
+  api::Sort getDataSort() const;
+  void invoke(api::Solver* solver) override;
+  Command* clone() const override;
+  std::string getCommandName() const override;
+  void toStream(
+      std::ostream& out,
+      int toDepth = -1,
+      size_t dag = 1,
+      OutputLanguage language = language::output::LANG_AUTO) const override;
+ protected:
+   /** The location sort */
+  api::Sort d_locSort;
+   /** The data sort */
+  api::Sort d_dataSort;
+}; /* class DeclareHeapCommand */
 
 /**
  * The command when an attribute is set by a user.  In SMT-LIBv2 this is done

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1513,7 +1513,7 @@ void SmtEngine::checkUnsatCore() {
 
   // set up separation logic heap if necessary
   TypeNode sepLocType, sepDataType;
-  if (coreChecker->getSepHeapTypes(sepLocType, sepDataType))
+  if (getSepHeapTypes(sepLocType, sepDataType))
   {
     coreChecker->declareSepHeap(sepLocType, sepDataType);
   }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -66,6 +66,7 @@
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/rewriter.h"
 #include "theory/theory_engine.h"
+#include "theory/smt_engine_subsolver.h"
 #include "util/hash.h"
 #include "util/random.h"
 #include "util/resource_manager.h"
@@ -1462,6 +1463,14 @@ void SmtEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
   te->declareSepHeap(locT, dataT);
 }
 
+bool SmtEngine::getSepHeapTypes(TypeNode& locT, TypeNode& dataT)
+{
+  SmtScope smts(this);
+  finishInit();
+  TheoryEngine* te = getTheoryEngine();
+  return te->getSepHeapTypes(locT, dataT);
+}
+
 Node SmtEngine::getSepHeapExpr() { return getSepHeapAndNilExpr().first; }
 
 Node SmtEngine::getSepNilExpr() { return getSepHeapAndNilExpr().second; }
@@ -1497,21 +1506,28 @@ void SmtEngine::checkUnsatCore() {
   Notice() << "SmtEngine::checkUnsatCore(): generating unsat core" << endl;
   UnsatCore core = getUnsatCore();
 
-  SmtEngine coreChecker(d_exprManager, &d_options);
-  coreChecker.setIsInternalSubsolver();
-  coreChecker.setLogic(getLogicInfo());
-  coreChecker.getOptions().set(options::checkUnsatCores, false);
+  // initialize the core checker
+  std::unique_ptr<SmtEngine> coreChecker;
+  initializeSubsolver(coreChecker);
+  coreChecker->getOptions().set(options::checkUnsatCores, false);
 
+  // set up separation logic heap if necessary
+  TypeNode sepLocType, sepDataType;
+  if (coreChecker->getSepHeapTypes(sepLocType, sepDataType))
+  {
+    coreChecker->declareSepHeap(sepLocType, sepDataType);
+  }
+  
   Notice() << "SmtEngine::checkUnsatCore(): pushing core assertions (size == " << core.size() << ")" << endl;
   for(UnsatCore::iterator i = core.begin(); i != core.end(); ++i) {
     Node assertionAfterExpansion = expandDefinitions(*i);
     Notice() << "SmtEngine::checkUnsatCore(): pushing core member " << *i
              << ", expanded to " << assertionAfterExpansion << "\n";
-    coreChecker.assertFormula(assertionAfterExpansion);
+    coreChecker->assertFormula(assertionAfterExpansion);
   }
   Result r;
   try {
-    r = coreChecker.checkSat();
+    r = coreChecker->checkSat();
   } catch(...) {
     throw;
   }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -65,8 +65,8 @@
 #include "theory/logic_info.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/rewriter.h"
-#include "theory/theory_engine.h"
 #include "theory/smt_engine_subsolver.h"
+#include "theory/theory_engine.h"
 #include "util/hash.h"
 #include "util/random.h"
 #include "util/resource_manager.h"
@@ -1517,7 +1517,7 @@ void SmtEngine::checkUnsatCore() {
   {
     coreChecker->declareSepHeap(sepLocType, sepDataType);
   }
-  
+
   Notice() << "SmtEngine::checkUnsatCore(): pushing core assertions (size == " << core.size() << ")" << endl;
   for(UnsatCore::iterator i = core.begin(); i != core.end(); ++i) {
     Node assertionAfterExpansion = expandDefinitions(*i);

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1448,6 +1448,21 @@ std::vector<Node> SmtEngine::getExpandedAssertions()
   return eassertsProc;
 }
 
+
+void SmtEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
+{
+  if (!d_logic.isTheoryEnabled(THEORY_SEP))
+  {
+    const char* msg =
+        "Cannot declare heap if not using the separation logic theory.";
+    throw RecoverableModalException(msg);
+  }
+  SmtScope smts(this);
+  finishInit();
+  TheoryEngine* te = getTheoryEngine();
+  te->declareSepHeap(locT, dataT);
+}
+
 Node SmtEngine::getSepHeapExpr() { return getSepHeapAndNilExpr().first; }
 
 Node SmtEngine::getSepNilExpr() { return getSepHeapAndNilExpr().second; }

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1448,7 +1448,6 @@ std::vector<Node> SmtEngine::getExpandedAssertions()
   return eassertsProc;
 }
 
-
 void SmtEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
 {
   if (!d_logic.isTheoryEnabled(THEORY_SEP))

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -317,6 +317,14 @@ class CVC4_PUBLIC SmtEngine
    * inputs.
    */
   void declareSepHeap(TypeNode locT, TypeNode dataT);
+  
+  /**
+   * Get the separation heap types, which extracts which types were passed to
+   * the method above.
+   *
+   * @return true if the separation logic heap types have been declared.
+   */
+  bool getSepHeapTypes(TypeNode& locT, TypeNode& dataT);
 
   /** When using separation logic, obtain the expression for the heap.  */
   Node getSepHeapExpr();

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -309,6 +309,15 @@ class CVC4_PUBLIC SmtEngine
    */
   Result blockModelValues(const std::vector<Node>& exprs);
 
+  /**
+   * Declare heap. For smt2 inputs, this is called when the command
+   * (declare-heap (locT datat)) is invoked by the user. This sets locT as the
+   * location type and dataT is the data type for the heap. This command should
+   * be executed only once, and must be invoked before solving separation logic
+   * inputs.
+   */
+  void declareSepHeap(TypeNode locT, TypeNode dataT);
+  
   /** When using separation logic, obtain the expression for the heap.  */
   Node getSepHeapExpr();
 

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -317,7 +317,7 @@ class CVC4_PUBLIC SmtEngine
    * inputs.
    */
   void declareSepHeap(TypeNode locT, TypeNode dataT);
-  
+
   /**
    * Get the separation heap types, which extracts which types were passed to
    * the method above.

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -317,7 +317,7 @@ class CVC4_PUBLIC SmtEngine
    * inputs.
    */
   void declareSepHeap(TypeNode locT, TypeNode dataT);
-  
+
   /** When using separation logic, obtain the expression for the heap.  */
   Node getSepHeapExpr();
 

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -75,7 +75,7 @@ void TheorySep::declareSepHeap(TypeNode locT, TypeNode dataT)
   {
     TypeNode te1 = d_loc_to_data_type.begin()->first;
     std::stringstream ss;
-    ss << "ERROR: declaring heap constraints for two different types : ";
+    ss << "ERROR: cannot declare heap types for separation logic more than once.  We are declaring heap of type ";
     ss << locT << " -> " << dataT << ", but we already have ";
     ss << d_type_ref << " -> " << d_type_data;
     throw LogicException(ss.str());

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1135,13 +1135,20 @@ int TheorySep::processAssertion( Node n, std::map< int, std::map< Node, int > >&
 }
 
 void TheorySep::registerRefDataTypes( TypeNode tn1, TypeNode tn2, Node atom ){
-  if( !d_type_ref.isNull() ){
-    Assert (!atom.isNull());
+  if (!d_type_ref.isNull())
+  {
+    Assert(!atom.isNull());
     // already declared, ensure compatible
-    if (!tn1.isNull() && !tn1.isComparableTo(d_type_ref) || (!tn2.isNull() && !tn2.isComparableTo(d_type_data)))
+    if (!tn1.isNull() && !tn1.isComparableTo(d_type_ref)
+        || (!tn2.isNull() && !tn2.isComparableTo(d_type_data)))
     {
-        std::stringstream ss;
-        ss << "ERROR: the separation logic heap type has already been set to " << d_type_ref << " -> " << d_type_data << " but we have a constraint that uses different heap types, offending atom is " << atom << " with associated heap type " << tn1 << " -> " << tn2 << std::endl;
+      std::stringstream ss;
+      ss << "ERROR: the separation logic heap type has already been set to "
+         << d_type_ref << " -> " << d_type_data
+         << " but we have a constraint that uses different heap types, "
+            "offending atom is "
+         << atom << " with associated heap type " << tn1 << " -> " << tn2
+         << std::endl;
     }
     return;
   }
@@ -1151,13 +1158,17 @@ void TheorySep::registerRefDataTypes( TypeNode tn1, TypeNode tn2, Node atom ){
   {
     std::stringstream ss;
     // error, heap not declared
-    ss << "ERROR: the type of the separation logic heap has not been declared (e.g. via a declare-heap command), and we have a separation logic constraint " << atom << std::endl;
+    ss << "ERROR: the type of the separation logic heap has not been declared "
+          "(e.g. via a declare-heap command), and we have a separation logic "
+          "constraint "
+       << atom << std::endl;
     throw LogicException(ss.str());
   }
   // otherwise set it
-  Trace("sep-type") << "Sep: assume location type " << tn1 << " is associated with data type " << tn2 << std::endl;
+  Trace("sep-type") << "Sep: assume location type " << tn1
+                    << " is associated with data type " << tn2 << std::endl;
   d_loc_to_data_type[tn1] = tn2;
-  //for now, we only allow heap constraints of one type
+  // for now, we only allow heap constraints of one type
   d_type_ref = tn1;
   d_type_data = tn2;
   d_bound_kind[tn1] = bound_default;

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -305,10 +305,7 @@ void TheorySep::notifyFact(TNode atom,
   doPending();
 }
 
-bool TheorySep::hasHeapTypes() const
-{
-  return !d_loc_to_data_type.empty();
-}
+bool TheorySep::hasHeapTypes() const { return !d_loc_to_data_type.empty(); }
 
 void TheorySep::reduceFact(TNode atom, bool polarity, TNode fact)
 {

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -69,7 +69,7 @@ TheorySep::~TheorySep() {
   }
 }
 
-void TheorySep::declareHeap(TypeNode locT, TypeNode dataT)
+void TheorySep::declareSepHeap(TypeNode locT, TypeNode dataT)
 {
   if (!d_type_ref.isNull())
   {
@@ -1139,7 +1139,7 @@ void TheorySep::registerRefDataTypes( TypeNode tn1, TypeNode tn2, Node atom ){
   {
     Assert(!atom.isNull());
     // already declared, ensure compatible
-    if (!tn1.isNull() && !tn1.isComparableTo(d_type_ref)
+    if ((!tn1.isNull() && !tn1.isComparableTo(d_type_ref))
         || (!tn2.isNull() && !tn2.isComparableTo(d_type_data)))
     {
       std::stringstream ss;

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -302,8 +302,6 @@ void TheorySep::notifyFact(TNode atom,
   doPending();
 }
 
-bool TheorySep::hasHeapTypes() const { return !d_loc_to_data_type.empty(); }
-
 void TheorySep::reduceFact(TNode atom, bool polarity, TNode fact)
 {
   if (d_reduce.find(fact) != d_reduce.end())

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -75,7 +75,8 @@ void TheorySep::declareSepHeap(TypeNode locT, TypeNode dataT)
   {
     TypeNode te1 = d_loc_to_data_type.begin()->first;
     std::stringstream ss;
-    ss << "ERROR: cannot declare heap types for separation logic more than once.  We are declaring heap of type ";
+    ss << "ERROR: cannot declare heap types for separation logic more than "
+          "once.  We are declaring heap of type ";
     ss << locT << " -> " << dataT << ", but we already have ";
     ss << d_type_ref << " -> " << d_type_data;
     throw LogicException(ss.str());

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -86,7 +86,7 @@ class TheorySep : public Theory {
    * executed once only, and must be invoked before solving separation logic
    * inputs.
    */
-  void declareHeap(TypeNode locT, TypeNode dataT);
+  void declareSepHeap(TypeNode locT, TypeNode dataT) override;
 
   //--------------------------------- initialization
   /** get the official theory rewriter of this theory */

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -78,6 +78,15 @@ class TheorySep : public Theory {
             const LogicInfo& logicInfo,
             ProofNodeManager* pnm = nullptr);
   ~TheorySep();
+  
+  /**
+   * Declare heap. For smt2 inputs, this is called when the command
+   * (declare-heap (locT datat)) is invoked by the user. This sets locT as the
+   * location type and dataT is the data type for the heap. This command can be
+   * executed once only, and must be invoked before solving separation logic
+   * inputs.
+   */
+  void declareHeap(TypeNode locT, TypeNode dataT);
 
   //--------------------------------- initialization
   /** get the official theory rewriter of this theory */
@@ -152,6 +161,8 @@ class TheorySep : public Theory {
   //--------------------------------- end standard check
 
  private:
+  /** Have we set the heap types? */
+  bool hasHeapTypes() const;
   /** Ensures that the reduction has been added for the given fact */
   void reduceFact(TNode atom, bool polarity, TNode fact);
   /** Is spatial kind? */

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -78,7 +78,7 @@ class TheorySep : public Theory {
             const LogicInfo& logicInfo,
             ProofNodeManager* pnm = nullptr);
   ~TheorySep();
-  
+
   /**
    * Declare heap. For smt2 inputs, this is called when the command
    * (declare-heap (locT datat)) is invoked by the user. This sets locT as the

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -290,7 +290,7 @@ class TheorySep : public Theory {
    * (A) a declare-heap command is issued with tn1/tn2, and atom is null, or
    * (B) an atom specifying the heap type tn1/tn2 is registered to this theory.
    * We set the heap type if we are are case (A), and check whether the
-   * heap type is consistent in the case of (B). 
+   * heap type is consistent in the case of (B).
    */
   void registerRefDataTypes(TypeNode tn1, TypeNode tn2, Node atom);
   //get location/data type

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -285,7 +285,14 @@ class TheorySep : public Theory {
   //get global reference/data type
   TypeNode getReferenceType( Node n );
   TypeNode getDataType( Node n );
-  void registerRefDataTypes( TypeNode tn1, TypeNode tn2, Node atom );
+  /**
+   * This is called either when:
+   * (A) a declare-heap command is issued with tn1/tn2, and atom is null, or
+   * (B) an atom specifying the heap type tn1/tn2 is registered to this theory.
+   * We set the heap type if we are are case (A), and check whether the
+   * heap type is consistent in the case of (B). 
+   */
+  void registerRefDataTypes(TypeNode tn1, TypeNode tn2, Node atom);
   //get location/data type
   //get the base label for the spatial assertion
   Node getBaseLabel( TypeNode tn );

--- a/src/theory/sep/theory_sep.h
+++ b/src/theory/sep/theory_sep.h
@@ -161,8 +161,6 @@ class TheorySep : public Theory {
   //--------------------------------- end standard check
 
  private:
-  /** Have we set the heap types? */
-  bool hasHeapTypes() const;
   /** Ensures that the reduction has been added for the given fact */
   void reduceFact(TNode atom, bool polarity, TNode fact);
   /** Is spatial kind? */

--- a/src/theory/smt_engine_subsolver.cpp
+++ b/src/theory/smt_engine_subsolver.cpp
@@ -51,11 +51,11 @@ void initializeSubsolver(std::unique_ptr<SmtEngine>& smte,
   smte.reset(new SmtEngine(nm->toExprManager(), &smtCurr->getOptions()));
   smte->setIsInternalSubsolver();
   smte->setLogic(smtCurr->getLogicInfo());
+  // set the options
   if (needsTimeout)
   {
     smte->setTimeLimit(timeout);
   }
-  smte->setLogic(smt::currentSmtEngine()->getLogicInfo());
 }
 
 Result checkWithSubsolver(std::unique_ptr<SmtEngine>& smte,

--- a/src/theory/smt_engine_subsolver.h
+++ b/src/theory/smt_engine_subsolver.h
@@ -33,11 +33,11 @@ namespace theory {
  * This function initializes the smt engine smte to check the satisfiability
  * of the argument "query". It takes the logic and options of the current
  * SMT engine in scope.
- * 
+ *
  * Notice this method intentionally does not fully initialize smte. This means
  * that the options of smte can still be modified after it is returned by
  * this method.
- * 
+ *
  * Notice that some aspects of subsolvers are not incoporated by this call.
  * For example, the type of separation logic heaps is not set on smte, even
  * if the current SMT engine has declared a separation logic heap.

--- a/src/theory/smt_engine_subsolver.h
+++ b/src/theory/smt_engine_subsolver.h
@@ -31,7 +31,16 @@ namespace theory {
 
 /**
  * This function initializes the smt engine smte to check the satisfiability
- * of the argument "query".
+ * of the argument "query". It takes the logic and options of the current
+ * SMT engine in scope.
+ * 
+ * Notice this method intentionally does not fully initialize smte. This means
+ * that the options of smte can still be modified after it is returned by
+ * this method.
+ * 
+ * Notice that some aspects of subsolvers are not incoporated by this call.
+ * For example, the type of separation logic heaps is not set on smte, even
+ * if the current SMT engine has declared a separation logic heap.
  *
  * @param smte The smt engine pointer to initialize
  * @param needsTimeout Whether we would like to set a timeout

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -247,15 +247,15 @@ class Theory {
   const LogicInfo& getLogicInfo() const {
     return d_logicInfo;
   }
-  
-  /** 
+
+  /**
    * Set separation logic heap. This is called when the location and data
    * types for separation logic are determined. This should be called at
    * most once, before solving.
    *
    * This currently should be overridden by the separation logic theory only.
    */
-  virtual void declareSepHeap(TypeNode locT, TypeNode dataT){}
+  virtual void declareSepHeap(TypeNode locT, TypeNode dataT) {}
 
   /**
    * The theory that owns the uninterpreted sort.

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -247,6 +247,15 @@ class Theory {
   const LogicInfo& getLogicInfo() const {
     return d_logicInfo;
   }
+  
+  /** 
+   * Set separation logic heap. This is called when the location and data
+   * types for separation logic are determined. This should be called at
+   * most once, before solving.
+   *
+   * This currently should be overridden by the separation logic theory only.
+   */
+  virtual void declareSepHeap(TypeNode locT, TypeNode dataT){}
 
   /**
    * The theory that owns the uninterpreted sort.

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1130,7 +1130,7 @@ void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
 #undef CVC4_FOR_EACH_THEORY_STATEMENT
 #endif
 #define CVC4_FOR_EACH_THEORY_STATEMENT(THEORY) \
-  theoryOf(THEORY)->declareHeap(locT, dataT);
+  theoryOf(THEORY)->declareSepHeap(locT, dataT);
 
   // notify each theory using the statement above
   CVC4_FOR_EACH_THEORY;

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1116,6 +1116,17 @@ bool TheoryEngine::propagate(TNode literal, theory::TheoryId theory) {
 
 const LogicInfo& TheoryEngine::getLogicInfo() const { return d_logicInfo; }
 
+bool TheoryEngine::getSepHeapTypes(TypeNode& locType, TypeNode& dataType) const
+{
+  if (d_sepLocType.isNull())
+  {
+    return false;
+  }
+  locType = d_sepLocType;
+  dataType = d_sepDataType;
+  return true;
+}
+
 void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
 {
   Theory* tsep = theoryOf(THEORY_SEP);
@@ -1134,6 +1145,10 @@ void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
 
   // notify each theory using the statement above
   CVC4_FOR_EACH_THEORY;
+  
+  // remember the types we have set
+  d_sepLocType = locT;
+  d_sepDataType = dataT;
 }
 
 theory::EqualityStatus TheoryEngine::getEqualityStatus(TNode a, TNode b) {

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1119,14 +1119,12 @@ const LogicInfo& TheoryEngine::getLogicInfo() const { return d_logicInfo; }
 void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
 {
   Theory* tsep = theoryOf(THEORY_SEP);
-  if (tsep != nullptr)
+  if (tsep == nullptr)
   {
-    tsep->declareHeap(locT, dataT);
+    Assert(false) << "TheoryEngine::declareSepHeap called without the separation logic theory enabled";
+    return;
   }
-  else
-  {
-    Assert(false) << "setSepHeapTypes 
-  }
+  static_cast<TheorySep*>(tsep)->declareHeap(locT, dataT);
 }
 
 theory::EqualityStatus TheoryEngine::getEqualityStatus(TNode a, TNode b) {

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1116,6 +1116,19 @@ bool TheoryEngine::propagate(TNode literal, theory::TheoryId theory) {
 
 const LogicInfo& TheoryEngine::getLogicInfo() const { return d_logicInfo; }
 
+void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
+{
+  Theory * tsep = theoryOf(THEORY_SEP);
+  if (tsep!=nullptr)
+  {
+    tsep->declareHeap(locT, dataT);
+  }
+  else
+  {
+    Assert(false) << "setSepHeapTypes 
+  }
+}
+
 theory::EqualityStatus TheoryEngine::getEqualityStatus(TNode a, TNode b) {
   Assert(a.getType().isComparableTo(b.getType()));
   return d_sharedSolver->getEqualityStatus(a, b);

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1132,7 +1132,8 @@ void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
   Theory* tsep = theoryOf(THEORY_SEP);
   if (tsep == nullptr)
   {
-    Assert(false) << "TheoryEngine::declareSepHeap called without the separation logic theory enabled";
+    Assert(false) << "TheoryEngine::declareSepHeap called without the "
+                     "separation logic theory enabled";
     return;
   }
 
@@ -1145,7 +1146,7 @@ void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
 
   // notify each theory using the statement above
   CVC4_FOR_EACH_THEORY;
-  
+
   // remember the types we have set
   d_sepLocType = locT;
   d_sepDataType = dataT;

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1124,7 +1124,16 @@ void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
     Assert(false) << "TheoryEngine::declareSepHeap called without the separation logic theory enabled";
     return;
   }
-  static_cast<TheorySep*>(tsep)->declareHeap(locT, dataT);
+
+  // Definition of the statement that is to be run by every theory
+#ifdef CVC4_FOR_EACH_THEORY_STATEMENT
+#undef CVC4_FOR_EACH_THEORY_STATEMENT
+#endif
+#define CVC4_FOR_EACH_THEORY_STATEMENT(THEORY) \
+  theoryOf(THEORY)->declareHeap(locT, dataT);
+
+  // notify each theory using the statement above
+  CVC4_FOR_EACH_THEORY;
 }
 
 theory::EqualityStatus TheoryEngine::getEqualityStatus(TNode a, TNode b) {

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -1118,8 +1118,8 @@ const LogicInfo& TheoryEngine::getLogicInfo() const { return d_logicInfo; }
 
 void TheoryEngine::declareSepHeap(TypeNode locT, TypeNode dataT)
 {
-  Theory * tsep = theoryOf(THEORY_SEP);
-  if (tsep!=nullptr)
+  Theory* tsep = theoryOf(THEORY_SEP);
+  if (tsep != nullptr)
   {
     tsep->declareHeap(locT, dataT);
   }

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -637,6 +637,13 @@ class TheoryEngine {
   }
   /** get the logic info used by this theory engine */
   const LogicInfo& getLogicInfo() const;
+  
+  /** 
+   * Declare heap. This is used for separation logics to set the location
+   * and data types. It should be called only once, and before 
+   */
+  void declareSepHeap(TypeNode locT, TypeNode dataT);
+  
   /**
    * Returns the equality status of the two terms, from the theory
    * that owns the domain type.  The types of a and b must be the same.

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -637,13 +637,14 @@ class TheoryEngine {
   }
   /** get the logic info used by this theory engine */
   const LogicInfo& getLogicInfo() const;
-  
-  /** 
+
+  /**
    * Declare heap. This is used for separation logics to set the location
-   * and data types. It should be called only once, and before 
+   * and data types. It should be called only once, and before any separation
+   * logic constraints are asserted to this theory engine.
    */
   void declareSepHeap(TypeNode locT, TypeNode dataT);
-  
+
   /**
    * Returns the equality status of the two terms, from the theory
    * that owns the domain type.  The types of a and b must be the same.

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -139,6 +139,9 @@ class TheoryEngine {
    * the cost of walking the DAG on registration, etc.
    */
   const LogicInfo& d_logicInfo;
+  /** The separation logic location and data types */
+  TypeNode d_sepLocType;
+  TypeNode d_sepDataType;
 
   /** Reference to the output manager of the smt engine */
   OutputManager& d_outMgr;
@@ -637,6 +640,8 @@ class TheoryEngine {
   }
   /** get the logic info used by this theory engine */
   const LogicInfo& getLogicInfo() const;
+  /** get the separation logic heap types */
+  bool getSepHeapTypes(TypeNode& locType, TypeNode& dataType) const;
 
   /**
    * Declare heap. This is used for separation logics to set the location

--- a/test/api/sep_log_api.cpp
+++ b/test/api/sep_log_api.cpp
@@ -45,7 +45,7 @@ int validate_exception(void)
 
   /* Our integer type */
   Sort integer = slv.getIntegerSort();
-  
+
   /** we intentionally do not set the separation logic heap */
 
   /* Our SMT constants */
@@ -135,7 +135,7 @@ int validate_getters(void)
 
   /* Our integer type */
   Sort integer = slv.getIntegerSort();
-  
+
   /** Declare the separation logic heap types */
   slv.declareSeparationHeap(integer, integer);
 

--- a/test/api/sep_log_api.cpp
+++ b/test/api/sep_log_api.cpp
@@ -46,6 +46,9 @@ int validate_exception(void)
   /* Our integer type */
   Sort integer = slv.getIntegerSort();
 
+  /** Declare the separation logic heap types */
+  slv.declareSeparationHeap(integer, integer);
+
   /* Our SMT constants */
   Term x = slv.mkConst(integer, "x");
   Term y = slv.mkConst(integer, "y");
@@ -133,6 +136,9 @@ int validate_getters(void)
 
   /* Our integer type */
   Sort integer = slv.getIntegerSort();
+  
+  /** Declare the separation logic heap types */
+  slv.declareSeparationHeap(integer, integer);
 
   /* A "random" constant */
   Term random_constant = slv.mkInteger(0xDEADBEEF);

--- a/test/api/sep_log_api.cpp
+++ b/test/api/sep_log_api.cpp
@@ -45,9 +45,8 @@ int validate_exception(void)
 
   /* Our integer type */
   Sort integer = slv.getIntegerSort();
-
-  /** Declare the separation logic heap types */
-  slv.declareSeparationHeap(integer, integer);
+  
+  /** we intentionally do not set the separation logic heap */
 
   /* Our SMT constants */
   Term x = slv.mkConst(integer, "x");

--- a/test/regress/regress0/sep/dispose-1.smt2
+++ b/test/regress/regress0/sep/dispose-1.smt2
@@ -1,6 +1,8 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
 
+(declare-heap (Int Int))
+
 (declare-const w Int)
 (declare-const w1 Int)
 (declare-const w2 Int)

--- a/test/regress/regress0/sep/dup-nemp.smt2
+++ b/test/regress/regress0/sep/dup-nemp.smt2
@@ -2,6 +2,7 @@
 (set-info :status unsat)
 (declare-sort Loc 0)
 (declare-const l Loc)
+(declare-heap (Loc Loc))
 (assert (sep (not (_ emp Loc Loc)) (not (_ emp Loc Loc))))
 (assert (pto l l))
 (check-sat)

--- a/test/regress/regress0/sep/issue3720-check-model.smt2
+++ b/test/regress/regress0/sep/issue3720-check-model.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --quiet
 ; EXPECT: sat
 (set-logic ALL)
+(declare-heap (Int Int))
 (assert (_ emp Int Int))
 (check-sat)

--- a/test/regress/regress0/sep/nemp.smt2
+++ b/test/regress/regress0/sep/nemp.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --no-check-models
 ; EXPECT: sat
 (set-logic QF_SEP_LIA)
+(declare-heap (Int Int))
 (assert (not (_ emp Int Int)))
 (check-sat)

--- a/test/regress/regress0/sep/nil-no-elim.smt2
+++ b/test/regress/regress0/sep/nil-no-elim.smt2
@@ -3,6 +3,7 @@
 (declare-sort U 0)
 (declare-fun f (U) U)
 (declare-fun a () U)
+(declare-heap (U Int))
 
 (assert (= (as sep.nil U) (f a)))
 

--- a/test/regress/regress0/sep/nspatial-simp.smt2
+++ b/test/regress/regress0/sep/nspatial-simp.smt2
@@ -3,6 +3,7 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
 (declare-fun x () Int)
+(declare-heap (Int Int))
 
 (assert (sep (= x 0) (not (= x 5))))
 

--- a/test/regress/regress0/sep/pto-01.smt2
+++ b/test/regress/regress0/sep/pto-01.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 

--- a/test/regress/regress0/sep/pto-02.smt2
+++ b/test/regress/regress0/sep/pto-02.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 
 (declare-const x Int)

--- a/test/regress/regress0/sep/sep-01.smt2
+++ b/test/regress/regress0/sep/sep-01.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress0/sep/sep-plus1.smt2
+++ b/test/regress/regress0/sep/sep-plus1.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress0/sep/sep-simp-unsat-emp.smt2
+++ b/test/regress/regress0/sep/sep-simp-unsat-emp.smt2
@@ -1,7 +1,8 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
-
 (declare-sort U 0)
+(declare-heap (U U))
+
 (declare-fun x () U)
 (declare-fun y () U)
 (declare-fun a () U)

--- a/test/regress/regress0/sep/simple-080420-const-sets.smt2
+++ b/test/regress/regress0/sep/simple-080420-const-sets.smt2
@@ -3,6 +3,7 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-option :produce-models true)
 (set-info :status sat)
+(declare-heap (Int Int))
 (declare-fun x () Int)
 
 ; works

--- a/test/regress/regress0/sep/skolem_emp.smt2
+++ b/test/regress/regress0/sep/skolem_emp.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --no-check-models --sep-pre-skolem-emp
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
+(declare-heap (Int Int))
 (assert (not (_ emp Int Int)))
 (check-sat)

--- a/test/regress/regress0/sep/trees-1.smt2
+++ b/test/regress/regress0/sep/trees-1.smt2
@@ -5,6 +5,7 @@
 (declare-const loc0 Loc)
 
 (declare-datatypes ((Node 0)) (((node (data Int) (left Loc) (right Loc)))))
+(declare-heap (Loc Node))
 
 (declare-fun data0 () Node)
 

--- a/test/regress/regress0/sep/wand-crash.smt2
+++ b/test/regress/regress0/sep/wand-crash.smt2
@@ -1,5 +1,6 @@
 ; COMMAND-LINE: --no-check-models
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
+(declare-heap (Int Int))
 (assert (wand (_ emp Int Int) (_ emp Int Int)))
 (check-sat)

--- a/test/regress/regress1/sep/chain-int.smt2
+++ b/test/regress/regress1/sep/chain-int.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/crash1220.smt2
+++ b/test/regress/regress1/sep/crash1220.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const a Int)

--- a/test/regress/regress1/sep/dispose-list-4-init.smt2
+++ b/test/regress/regress1/sep/dispose-list-4-init.smt2
@@ -3,6 +3,7 @@
 (set-logic QF_ALL_SUPPORTED)
 
 (declare-sort Loc 0)
+(declare-heap (Loc Loc))
 
 (declare-const w Loc)
 (declare-const u1 Loc)

--- a/test/regress/regress1/sep/emp2-quant-unsat.smt2
+++ b/test/regress/regress1/sep/emp2-quant-unsat.smt2
@@ -4,6 +4,7 @@
 (set-info :status unsat)
 (declare-sort U 0)
 (declare-fun u () U)
+(declare-heap (U U))
 
 (assert (sep (not (_ emp U U)) (not (_ emp U U))))
 

--- a/test/regress/regress1/sep/finite-witness-sat.smt2
+++ b/test/regress/regress1/sep/finite-witness-sat.smt2
@@ -3,6 +3,7 @@
 (set-logic ALL_SUPPORTED)
 (declare-sort Loc 0)
 (declare-const l Loc)
+(declare-heap (Loc Loc))
 
 (assert (not (_ emp Loc Loc)))
 (assert (forall ((x Loc) (y Loc)) (not (pto x y))))

--- a/test/regress/regress1/sep/fmf-nemp-2.smt2
+++ b/test/regress/regress1/sep/fmf-nemp-2.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic ALL_SUPPORTED)
 (declare-sort U 0)
+(declare-heap (U Int))
 (declare-fun u1 () U)
 (declare-fun u2 () U)
 (assert (not (= u1 u2)))

--- a/test/regress/regress1/sep/loop-1220.smt2
+++ b/test/regress/regress1/sep/loop-1220.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const a Int)

--- a/test/regress/regress1/sep/pto-04.smt2
+++ b/test/regress/regress1/sep/pto-04.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x1 Int)
 (declare-const x2 Int)

--- a/test/regress/regress1/sep/quant_wand.smt2
+++ b/test/regress/regress1/sep/quant_wand.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: unsat
 (set-logic ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const u Int)
 

--- a/test/regress/regress1/sep/sep-02.smt2
+++ b/test/regress/regress1/sep/sep-02.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-03.smt2
+++ b/test/regress/regress1/sep/sep-03.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-find2.smt2
+++ b/test/regress/regress1/sep/sep-find2.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_SEP_LIA)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x1 Int)
 (declare-const x2 Int)

--- a/test/regress/regress1/sep/sep-fmf-priority.smt2
+++ b/test/regress/regress1/sep/sep-fmf-priority.smt2
@@ -5,6 +5,7 @@
 (declare-sort Loc 0)
 (declare-const l Loc)
 (declare-const x Loc)
+(declare-heap (Loc Loc))
 
 (assert (wand (pto x x) false))
 (assert (forall ((x Loc) (y Loc)) (not (pto x y))))

--- a/test/regress/regress1/sep/sep-neg-1refine.smt2
+++ b/test/regress/regress1/sep/sep-neg-1refine.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-neg-nstrict.smt2
+++ b/test/regress/regress1/sep/sep-neg-nstrict.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-neg-nstrict2.smt2
+++ b/test/regress/regress1/sep/sep-neg-nstrict2.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-neg-simple.smt2
+++ b/test/regress/regress1/sep/sep-neg-simple.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-neg-swap.smt2
+++ b/test/regress/regress1/sep/sep-neg-swap.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-nterm-again.smt2
+++ b/test/regress/regress1/sep/sep-nterm-again.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-nterm-val-model.smt2
+++ b/test/regress/regress1/sep/sep-nterm-val-model.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/sep-simp-unc.smt2
+++ b/test/regress/regress1/sep/sep-simp-unc.smt2
@@ -3,6 +3,7 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
 (declare-sort U 0)
+(declare-heap (U U))
 (declare-fun x () U)
 (declare-fun y () U)
 (declare-fun a () U)

--- a/test/regress/regress1/sep/simple-neg-sat.smt2
+++ b/test/regress/regress1/sep/simple-neg-sat.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/split-find-unsat-w-emp.smt2
+++ b/test/regress/regress1/sep/split-find-unsat-w-emp.smt2
@@ -1,5 +1,6 @@
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/split-find-unsat.smt2
+++ b/test/regress/regress1/sep/split-find-unsat.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: unsat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status unsat)
+(declare-heap (Int Int))
 
 (declare-const x Int)
 (declare-const y Int)

--- a/test/regress/regress1/sep/wand-0526-sat.smt2
+++ b/test/regress/regress1/sep/wand-0526-sat.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --no-check-models
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
+(declare-heap (Int Int))
 (declare-fun x () Int)
 (declare-fun y () Int)
 (declare-fun u () Int)

--- a/test/regress/regress1/sep/wand-false.smt2
+++ b/test/regress/regress1/sep/wand-false.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 (declare-fun x () Int)
 (assert (wand (pto x x) false))
 (check-sat)

--- a/test/regress/regress1/sep/wand-nterm-simp.smt2
+++ b/test/regress/regress1/sep/wand-nterm-simp.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --no-check-models
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
+(declare-heap (Int Int))
 (declare-fun x () Int)
 (assert (wand (_ emp Int Int) (pto x 3)))
 (check-sat)

--- a/test/regress/regress1/sep/wand-nterm-simp2.smt2
+++ b/test/regress/regress1/sep/wand-nterm-simp2.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 (declare-fun x () Int)
 (assert (wand (pto x 1) (_ emp Int Int)))
 (check-sat)

--- a/test/regress/regress1/sep/wand-simp-sat.smt2
+++ b/test/regress/regress1/sep/wand-simp-sat.smt2
@@ -1,6 +1,7 @@
 ; COMMAND-LINE: --no-check-models
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
+(declare-heap (Int Int))
 (declare-fun x () Int)
 (assert (wand (pto x 1) (pto x 1)))
 (check-sat)

--- a/test/regress/regress1/sep/wand-simp-sat2.smt2
+++ b/test/regress/regress1/sep/wand-simp-sat2.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: sat
 (set-logic QF_ALL_SUPPORTED)
 (set-info :status sat)
+(declare-heap (Int Int))
 (declare-fun x () Int)
 (assert (wand (pto x 1) (pto x 3)))
 (check-sat)

--- a/test/regress/regress1/sep/wand-simp-unsat.smt2
+++ b/test/regress/regress1/sep/wand-simp-unsat.smt2
@@ -2,6 +2,7 @@
 ; EXPECT: unsat
 (set-logic QF_ALL_SUPPORTED)
 (declare-fun x () Int)
+(declare-heap (Int Int))
 (assert (wand (pto x 1) (pto x 3)))
 (assert (_ emp Int Int))
 (check-sat)

--- a/test/unit/api/solver_black.h
+++ b/test/unit/api/solver_black.h
@@ -1698,14 +1698,14 @@ void SolverBlack::testGetQuantifierEliminationDisjunct()
   TS_ASSERT_THROWS_NOTHING(d_solver->getQuantifierEliminationDisjunct(forall));
 }
 
-
 void SolverBlack::testDeclareSeparationHeap()
 {
   d_solver->setLogic("ALL_SUPPORTED");
   Sort integer = d_solver->getIntegerSort();
   TS_ASSERT_THROWS_NOTHING(d_solver->declareSeparationHeap(integer, integer));
   // cannot declare separation logic heap more than once
-  TS_ASSERT_THROWS(d_solver->declareSeparationHeap(integer, integer), CVC4ApiException&);
+  TS_ASSERT_THROWS(d_solver->declareSeparationHeap(integer, integer),
+                   CVC4ApiException&);
 }
 
 namespace {

--- a/test/unit/api/solver_black.h
+++ b/test/unit/api/solver_black.h
@@ -118,6 +118,7 @@ class SolverBlack : public CxxTest::TestSuite
   void testGetValue3();
   void testGetQuantifierElimination();
   void testGetQuantifierEliminationDisjunct();
+  void testDeclareSeparationHeap();
   void testGetSeparationHeapTerm1();
   void testGetSeparationHeapTerm2();
   void testGetSeparationHeapTerm3();
@@ -1697,6 +1698,16 @@ void SolverBlack::testGetQuantifierEliminationDisjunct()
   TS_ASSERT_THROWS_NOTHING(d_solver->getQuantifierEliminationDisjunct(forall));
 }
 
+
+void SolverBlack::testDeclareSeparationHeap()
+{
+  d_solver->setLogic("ALL_SUPPORTED");
+  Sort integer = d_solver->getIntegerSort();
+  TS_ASSERT_THROWS_NOTHING(d_solver->declareSeparationHeap(integer, integer));
+  // cannot declare separation logic heap more than once
+  TS_ASSERT_THROWS(d_solver->declareSeparationHeap(integer, integer), CVC4ApiException&);
+}
+
 namespace {
 /**
  * Helper function for testGetSeparation{Heap,Nil}TermX. Asserts and checks
@@ -1705,6 +1716,8 @@ namespace {
 void checkSimpleSeparationConstraints(Solver* solver)
 {
   Sort integer = solver->getIntegerSort();
+  // declare the separation heap
+  solver->declareSeparationHeap(integer, integer);
   Term x = solver->mkConst(integer, "x");
   Term p = solver->mkConst(integer, "p");
   Term heap = solver->mkTerm(Kind::SEP_PTO, p, x);


### PR DESCRIPTION
This adds proper support for the `(declare-heap (T U))`  command, which declares the type of the heap in separation logic.  This command is part of the standard for separation logic.

This previous was handled in an ad-hoc way where the type of the heap would be inferred on demand. This was a poor solution and has led to a number of issues related to when the heap is inferred.

Fixes #5343, fixes #4926.

Work towards https://github.com/CVC4/cvc4-wishues/issues/22.