### PR TITLE
Pin LFSC version

### DIFF
--- a/contrib/get-lfsc-checker
+++ b/contrib/get-lfsc-checker
@@ -3,7 +3,7 @@
 source "$(dirname "$0")/get-script-header.sh"
 
 LFSC_DIR="$DEPS_DIR/lfsc-checker"
-version="master"
+version="61ef1dc55d2bc909656f905699b28c99ddcfc518"
 
 setup_dep "https://github.com/CVC4/LFSC/archive/$version.tar.gz" "$LFSC_DIR"
 cd "$LFSC_DIR"


### PR DESCRIPTION
I chose commit 61ef1dc55d2bc909656f905699b28c99ddcfc518,
which is missing:
  * any changes to the OSX build process
    (We're still figuring this out)
  * change to top-level identifier shadowing
    (we have a few versions of the signatures floating around, and I
    worry that they may not all be fixed w.r.t. no re-using identifiers)

@mpreiner: Is changing the contrib script enough to change the CI?