### PR TITLE
Add support for cross compiling 32-bit windows version with mingw

### DIFF
--- a/cmake/Toolchain-mingw32.cmake
+++ b/cmake/Toolchain-mingw32.cmake
@@ -1,0 +1,23 @@
+# Toolchain file for building for Windows from Ubuntu.
+#
+# Use: cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw32.cmake
+
+SET(CMAKE_SYSTEM_NAME Windows)
+
+set(TOOLCHAIN_PREFIX i686-w64-mingw32)
+
+SET(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+SET(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+SET(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# Set target environment path
+SET(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# Adjust the default behaviour of the find_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+
+set(CVC4_WINDOWS_BUILD TRUE)

--- a/configure.sh
+++ b/configure.sh
@@ -23,6 +23,7 @@ General options;
   --best                   turn on dependencies known to give best performance
   --gpl                    permit GPL dependencies, if available
   --win64                  cross-compile for Windows 64 bit
+  --win32                  cross-compile for Windows 32 bit
   --ninja                  use Ninja build system
 
 
@@ -151,6 +152,7 @@ ubsan=default
 unit_testing=default
 valgrind=default
 win64=default
+win32=default
 
 abc_dir=default
 antlr_dir=default
@@ -242,6 +244,8 @@ do
 
     --win64) win64=ON;;
     --no-win64) win64=OFF;;
+
+    --win32) win32=ON;;
 
     --ninja) ninja=ON;;
 
@@ -388,6 +392,8 @@ cmake_opts=""
   && cmake_opts="$cmake_opts -DENABLE_GPL=$gpl"
 [ $win64 != default ] \
   && cmake_opts="$cmake_opts -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw64.cmake"
+[ $win32 != default ] \
+  && cmake_opts="$cmake_opts -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw32.cmake"
 [ $ninja != default ] && cmake_opts="$cmake_opts -G Ninja"
 [ $muzzle != default ] \
   && cmake_opts="$cmake_opts -DENABLE_MUZZLE=$muzzle"
@@ -475,6 +481,7 @@ root_dir=$(pwd)
 # The cmake toolchain can't be changed once it is configured in $build_dir.
 # Thus, remove $build_dir and create an empty directory.
 [ $win64 = ON ] && [ -e "$build_dir" ] && rm -r "$build_dir"
+[ $win32 = ON ] && [ -e "$build_dir" ] && rm -r "$build_dir"
 mkdir -p "$build_dir"
 
 cd "$build_dir"

--- a/contrib/get-antlr-3.4
+++ b/contrib/get-antlr-3.4
@@ -34,7 +34,7 @@ webget \
 mkdir -p "$ANTLR_HOME_DIR/bin"
 tee "$ANTLR_HOME_DIR/bin/antlr3" <<EOF
 #!/usr/bin/env bash
-JAR_FILE="\$(find "\$(dirname "\$0")/../" -name antlr-3.4-complete.jar)"
+JAR_FILE="\$(find "\$(dirname "\$0")/../../" -name antlr-3.4-complete.jar)"
 exec java -cp "\$JAR_FILE" org.antlr.Tool "\$@"
 EOF
 chmod a+x "$ANTLR_HOME_DIR/bin/antlr3"

--- a/contrib/get-win-dependencies
+++ b/contrib/get-win-dependencies
@@ -38,6 +38,12 @@ if [ -z "$HOST" ]; then
   echo "WARNING:"
 fi
 
+MACHINE_TYPE=x86_64
+
+if [[ $HOST == *"i686"* ]]; then
+  MACHINE_TYPE=i686
+fi
+
 GMPVERSION=6.2.0
 BOOSTVERSION=1.55.0
 BOOSTBASE=boost_1_55_0
@@ -73,7 +79,7 @@ echo ===========================================================================
 echo
 echo "Setting up ANTLR 3.4..."
 echo
-MACHINE_TYPE="x86_64" ANTLR_CONFIGURE_ARGS="--host=$HOST" contrib/get-antlr-3.4 | grep -v 'Now configure CVC4 with' | grep -v '\./configure --with-antlr-dir='
+MACHINE_TYPE=${MACHINE_TYPE} ANTLR_CONFIGURE_ARGS="--host=$HOST" contrib/get-antlr-3.4 | grep -v 'Now configure CVC4 with' | grep -v '\./configure --with-antlr-dir='
 [ ${PIPESTATUS[0]} -eq 0 ] || reporterror
 echo
 


### PR DESCRIPTION
Added support for cross compiling 32-bit windows version with mingw using -win32 option in configure.sh.
Example build order:
```
HOST=i686-w64-mingw32 ./contrib/get-win-dependencies
./configure.sh --win32 --antlr-dir="/home/test/CVC4/deps/antlr-3.4" --gmp-dir="/home/test/CVC4/deps/gmp-6.2.0"
cd ./build
make
```

Remarks
1) At end of his work, get-win-dependencies says I should run next this command:
`./configure --enable-static-binary --disable-shared --host=i686-w64-mingw32 LDFLAGS="-L/home/test/CVC4/gmp-6.2.0/lib -L/home/test/CVC4/antlr-3.4/lib -L/home/test/CVC4/boost-1.55.0/lib" CPPFLAGS="-I/home/test/CVC4/gmp-6.2.0/include -I/home/test/CVC4/antlr-3.4/include -I/home/test/CVC4/boost-1.55.0/include" --with-antlr-dir="/home/test/CVC4/antlr-3.4" ANTLR="/home/test/CVC4/antlr-3.4/bin/antlr3"
`
The paths in this message are wrong. I've did not change this message output code.

2) The code for searching antlr jar file in get-antlr-3.4 searched in the wrong dir. I've corrected this, but not sure if that's right, because this code works also for other build targets and they can have a different folder layout.