### PR TITLE
(proof-new) Add proof checker for transcendental solver

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -413,6 +413,8 @@ libcvc4_add_sources(
   theory/arith/nl/strategy.h
   theory/arith/nl/transcendental/exponential_solver.cpp
   theory/arith/nl/transcendental/exponential_solver.h
+  theory/arith/nl/transcendental/proof_checker.cpp
+  theory/arith/nl/transcendental/proof_checker.h
   theory/arith/nl/transcendental/sine_solver.cpp
   theory/arith/nl/transcendental/sine_solver.h
   theory/arith/nl/transcendental/taylor_generator.cpp

--- a/src/theory/arith/nl/ext/proof_checker.cpp
+++ b/src/theory/arith/nl/ext/proof_checker.cpp
@@ -28,7 +28,6 @@ namespace nl {
 void ExtProofRuleChecker::registerTo(ProofChecker* pc)
 {
   pc->registerChecker(PfRule::ARITH_MULT_TANGENT, this);
-  pc->registerChecker(PfRule::ARITH_TRANS_PI, this);
 }
 
 Node ExtProofRuleChecker::checkInternal(PfRule id,
@@ -80,13 +79,6 @@ Node ExtProofRuleChecker::checkInternal(PfRule id,
             nm->mkNode(Kind::AND,
                        nm->mkNode(Kind::GEQ, x, a),
                        nm->mkNode(sgn == -1 ? Kind::LEQ : Kind::GEQ, y, b))));
-  }
-  else if (id == PfRule::ARITH_TRANS_PI)
-  {
-    Assert(children.empty());
-    Assert(args.size() == 2);
-    return nm->mkAnd(std::vector<Node>{nm->mkNode(Kind::GEQ, pi, args[0]),
-                                       nm->mkNode(Kind::LEQ, pi, args[1])});
   }
   return Node::null();
 }

--- a/src/theory/arith/nl/transcendental/proof_checker.cpp
+++ b/src/theory/arith/nl/transcendental/proof_checker.cpp
@@ -1,0 +1,65 @@
+/*********************                                                        */
+/*! \file proof_checker.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Gereon Kremer
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Implementation of NlExt proof checker
+ **/
+
+#include "theory/arith/nl/transcendental/proof_checker.h"
+
+#include "expr/sequence.h"
+#include "theory/arith/arith_utilities.h"
+#include "theory/rewriter.h"
+
+using namespace CVC4::kind;
+
+namespace CVC4 {
+namespace theory {
+namespace arith {
+namespace nl {
+namespace transcendental {
+
+void TranscendentalProofRuleChecker::registerTo(ProofChecker* pc)
+{
+  pc->registerChecker(PfRule::ARITH_TRANS_PI, this);
+}
+
+Node TranscendentalProofRuleChecker::checkInternal(PfRule id,
+                                        const std::vector<Node>& children,
+                                        const std::vector<Node>& args)
+{
+  NodeManager* nm = NodeManager::currentNM();
+  auto zero = nm->mkConst<Rational>(0);
+  auto one = nm->mkConst<Rational>(1);
+  auto mone = nm->mkConst<Rational>(-1);
+  auto pi = nm->mkNullaryOperator(nm->realType(), Kind::PI);
+  auto mpi = nm->mkNode(Kind::MULT, mone, pi);
+  Trace("nl-trans-checker") << "Checking " << id << std::endl;
+  for (const auto& c : children)
+  {
+    Trace("nl-trans-checker") << "\t" << c << std::endl;
+  }
+  if (id == PfRule::ARITH_TRANS_PI)
+  {
+    Assert(children.empty());
+    Assert(args.size() == 2);
+    return nm->mkAnd(std::vector<Node>{
+      nm->mkNode(Kind::GEQ, pi, args[0]),
+      nm->mkNode(Kind::LEQ, pi, args[1])
+    });
+  }
+  return Node::null();
+}
+
+}
+}  // namespace nl
+}  // namespace arith
+}  // namespace theory
+}  // namespace CVC4

--- a/src/theory/arith/nl/transcendental/proof_checker.h
+++ b/src/theory/arith/nl/transcendental/proof_checker.h
@@ -9,13 +9,13 @@
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief NlExt proof checker utility
+ ** \brief Proof checker utility for transcendental solver
  **/
 
 #include "cvc4_private.h"
 
-#ifndef CVC4__THEORY__ARITH__NL__EXT__PROOF_CHECKER_H
-#define CVC4__THEORY__ARITH__NL__EXT__PROOF_CHECKER_H
+#ifndef CVC4__THEORY__ARITH__NL__TRANSCENDENTAL__PROOF_CHECKER_H
+#define CVC4__THEORY__ARITH__NL__TRANSCENDENTAL__PROOF_CHECKER_H
 
 #include "expr/node.h"
 #include "expr/proof_checker.h"
@@ -25,18 +25,19 @@ namespace CVC4 {
 namespace theory {
 namespace arith {
 namespace nl {
+namespace transcendental {
 
 /**
  * A checker for NlExt proofs
  *
- * This proof checker takes care of all proofs for lemmas from the ext
- * subsolver.
+ * This proof checker takes care of all proofs for lemmas from the
+ * transcendental subsolver.
  */
-class ExtProofRuleChecker : public ProofRuleChecker
+class TranscendentalProofRuleChecker : public ProofRuleChecker
 {
  public:
-  ExtProofRuleChecker() = default;
-  ~ExtProofRuleChecker() = default;
+  TranscendentalProofRuleChecker() = default;
+  ~TranscendentalProofRuleChecker() = default;
 
   /** Register all rules owned by this rule checker in pc. */
   void registerTo(ProofChecker* pc) override;
@@ -48,6 +49,7 @@ class ExtProofRuleChecker : public ProofRuleChecker
                      const std::vector<Node>& args) override;
 };
 
+}  // namespace transcendental
 }  // namespace nl
 }  // namespace arith
 }  // namespace theory

--- a/src/theory/arith/nl/transcendental/transcendental_state.cpp
+++ b/src/theory/arith/nl/transcendental/transcendental_state.cpp
@@ -52,6 +52,8 @@ TranscendentalState::TranscendentalState(InferenceManager& im,
   if (d_pnm != nullptr)
   {
     d_proof.reset(new CDProofSet<CDProof>(d_pnm, d_ctx, "nl-trans"));
+    d_proofChecker.reset(new TranscendentalProofRuleChecker());
+    d_proofChecker->registerTo(pnm->getChecker());
   }
 }
 

--- a/src/theory/arith/nl/transcendental/transcendental_state.h
+++ b/src/theory/arith/nl/transcendental/transcendental_state.h
@@ -19,6 +19,7 @@
 #include "expr/proof_set.h"
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/nl/nl_model.h"
+#include "theory/arith/nl/transcendental/proof_checker.h"
 #include "theory/arith/nl/transcendental/taylor_generator.h"
 
 namespace CVC4 {
@@ -175,6 +176,9 @@ struct TranscendentalState
    * A CDProofSet that hands out CDProof objects for lemmas.
    */
   std::unique_ptr<CDProofSet<CDProof>> d_proof;
+
+  /** The proof checker for transcendental proofs */
+  std::unique_ptr<TranscendentalProofRuleChecker> d_proofChecker;
 
   /**
    * Some transcendental functions f(t) are "purified", e.g. we add


### PR DESCRIPTION
This PR adds a separate proof checker for the transcendental solver and moves the proof for pi bounds over.