### PR TITLE
Models standard

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,9 @@ Changes:
   now restrict bvxnor to only allow two operands in order to avoid confusion
   about the semantics, since the behavior of n-ary operands to bvxnor is now
   undefined in SMT-LIB.
+* SMT-LIB output for `get-model` command now conforms with the standard,
+  and does *not* begin with the keyword `model`. The output
+  is the same as before, only with this word removed from the beginning.
 
 
 Changes since 1.7

--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -1350,7 +1350,7 @@ void Smt2Printer::toStream(std::ostream& out, const smt::Model& m) const
     out << "; " << ln << std::endl;
   }
   //print the model
-  out << "(model" << endl;
+  out << "(" << endl;
   // don't need to print approximations since they are built into choice
   // functions in the values of variables.
   this->Printer::toStream(out, m);

--- a/src/prop/minisat/minisat.cpp
+++ b/src/prop/minisat/minisat.cpp
@@ -182,7 +182,9 @@ SatValue MinisatSatSolver::solve(unsigned long& resource) {
 SatValue MinisatSatSolver::solve() {
   setupOptions();
   d_minisat->budgetOff();
-  return toSatLiteralValue(d_minisat->solve());
+  SatValue result = toSatLiteralValue(d_minisat->solve());
+  d_minisat->clearInterrupt();
+  return result;
 }
 
 bool MinisatSatSolver::ok() const {

--- a/test/regress/regress0/datatypes/dt-param-2.6-print.smt2
+++ b/test/regress/regress0/datatypes/dt-param-2.6-print.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; EXPECT: (model
+; EXPECT: (
 ; EXPECT: (declare-datatypes ((Pair 2)) ((par (X Y)((mkPair (first X) (second Y))))))
 ; EXPECT: (define-fun x () (Pair Int Real) ((as mkPair (Pair Int Real)) 2 (/ 3 2)))
 ; EXPECT: )

--- a/test/regress/regress0/parser/strings20.smt2
+++ b/test/regress/regress0/parser/strings20.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; EXPECT: (model
+; EXPECT: (
 ; EXPECT: (define-fun s () String "\"")
 ; EXPECT: )
 

--- a/test/regress/regress0/parser/strings25.smt2
+++ b/test/regress/regress0/parser/strings25.smt2
@@ -1,5 +1,5 @@
 ; EXPECT: sat
-; EXPECT: (model
+; EXPECT: (
 ; EXPECT: (define-fun s () String """")
 ; EXPECT: )
 

--- a/test/regress/regress0/simple-dump-model.smt2
+++ b/test/regress/regress0/simple-dump-model.smt2
@@ -1,6 +1,6 @@
 ; COMMAND-LINE: --dump-models
 ; EXPECT: sat
-; EXPECT: (model
+; EXPECT: (
 ; EXPECT: (define-fun x () Int 1)
 ; EXPECT: (define-fun y () Int 1)
 ; EXPECT: )

--- a/test/regress/regress0/smt2output.smt2
+++ b/test/regress/regress0/smt2output.smt2
@@ -8,7 +8,7 @@
 (check-sat)
 ; EXPECT: sat
 (get-model)
-; EXPECT: (model
+; EXPECT: (
 ; EXPECT: (define-fun toto () Bool true)
 ; EXPECT: (define-fun |to to| () Bool true)
 ; EXPECT: )


### PR DESCRIPTION
This PR relates to #4987 .
Our plan is to:
1. delete the `model` keyword
2. avoid printing extra declarations by default
3. wrap UF values with `as` expressions.

This PR does step 1, and fixes regressions accordingly.