### PR TITLE
Add div, mod, abs in non-strict parsing mode

### DIFF
--- a/src/parser/smt2/smt2.cpp
+++ b/src/parser/smt2/smt2.cpp
@@ -550,7 +550,7 @@ Command* Smt2::setLogic(std::string name, bool fromCommand)
     if(d_logic.areIntegersUsed()) {
       defineType("Int", d_solver->getIntegerSort(), true, true);
       addArithmeticOperators();
-      if (!d_logic.isLinear())
+      if (!strictModeEnabled() || !d_logic.isLinear())
       {
         addOperator(api::INTS_DIVISION, "div");
         addOperator(api::INTS_MODULUS, "mod");

--- a/test/regress/regress0/expect/scrub.08.sy
+++ b/test/regress/regress0/expect/scrub.08.sy
@@ -1,5 +1,5 @@
 ; REQUIRES: no-competition
-; COMMAND-LINE: --lang=sygus2 --sygus-si=all --sygus-out=status --no-sygus-repair-const
+; COMMAND-LINE: --lang=sygus2 --sygus-si=all --sygus-out=status --no-sygus-repair-const --strict-parsing
 ; ERROR-SCRUBBER: grep -o "Symbol 'div' not declared as a variable"
 ; EXPECT-ERROR: Symbol 'div' not declared as a variable
 ; EXIT: 1

--- a/test/regress/regress0/parser/linear_arithmetic_err1.smt2
+++ b/test/regress/regress0/parser/linear_arithmetic_err1.smt2
@@ -1,4 +1,5 @@
 ; REQUIRES: no-competition
+; COMMAND-LINE: --strict-parsing
 ; SCRUBBER: grep -o "Symbol 'div' not declared as a variable"
 ; EXPECT: Symbol 'div' not declared as a variable
 ; EXIT: 1

--- a/test/regress/regress0/parser/linear_arithmetic_err2.smt2
+++ b/test/regress/regress0/parser/linear_arithmetic_err2.smt2
@@ -1,4 +1,5 @@
 ; REQUIRES: no-competition
+; COMMAND-LINE: --strict-parsing
 ; SCRUBBER: grep -o "Symbol 'mod' not declared as a variable"
 ; EXPECT: Symbol 'mod' not declared as a variable
 ; EXIT: 1

--- a/test/regress/regress0/parser/linear_arithmetic_err3.smt2
+++ b/test/regress/regress0/parser/linear_arithmetic_err3.smt2
@@ -1,4 +1,5 @@
 ; REQUIRES: no-competition
+; COMMAND-LINE: --strict-parsing
 ; SCRUBBER: grep -o "Symbol 'abs' not declared as a variable"
 ; EXPECT: Symbol 'abs' not declared as a variable
 ; EXIT: 1


### PR DESCRIPTION
The recent change to the parser currently breaks our performance on several critical applications, including the use of CVC4 in Facebook.  We should only throw a parse error for div in linear logics when strict mode is enabled. 