### PR TITLE
Adding str.len to triggers

### DIFF
--- a/src/theory/quantifiers/ematching/trigger.cpp
+++ b/src/theory/quantifiers/ematching/trigger.cpp
@@ -419,6 +419,7 @@ bool Trigger::isAtomicTriggerKind( Kind k ) {
          || k == APPLY_TESTER || k == UNION || k == INTERSECTION || k == SUBSET
          || k == SETMINUS || k == MEMBER || k == SINGLETON || k == SEP_PTO
          || k == BITVECTOR_TO_NAT || k == INT_TO_BITVECTOR || k == HO_APPLY
+         || k == STRING_LENGTH
          || k == SEQ_NTH;
 }
 

--- a/src/theory/quantifiers/ematching/trigger.cpp
+++ b/src/theory/quantifiers/ematching/trigger.cpp
@@ -419,8 +419,7 @@ bool Trigger::isAtomicTriggerKind( Kind k ) {
          || k == APPLY_TESTER || k == UNION || k == INTERSECTION || k == SUBSET
          || k == SETMINUS || k == MEMBER || k == SINGLETON || k == SEP_PTO
          || k == BITVECTOR_TO_NAT || k == INT_TO_BITVECTOR || k == HO_APPLY
-         || k == STRING_LENGTH
-         || k == SEQ_NTH;
+         || k == STRING_LENGTH || k == SEQ_NTH;
 }
 
 bool Trigger::isRelationalTrigger( Node n ) {

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -975,6 +975,7 @@ set(regress_0_tests
   regress0/seq/seq-nth.smt2
   regress0/seq/seq-rewrites.smt2
   regress0/seq/seq-types.smt2
+  regress0/seq/quant_len_trigger.smt2
   regress0/sets/abt-min.smt2
   regress0/sets/abt-te-exh.smt2
   regress0/sets/abt-te-exh2.smt2

--- a/test/regress/regress0/seq/quant_len_trigger.smt2
+++ b/test/regress/regress0/seq/quant_len_trigger.smt2
@@ -1,0 +1,13 @@
+; EXPECT: unsat
+
+(set-option :strings-exp true)
+(set-logic ALL)
+
+(assert (forall ((x (Seq Int)) (xx (Seq Int)) ) (=> (and (= (seq.len x) (seq.len xx)) (forall ((i Int) )   (=> (and (<= 0 i) (< i (seq.len x))) (= (seq.nth x i) (seq.nth xx i))))) (= x xx))))
+
+(declare-fun s@@1 () (Seq Int))
+(declare-fun |s'| () (Seq Int))
+
+(assert (not (=> (= (seq.len s@@1) (seq.len |s'|)) (=> (forall ((i@@2 Int) )   (=> (and (<= 0 i@@2) (< i@@2 (seq.len s@@1))) (= (seq.nth s@@1 i@@2) (seq.nth |s'| i@@2)))) (= s@@1 |s'|)))))
+
+(check-sat)

--- a/test/regress/regress0/seq/quant_len_trigger.smt2
+++ b/test/regress/regress0/seq/quant_len_trigger.smt2
@@ -5,9 +5,9 @@
 
 (assert (forall ((x (Seq Int)) (xx (Seq Int)) ) (=> (and (= (seq.len x) (seq.len xx)) (forall ((i Int) )   (=> (and (<= 0 i) (< i (seq.len x))) (= (seq.nth x i) (seq.nth xx i))))) (= x xx))))
 
-(declare-fun s@@1 () (Seq Int))
-(declare-fun |s'| () (Seq Int))
+(declare-fun x () (Seq Int))
+(declare-fun y () (Seq Int))
 
-(assert (not (=> (= (seq.len s@@1) (seq.len |s'|)) (=> (forall ((i@@2 Int) )   (=> (and (<= 0 i@@2) (< i@@2 (seq.len s@@1))) (= (seq.nth s@@1 i@@2) (seq.nth |s'| i@@2)))) (= s@@1 |s'|)))))
+(assert (not (=> (= (seq.len x) (seq.len y)) (=> (forall ((i Int) )   (=> (and (<= 0 i) (< i (seq.len x))) (= (seq.nth x i) (seq.nth y i)))) (= x y)))))
 
 (check-sat)


### PR DESCRIPTION
This PR adds `str.len` to symbols that are considered for instantiations.
It is motivated by a benchmark that originated from Boogie.
A minimized version of that benchmark is added as a regression.