### PR TITLE
Proper expand definitions for sets

### DIFF
--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -129,11 +129,6 @@ void TheorySets::preRegisterTerm(TNode node)
   d_internal->preRegisterTerm(node);
 }
 
-TrustNode TheorySets::expandDefinition(Node n)
-{
-  return d_internal->expandDefinition(n);
-}
-
 TrustNode TheorySets::ppRewrite(TNode n)
 {
   Kind nk = n.getKind();
@@ -158,8 +153,7 @@ TrustNode TheorySets::ppRewrite(TNode n)
       throw LogicException(ss.str());
     }
   }
-  // just expand definitions
-  return expandDefinition(n);
+  return d_internal->ppRewrite(n);
 }
 
 Theory::PPAssertStatus TheorySets::ppAssert(

--- a/src/theory/sets/theory_sets.cpp
+++ b/src/theory/sets/theory_sets.cpp
@@ -129,6 +129,11 @@ void TheorySets::preRegisterTerm(TNode node)
   d_internal->preRegisterTerm(node);
 }
 
+TrustNode TheorySets::expandDefinition(Node n)
+{
+  return d_internal->expandDefinition(n);
+}
+
 TrustNode TheorySets::ppRewrite(TNode n)
 {
   Kind nk = n.getKind();

--- a/src/theory/sets/theory_sets.h
+++ b/src/theory/sets/theory_sets.h
@@ -76,7 +76,11 @@ class TheorySets : public Theory
   Node getModelValue(TNode) override;
   std::string identify() const override { return "THEORY_SETS"; }
   void preRegisterTerm(TNode node) override;
-  TrustNode expandDefinition(Node n) override;
+  /**
+   * If the sets-ext option is not set and we have an extended operator,
+   * we throw an exception. Additionally, we expand operators like choose
+   * and is_singleton.
+   */
   TrustNode ppRewrite(TNode n) override;
   PPAssertStatus ppAssert(TrustNode tin,
                           TrustSubstitutionMap& outSubstitutions) override;

--- a/src/theory/sets/theory_sets.h
+++ b/src/theory/sets/theory_sets.h
@@ -76,6 +76,8 @@ class TheorySets : public Theory
   Node getModelValue(TNode) override;
   std::string identify() const override { return "THEORY_SETS"; }
   void preRegisterTerm(TNode node) override;
+  /**  Expand partial operators (choose) from n. */
+  TrustNode expandDefinition(Node n) override;
   /**
    * If the sets-ext option is not set and we have an extended operator,
    * we throw an exception. Additionally, we expand operators like choose

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -1265,6 +1265,17 @@ void TheorySetsPrivate::preRegisterTerm(TNode node)
   }
 }
 
+TrustNode TheorySetsPrivate::expandDefinition(Node node)
+{
+  Debug("sets-proc") << "expandDefinition : " << node << std::endl;
+
+  if (node.getKind()==kind::CHOOSE)
+  {
+    return expandChooseOperator(node);
+  }
+  return TrustNode::null();
+}
+
 TrustNode TheorySetsPrivate::ppRewrite(Node node)
 {
   Debug("sets-proc") << "ppRewrite : " << node << std::endl;

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -1265,9 +1265,9 @@ void TheorySetsPrivate::preRegisterTerm(TNode node)
   }
 }
 
-TrustNode TheorySetsPrivate::expandDefinition(Node node)
+TrustNode TheorySetsPrivate::ppRewrite(Node node)
 {
-  Debug("sets-proc") << "expandDefinition : " << node << std::endl;
+  Debug("sets-proc") << "ppRewrite : " << node << std::endl;
 
   switch (node.getKind())
   {

--- a/src/theory/sets/theory_sets_private.h
+++ b/src/theory/sets/theory_sets_private.h
@@ -167,36 +167,10 @@ class TheorySetsPrivate {
 
   void preRegisterTerm(TNode node);
 
-  /** expandDefinition
-   * If the sets-ext option is not set and we have an extended operator, 
-   * we throw an exception. This function is a no-op otherwise.
-   *
-   * TheorySets uses expandDefinition as an entry point to see if the input
-   * contains extended operators.
-   *
-   * We need to be notified when a universe set occurs in our input,
-   * before preprocessing and simplification takes place. Otherwise the models
-   * may be inaccurate when setsExt is false, here is an example:
-   *
-   * x,y : (Set Int)
-   * x = (as univset (Set Int));
-   * 0 in y;
-   * check-sat;
-   *
-   * If setsExt is enabled, the model value of (as univset (Set Int)) is always accurate.
-   *
-   * If setsExt is not enabled, the following can happen for the above example:
-   * x = (as univset (Set Int)) is made into a model substitution during 
-   * simplification. This means (as univset (Set Int)) is not a term in any assertion, 
-   * and hence we do not throw an exception, nor do we infer that 0 is a member of 
-   * (as univset (Set Int)). We instead report a model where x = {}. The correct behavior 
-   * is to throw an exception that says universe set is not supported when setsExt disabled.
-   * Hence we check for the existence of universe set before simplification here.
-   *
-   * Another option to fix this is to make TheoryModel::getValue more general
-   * so that it makes theory-specific calls to evaluate interpreted symbols.
+  /** 
+   * ppRewrite, which expands choose and is_singleton.
    */
-  TrustNode expandDefinition(Node n);
+  TrustNode ppRewrite(Node n);
 
   void presolve();
 

--- a/src/theory/sets/theory_sets_private.h
+++ b/src/theory/sets/theory_sets_private.h
@@ -167,9 +167,9 @@ class TheorySetsPrivate {
 
   void preRegisterTerm(TNode node);
 
-  /**
-   * ppRewrite, which expands choose and is_singleton.
-   */
+  /** ppRewrite, which expands choose.  */
+  TrustNode expandDefinition(Node n);
+  /** ppRewrite, which expands choose and is_singleton.  */
   TrustNode ppRewrite(Node n);
 
   void presolve();

--- a/src/theory/sets/theory_sets_private.h
+++ b/src/theory/sets/theory_sets_private.h
@@ -167,7 +167,7 @@ class TheorySetsPrivate {
 
   void preRegisterTerm(TNode node);
 
-  /** 
+  /**
    * ppRewrite, which expands choose and is_singleton.
    */
   TrustNode ppRewrite(Node n);


### PR DESCRIPTION
In the new view, `expandDefinitions` is used for eliminating partial operators and is not called during solving, and `ppRewrite` is called during preprocessing.

For sets, `choose` is a partial operator that should be applied in expand definitions, *and* in `ppRewrite`.  On the other hand, `is_singleton` should not be expanded in expandDefinitions since it is not a partial operator, so it should only be handled in ppRewrite.

It also removes some outdated documentation regarding expandDefinitions with universe set, which is now handled by preventing universe set from occurring in solved substitutions.

This is in preparation for refactoring `check-model`.