### PR TITLE
(proof-new) Fix nl factoring lemma proof

### DIFF
--- a/src/theory/arith/nl/ext/factoring_check.cpp
+++ b/src/theory/arith/nl/ext/factoring_check.cpp
@@ -182,7 +182,7 @@ Node FactoringCheck::getFactorSkolem(Node n, CDProof* proof)
   {
     NodeManager* nm = NodeManager::currentNM();
     Node k = nm->getSkolemManager()->mkPurifySkolem(n, "kf");
-    Node k_eq = Rewriter::rewrite(k.eqNode(n));
+    Node k_eq = k.eqNode(n);
     Trace("nl-ext-factor") << "...adding factor skolem " << k << " == " << n
                            << std::endl;
     if (d_data->isProofEnabled())


### PR DESCRIPTION
We removed the rewrite when using the lemma, but did not remove it when introducing it in the first place.