### PR TITLE
Make symbol manager context dependent

### DIFF
--- a/src/expr/symbol_manager.cpp
+++ b/src/expr/symbol_manager.cpp
@@ -25,9 +25,8 @@ namespace CVC4 {
 
 class SymbolManager::Implementation
 {
-  typedef CDHashMap<api::Term, std::string, api::TermHashFunction>
-      TermStringMap;
-  typedef CDHashSet<api::Term, api::TermHashFunction> TermSet;
+  using TermStringMap = CDHashMap<api::Term, std::string, api::TermHashFunction>;
+  using TermSet = CDHashSet<api::Term, api::TermHashFunction>;
 
  public:
   Implementation()

--- a/src/expr/symbol_manager.cpp
+++ b/src/expr/symbol_manager.cpp
@@ -23,19 +23,19 @@ namespace CVC4 {
 
 // ---------------------------------------------- SymbolManager::Implementation
 
-class SymbolManager::Implementation {
-  typedef CDHashMap<api::Term, std::string, api::TermHashFunction> TermStringMap;
+class SymbolManager::Implementation
+{
+  typedef CDHashMap<api::Term, std::string, api::TermHashFunction>
+      TermStringMap;
   typedef CDHashSet<api::Term, api::TermHashFunction> TermSet;
+
  public:
   Implementation()
-      : d_context(),
-      d_names(&d_context),
-      d_namedAsserts(&d_context)
+      : d_context(), d_names(&d_context), d_namedAsserts(&d_context)
   {
   }
 
-  ~Implementation() {
-  }
+  ~Implementation() {}
   /** set expression name */
   bool setExpressionName(api::Term t,
                          const std::string& name,
@@ -50,7 +50,8 @@ class SymbolManager::Implementation {
                           bool areAssertions = false) const;
   /** reset */
   void reset();
-private:
+
+ private:
   /** The context manager for the scope maps. */
   Context d_context;
   /** Map terms to names */
@@ -58,11 +59,10 @@ private:
   /** The set of terms with assertion names */
   TermSet d_namedAsserts;
 };
-  
 
 bool SymbolManager::Implementation::setExpressionName(api::Term t,
-                                      const std::string& name,
-                                      bool isAssertion)
+                                                      const std::string& name,
+                                                      bool isAssertion)
 {
   if (d_names.find(t) != d_names.end())
   {
@@ -78,8 +78,8 @@ bool SymbolManager::Implementation::setExpressionName(api::Term t,
 }
 
 bool SymbolManager::Implementation::getExpressionName(api::Term t,
-                                      std::string& name,
-                                      bool isAssertion) const
+                                                      std::string& name,
+                                                      bool isAssertion) const
 {
   TermStringMap::const_iterator it = d_names.find(t);
   if (it == d_names.end())
@@ -98,9 +98,10 @@ bool SymbolManager::Implementation::getExpressionName(api::Term t,
   return true;
 }
 
-void SymbolManager::Implementation::getExpressionNames(const std::vector<api::Term>& ts,
-                                       std::vector<std::string>& names,
-                                       bool areAssertions) const
+void SymbolManager::Implementation::getExpressionNames(
+    const std::vector<api::Term>& ts,
+    std::vector<std::string>& names,
+    bool areAssertions) const
 {
   for (const api::Term& t : ts)
   {
@@ -119,9 +120,10 @@ void SymbolManager::Implementation::reset()
 
 // ---------------------------------------------- SymbolManager
 
-SymbolManager::SymbolManager(api::Solver* s) : d_solver(s), 
-d_implementation(new SymbolManager::Implementation())
-{}
+SymbolManager::SymbolManager(api::Solver* s)
+    : d_solver(s), d_implementation(new SymbolManager::Implementation())
+{
+}
 
 SymbolManager::~SymbolManager() {}
 
@@ -153,14 +155,9 @@ size_t SymbolManager::scopeLevel() const
   return d_symtabAllocated.getLevel();
 }
 
-void SymbolManager::pushScope() 
-{
-  d_symtabAllocated.pushScope();
-}
+void SymbolManager::pushScope() { d_symtabAllocated.pushScope(); }
 
-void SymbolManager::popScope() {
-  d_symtabAllocated.popScope();
-}
+void SymbolManager::popScope() { d_symtabAllocated.popScope(); }
 
 void SymbolManager::reset()
 {

--- a/src/expr/symbol_manager.h
+++ b/src/expr/symbol_manager.h
@@ -18,9 +18,9 @@
 #define CVC4__EXPR__SYMBOL_MANAGER_H
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
-#include <memory>
 
 #include "api/cvc4cpp.h"
 #include "expr/symbol_table.h"
@@ -85,9 +85,9 @@ class CVC4_PUBLIC SymbolManager
                           std::vector<std::string>& names,
                           bool areAssertions = false) const;
   //---------------------------- end named expressions
-  /** 
+  /**
    * Get the scope level of the symbol table.
-    */
+   */
   size_t scopeLevel() const;
   /**
    * Push a scope in the symbol table.
@@ -101,6 +101,7 @@ class CVC4_PUBLIC SymbolManager
    * Reset this symbol manager, which resets the symbol table.
    */
   void reset();
+
  private:
   /** The API Solver object. */
   api::Solver* d_solver;

--- a/src/expr/symbol_manager.h
+++ b/src/expr/symbol_manager.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <memory>
 
 #include "api/cvc4cpp.h"
 #include "expr/symbol_table.h"
@@ -38,7 +39,7 @@ class CVC4_PUBLIC SymbolManager
 {
  public:
   SymbolManager(api::Solver* s);
-  ~SymbolManager() {}
+  ~SymbolManager();
   /** Get the underlying symbol table */
   SymbolTable* getSymbolTable();
   //---------------------------- named expressions
@@ -84,7 +85,22 @@ class CVC4_PUBLIC SymbolManager
                           std::vector<std::string>& names,
                           bool areAssertions = false) const;
   //---------------------------- end named expressions
-
+  /** 
+   * Get the scope level of the symbol table.
+    */
+  size_t scopeLevel() const;
+  /**
+   * Push a scope in the symbol table.
+   */
+  void pushScope();
+  /**
+   * Pop a scope in the symbol table.
+   */
+  void popScope();
+  /**
+   * Reset this symbol manager, which resets the symbol table.
+   */
+  void reset();
  private:
   /** The API Solver object. */
   api::Solver* d_solver;
@@ -92,10 +108,9 @@ class CVC4_PUBLIC SymbolManager
    * The declaration scope that is "owned" by this symbol manager.
    */
   SymbolTable d_symtabAllocated;
-  /** Map terms to names */
-  std::map<api::Term, std::string> d_names;
-  /** The set of terms with assertion names */
-  std::set<api::Term> d_namedAsserts;
+  /** The implementation of the symbol manager */
+  class Implementation;
+  std::unique_ptr<Implementation> d_implementation;
 };
 
 }  // namespace CVC4

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -770,26 +770,28 @@ void Parser::attributeNotSupported(const std::string& attr) {
   }
 }
 
-  size_t Parser::scopeLevel() const { return d_symman->scopeLevel(); }
-  
-  void Parser::pushScope(bool bindingLevel) {
-    d_symman->pushScope();
-    if(!bindingLevel) {
-      d_assertionLevel = scopeLevel();
-    }
-  }
+size_t Parser::scopeLevel() const { return d_symman->scopeLevel(); }
 
-  void Parser::popScope() {
-    d_symman->popScope();
-    if(scopeLevel() < d_assertionLevel) {
-      d_assertionLevel = scopeLevel();
-      d_reservedSymbols.clear();
-    }
+void Parser::pushScope(bool bindingLevel)
+{
+  d_symman->pushScope();
+  if (!bindingLevel)
+  {
+    d_assertionLevel = scopeLevel();
   }
+}
 
-  void Parser::reset() {
-    d_symman->reset();
+void Parser::popScope()
+{
+  d_symman->popScope();
+  if (scopeLevel() < d_assertionLevel)
+  {
+    d_assertionLevel = scopeLevel();
+    d_reservedSymbols.clear();
   }
+}
+
+void Parser::reset() { d_symman->reset(); }
 
 std::vector<unsigned> Parser::processAdHocStringEsc(const std::string& s)
 {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -770,6 +770,27 @@ void Parser::attributeNotSupported(const std::string& attr) {
   }
 }
 
+  size_t Parser::scopeLevel() const { return d_symman->scopeLevel(); }
+  
+  void Parser::pushScope(bool bindingLevel) {
+    d_symman->pushScope();
+    if(!bindingLevel) {
+      d_assertionLevel = scopeLevel();
+    }
+  }
+
+  void Parser::popScope() {
+    d_symman->popScope();
+    if(scopeLevel() < d_assertionLevel) {
+      d_assertionLevel = scopeLevel();
+      d_reservedSymbols.clear();
+    }
+  }
+
+  void Parser::reset() {
+    d_symman->reset();
+  }
+
 std::vector<unsigned> Parser::processAdHocStringEsc(const std::string& s)
 {
   std::vector<unsigned> str;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -751,7 +751,7 @@ public:
   /**
    * Gets the current declaration level.
    */
-  inline size_t scopeLevel() const { return d_symtab->getLevel(); }
+  size_t scopeLevel() const;
 
   /**
    * Pushes a scope. All subsequent symbol declarations made are only valid in
@@ -761,25 +761,12 @@ public:
    * current scope level. This determines which scope assertions are declared
    * at.
    */
-  inline void pushScope(bool bindingLevel = false) {
-    d_symtab->pushScope();
-    if(!bindingLevel) {
-      d_assertionLevel = scopeLevel();
-    }
-  }
+  void pushScope(bool bindingLevel = false);
 
-  inline void popScope() {
-    d_symtab->popScope();
-    if(scopeLevel() < d_assertionLevel) {
-      d_assertionLevel = scopeLevel();
-      d_reservedSymbols.clear();
-    }
-  }
+  void popScope();
 
-  virtual void reset() {
-    d_symtab->reset();
-  }
-
+  virtual void reset();
+  
   void setGlobalDeclarations(bool flag) {
     d_globalDeclarations = flag;
   }

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -766,7 +766,7 @@ public:
   void popScope();
 
   virtual void reset();
-  
+
   void setGlobalDeclarations(bool flag) {
     d_globalDeclarations = flag;
   }


### PR DESCRIPTION
This follows a similar style to symbol_table.h/cpp.  This is required since context dependent data structures are cvc4_private, and symbol manager is cvc4_public.