### PR TITLE
Pass symbol manager to commands

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -119,7 +119,8 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
 {
   bool status = true;
   if(d_options.getVerbosity() >= -1) {
-    status = solverInvoke(d_solver.get(), d_symman.get(), cmd, d_options.getOut());
+    status =
+        solverInvoke(d_solver.get(), d_symman.get(), cmd, d_options.getOut());
   } else {
     status = solverInvoke(d_solver.get(), d_symman.get(), cmd, nullptr);
   }

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -199,7 +199,10 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
   return status;
 }
 
-bool solverInvoke(api::Solver* solver, parser::SymbolManager* sm, Command* cmd, std::ostream* out)
+bool solverInvoke(api::Solver* solver,
+                  parser::SymbolManager* sm,
+                  Command* cmd,
+                  std::ostream* out)
 {
   if (out == NULL)
   {

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -119,9 +119,9 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
 {
   bool status = true;
   if(d_options.getVerbosity() >= -1) {
-    status = solverInvoke(d_solver.get(), cmd, d_options.getOut());
+    status = solverInvoke(d_solver.get(), d_symman.get(), cmd, d_options.getOut());
   } else {
-    status = solverInvoke(d_solver.get(), cmd, nullptr);
+    status = solverInvoke(d_solver.get(), d_symman.get(), cmd, nullptr);
   }
 
   api::Result res;

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -199,15 +199,15 @@ bool CommandExecutor::doCommandSingleton(Command* cmd)
   return status;
 }
 
-bool solverInvoke(api::Solver* solver, Command* cmd, std::ostream* out)
+bool solverInvoke(api::Solver* solver, parser::SymbolManager* sm, Command* cmd, std::ostream* out)
 {
   if (out == NULL)
   {
-    cmd->invoke(solver);
+    cmd->invoke(solver, sm);
   }
   else
   {
-    cmd->invoke(solver, *out);
+    cmd->invoke(solver, sm, *out);
   }
   // ignore the error if the command-verbosity is 0 for this command
   std::string commandName =

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -116,7 +116,10 @@ private:
 
 }; /* class CommandExecutor */
 
-bool solverInvoke(api::Solver* solver, parser::SymbolManager* sm, Command* cmd, std::ostream* out);
+bool solverInvoke(api::Solver* solver,
+                  parser::SymbolManager* sm,
+                  Command* cmd,
+                  std::ostream* out);
 
 }/* CVC4::main namespace */
 }/* CVC4 namespace */

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -116,7 +116,7 @@ private:
 
 }; /* class CommandExecutor */
 
-bool solverInvoke(api::Solver* solver, Command* cmd, std::ostream* out);
+bool solverInvoke(api::Solver* solver, parser::SymbolManager* sm, Command* cmd, std::ostream* out);
 
 }/* CVC4::main namespace */
 }/* CVC4 namespace */

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -247,7 +247,9 @@ void EchoCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
   d_commandStatus = CommandSuccess::instance();
 }
 
-void EchoCommand::invoke(api::Solver* solver, parser::SymbolManager* sm, std::ostream& out)
+void EchoCommand::invoke(api::Solver* solver,
+                         parser::SymbolManager* sm,
+                         std::ostream& out)
 {
   out << d_output << std::endl;
   Trace("dtview::command") << "* ~COMMAND: echo |" << d_output << "|~"
@@ -978,7 +980,9 @@ void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager* sm)
   d_commandStatus = CommandSuccess::instance();
 }
 
-void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager* sm, std::ostream& out)
+void CommandSequence::invoke(api::Solver* solver,
+                             parser::SymbolManager* sm,
+                             std::ostream& out)
 {
   for (; d_index < d_commandSequence.size(); ++d_index)
   {

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -31,6 +31,7 @@
 #include "expr/type.h"
 #include "options/options.h"
 #include "options/smt_options.h"
+#include "parser/symbol_manager.h"
 #include "printer/printer.h"
 #include "proof/unsat_core.h"
 #include "smt/dump.h"
@@ -39,7 +40,6 @@
 #include "smt/smt_engine_scope.h"
 #include "util/sexpr.h"
 #include "util/utility.h"
-#include "parser/symbol_manager.h"
 
 using namespace std;
 
@@ -176,7 +176,9 @@ bool Command::interrupted() const
          && dynamic_cast<const CommandInterrupted*>(d_commandStatus) != NULL;
 }
 
-void Command::invoke(api::Solver* solver, parser::SymbolManager * sm, std::ostream& out)
+void Command::invoke(api::Solver* solver,
+                     parser::SymbolManager* sm,
+                     std::ostream& out)
 {
   invoke(solver, sm);
   if (!(isMuted() && ok()))
@@ -216,7 +218,7 @@ void Command::printResult(std::ostream& out, uint32_t verbosity) const
 
 EmptyCommand::EmptyCommand(std::string name) : d_name(name) {}
 std::string EmptyCommand::getName() const { return d_name; }
-void EmptyCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void EmptyCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   /* empty commands have no implementation */
   d_commandStatus = CommandSuccess::instance();
@@ -240,7 +242,7 @@ void EmptyCommand::toStream(std::ostream& out,
 
 EchoCommand::EchoCommand(std::string output) : d_output(output) {}
 std::string EchoCommand::getOutput() const { return d_output; }
-void EchoCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void EchoCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   /* we don't have an output stream here, nothing to do */
   d_commandStatus = CommandSuccess::instance();
@@ -279,7 +281,7 @@ AssertCommand::AssertCommand(const api::Term& t, bool inUnsatCore)
 }
 
 api::Term AssertCommand::getTerm() const { return d_term; }
-void AssertCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void AssertCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -316,7 +318,7 @@ void AssertCommand::toStream(std::ostream& out,
 /* class PushCommand                                                          */
 /* -------------------------------------------------------------------------- */
 
-void PushCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void PushCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -349,7 +351,7 @@ void PushCommand::toStream(std::ostream& out,
 /* class PopCommand                                                           */
 /* -------------------------------------------------------------------------- */
 
-void PopCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void PopCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -387,7 +389,7 @@ CheckSatCommand::CheckSatCommand() : d_term() {}
 CheckSatCommand::CheckSatCommand(const api::Term& term) : d_term(term) {}
 
 api::Term CheckSatCommand::getTerm() const { return d_term; }
-void CheckSatCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void CheckSatCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   Trace("dtview::command") << "* ~COMMAND: " << getCommandName() << "~"
                            << std::endl;
@@ -456,7 +458,8 @@ const std::vector<api::Term>& CheckSatAssumingCommand::getTerms() const
   return d_terms;
 }
 
-void CheckSatAssumingCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void CheckSatAssumingCommand::invoke(api::Solver* solver,
+                                     parser::SymbolManager* sm)
 {
   Trace("dtview::command") << "* ~COMMAND: (check-sat-assuming ( " << d_terms
                            << " )~" << std::endl;
@@ -522,7 +525,7 @@ QueryCommand::QueryCommand(const api::Term& t, bool inUnsatCore)
 }
 
 api::Term QueryCommand::getTerm() const { return d_term; }
-void QueryCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void QueryCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -580,7 +583,8 @@ DeclareSygusVarCommand::DeclareSygusVarCommand(const std::string& id,
 api::Term DeclareSygusVarCommand::getVar() const { return d_var; }
 api::Sort DeclareSygusVarCommand::getSort() const { return d_sort; }
 
-void DeclareSygusVarCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DeclareSygusVarCommand::invoke(api::Solver* solver,
+                                    parser::SymbolManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -636,7 +640,7 @@ bool SynthFunCommand::isInv() const { return d_isInv; }
 
 const api::Grammar* SynthFunCommand::getGrammar() const { return d_grammar; }
 
-void SynthFunCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SynthFunCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -676,7 +680,8 @@ SygusConstraintCommand::SygusConstraintCommand(const api::Term& t) : d_term(t)
 {
 }
 
-void SygusConstraintCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SygusConstraintCommand::invoke(api::Solver* solver,
+                                    parser::SymbolManager* sm)
 {
   try
   {
@@ -728,7 +733,8 @@ SygusInvConstraintCommand::SygusInvConstraintCommand(const api::Term& inv,
 {
 }
 
-void SygusInvConstraintCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SygusInvConstraintCommand::invoke(api::Solver* solver,
+                                       parser::SymbolManager* sm)
 {
   try
   {
@@ -775,7 +781,7 @@ void SygusInvConstraintCommand::toStream(std::ostream& out,
 /* class CheckSynthCommand                                                    */
 /* -------------------------------------------------------------------------- */
 
-void CheckSynthCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void CheckSynthCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -844,7 +850,7 @@ void CheckSynthCommand::toStream(std::ostream& out,
 /* class ResetCommand                                                         */
 /* -------------------------------------------------------------------------- */
 
-void ResetCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void ResetCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -873,7 +879,8 @@ void ResetCommand::toStream(std::ostream& out,
 /* class ResetAssertionsCommand                                               */
 /* -------------------------------------------------------------------------- */
 
-void ResetAssertionsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void ResetAssertionsCommand::invoke(api::Solver* solver,
+                                    parser::SymbolManager* sm)
 {
   try
   {
@@ -909,7 +916,7 @@ void ResetAssertionsCommand::toStream(std::ostream& out,
 /* class QuitCommand                                                          */
 /* -------------------------------------------------------------------------- */
 
-void QuitCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void QuitCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   Dump("benchmark") << *this;
   d_commandStatus = CommandSuccess::instance();
@@ -933,7 +940,7 @@ void QuitCommand::toStream(std::ostream& out,
 
 CommentCommand::CommentCommand(std::string comment) : d_comment(comment) {}
 std::string CommentCommand::getComment() const { return d_comment; }
-void CommentCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void CommentCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   Dump("benchmark") << *this;
   d_commandStatus = CommandSuccess::instance();
@@ -970,7 +977,7 @@ void CommandSequence::addCommand(Command* cmd)
 }
 
 void CommandSequence::clear() { d_commandSequence.clear(); }
-void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   for (; d_index < d_commandSequence.size(); ++d_index)
   {
@@ -1104,7 +1111,8 @@ void DeclareFunctionCommand::setPrintInModel(bool p)
   d_printInModelSetByUser = true;
 }
 
-void DeclareFunctionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DeclareFunctionCommand::invoke(api::Solver* solver,
+                                    parser::SymbolManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -1146,7 +1154,7 @@ DeclareSortCommand::DeclareSortCommand(const std::string& id,
 
 size_t DeclareSortCommand::getArity() const { return d_arity; }
 api::Sort DeclareSortCommand::getSort() const { return d_sort; }
-void DeclareSortCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DeclareSortCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -1193,7 +1201,7 @@ const std::vector<api::Sort>& DefineSortCommand::getParameters() const
 }
 
 api::Sort DefineSortCommand::getSort() const { return d_sort; }
-void DefineSortCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DefineSortCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -1255,7 +1263,8 @@ const std::vector<api::Term>& DefineFunctionCommand::getFormals() const
 }
 
 api::Term DefineFunctionCommand::getFormula() const { return d_formula; }
-void DefineFunctionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DefineFunctionCommand::invoke(api::Solver* solver,
+                                   parser::SymbolManager* sm)
 {
   try
   {
@@ -1311,7 +1320,8 @@ DefineNamedFunctionCommand::DefineNamedFunctionCommand(
 {
 }
 
-void DefineNamedFunctionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DefineNamedFunctionCommand::invoke(api::Solver* solver,
+                                        parser::SymbolManager* sm)
 {
   this->DefineFunctionCommand::invoke(solver);
   if (!d_func.isNull() && d_func.getSort().isBoolean())
@@ -1384,7 +1394,8 @@ const std::vector<api::Term>& DefineFunctionRecCommand::getFormulas() const
   return d_formulas;
 }
 
-void DefineFunctionRecCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DefineFunctionRecCommand::invoke(api::Solver* solver,
+                                      parser::SymbolManager* sm)
 {
   try
   {
@@ -1461,7 +1472,8 @@ SetUserAttributeCommand::SetUserAttributeCommand(const std::string& attr,
 {
 }
 
-void SetUserAttributeCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SetUserAttributeCommand::invoke(api::Solver* solver,
+                                     parser::SymbolManager* sm)
 {
   try
   {
@@ -1507,7 +1519,7 @@ void SetUserAttributeCommand::toStream(std::ostream& out,
 
 SimplifyCommand::SimplifyCommand(api::Term term) : d_term(term) {}
 api::Term SimplifyCommand::getTerm() const { return d_term; }
-void SimplifyCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SimplifyCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -1575,7 +1587,7 @@ const std::vector<api::Term>& GetValueCommand::getTerms() const
 {
   return d_terms;
 }
-void GetValueCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetValueCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -1642,7 +1654,8 @@ void GetValueCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetAssignmentCommand::GetAssignmentCommand() {}
-void GetAssignmentCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetAssignmentCommand::invoke(api::Solver* solver,
+                                  parser::SymbolManager* sm)
 {
   try
   {
@@ -1713,7 +1726,7 @@ void GetAssignmentCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetModelCommand::GetModelCommand() : d_result(nullptr) {}
-void GetModelCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetModelCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -1775,7 +1788,7 @@ void GetModelCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 BlockModelCommand::BlockModelCommand() {}
-void BlockModelCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void BlockModelCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -1830,7 +1843,8 @@ const std::vector<api::Term>& BlockModelValuesCommand::getTerms() const
 {
   return d_terms;
 }
-void BlockModelValuesCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void BlockModelValuesCommand::invoke(api::Solver* solver,
+                                     parser::SymbolManager* sm)
 {
   try
   {
@@ -1877,7 +1891,7 @@ void BlockModelValuesCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetProofCommand::GetProofCommand() {}
-void GetProofCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetProofCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   Unimplemented() << "Unimplemented get-proof\n";
 }
@@ -1904,7 +1918,8 @@ void GetProofCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetInstantiationsCommand::GetInstantiationsCommand() : d_solver(nullptr) {}
-void GetInstantiationsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetInstantiationsCommand::invoke(api::Solver* solver,
+                                      parser::SymbolManager* sm)
 {
   try
   {
@@ -1957,7 +1972,8 @@ void GetInstantiationsCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetSynthSolutionCommand::GetSynthSolutionCommand() : d_solver(nullptr) {}
-void GetSynthSolutionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetSynthSolutionCommand::invoke(api::Solver* solver,
+                                     parser::SymbolManager* sm)
 {
   try
   {
@@ -2028,7 +2044,7 @@ const api::Grammar* GetInterpolCommand::getGrammar() const
 
 api::Term GetInterpolCommand::getResult() const { return d_result; }
 
-void GetInterpolCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetInterpolCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -2120,7 +2136,7 @@ const api::Grammar* GetAbductCommand::getGrammar() const
 std::string GetAbductCommand::getAbductName() const { return d_name; }
 api::Term GetAbductCommand::getResult() const { return d_result; }
 
-void GetAbductCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetAbductCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -2197,7 +2213,8 @@ GetQuantifierEliminationCommand::GetQuantifierEliminationCommand(
 
 api::Term GetQuantifierEliminationCommand::getTerm() const { return d_term; }
 bool GetQuantifierEliminationCommand::getDoFull() const { return d_doFull; }
-void GetQuantifierEliminationCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetQuantifierEliminationCommand::invoke(api::Solver* solver,
+                                             parser::SymbolManager* sm)
 {
   try
   {
@@ -2263,7 +2280,8 @@ void GetQuantifierEliminationCommand::toStream(std::ostream& out,
 
 GetUnsatAssumptionsCommand::GetUnsatAssumptionsCommand() {}
 
-void GetUnsatAssumptionsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetUnsatAssumptionsCommand::invoke(api::Solver* solver,
+                                        parser::SymbolManager* sm)
 {
   try
   {
@@ -2324,7 +2342,7 @@ void GetUnsatAssumptionsCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetUnsatCoreCommand::GetUnsatCoreCommand() {}
-void GetUnsatCoreCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetUnsatCoreCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -2390,7 +2408,8 @@ void GetUnsatCoreCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetAssertionsCommand::GetAssertionsCommand() {}
-void GetAssertionsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetAssertionsCommand::invoke(api::Solver* solver,
+                                  parser::SymbolManager* sm)
 {
   try
   {
@@ -2457,7 +2476,8 @@ BenchmarkStatus SetBenchmarkStatusCommand::getStatus() const
   return d_status;
 }
 
-void SetBenchmarkStatusCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SetBenchmarkStatusCommand::invoke(api::Solver* solver,
+                                       parser::SymbolManager* sm)
 {
   try
   {
@@ -2509,7 +2529,8 @@ SetBenchmarkLogicCommand::SetBenchmarkLogicCommand(std::string logic)
 }
 
 std::string SetBenchmarkLogicCommand::getLogic() const { return d_logic; }
-void SetBenchmarkLogicCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SetBenchmarkLogicCommand::invoke(api::Solver* solver,
+                                      parser::SymbolManager* sm)
 {
   try
   {
@@ -2552,7 +2573,7 @@ SetInfoCommand::SetInfoCommand(std::string flag, const SExpr& sexpr)
 
 std::string SetInfoCommand::getFlag() const { return d_flag; }
 SExpr SetInfoCommand::getSExpr() const { return d_sexpr; }
-void SetInfoCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SetInfoCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -2592,7 +2613,7 @@ void SetInfoCommand::toStream(std::ostream& out,
 
 GetInfoCommand::GetInfoCommand(std::string flag) : d_flag(flag) {}
 std::string GetInfoCommand::getFlag() const { return d_flag; }
-void GetInfoCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetInfoCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -2664,7 +2685,7 @@ SetOptionCommand::SetOptionCommand(std::string flag, const SExpr& sexpr)
 
 std::string SetOptionCommand::getFlag() const { return d_flag; }
 SExpr SetOptionCommand::getSExpr() const { return d_sexpr; }
-void SetOptionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SetOptionCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -2703,7 +2724,7 @@ void SetOptionCommand::toStream(std::ostream& out,
 
 GetOptionCommand::GetOptionCommand(std::string flag) : d_flag(flag) {}
 std::string GetOptionCommand::getFlag() const { return d_flag; }
-void GetOptionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void GetOptionCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   try
   {
@@ -2761,7 +2782,8 @@ SetExpressionNameCommand::SetExpressionNameCommand(api::Term term,
 {
 }
 
-void SetExpressionNameCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void SetExpressionNameCommand::invoke(api::Solver* solver,
+                                      parser::SymbolManager* sm)
 {
   solver->getSmtEngine()->setExpressionName(d_term.getExpr(), d_name);
   d_commandStatus = CommandSuccess::instance();
@@ -2810,7 +2832,8 @@ const std::vector<api::Sort>& DatatypeDeclarationCommand::getDatatypes() const
   return d_datatypes;
 }
 
-void DatatypeDeclarationCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
+void DatatypeDeclarationCommand::invoke(api::Solver* solver,
+                                        parser::SymbolManager* sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -39,6 +39,7 @@
 #include "smt/smt_engine_scope.h"
 #include "util/sexpr.h"
 #include "util/utility.h"
+#include "parser/symbol_manager.h"
 
 using namespace std;
 
@@ -175,9 +176,9 @@ bool Command::interrupted() const
          && dynamic_cast<const CommandInterrupted*>(d_commandStatus) != NULL;
 }
 
-void Command::invoke(api::Solver* solver, std::ostream& out)
+void Command::invoke(api::Solver* solver, parser::SymbolManager * sm, std::ostream& out)
 {
-  invoke(solver);
+  invoke(solver, sm);
   if (!(isMuted() && ok()))
   {
     printResult(
@@ -215,7 +216,7 @@ void Command::printResult(std::ostream& out, uint32_t verbosity) const
 
 EmptyCommand::EmptyCommand(std::string name) : d_name(name) {}
 std::string EmptyCommand::getName() const { return d_name; }
-void EmptyCommand::invoke(api::Solver* solver)
+void EmptyCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   /* empty commands have no implementation */
   d_commandStatus = CommandSuccess::instance();
@@ -239,7 +240,7 @@ void EmptyCommand::toStream(std::ostream& out,
 
 EchoCommand::EchoCommand(std::string output) : d_output(output) {}
 std::string EchoCommand::getOutput() const { return d_output; }
-void EchoCommand::invoke(api::Solver* solver)
+void EchoCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   /* we don't have an output stream here, nothing to do */
   d_commandStatus = CommandSuccess::instance();
@@ -278,7 +279,7 @@ AssertCommand::AssertCommand(const api::Term& t, bool inUnsatCore)
 }
 
 api::Term AssertCommand::getTerm() const { return d_term; }
-void AssertCommand::invoke(api::Solver* solver)
+void AssertCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -315,7 +316,7 @@ void AssertCommand::toStream(std::ostream& out,
 /* class PushCommand                                                          */
 /* -------------------------------------------------------------------------- */
 
-void PushCommand::invoke(api::Solver* solver)
+void PushCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -348,7 +349,7 @@ void PushCommand::toStream(std::ostream& out,
 /* class PopCommand                                                           */
 /* -------------------------------------------------------------------------- */
 
-void PopCommand::invoke(api::Solver* solver)
+void PopCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -386,7 +387,7 @@ CheckSatCommand::CheckSatCommand() : d_term() {}
 CheckSatCommand::CheckSatCommand(const api::Term& term) : d_term(term) {}
 
 api::Term CheckSatCommand::getTerm() const { return d_term; }
-void CheckSatCommand::invoke(api::Solver* solver)
+void CheckSatCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   Trace("dtview::command") << "* ~COMMAND: " << getCommandName() << "~"
                            << std::endl;
@@ -455,7 +456,7 @@ const std::vector<api::Term>& CheckSatAssumingCommand::getTerms() const
   return d_terms;
 }
 
-void CheckSatAssumingCommand::invoke(api::Solver* solver)
+void CheckSatAssumingCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   Trace("dtview::command") << "* ~COMMAND: (check-sat-assuming ( " << d_terms
                            << " )~" << std::endl;
@@ -521,7 +522,7 @@ QueryCommand::QueryCommand(const api::Term& t, bool inUnsatCore)
 }
 
 api::Term QueryCommand::getTerm() const { return d_term; }
-void QueryCommand::invoke(api::Solver* solver)
+void QueryCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -579,7 +580,7 @@ DeclareSygusVarCommand::DeclareSygusVarCommand(const std::string& id,
 api::Term DeclareSygusVarCommand::getVar() const { return d_var; }
 api::Sort DeclareSygusVarCommand::getSort() const { return d_sort; }
 
-void DeclareSygusVarCommand::invoke(api::Solver* solver)
+void DeclareSygusVarCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -635,7 +636,7 @@ bool SynthFunCommand::isInv() const { return d_isInv; }
 
 const api::Grammar* SynthFunCommand::getGrammar() const { return d_grammar; }
 
-void SynthFunCommand::invoke(api::Solver* solver)
+void SynthFunCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -675,7 +676,7 @@ SygusConstraintCommand::SygusConstraintCommand(const api::Term& t) : d_term(t)
 {
 }
 
-void SygusConstraintCommand::invoke(api::Solver* solver)
+void SygusConstraintCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -727,7 +728,7 @@ SygusInvConstraintCommand::SygusInvConstraintCommand(const api::Term& inv,
 {
 }
 
-void SygusInvConstraintCommand::invoke(api::Solver* solver)
+void SygusInvConstraintCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -774,7 +775,7 @@ void SygusInvConstraintCommand::toStream(std::ostream& out,
 /* class CheckSynthCommand                                                    */
 /* -------------------------------------------------------------------------- */
 
-void CheckSynthCommand::invoke(api::Solver* solver)
+void CheckSynthCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -843,7 +844,7 @@ void CheckSynthCommand::toStream(std::ostream& out,
 /* class ResetCommand                                                         */
 /* -------------------------------------------------------------------------- */
 
-void ResetCommand::invoke(api::Solver* solver)
+void ResetCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -872,7 +873,7 @@ void ResetCommand::toStream(std::ostream& out,
 /* class ResetAssertionsCommand                                               */
 /* -------------------------------------------------------------------------- */
 
-void ResetAssertionsCommand::invoke(api::Solver* solver)
+void ResetAssertionsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -908,7 +909,7 @@ void ResetAssertionsCommand::toStream(std::ostream& out,
 /* class QuitCommand                                                          */
 /* -------------------------------------------------------------------------- */
 
-void QuitCommand::invoke(api::Solver* solver)
+void QuitCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   Dump("benchmark") << *this;
   d_commandStatus = CommandSuccess::instance();
@@ -932,7 +933,7 @@ void QuitCommand::toStream(std::ostream& out,
 
 CommentCommand::CommentCommand(std::string comment) : d_comment(comment) {}
 std::string CommentCommand::getComment() const { return d_comment; }
-void CommentCommand::invoke(api::Solver* solver)
+void CommentCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   Dump("benchmark") << *this;
   d_commandStatus = CommandSuccess::instance();
@@ -969,7 +970,7 @@ void CommandSequence::addCommand(Command* cmd)
 }
 
 void CommandSequence::clear() { d_commandSequence.clear(); }
-void CommandSequence::invoke(api::Solver* solver)
+void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   for (; d_index < d_commandSequence.size(); ++d_index)
   {
@@ -1103,7 +1104,7 @@ void DeclareFunctionCommand::setPrintInModel(bool p)
   d_printInModelSetByUser = true;
 }
 
-void DeclareFunctionCommand::invoke(api::Solver* solver)
+void DeclareFunctionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -1145,7 +1146,7 @@ DeclareSortCommand::DeclareSortCommand(const std::string& id,
 
 size_t DeclareSortCommand::getArity() const { return d_arity; }
 api::Sort DeclareSortCommand::getSort() const { return d_sort; }
-void DeclareSortCommand::invoke(api::Solver* solver)
+void DeclareSortCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -1192,7 +1193,7 @@ const std::vector<api::Sort>& DefineSortCommand::getParameters() const
 }
 
 api::Sort DefineSortCommand::getSort() const { return d_sort; }
-void DefineSortCommand::invoke(api::Solver* solver)
+void DefineSortCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }
@@ -1254,7 +1255,7 @@ const std::vector<api::Term>& DefineFunctionCommand::getFormals() const
 }
 
 api::Term DefineFunctionCommand::getFormula() const { return d_formula; }
-void DefineFunctionCommand::invoke(api::Solver* solver)
+void DefineFunctionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1310,7 +1311,7 @@ DefineNamedFunctionCommand::DefineNamedFunctionCommand(
 {
 }
 
-void DefineNamedFunctionCommand::invoke(api::Solver* solver)
+void DefineNamedFunctionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   this->DefineFunctionCommand::invoke(solver);
   if (!d_func.isNull() && d_func.getSort().isBoolean())
@@ -1383,7 +1384,7 @@ const std::vector<api::Term>& DefineFunctionRecCommand::getFormulas() const
   return d_formulas;
 }
 
-void DefineFunctionRecCommand::invoke(api::Solver* solver)
+void DefineFunctionRecCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1460,7 +1461,7 @@ SetUserAttributeCommand::SetUserAttributeCommand(const std::string& attr,
 {
 }
 
-void SetUserAttributeCommand::invoke(api::Solver* solver)
+void SetUserAttributeCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1506,7 +1507,7 @@ void SetUserAttributeCommand::toStream(std::ostream& out,
 
 SimplifyCommand::SimplifyCommand(api::Term term) : d_term(term) {}
 api::Term SimplifyCommand::getTerm() const { return d_term; }
-void SimplifyCommand::invoke(api::Solver* solver)
+void SimplifyCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1574,7 +1575,7 @@ const std::vector<api::Term>& GetValueCommand::getTerms() const
 {
   return d_terms;
 }
-void GetValueCommand::invoke(api::Solver* solver)
+void GetValueCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1641,7 +1642,7 @@ void GetValueCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetAssignmentCommand::GetAssignmentCommand() {}
-void GetAssignmentCommand::invoke(api::Solver* solver)
+void GetAssignmentCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1712,7 +1713,7 @@ void GetAssignmentCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetModelCommand::GetModelCommand() : d_result(nullptr) {}
-void GetModelCommand::invoke(api::Solver* solver)
+void GetModelCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1774,7 +1775,7 @@ void GetModelCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 BlockModelCommand::BlockModelCommand() {}
-void BlockModelCommand::invoke(api::Solver* solver)
+void BlockModelCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1829,7 +1830,7 @@ const std::vector<api::Term>& BlockModelValuesCommand::getTerms() const
 {
   return d_terms;
 }
-void BlockModelValuesCommand::invoke(api::Solver* solver)
+void BlockModelValuesCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1876,7 +1877,7 @@ void BlockModelValuesCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetProofCommand::GetProofCommand() {}
-void GetProofCommand::invoke(api::Solver* solver)
+void GetProofCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   Unimplemented() << "Unimplemented get-proof\n";
 }
@@ -1903,7 +1904,7 @@ void GetProofCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetInstantiationsCommand::GetInstantiationsCommand() : d_solver(nullptr) {}
-void GetInstantiationsCommand::invoke(api::Solver* solver)
+void GetInstantiationsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -1956,7 +1957,7 @@ void GetInstantiationsCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetSynthSolutionCommand::GetSynthSolutionCommand() : d_solver(nullptr) {}
-void GetSynthSolutionCommand::invoke(api::Solver* solver)
+void GetSynthSolutionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2027,7 +2028,7 @@ const api::Grammar* GetInterpolCommand::getGrammar() const
 
 api::Term GetInterpolCommand::getResult() const { return d_result; }
 
-void GetInterpolCommand::invoke(api::Solver* solver)
+void GetInterpolCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2119,7 +2120,7 @@ const api::Grammar* GetAbductCommand::getGrammar() const
 std::string GetAbductCommand::getAbductName() const { return d_name; }
 api::Term GetAbductCommand::getResult() const { return d_result; }
 
-void GetAbductCommand::invoke(api::Solver* solver)
+void GetAbductCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2196,7 +2197,7 @@ GetQuantifierEliminationCommand::GetQuantifierEliminationCommand(
 
 api::Term GetQuantifierEliminationCommand::getTerm() const { return d_term; }
 bool GetQuantifierEliminationCommand::getDoFull() const { return d_doFull; }
-void GetQuantifierEliminationCommand::invoke(api::Solver* solver)
+void GetQuantifierEliminationCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2262,7 +2263,7 @@ void GetQuantifierEliminationCommand::toStream(std::ostream& out,
 
 GetUnsatAssumptionsCommand::GetUnsatAssumptionsCommand() {}
 
-void GetUnsatAssumptionsCommand::invoke(api::Solver* solver)
+void GetUnsatAssumptionsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2323,7 +2324,7 @@ void GetUnsatAssumptionsCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetUnsatCoreCommand::GetUnsatCoreCommand() {}
-void GetUnsatCoreCommand::invoke(api::Solver* solver)
+void GetUnsatCoreCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2389,7 +2390,7 @@ void GetUnsatCoreCommand::toStream(std::ostream& out,
 /* -------------------------------------------------------------------------- */
 
 GetAssertionsCommand::GetAssertionsCommand() {}
-void GetAssertionsCommand::invoke(api::Solver* solver)
+void GetAssertionsCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2456,7 +2457,7 @@ BenchmarkStatus SetBenchmarkStatusCommand::getStatus() const
   return d_status;
 }
 
-void SetBenchmarkStatusCommand::invoke(api::Solver* solver)
+void SetBenchmarkStatusCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2508,7 +2509,7 @@ SetBenchmarkLogicCommand::SetBenchmarkLogicCommand(std::string logic)
 }
 
 std::string SetBenchmarkLogicCommand::getLogic() const { return d_logic; }
-void SetBenchmarkLogicCommand::invoke(api::Solver* solver)
+void SetBenchmarkLogicCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2551,7 +2552,7 @@ SetInfoCommand::SetInfoCommand(std::string flag, const SExpr& sexpr)
 
 std::string SetInfoCommand::getFlag() const { return d_flag; }
 SExpr SetInfoCommand::getSExpr() const { return d_sexpr; }
-void SetInfoCommand::invoke(api::Solver* solver)
+void SetInfoCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2591,7 +2592,7 @@ void SetInfoCommand::toStream(std::ostream& out,
 
 GetInfoCommand::GetInfoCommand(std::string flag) : d_flag(flag) {}
 std::string GetInfoCommand::getFlag() const { return d_flag; }
-void GetInfoCommand::invoke(api::Solver* solver)
+void GetInfoCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2663,7 +2664,7 @@ SetOptionCommand::SetOptionCommand(std::string flag, const SExpr& sexpr)
 
 std::string SetOptionCommand::getFlag() const { return d_flag; }
 SExpr SetOptionCommand::getSExpr() const { return d_sexpr; }
-void SetOptionCommand::invoke(api::Solver* solver)
+void SetOptionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2702,7 +2703,7 @@ void SetOptionCommand::toStream(std::ostream& out,
 
 GetOptionCommand::GetOptionCommand(std::string flag) : d_flag(flag) {}
 std::string GetOptionCommand::getFlag() const { return d_flag; }
-void GetOptionCommand::invoke(api::Solver* solver)
+void GetOptionCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   try
   {
@@ -2760,7 +2761,7 @@ SetExpressionNameCommand::SetExpressionNameCommand(api::Term term,
 {
 }
 
-void SetExpressionNameCommand::invoke(api::Solver* solver)
+void SetExpressionNameCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   solver->getSmtEngine()->setExpressionName(d_term.getExpr(), d_name);
   d_commandStatus = CommandSuccess::instance();
@@ -2809,7 +2810,7 @@ const std::vector<api::Sort>& DatatypeDeclarationCommand::getDatatypes() const
   return d_datatypes;
 }
 
-void DatatypeDeclarationCommand::invoke(api::Solver* solver)
+void DatatypeDeclarationCommand::invoke(api::Solver* solver, parser::SymbolManager * sm)
 {
   d_commandStatus = CommandSuccess::instance();
 }

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -229,7 +229,6 @@ std::string EmptyCommand::getCommandName() const { return "empty"; }
 
 void EmptyCommand::toStream(std::ostream& out,
                             int toDepth,
-
                             size_t dag,
                             OutputLanguage language) const
 {
@@ -248,7 +247,7 @@ void EchoCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
   d_commandStatus = CommandSuccess::instance();
 }
 
-void EchoCommand::invoke(api::Solver* solver, std::ostream& out)
+void EchoCommand::invoke(api::Solver* solver, parser::SymbolManager* sm, std::ostream& out)
 {
   out << d_output << std::endl;
   Trace("dtview::command") << "* ~COMMAND: echo |" << d_output << "|~"
@@ -264,7 +263,6 @@ std::string EchoCommand::getCommandName() const { return "echo"; }
 
 void EchoCommand::toStream(std::ostream& out,
                            int toDepth,
-
                            size_t dag,
                            OutputLanguage language) const
 {
@@ -307,7 +305,6 @@ std::string AssertCommand::getCommandName() const { return "assert"; }
 
 void AssertCommand::toStream(std::ostream& out,
                              int toDepth,
-
                              size_t dag,
                              OutputLanguage language) const
 {
@@ -340,7 +337,6 @@ std::string PushCommand::getCommandName() const { return "push"; }
 
 void PushCommand::toStream(std::ostream& out,
                            int toDepth,
-
                            size_t dag,
                            OutputLanguage language) const
 {
@@ -373,7 +369,6 @@ std::string PopCommand::getCommandName() const { return "pop"; }
 
 void PopCommand::toStream(std::ostream& out,
                           int toDepth,
-
                           size_t dag,
                           OutputLanguage language) const
 {
@@ -431,7 +426,6 @@ std::string CheckSatCommand::getCommandName() const { return "check-sat"; }
 
 void CheckSatCommand::toStream(std::ostream& out,
                                int toDepth,
-
                                size_t dag,
                                OutputLanguage language) const
 {
@@ -507,7 +501,6 @@ std::string CheckSatAssumingCommand::getCommandName() const
 
 void CheckSatAssumingCommand::toStream(std::ostream& out,
                                        int toDepth,
-
                                        size_t dag,
                                        OutputLanguage language) const
 {
@@ -562,7 +555,6 @@ std::string QueryCommand::getCommandName() const { return "query"; }
 
 void QueryCommand::toStream(std::ostream& out,
                             int toDepth,
-
                             size_t dag,
                             OutputLanguage language) const
 {
@@ -601,7 +593,6 @@ std::string DeclareSygusVarCommand::getCommandName() const
 
 void DeclareSygusVarCommand::toStream(std::ostream& out,
                                       int toDepth,
-
                                       size_t dag,
                                       OutputLanguage language) const
 {
@@ -658,7 +649,6 @@ std::string SynthFunCommand::getCommandName() const
 
 void SynthFunCommand::toStream(std::ostream& out,
                                int toDepth,
-
                                size_t dag,
                                OutputLanguage language) const
 {
@@ -708,7 +698,6 @@ std::string SygusConstraintCommand::getCommandName() const
 
 void SygusConstraintCommand::toStream(std::ostream& out,
                                       int toDepth,
-
                                       size_t dag,
                                       OutputLanguage language) const
 {
@@ -765,7 +754,6 @@ std::string SygusInvConstraintCommand::getCommandName() const
 
 void SygusInvConstraintCommand::toStream(std::ostream& out,
                                          int toDepth,
-
                                          size_t dag,
                                          OutputLanguage language) const
 {
@@ -839,7 +827,6 @@ std::string CheckSynthCommand::getCommandName() const { return "check-synth"; }
 
 void CheckSynthCommand::toStream(std::ostream& out,
                                  int toDepth,
-
                                  size_t dag,
                                  OutputLanguage language) const
 {
@@ -868,7 +855,6 @@ std::string ResetCommand::getCommandName() const { return "reset"; }
 
 void ResetCommand::toStream(std::ostream& out,
                             int toDepth,
-
                             size_t dag,
                             OutputLanguage language) const
 {
@@ -905,7 +891,6 @@ std::string ResetAssertionsCommand::getCommandName() const
 
 void ResetAssertionsCommand::toStream(std::ostream& out,
                                       int toDepth,
-
                                       size_t dag,
                                       OutputLanguage language) const
 {
@@ -927,7 +912,6 @@ std::string QuitCommand::getCommandName() const { return "exit"; }
 
 void QuitCommand::toStream(std::ostream& out,
                            int toDepth,
-
                            size_t dag,
                            OutputLanguage language) const
 {
@@ -951,7 +935,6 @@ std::string CommentCommand::getCommandName() const { return "comment"; }
 
 void CommentCommand::toStream(std::ostream& out,
                               int toDepth,
-
                               size_t dag,
                               OutputLanguage language) const
 {
@@ -981,7 +964,7 @@ void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   for (; d_index < d_commandSequence.size(); ++d_index)
   {
-    d_commandSequence[d_index]->invoke(solver);
+    d_commandSequence[d_index]->invoke(solver, sm);
     if (!d_commandSequence[d_index]->ok())
     {
       // abort execution
@@ -995,11 +978,11 @@ void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager* sm)
   d_commandStatus = CommandSuccess::instance();
 }
 
-void CommandSequence::invoke(api::Solver* solver, std::ostream& out)
+void CommandSequence::invoke(api::Solver* solver, parser::SymbolManager* sm, std::ostream& out)
 {
   for (; d_index < d_commandSequence.size(); ++d_index)
   {
-    d_commandSequence[d_index]->invoke(solver, out);
+    d_commandSequence[d_index]->invoke(solver, sm, out);
     if (!d_commandSequence[d_index]->ok())
     {
       // abort execution
@@ -1048,7 +1031,6 @@ std::string CommandSequence::getCommandName() const { return "sequence"; }
 
 void CommandSequence::toStream(std::ostream& out,
                                int toDepth,
-
                                size_t dag,
                                OutputLanguage language) const
 {
@@ -1062,7 +1044,6 @@ void CommandSequence::toStream(std::ostream& out,
 
 void DeclarationSequence::toStream(std::ostream& out,
                                    int toDepth,
-
                                    size_t dag,
                                    OutputLanguage language) const
 {
@@ -1133,7 +1114,6 @@ std::string DeclareFunctionCommand::getCommandName() const
 
 void DeclareFunctionCommand::toStream(std::ostream& out,
                                       int toDepth,
-
                                       size_t dag,
                                       OutputLanguage language) const
 {
@@ -1171,7 +1151,6 @@ std::string DeclareSortCommand::getCommandName() const
 
 void DeclareSortCommand::toStream(std::ostream& out,
                                   int toDepth,
-
                                   size_t dag,
                                   OutputLanguage language) const
 {
@@ -1215,7 +1194,6 @@ std::string DefineSortCommand::getCommandName() const { return "define-sort"; }
 
 void DefineSortCommand::toStream(std::ostream& out,
                                  int toDepth,
-
                                  size_t dag,
                                  OutputLanguage language) const
 {
@@ -1293,7 +1271,6 @@ std::string DefineFunctionCommand::getCommandName() const
 
 void DefineFunctionCommand::toStream(std::ostream& out,
                                      int toDepth,
-
                                      size_t dag,
                                      OutputLanguage language) const
 {
@@ -1323,7 +1300,7 @@ DefineNamedFunctionCommand::DefineNamedFunctionCommand(
 void DefineNamedFunctionCommand::invoke(api::Solver* solver,
                                         parser::SymbolManager* sm)
 {
-  this->DefineFunctionCommand::invoke(solver);
+  this->DefineFunctionCommand::invoke(solver, sm);
   if (!d_func.isNull() && d_func.getSort().isBoolean())
   {
     solver->getSmtEngine()->addToAssignment(d_func.getExpr());
@@ -1339,7 +1316,6 @@ Command* DefineNamedFunctionCommand::clone() const
 
 void DefineNamedFunctionCommand::toStream(std::ostream& out,
                                           int toDepth,
-
                                           size_t dag,
                                           OutputLanguage language) const
 {
@@ -1420,7 +1396,6 @@ std::string DefineFunctionRecCommand::getCommandName() const
 
 void DefineFunctionRecCommand::toStream(std::ostream& out,
                                         int toDepth,
-
                                         size_t dag,
                                         OutputLanguage language) const
 {
@@ -1505,7 +1480,6 @@ std::string SetUserAttributeCommand::getCommandName() const
 
 void SetUserAttributeCommand::toStream(std::ostream& out,
                                        int toDepth,
-
                                        size_t dag,
                                        OutputLanguage language) const
 {
@@ -1560,7 +1534,6 @@ std::string SimplifyCommand::getCommandName() const { return "simplify"; }
 
 void SimplifyCommand::toStream(std::ostream& out,
                                int toDepth,
-
                                size_t dag,
                                OutputLanguage language) const
 {
@@ -1641,7 +1614,6 @@ std::string GetValueCommand::getCommandName() const { return "get-value"; }
 
 void GetValueCommand::toStream(std::ostream& out,
                                int toDepth,
-
                                size_t dag,
                                OutputLanguage language) const
 {
@@ -1714,7 +1686,6 @@ std::string GetAssignmentCommand::getCommandName() const
 
 void GetAssignmentCommand::toStream(std::ostream& out,
                                     int toDepth,
-
                                     size_t dag,
                                     OutputLanguage language) const
 {
@@ -1776,7 +1747,6 @@ std::string GetModelCommand::getCommandName() const { return "get-model"; }
 
 void GetModelCommand::toStream(std::ostream& out,
                                int toDepth,
-
                                size_t dag,
                                OutputLanguage language) const
 {
@@ -1819,7 +1789,6 @@ std::string BlockModelCommand::getCommandName() const { return "block-model"; }
 
 void BlockModelCommand::toStream(std::ostream& out,
                                  int toDepth,
-
                                  size_t dag,
                                  OutputLanguage language) const
 {
@@ -1878,7 +1847,6 @@ std::string BlockModelValuesCommand::getCommandName() const
 
 void BlockModelValuesCommand::toStream(std::ostream& out,
                                        int toDepth,
-
                                        size_t dag,
                                        OutputLanguage language) const
 {
@@ -1906,7 +1874,6 @@ std::string GetProofCommand::getCommandName() const { return "get-proof"; }
 
 void GetProofCommand::toStream(std::ostream& out,
                                int toDepth,
-
                                size_t dag,
                                OutputLanguage language) const
 {
@@ -1960,7 +1927,6 @@ std::string GetInstantiationsCommand::getCommandName() const
 
 void GetInstantiationsCommand::toStream(std::ostream& out,
                                         int toDepth,
-
                                         size_t dag,
                                         OutputLanguage language) const
 {
@@ -2013,7 +1979,6 @@ std::string GetSynthSolutionCommand::getCommandName() const
 
 void GetSynthSolutionCommand::toStream(std::ostream& out,
                                        int toDepth,
-
                                        size_t dag,
                                        OutputLanguage language) const
 {
@@ -2103,7 +2068,6 @@ std::string GetInterpolCommand::getCommandName() const
 
 void GetInterpolCommand::toStream(std::ostream& out,
                                   int toDepth,
-
                                   size_t dag,
                                   OutputLanguage language) const
 {
@@ -2189,7 +2153,6 @@ std::string GetAbductCommand::getCommandName() const { return "get-abduct"; }
 
 void GetAbductCommand::toStream(std::ostream& out,
                                 int toDepth,
-
                                 size_t dag,
                                 OutputLanguage language) const
 {
@@ -2266,7 +2229,6 @@ std::string GetQuantifierEliminationCommand::getCommandName() const
 
 void GetQuantifierEliminationCommand::toStream(std::ostream& out,
                                                int toDepth,
-
                                                size_t dag,
                                                OutputLanguage language) const
 {
@@ -2330,7 +2292,6 @@ std::string GetUnsatAssumptionsCommand::getCommandName() const
 
 void GetUnsatAssumptionsCommand::toStream(std::ostream& out,
                                           int toDepth,
-
                                           size_t dag,
                                           OutputLanguage language) const
 {
@@ -2396,7 +2357,6 @@ std::string GetUnsatCoreCommand::getCommandName() const
 
 void GetUnsatCoreCommand::toStream(std::ostream& out,
                                    int toDepth,
-
                                    size_t dag,
                                    OutputLanguage language) const
 {
@@ -2455,7 +2415,6 @@ std::string GetAssertionsCommand::getCommandName() const
 
 void GetAssertionsCommand::toStream(std::ostream& out,
                                     int toDepth,
-
                                     size_t dag,
                                     OutputLanguage language) const
 {
@@ -2504,7 +2463,6 @@ std::string SetBenchmarkStatusCommand::getCommandName() const
 
 void SetBenchmarkStatusCommand::toStream(std::ostream& out,
                                          int toDepth,
-
                                          size_t dag,
                                          OutputLanguage language) const
 {
@@ -2555,7 +2513,6 @@ std::string SetBenchmarkLogicCommand::getCommandName() const
 
 void SetBenchmarkLogicCommand::toStream(std::ostream& out,
                                         int toDepth,
-
                                         size_t dag,
                                         OutputLanguage language) const
 {
@@ -2600,7 +2557,6 @@ std::string SetInfoCommand::getCommandName() const { return "set-info"; }
 
 void SetInfoCommand::toStream(std::ostream& out,
                               int toDepth,
-
                               size_t dag,
                               OutputLanguage language) const
 {
@@ -2667,7 +2623,6 @@ std::string GetInfoCommand::getCommandName() const { return "get-info"; }
 
 void GetInfoCommand::toStream(std::ostream& out,
                               int toDepth,
-
                               size_t dag,
                               OutputLanguage language) const
 {
@@ -2711,7 +2666,6 @@ std::string SetOptionCommand::getCommandName() const { return "set-option"; }
 
 void SetOptionCommand::toStream(std::ostream& out,
                                 int toDepth,
-
                                 size_t dag,
                                 OutputLanguage language) const
 {
@@ -2765,7 +2719,6 @@ std::string GetOptionCommand::getCommandName() const { return "get-option"; }
 
 void GetOptionCommand::toStream(std::ostream& out,
                                 int toDepth,
-
                                 size_t dag,
                                 OutputLanguage language) const
 {
@@ -2802,7 +2755,6 @@ std::string SetExpressionNameCommand::getCommandName() const
 
 void SetExpressionNameCommand::toStream(std::ostream& out,
                                         int toDepth,
-
                                         size_t dag,
                                         OutputLanguage language) const
 {
@@ -2850,7 +2802,6 @@ std::string DatatypeDeclarationCommand::getCommandName() const
 
 void DatatypeDeclarationCommand::toStream(std::ostream& out,
                                           int toDepth,
-
                                           size_t dag,
                                           OutputLanguage language) const
 {

--- a/src/smt/command.cpp
+++ b/src/smt/command.cpp
@@ -1427,7 +1427,7 @@ DeclareHeapCommand::DeclareHeapCommand(api::Sort locSort, api::Sort dataSort)
 api::Sort DeclareHeapCommand::getLocationSort() const { return d_locSort; }
 api::Sort DeclareHeapCommand::getDataSort() const { return d_dataSort; }
 
-void DeclareHeapCommand::invoke(api::Solver* solver)
+void DeclareHeapCommand::invoke(api::Solver* solver, parser::SymbolManager* sm)
 {
   solver->declareSeparationHeap(d_locSort, d_dataSort);
 }

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -576,7 +576,7 @@ class CVC4_PUBLIC DeclareHeapCommand : public Command
   DeclareHeapCommand(api::Sort locSort, api::Sort dataSort);
   api::Sort getLocationSort() const;
   api::Sort getDataSort() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -41,6 +41,10 @@ class Solver;
 class Term;
 }  // namespace api
 
+namespace parser {
+class SymbolManager;
+}
+
 class UnsatCore;
 class SmtEngine;
 class Command;
@@ -202,8 +206,8 @@ class CVC4_PUBLIC Command
 
   virtual ~Command();
 
-  virtual void invoke(api::Solver* solver) = 0;
-  virtual void invoke(api::Solver* solver, std::ostream& out);
+  virtual void invoke(api::Solver* solver, parser::SymbolManager * sm) = 0;
+  virtual void invoke(api::Solver* solver, parser::SymbolManager * sm, std::ostream& out);
 
   virtual void toStream(
       std::ostream& out,
@@ -276,13 +280,12 @@ class CVC4_PUBLIC EmptyCommand : public Command
  public:
   EmptyCommand(std::string name = "");
   std::string getName() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -297,15 +300,14 @@ class CVC4_PUBLIC EchoCommand : public Command
 
   std::string getOutput() const;
 
-  void invoke(api::Solver* solver) override;
-  void invoke(api::Solver* solver, std::ostream& out) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm, std::ostream& out) override;
 
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -324,14 +326,13 @@ class CVC4_PUBLIC AssertCommand : public Command
 
   api::Term getTerm() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
 
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class AssertCommand */
@@ -339,13 +340,12 @@ class CVC4_PUBLIC AssertCommand : public Command
 class CVC4_PUBLIC PushCommand : public Command
 {
  public:
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class PushCommand */
@@ -353,13 +353,12 @@ class CVC4_PUBLIC PushCommand : public Command
 class CVC4_PUBLIC PopCommand : public Command
 {
  public:
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class PopCommand */
@@ -372,7 +371,7 @@ class CVC4_PUBLIC DeclarationDefinitionCommand : public Command
  public:
   DeclarationDefinitionCommand(const std::string& id);
 
-  void invoke(api::Solver* solver) override = 0;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override = 0;
   std::string getSymbol() const;
 }; /* class DeclarationDefinitionCommand */
 
@@ -392,7 +391,7 @@ class CVC4_PUBLIC DeclareFunctionCommand : public DeclarationDefinitionCommand
   bool getPrintInModelSetByUser() const;
   void setPrintInModel(bool p);
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -415,7 +414,7 @@ class CVC4_PUBLIC DeclareSortCommand : public DeclarationDefinitionCommand
   size_t getArity() const;
   api::Sort getSort() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -441,7 +440,7 @@ class CVC4_PUBLIC DefineSortCommand : public DeclarationDefinitionCommand
   const std::vector<api::Sort>& getParameters() const;
   api::Sort getSort() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -469,7 +468,7 @@ class CVC4_PUBLIC DefineFunctionCommand : public DeclarationDefinitionCommand
   const std::vector<api::Term>& getFormals() const;
   api::Term getFormula() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -506,7 +505,7 @@ class CVC4_PUBLIC DefineNamedFunctionCommand : public DefineFunctionCommand
                              const std::vector<api::Term>& formals,
                              api::Term formula,
                              bool global);
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   void toStream(
       std::ostream& out,
@@ -537,7 +536,7 @@ class CVC4_PUBLIC DefineFunctionRecCommand : public Command
   const std::vector<std::vector<api::Term> >& getFormals() const;
   const std::vector<api::Term>& getFormulas() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -576,7 +575,7 @@ class CVC4_PUBLIC SetUserAttributeCommand : public Command
                           api::Term term,
                           const std::string& value);
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -610,7 +609,7 @@ class CVC4_PUBLIC CheckSatCommand : public Command
 
   api::Term getTerm() const;
   api::Result getResult() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -639,7 +638,7 @@ class CVC4_PUBLIC CheckSatAssumingCommand : public Command
 
   const std::vector<api::Term>& getTerms() const;
   api::Result getResult() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -667,7 +666,7 @@ class CVC4_PUBLIC QueryCommand : public Command
 
   api::Term getTerm() const;
   api::Result getResult() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -695,7 +694,7 @@ class CVC4_PUBLIC DeclareSygusVarCommand : public DeclarationDefinitionCommand
    * The declared sygus variable is communicated to the SMT engine in case a
    * synthesis conjecture is built later on.
    */
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -745,7 +744,7 @@ class CVC4_PUBLIC SynthFunCommand : public DeclarationDefinitionCommand
    * The declared function-to-synthesize is communicated to the SMT engine in
    * case a synthesis conjecture is built later on.
    */
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -783,7 +782,7 @@ class CVC4_PUBLIC SygusConstraintCommand : public Command
    * The declared constraint is communicated to the SMT engine in case a
    * synthesis conjecture is built later on.
    */
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -827,7 +826,7 @@ class CVC4_PUBLIC SygusInvConstraintCommand : public Command
    * invariant constraint is built, in case an actual synthesis conjecture is
    * built later on.
    */
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -864,7 +863,7 @@ class CVC4_PUBLIC CheckSynthCommand : public Command
    * and then perform a satisfiability check, whose result is stored in
    * d_result.
    */
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -898,7 +897,7 @@ class CVC4_PUBLIC SimplifyCommand : public Command
 
   api::Term getTerm() const;
   api::Term getResult() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -922,7 +921,7 @@ class CVC4_PUBLIC GetValueCommand : public Command
 
   const std::vector<api::Term>& getTerms() const;
   api::Term getResult() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -943,7 +942,7 @@ class CVC4_PUBLIC GetAssignmentCommand : public Command
   GetAssignmentCommand();
 
   SExpr getResult() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -962,7 +961,7 @@ class CVC4_PUBLIC GetModelCommand : public Command
 
   // Model is private to the library -- for now
   // Model* getResult() const ;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -983,7 +982,7 @@ class CVC4_PUBLIC BlockModelCommand : public Command
  public:
   BlockModelCommand();
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1001,7 +1000,7 @@ class CVC4_PUBLIC BlockModelValuesCommand : public Command
   BlockModelValuesCommand(const std::vector<api::Term>& terms);
 
   const std::vector<api::Term>& getTerms() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1021,7 +1020,7 @@ class CVC4_PUBLIC GetProofCommand : public Command
  public:
   GetProofCommand();
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1037,7 +1036,7 @@ class CVC4_PUBLIC GetInstantiationsCommand : public Command
  public:
   GetInstantiationsCommand();
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1057,7 +1056,7 @@ class CVC4_PUBLIC GetSynthSolutionCommand : public Command
  public:
   GetSynthSolutionCommand();
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1096,7 +1095,7 @@ class CVC4_PUBLIC GetInterpolCommand : public Command
    * query. */
   api::Term getResult() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1148,7 +1147,7 @@ class CVC4_PUBLIC GetAbductCommand : public Command
    */
   api::Term getResult() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1185,7 +1184,7 @@ class CVC4_PUBLIC GetQuantifierEliminationCommand : public Command
 
   api::Term getTerm() const;
   bool getDoFull() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   api::Term getResult() const;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
 
@@ -1203,7 +1202,7 @@ class CVC4_PUBLIC GetUnsatAssumptionsCommand : public Command
 {
  public:
   GetUnsatAssumptionsCommand();
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   std::vector<api::Term> getResult() const;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
@@ -1225,7 +1224,7 @@ class CVC4_PUBLIC GetUnsatCoreCommand : public Command
   GetUnsatCoreCommand();
   const std::vector<api::Term>& getUnsatCore() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
 
   Command* clone() const override;
@@ -1252,7 +1251,7 @@ class CVC4_PUBLIC GetAssertionsCommand : public Command
  public:
   GetAssertionsCommand();
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   std::string getResult() const;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
@@ -1274,7 +1273,7 @@ class CVC4_PUBLIC SetBenchmarkStatusCommand : public Command
 
   BenchmarkStatus getStatus() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1293,7 +1292,7 @@ class CVC4_PUBLIC SetBenchmarkLogicCommand : public Command
   SetBenchmarkLogicCommand(std::string logic);
 
   std::string getLogic() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1315,7 +1314,7 @@ class CVC4_PUBLIC SetInfoCommand : public Command
   std::string getFlag() const;
   SExpr getSExpr() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1337,7 +1336,7 @@ class CVC4_PUBLIC GetInfoCommand : public Command
   std::string getFlag() const;
   std::string getResult() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1360,7 +1359,7 @@ class CVC4_PUBLIC SetOptionCommand : public Command
   std::string getFlag() const;
   SExpr getSExpr() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1383,7 +1382,7 @@ class CVC4_PUBLIC GetOptionCommand : public Command
   std::string getFlag() const;
   std::string getResult() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1411,7 +1410,7 @@ class CVC4_PUBLIC SetExpressionNameCommand : public Command
  public:
   SetExpressionNameCommand(api::Term term, std::string name);
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1432,7 +1431,7 @@ class CVC4_PUBLIC DatatypeDeclarationCommand : public Command
 
   DatatypeDeclarationCommand(const std::vector<api::Sort>& datatypes);
   const std::vector<api::Sort>& getDatatypes() const;
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1447,7 +1446,7 @@ class CVC4_PUBLIC ResetCommand : public Command
 {
  public:
   ResetCommand() {}
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1462,7 +1461,7 @@ class CVC4_PUBLIC ResetAssertionsCommand : public Command
 {
  public:
   ResetAssertionsCommand() {}
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1477,7 +1476,7 @@ class CVC4_PUBLIC QuitCommand : public Command
 {
  public:
   QuitCommand() {}
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1497,7 +1496,7 @@ class CVC4_PUBLIC CommentCommand : public Command
 
   std::string getComment() const;
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1523,7 +1522,7 @@ class CVC4_PUBLIC CommandSequence : public Command
   void addCommand(Command* cmd);
   void clear();
 
-  void invoke(api::Solver* solver) override;
+  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
   void invoke(api::Solver* solver, std::ostream& out) override;
 
   typedef std::vector<Command*>::iterator iterator;

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -206,7 +206,13 @@ class CVC4_PUBLIC Command
 
   virtual ~Command();
 
+  /**
+   * Invoke the command on the solver and symbol manager sm.
+   */
   virtual void invoke(api::Solver* solver, parser::SymbolManager* sm) = 0;
+  /**
+   * Same as above, and prints the result to output stream out.
+   */
   virtual void invoke(api::Solver* solver,
                       parser::SymbolManager* sm,
                       std::ostream& out);
@@ -401,7 +407,6 @@ class CVC4_PUBLIC DeclareFunctionCommand : public DeclarationDefinitionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class DeclareFunctionCommand */
@@ -424,7 +429,6 @@ class CVC4_PUBLIC DeclareSortCommand : public DeclarationDefinitionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class DeclareSortCommand */
@@ -450,7 +454,6 @@ class CVC4_PUBLIC DefineSortCommand : public DeclarationDefinitionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class DefineSortCommand */
@@ -478,7 +481,6 @@ class CVC4_PUBLIC DefineFunctionCommand : public DeclarationDefinitionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -514,7 +516,6 @@ class CVC4_PUBLIC DefineNamedFunctionCommand : public DefineFunctionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class DefineNamedFunctionCommand */
@@ -546,7 +547,6 @@ class CVC4_PUBLIC DefineFunctionRecCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -585,7 +585,6 @@ class CVC4_PUBLIC SetUserAttributeCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -620,7 +619,6 @@ class CVC4_PUBLIC CheckSatCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -649,7 +647,6 @@ class CVC4_PUBLIC CheckSatAssumingCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -677,7 +674,6 @@ class CVC4_PUBLIC QueryCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class QueryCommand */
@@ -707,7 +703,6 @@ class CVC4_PUBLIC DeclareSygusVarCommand : public DeclarationDefinitionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -757,7 +752,6 @@ class CVC4_PUBLIC SynthFunCommand : public DeclarationDefinitionCommand
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -795,7 +789,6 @@ class CVC4_PUBLIC SygusConstraintCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -839,7 +832,6 @@ class CVC4_PUBLIC SygusInvConstraintCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -876,7 +868,6 @@ class CVC4_PUBLIC CheckSynthCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -908,7 +899,6 @@ class CVC4_PUBLIC SimplifyCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class SimplifyCommand */
@@ -932,7 +922,6 @@ class CVC4_PUBLIC GetValueCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class GetValueCommand */
@@ -953,7 +942,6 @@ class CVC4_PUBLIC GetAssignmentCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class GetAssignmentCommand */
@@ -972,7 +960,6 @@ class CVC4_PUBLIC GetModelCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -992,7 +979,6 @@ class CVC4_PUBLIC BlockModelCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class BlockModelCommand */
@@ -1010,7 +996,6 @@ class CVC4_PUBLIC BlockModelValuesCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -1030,7 +1015,6 @@ class CVC4_PUBLIC GetProofCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class GetProofCommand */
@@ -1047,7 +1031,6 @@ class CVC4_PUBLIC GetInstantiationsCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -1067,7 +1050,6 @@ class CVC4_PUBLIC GetSynthSolutionCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -1106,7 +1088,6 @@ class CVC4_PUBLIC GetInterpolCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -1158,7 +1139,6 @@ class CVC4_PUBLIC GetAbductCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -1197,7 +1177,6 @@ class CVC4_PUBLIC GetQuantifierEliminationCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class GetQuantifierEliminationCommand */
@@ -1214,7 +1193,6 @@ class CVC4_PUBLIC GetUnsatAssumptionsCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -1236,7 +1214,6 @@ class CVC4_PUBLIC GetUnsatCoreCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 
@@ -1369,7 +1346,6 @@ class CVC4_PUBLIC SetOptionCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class SetOptionCommand */
@@ -1393,7 +1369,6 @@ class CVC4_PUBLIC GetOptionCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class GetOptionCommand */
@@ -1420,7 +1395,6 @@ class CVC4_PUBLIC SetExpressionNameCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class SetExpressionNameCommand */
@@ -1441,7 +1415,6 @@ class CVC4_PUBLIC DatatypeDeclarationCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class DatatypeDeclarationCommand */
@@ -1456,7 +1429,6 @@ class CVC4_PUBLIC ResetCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class ResetCommand */
@@ -1471,7 +1443,6 @@ class CVC4_PUBLIC ResetAssertionsCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class ResetAssertionsCommand */
@@ -1486,7 +1457,6 @@ class CVC4_PUBLIC QuitCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class QuitCommand */
@@ -1506,7 +1476,6 @@ class CVC4_PUBLIC CommentCommand : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class CommentCommand */
@@ -1527,7 +1496,7 @@ class CVC4_PUBLIC CommandSequence : public Command
   void clear();
 
   void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
-  void invoke(api::Solver* solver, std::ostream& out) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm, std::ostream& out) override;
 
   typedef std::vector<Command*>::iterator iterator;
   typedef std::vector<Command*>::const_iterator const_iterator;
@@ -1543,7 +1512,6 @@ class CVC4_PUBLIC CommandSequence : public Command
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 }; /* class CommandSequence */
@@ -1553,7 +1521,6 @@ class CVC4_PUBLIC DeclarationSequence : public CommandSequence
   void toStream(
       std::ostream& out,
       int toDepth = -1,
-
       size_t dag = 1,
       OutputLanguage language = language::output::LANG_AUTO) const override;
 };

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -206,8 +206,10 @@ class CVC4_PUBLIC Command
 
   virtual ~Command();
 
-  virtual void invoke(api::Solver* solver, parser::SymbolManager * sm) = 0;
-  virtual void invoke(api::Solver* solver, parser::SymbolManager * sm, std::ostream& out);
+  virtual void invoke(api::Solver* solver, parser::SymbolManager* sm) = 0;
+  virtual void invoke(api::Solver* solver,
+                      parser::SymbolManager* sm,
+                      std::ostream& out);
 
   virtual void toStream(
       std::ostream& out,
@@ -280,7 +282,7 @@ class CVC4_PUBLIC EmptyCommand : public Command
  public:
   EmptyCommand(std::string name = "");
   std::string getName() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -300,8 +302,10 @@ class CVC4_PUBLIC EchoCommand : public Command
 
   std::string getOutput() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm, std::ostream& out) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
+  void invoke(api::Solver* solver,
+              parser::SymbolManager* sm,
+              std::ostream& out) override;
 
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -326,7 +330,7 @@ class CVC4_PUBLIC AssertCommand : public Command
 
   api::Term getTerm() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
 
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -340,7 +344,7 @@ class CVC4_PUBLIC AssertCommand : public Command
 class CVC4_PUBLIC PushCommand : public Command
 {
  public:
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -353,7 +357,7 @@ class CVC4_PUBLIC PushCommand : public Command
 class CVC4_PUBLIC PopCommand : public Command
 {
  public:
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -371,7 +375,7 @@ class CVC4_PUBLIC DeclarationDefinitionCommand : public Command
  public:
   DeclarationDefinitionCommand(const std::string& id);
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override = 0;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override = 0;
   std::string getSymbol() const;
 }; /* class DeclarationDefinitionCommand */
 
@@ -391,7 +395,7 @@ class CVC4_PUBLIC DeclareFunctionCommand : public DeclarationDefinitionCommand
   bool getPrintInModelSetByUser() const;
   void setPrintInModel(bool p);
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -414,7 +418,7 @@ class CVC4_PUBLIC DeclareSortCommand : public DeclarationDefinitionCommand
   size_t getArity() const;
   api::Sort getSort() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -440,7 +444,7 @@ class CVC4_PUBLIC DefineSortCommand : public DeclarationDefinitionCommand
   const std::vector<api::Sort>& getParameters() const;
   api::Sort getSort() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -468,7 +472,7 @@ class CVC4_PUBLIC DefineFunctionCommand : public DeclarationDefinitionCommand
   const std::vector<api::Term>& getFormals() const;
   api::Term getFormula() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -505,7 +509,7 @@ class CVC4_PUBLIC DefineNamedFunctionCommand : public DefineFunctionCommand
                              const std::vector<api::Term>& formals,
                              api::Term formula,
                              bool global);
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   void toStream(
       std::ostream& out,
@@ -536,7 +540,7 @@ class CVC4_PUBLIC DefineFunctionRecCommand : public Command
   const std::vector<std::vector<api::Term> >& getFormals() const;
   const std::vector<api::Term>& getFormulas() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -575,7 +579,7 @@ class CVC4_PUBLIC SetUserAttributeCommand : public Command
                           api::Term term,
                           const std::string& value);
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -609,7 +613,7 @@ class CVC4_PUBLIC CheckSatCommand : public Command
 
   api::Term getTerm() const;
   api::Result getResult() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -638,7 +642,7 @@ class CVC4_PUBLIC CheckSatAssumingCommand : public Command
 
   const std::vector<api::Term>& getTerms() const;
   api::Result getResult() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -666,7 +670,7 @@ class CVC4_PUBLIC QueryCommand : public Command
 
   api::Term getTerm() const;
   api::Result getResult() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -694,7 +698,7 @@ class CVC4_PUBLIC DeclareSygusVarCommand : public DeclarationDefinitionCommand
    * The declared sygus variable is communicated to the SMT engine in case a
    * synthesis conjecture is built later on.
    */
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -744,7 +748,7 @@ class CVC4_PUBLIC SynthFunCommand : public DeclarationDefinitionCommand
    * The declared function-to-synthesize is communicated to the SMT engine in
    * case a synthesis conjecture is built later on.
    */
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -782,7 +786,7 @@ class CVC4_PUBLIC SygusConstraintCommand : public Command
    * The declared constraint is communicated to the SMT engine in case a
    * synthesis conjecture is built later on.
    */
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -826,7 +830,7 @@ class CVC4_PUBLIC SygusInvConstraintCommand : public Command
    * invariant constraint is built, in case an actual synthesis conjecture is
    * built later on.
    */
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -863,7 +867,7 @@ class CVC4_PUBLIC CheckSynthCommand : public Command
    * and then perform a satisfiability check, whose result is stored in
    * d_result.
    */
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   /** creates a copy of this command */
   Command* clone() const override;
   /** returns this command's name */
@@ -897,7 +901,7 @@ class CVC4_PUBLIC SimplifyCommand : public Command
 
   api::Term getTerm() const;
   api::Term getResult() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -921,7 +925,7 @@ class CVC4_PUBLIC GetValueCommand : public Command
 
   const std::vector<api::Term>& getTerms() const;
   api::Term getResult() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -942,7 +946,7 @@ class CVC4_PUBLIC GetAssignmentCommand : public Command
   GetAssignmentCommand();
 
   SExpr getResult() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -961,7 +965,7 @@ class CVC4_PUBLIC GetModelCommand : public Command
 
   // Model is private to the library -- for now
   // Model* getResult() const ;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -982,7 +986,7 @@ class CVC4_PUBLIC BlockModelCommand : public Command
  public:
   BlockModelCommand();
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1000,7 +1004,7 @@ class CVC4_PUBLIC BlockModelValuesCommand : public Command
   BlockModelValuesCommand(const std::vector<api::Term>& terms);
 
   const std::vector<api::Term>& getTerms() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1020,7 +1024,7 @@ class CVC4_PUBLIC GetProofCommand : public Command
  public:
   GetProofCommand();
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1036,7 +1040,7 @@ class CVC4_PUBLIC GetInstantiationsCommand : public Command
  public:
   GetInstantiationsCommand();
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1056,7 +1060,7 @@ class CVC4_PUBLIC GetSynthSolutionCommand : public Command
  public:
   GetSynthSolutionCommand();
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1095,7 +1099,7 @@ class CVC4_PUBLIC GetInterpolCommand : public Command
    * query. */
   api::Term getResult() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1147,7 +1151,7 @@ class CVC4_PUBLIC GetAbductCommand : public Command
    */
   api::Term getResult() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1184,7 +1188,7 @@ class CVC4_PUBLIC GetQuantifierEliminationCommand : public Command
 
   api::Term getTerm() const;
   bool getDoFull() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   api::Term getResult() const;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
 
@@ -1202,7 +1206,7 @@ class CVC4_PUBLIC GetUnsatAssumptionsCommand : public Command
 {
  public:
   GetUnsatAssumptionsCommand();
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   std::vector<api::Term> getResult() const;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
@@ -1224,7 +1228,7 @@ class CVC4_PUBLIC GetUnsatCoreCommand : public Command
   GetUnsatCoreCommand();
   const std::vector<api::Term>& getUnsatCore() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
 
   Command* clone() const override;
@@ -1251,7 +1255,7 @@ class CVC4_PUBLIC GetAssertionsCommand : public Command
  public:
   GetAssertionsCommand();
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   std::string getResult() const;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
@@ -1273,7 +1277,7 @@ class CVC4_PUBLIC SetBenchmarkStatusCommand : public Command
 
   BenchmarkStatus getStatus() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1292,7 +1296,7 @@ class CVC4_PUBLIC SetBenchmarkLogicCommand : public Command
   SetBenchmarkLogicCommand(std::string logic);
 
   std::string getLogic() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1314,7 +1318,7 @@ class CVC4_PUBLIC SetInfoCommand : public Command
   std::string getFlag() const;
   SExpr getSExpr() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1336,7 +1340,7 @@ class CVC4_PUBLIC GetInfoCommand : public Command
   std::string getFlag() const;
   std::string getResult() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1359,7 +1363,7 @@ class CVC4_PUBLIC SetOptionCommand : public Command
   std::string getFlag() const;
   SExpr getSExpr() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1382,7 +1386,7 @@ class CVC4_PUBLIC GetOptionCommand : public Command
   std::string getFlag() const;
   std::string getResult() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void printResult(std::ostream& out, uint32_t verbosity = 2) const override;
   Command* clone() const override;
   std::string getCommandName() const override;
@@ -1410,7 +1414,7 @@ class CVC4_PUBLIC SetExpressionNameCommand : public Command
  public:
   SetExpressionNameCommand(api::Term term, std::string name);
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1431,7 +1435,7 @@ class CVC4_PUBLIC DatatypeDeclarationCommand : public Command
 
   DatatypeDeclarationCommand(const std::vector<api::Sort>& datatypes);
   const std::vector<api::Sort>& getDatatypes() const;
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1446,7 +1450,7 @@ class CVC4_PUBLIC ResetCommand : public Command
 {
  public:
   ResetCommand() {}
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1461,7 +1465,7 @@ class CVC4_PUBLIC ResetAssertionsCommand : public Command
 {
  public:
   ResetAssertionsCommand() {}
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1476,7 +1480,7 @@ class CVC4_PUBLIC QuitCommand : public Command
 {
  public:
   QuitCommand() {}
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1496,7 +1500,7 @@ class CVC4_PUBLIC CommentCommand : public Command
 
   std::string getComment() const;
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   Command* clone() const override;
   std::string getCommandName() const override;
   void toStream(
@@ -1522,7 +1526,7 @@ class CVC4_PUBLIC CommandSequence : public Command
   void addCommand(Command* cmd);
   void clear();
 
-  void invoke(api::Solver* solver, parser::SymbolManager * sm) override;
+  void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
   void invoke(api::Solver* solver, std::ostream& out) override;
 
   typedef std::vector<Command*>::iterator iterator;

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -1496,7 +1496,9 @@ class CVC4_PUBLIC CommandSequence : public Command
   void clear();
 
   void invoke(api::Solver* solver, parser::SymbolManager* sm) override;
-  void invoke(api::Solver* solver, parser::SymbolManager* sm, std::ostream& out) override;
+  void invoke(api::Solver* solver,
+              parser::SymbolManager* sm,
+              std::ostream& out) override;
 
   typedef std::vector<Command*>::iterator iterator;
   typedef std::vector<Command*>::const_iterator const_iterator;

--- a/test/api/smt2_compliance.cpp
+++ b/test/api/smt2_compliance.cpp
@@ -70,7 +70,7 @@ void testGetInfo(api::Solver* solver, const char* s)
   assert(c != NULL);
   cout << c << endl;
   stringstream ss;
-  c->invoke(solver, ss);
+  c->invoke(solver, symman.get(), ss);
   assert(p->nextCommand() == NULL);
   delete p;
   delete c;


### PR DESCRIPTION
This PR passes the symbol manager to Command::invoke.

There are no behavior changes in this PR. This is in preparation for reimplementing several features in the parser related to symbols.