### PR TITLE
(proof-new) Add new CONG_LEMMA proof rule.

### DIFF
--- a/src/expr/proof_rule.cpp
+++ b/src/expr/proof_rule.cpp
@@ -107,6 +107,7 @@ const char* toString(PfRule id)
     case PfRule::SYMM: return "SYMM";
     case PfRule::TRANS: return "TRANS";
     case PfRule::CONG: return "CONG";
+    case PfRule::CONG_LEMMA: return "CONG_LEMMA";
     case PfRule::TRUE_INTRO: return "TRUE_INTRO";
     case PfRule::TRUE_ELIM: return "TRUE_ELIM";
     case PfRule::FALSE_INTRO: return "FALSE_INTRO";

--- a/src/expr/proof_rule.h
+++ b/src/expr/proof_rule.h
@@ -644,6 +644,14 @@ enum class PfRule : uint32_t
   // APPLY_UF. The actual node for <kind> is constructible via
   // ProofRuleChecker::mkKindNode.
   CONG,
+  // ======== Congruence lemma
+  // Children: none
+  // Arguments: (<kind> f? t1 s1 ... tn sn)
+  // ---------------------------------------------
+  // Conclusion: (=> (and (= t1 s1) ... (= tn sn)) (= (<kind> f? t1 ... tn) (<kind> f? s1 ... sn)))
+  // The same as CONG, but constructs a lemma instead of
+  // doing the inference directly.
+  CONG_LEMMA,
   // ======== True intro
   // Children: (P:F)
   // Arguments: none


### PR DESCRIPTION
We'll need a rule to generate a lemma for a congruence. While we have the CONG rule, we need SCOPE to turn it into a lemma, therefore @ajreynol and I agreed at some point that a CONG_LEMMA rule would be nice to have to avoid using SCOPE.