### PR TITLE
Simplify term formula removal interface

### DIFF
--- a/src/smt/term_formula_removal.cpp
+++ b/src/smt/term_formula_removal.cpp
@@ -467,54 +467,6 @@ Node RemoveTermFormulas::getSkolemForNode(Node node) const
   return Node::null();
 }
 
-Node RemoveTermFormulas::replace(TNode node) const
-{
-  TCtxStack ctx(&d_rtfc);
-  ctx.pushInitial(node);
-  return replaceInternal(ctx);
-}
-
-Node RemoveTermFormulas::replaceInternal(TCtxStack& ctx) const
-{
-  // get the current node, tagged with a term context identifier
-  Assert(!ctx.empty());
-  std::pair<Node, uint32_t> curr = ctx.getCurrent();
-  ctx.pop();
-  TNode node = curr.first;
-
-  if( node.getKind()==kind::INST_PATTERN_LIST ){
-    return Node(node);
-  }
-
-  // Check the cache
-  TermFormulaCache::const_iterator itc = d_tfCache.find(curr);
-  if (itc != d_tfCache.end())
-  {
-    return (*itc).second;
-  }
-
-  vector<Node> newChildren;
-  bool somethingChanged = false;
-  if(node.getMetaKind() == kind::metakind::PARAMETERIZED) {
-    newChildren.push_back(node.getOperator());
-  }
-  // Replace in children
-  uint32_t cval = curr.second;
-  for (size_t i = 0, nchild = node.getNumChildren(); i < nchild; i++)
-  {
-    ctx.pushChild(node, cval, i);
-    Node newChild = replaceInternal(ctx);
-    somethingChanged |= (newChild != node[i]);
-    newChildren.push_back(newChild);
-  }
-
-  // If changes, we rewrite
-  if(somethingChanged) {
-    return NodeManager::currentNM()->mkNode(node.getKind(), newChildren);
-  }
-  return node;
-}
-
 Node RemoveTermFormulas::getAxiomFor(Node n)
 {
   NodeManager* nm = NodeManager::currentNM();

--- a/src/smt/term_formula_removal.h
+++ b/src/smt/term_formula_removal.h
@@ -92,18 +92,6 @@ class RemoveTermFormulas {
                         std::vector<Node>& newSkolems);
 
   /**
-   * Substitute under node using pre-existing cache.  Do not remove
-   * any ITEs not seen during previous runs.
-   */
-  Node replace(TNode node) const;
-
-  /** Returns true if e contains a term ite. */
-  bool containsTermITE(TNode e) const;
-
-  /** Garbage collects non-context dependent data-structures. */
-  void garbageCollect();
-
-  /**
    * Get proof generator that is responsible for all proofs for removing term
    * formulas from nodes. When proofs are enabled, the returned trust node
    * of the run method use this proof generator (the trust nodes in newAsserts
@@ -199,8 +187,6 @@ class RemoveTermFormulas {
   Node runCurrent(std::pair<Node, uint32_t>& curr,
                   std::vector<theory::TrustNode>& newAsserts,
                   std::vector<Node>& newSkolems);
-  /** Replace internal */
-  Node replaceInternal(TCtxStack& ctx) const;
 
   /** Whether proofs are enabled */
   bool isProofEnabled() const;


### PR DESCRIPTION
This no longer needs some methods that were previously used specifically for ITE preprocessing and check-model.