### PR TITLE
bv-to-int: avoid binarizing nodes twice

### DIFF
--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -77,7 +77,13 @@ Node BVToInt::modpow2(Node n, uint64_t exponent)
  */
 Node BVToInt::makeBinary(Node n)
 {
-  for (TNode current : NodeDfsIterable(n, VisitOrder::POSTORDER))
+  for (TNode current : NodeDfsIterable(n,
+                                       VisitOrder::POSTORDER,
+                                       // skip visited nodes
+                                       [this](TNode tn) {
+                                         return d_binarizeCache.find(tn)
+                                                != d_binarizeCache.end();
+                                       }))
   {
     uint64_t numChildren = current.getNumChildren();
     /*


### PR DESCRIPTION
In bv-to-int, we first binarize the applications of associative-commutative operators (like `bvadd` etc.).
With this PR, we first check whether we already binarized a node, and only if we didn't, we perform binarization.