### PR TITLE
Flush statistics through NodeManager in SmtEngine

### DIFF
--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -26,6 +26,8 @@
 
 #include "main/main.h"
 #include "smt/command.h"
+// for statistics printing
+#include "expr/node_manager.h"
 
 namespace CVC4 {
 namespace main {
@@ -66,14 +68,14 @@ CommandExecutor::~CommandExecutor()
 
 void CommandExecutor::flushStatistics(std::ostream& out) const
 {
-  d_solver->getExprManager()->getStatistics().flushInformation(out);
+  d_nodeManager->getStatisticsRegistry()->flushInformation(out);
   d_smtEngine->getStatistics().flushInformation(out);
   d_stats.flushInformation(out);
 }
 
 void CommandExecutor::safeFlushStatistics(int fd) const
 {
-  d_solver->getExprManager()->safeFlushStatistics(fd);
+  d_nodeManager->getStatisticsRegistry()->safeFlushInformation(fd);
   d_smtEngine->safeFlushStatistics(fd);
   d_stats.safeFlushInformation(fd);
 }

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -66,12 +66,14 @@ CommandExecutor::~CommandExecutor()
 
 void CommandExecutor::flushStatistics(std::ostream& out) const
 {
+  // SmtEngine + node manager flush statistics is part of the call below
   d_smtEngine->flushStatistics(out);
   d_stats.flushInformation(out);
 }
 
 void CommandExecutor::safeFlushStatistics(int fd) const
 {
+  // SmtEngine + node manager flush statistics is part of the call below
   d_smtEngine->safeFlushStatistics(fd);
   d_stats.safeFlushInformation(fd);
 }

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -26,8 +26,6 @@
 
 #include "main/main.h"
 #include "smt/command.h"
-// for statistics printing
-#include "expr/node_manager.h"
 
 namespace CVC4 {
 namespace main {
@@ -68,14 +66,12 @@ CommandExecutor::~CommandExecutor()
 
 void CommandExecutor::flushStatistics(std::ostream& out) const
 {
-  d_nodeManager->getStatisticsRegistry()->flushInformation(out);
-  d_smtEngine->getStatistics().flushInformation(out);
+  d_smtEngine->flushStatistics(out);
   d_stats.flushInformation(out);
 }
 
 void CommandExecutor::safeFlushStatistics(int fd) const
 {
-  d_nodeManager->getStatisticsRegistry()->safeFlushInformation(fd);
   d_smtEngine->safeFlushStatistics(fd);
   d_stats.safeFlushInformation(fd);
 }

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -19,7 +19,6 @@
 #include <string>
 
 #include "api/cvc4cpp.h"
-#include "expr/expr_manager.h"
 #include "expr/symbol_manager.h"
 #include "options/options.h"
 #include "smt/smt_engine.h"

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -27,8 +27,6 @@
 #include "api/cvc4cpp.h"
 #include "base/configuration.h"
 #include "base/output.h"
-#include "expr/expr_iomanip.h"
-#include "expr/expr_manager.h"
 #include "main/command_executor.h"
 #include "main/interactive_shell.h"
 #include "main/main.h"

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -24,7 +24,6 @@
 
 #include "base/configuration.h"
 #include "base/output.h"
-#include "expr/expr_manager.h"
 #include "main/command_executor.h"
 #include "main/interactive_shell.h"
 #include "options/language.h"
@@ -32,7 +31,6 @@
 #include "parser/parser.h"
 #include "parser/parser_builder.h"
 #include "parser/parser_exception.h"
-#include "smt/smt_engine.h"
 #include "util/result.h"
 #include "util/statistics.h"
 

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -19,9 +19,7 @@
 
 #include "base/exception.h"
 #include "cvc4autoconfig.h"
-#include "expr/expr_manager.h"
 #include "options/options.h"
-#include "smt/smt_engine.h"
 #include "util/statistics.h"
 #include "util/statistics_registry.h"
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1770,8 +1770,8 @@ void SmtEngine::flushStatistics(std::ostream& out) const
   d_nodeManager->getStatisticsRegistry()->flushInformation(out);
   d_statisticsRegistry->flushInformation(out);
 }
-  
-void SmtEngine::safeFlushStatistics(int fd) const 
+
+void SmtEngine::safeFlushStatistics(int fd) const
 {
   d_nodeManager->getStatisticsRegistry()->safeFlushInformation(fd);
   d_statisticsRegistry->safeFlushInformation(fd);

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1765,7 +1765,15 @@ SExpr SmtEngine::getStatistic(std::string name) const
   return d_statisticsRegistry->getStatistic(name);
 }
 
-void SmtEngine::safeFlushStatistics(int fd) const {
+void SmtEngine::flushStatistics(std::ostream& out) const
+{
+  d_nodeManager->getStatisticsRegistry()->flushInformation(out);
+  d_statisticsRegistry->flushInformation(out);
+}
+  
+void SmtEngine::safeFlushStatistics(int fd) const 
+{
+  d_nodeManager->getStatisticsRegistry()->safeFlushInformation(fd);
   d_statisticsRegistry->safeFlushInformation(fd);
 }
 

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -801,7 +801,13 @@ class CVC4_PUBLIC SmtEngine
   /** Get the value of one named statistic from this SmtEngine. */
   SExpr getStatistic(std::string name) const;
 
-  /** Flush statistic from this SmtEngine. Safe to use in a signal handler. */
+  /** Flush statistics from this SmtEngine and the NodeManager it uses. */
+  void flushStatistics(std::ostream& out) const;
+  
+  /** 
+   * Flush statistics from this SmtEngine and the NodeManager it uses. Safe to
+   * use in a signal handler.
+   */
   void safeFlushStatistics(int fd) const;
 
   /**

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -803,8 +803,8 @@ class CVC4_PUBLIC SmtEngine
 
   /** Flush statistics from this SmtEngine and the NodeManager it uses. */
   void flushStatistics(std::ostream& out) const;
-  
-  /** 
+
+  /**
    * Flush statistics from this SmtEngine and the NodeManager it uses. Safe to
    * use in a signal handler.
    */


### PR DESCRIPTION
This removes the dependency on the Expr layer from src/main.

This requires moving the flushing of NodeManager statistics within SmtEngine.

This is a temporary solution until we have a permanent solution for statistics.