### PR TITLE
Remove rewrite that breaks MACRO_SR_PRED_TRANSFORM

### DIFF
--- a/src/theory/arith/nl/ext/factoring_check.cpp
+++ b/src/theory/arith/nl/ext/factoring_check.cpp
@@ -161,7 +161,7 @@ void FactoringCheck::check(const std::vector<Node>& asserts,
           Trace("nl-ext-factor") << "...lemma is " << flem << std::endl;
           if (d_data->isProofEnabled())
           {
-            Node k_eq = Rewriter::rewrite(kf.eqNode(sum));
+            Node k_eq = kf.eqNode(sum);
             Node split = nm->mkNode(Kind::OR, lit, lit.notNode());
             proof->addStep(split, PfRule::SPLIT, {}, {lit});
             proof->addStep(


### PR DESCRIPTION
The proof generation for the nonlinear factoring refinement used `MACRO_SR_PRED_TRANSFORM` incorrectly as it did a rewrite on the substitution. This PR fixes this issue.