### PR TITLE
Reorganize calls to quantifiers engine from SmtEngine layer

### DIFF
--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1622,9 +1622,7 @@ void SmtEngine::getInstantiationTermVectors(
 void SmtEngine::printSynthSolution( std::ostream& out ) {
   SmtScope smts(this);
   finishInit();
-  TheoryEngine* te = getTheoryEngine();
-  Assert(te != nullptr);
-  te->printSynthSolution(out);
+  d_sygusSolver->printSynthSolution(out);
 }
 
 bool SmtEngine::getSynthSolutions(std::map<Node, Node>& solMap)

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1533,9 +1533,8 @@ void SmtEngine::printInstantiations( std::ostream& out ) {
     out << "% SZS output start Proof for " << d_state->getFilename()
         << std::endl;
   }
-  TheoryEngine* te = getTheoryEngine();
-  Assert(te != nullptr);
-  QuantifiersEngine* qe = te->getQuantifiersEngine();
+  QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
+  Assert (qe!=nullptr);
 
   // First, extract and print the skolemizations
   bool printed = false;
@@ -1611,9 +1610,8 @@ void SmtEngine::getInstantiationTermVectors(
   }
   else
   {
-    TheoryEngine* te = getTheoryEngine();
-    Assert(te != nullptr);
-    QuantifiersEngine* qe = te->getQuantifiersEngine();
+    QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
+    Assert (qe!=nullptr);
     // otherwise, just get the list of all instantiations
     qe->getInstantiationTermVectors(insts);
   }
@@ -1684,9 +1682,8 @@ bool SmtEngine::getAbduct(const Node& conj, Node& abd)
 void SmtEngine::getInstantiatedQuantifiedFormulas(std::vector<Node>& qs)
 {
   SmtScope smts(this);
-  TheoryEngine* te = getTheoryEngine();
-  Assert(te != nullptr);
-  QuantifiersEngine* qe = te->getQuantifiersEngine();
+  QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
+  Assert (qe!=nullptr);
   qe->getInstantiatedQuantifiedFormulas(qs);
 }
 
@@ -1694,9 +1691,8 @@ void SmtEngine::getInstantiationTermVectors(
     Node q, std::vector<std::vector<Node>>& tvecs)
 {
   SmtScope smts(this);
-  TheoryEngine* te = getTheoryEngine();
-  Assert(te != nullptr);
-  QuantifiersEngine* qe = te->getQuantifiersEngine();
+  QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
+  Assert (qe!=nullptr);
   qe->getInstantiationTermVectors(q, tvecs);
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -1534,7 +1534,7 @@ void SmtEngine::printInstantiations( std::ostream& out ) {
         << std::endl;
   }
   QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-  Assert (qe!=nullptr);
+  Assert(qe != nullptr);
 
   // First, extract and print the skolemizations
   bool printed = false;
@@ -1611,7 +1611,7 @@ void SmtEngine::getInstantiationTermVectors(
   else
   {
     QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-    Assert (qe!=nullptr);
+    Assert(qe != nullptr);
     // otherwise, just get the list of all instantiations
     qe->getInstantiationTermVectors(insts);
   }
@@ -1683,7 +1683,7 @@ void SmtEngine::getInstantiatedQuantifiedFormulas(std::vector<Node>& qs)
 {
   SmtScope smts(this);
   QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-  Assert (qe!=nullptr);
+  Assert(qe != nullptr);
   qe->getInstantiatedQuantifiedFormulas(qs);
 }
 
@@ -1692,7 +1692,7 @@ void SmtEngine::getInstantiationTermVectors(
 {
   SmtScope smts(this);
   QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-  Assert (qe!=nullptr);
+  Assert(qe != nullptr);
   qe->getInstantiationTermVectors(q, tvecs);
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -844,10 +844,10 @@ Model* SmtEngine::getAvailableModel(const char* c) const
   return d_model.get();
 }
 
-QuantifiersEngine * SmtEngine::getAvailableQuantifiersEngine(const char* c) const
+QuantifiersEngine* SmtEngine::getAvailableQuantifiersEngine(const char* c) const
 {
   QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-  if(qe == nullptr)
+  if (qe == nullptr)
   {
     std::stringstream ss;
     ss << "Cannot " << c << " when quantifiers are not present.";
@@ -1621,7 +1621,8 @@ void SmtEngine::getInstantiationTermVectors(
   }
   else
   {
-    QuantifiersEngine* qe = getAvailableQuantifiersEngine("getInstantiationTermVectors");
+    QuantifiersEngine* qe =
+        getAvailableQuantifiersEngine("getInstantiationTermVectors");
     // otherwise, just get the list of all instantiations
     qe->getInstantiationTermVectors(insts);
   }
@@ -1692,7 +1693,8 @@ bool SmtEngine::getAbduct(const Node& conj, Node& abd)
 void SmtEngine::getInstantiatedQuantifiedFormulas(std::vector<Node>& qs)
 {
   SmtScope smts(this);
-  QuantifiersEngine* qe = getAvailableQuantifiersEngine("getInstantiatedQuantifiedFormulas");
+  QuantifiersEngine* qe =
+      getAvailableQuantifiersEngine("getInstantiatedQuantifiedFormulas");
   qe->getInstantiatedQuantifiedFormulas(qs);
 }
 
@@ -1700,7 +1702,8 @@ void SmtEngine::getInstantiationTermVectors(
     Node q, std::vector<std::vector<Node>>& tvecs)
 {
   SmtScope smts(this);
-  QuantifiersEngine* qe = getAvailableQuantifiersEngine("getInstantiationTermVectors");
+  QuantifiersEngine* qe =
+      getAvailableQuantifiersEngine("getInstantiationTermVectors");
   qe->getInstantiationTermVectors(q, tvecs);
 }
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -844,6 +844,18 @@ Model* SmtEngine::getAvailableModel(const char* c) const
   return d_model.get();
 }
 
+QuantifiersEngine * SmtEngine::getAvailableQuantifiersEngine(const char* c) const
+{
+  QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
+  if(qe == nullptr)
+  {
+    std::stringstream ss;
+    ss << "Cannot " << c << " when quantifiers are not present.";
+    throw ModalException(ss.str().c_str());
+  }
+  return qe;
+}
+
 void SmtEngine::notifyPushPre() { d_smtSolver->processAssertions(*d_asserts); }
 
 void SmtEngine::notifyPushPost()
@@ -1533,8 +1545,7 @@ void SmtEngine::printInstantiations( std::ostream& out ) {
     out << "% SZS output start Proof for " << d_state->getFilename()
         << std::endl;
   }
-  QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-  Assert(qe != nullptr);
+  QuantifiersEngine* qe = getAvailableQuantifiersEngine("printInstantiations");
 
   // First, extract and print the skolemizations
   bool printed = false;
@@ -1610,8 +1621,7 @@ void SmtEngine::getInstantiationTermVectors(
   }
   else
   {
-    QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-    Assert(qe != nullptr);
+    QuantifiersEngine* qe = getAvailableQuantifiersEngine("getInstantiationTermVectors");
     // otherwise, just get the list of all instantiations
     qe->getInstantiationTermVectors(insts);
   }
@@ -1682,8 +1692,7 @@ bool SmtEngine::getAbduct(const Node& conj, Node& abd)
 void SmtEngine::getInstantiatedQuantifiedFormulas(std::vector<Node>& qs)
 {
   SmtScope smts(this);
-  QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-  Assert(qe != nullptr);
+  QuantifiersEngine* qe = getAvailableQuantifiersEngine("getInstantiatedQuantifiedFormulas");
   qe->getInstantiatedQuantifiedFormulas(qs);
 }
 
@@ -1691,8 +1700,7 @@ void SmtEngine::getInstantiationTermVectors(
     Node q, std::vector<std::vector<Node>>& tvecs)
 {
   SmtScope smts(this);
-  QuantifiersEngine* qe = d_smtSolver->getQuantifiersEngine();
-  Assert(qe != nullptr);
+  QuantifiersEngine* qe = getAvailableQuantifiersEngine("getInstantiationTermVectors");
   qe->getInstantiationTermVectors(q, tvecs);
 }
 

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -127,6 +127,7 @@ ProofManager* currentProofManager();
 namespace theory {
   class TheoryModel;
   class Rewriter;
+  class QuantifiersEngine;
 }/* CVC4::theory namespace */
 
 
@@ -984,7 +985,7 @@ class CVC4_PUBLIC SmtEngine
    * @param c used for giving an error message to indicate the context
    * this method was called.
    */
-  QuantifiersEngine* getAvailableQuantifiersEngine(const char* c) const;
+  theory::QuantifiersEngine* getAvailableQuantifiersEngine(const char* c) const;
 
   // --------------------------------------- callbacks from the state
   /**

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -972,10 +972,19 @@ class CVC4_PUBLIC SmtEngine
    * by this class is currently available, which means that CVC4 is producing
    * models, and is in "SAT mode", otherwise a recoverable exception is thrown.
    *
-   * The flag c is used for giving an error message to indicate the context
+   * @param c used for giving an error message to indicate the context
    * this method was called.
    */
   smt::Model* getAvailableModel(const char* c) const;
+  /** 
+   * Get available quantifiers engine, which throws a modal exception if it
+   * does not exist. This can happen if a quantifiers-specific call (e.g.
+   * getInstantiatedQuantifiedFormulas) is called in a non-quantified logic.
+   * 
+   * @param c used for giving an error message to indicate the context
+   * this method was called.
+   */
+  QuantifiersEngine * getAvailableQuantifiersEngine(const char* c) const;
 
   // --------------------------------------- callbacks from the state
   /**

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -976,15 +976,15 @@ class CVC4_PUBLIC SmtEngine
    * this method was called.
    */
   smt::Model* getAvailableModel(const char* c) const;
-  /** 
+  /**
    * Get available quantifiers engine, which throws a modal exception if it
    * does not exist. This can happen if a quantifiers-specific call (e.g.
    * getInstantiatedQuantifiedFormulas) is called in a non-quantified logic.
-   * 
+   *
    * @param c used for giving an error message to indicate the context
    * this method was called.
    */
-  QuantifiersEngine * getAvailableQuantifiersEngine(const char* c) const;
+  QuantifiersEngine* getAvailableQuantifiersEngine(const char* c) const;
 
   // --------------------------------------- callbacks from the state
   /**

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -260,10 +260,10 @@ prop::PropEngine* SmtSolver::getPropEngine() { return d_propEngine.get(); }
 
 theory::QuantifiersEngine* SmtSolver::getQuantifiersEngine()
 {
-  Assert (d_theoryEngine!=nullptr);
+  Assert(d_theoryEngine != nullptr);
   return d_theoryEngine->getQuantifiersEngine();
 }
-  
+
 Preprocessor* SmtSolver::getPreprocessor() { return &d_pp; }
 
 }  // namespace smt

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -258,6 +258,12 @@ TheoryEngine* SmtSolver::getTheoryEngine() { return d_theoryEngine.get(); }
 
 prop::PropEngine* SmtSolver::getPropEngine() { return d_propEngine.get(); }
 
+theory::QuantifiersEngine* SmtSolver::getQuantifiersEngine()
+{
+  Assert (d_theoryEngine!=nullptr);
+  return d_theoryEngine->getQuantifiersEngine();
+}
+  
 Preprocessor* SmtSolver::getPreprocessor() { return &d_pp; }
 
 }  // namespace smt

--- a/src/smt/smt_solver.h
+++ b/src/smt/smt_solver.h
@@ -34,6 +34,10 @@ namespace prop {
 class PropEngine;
 }
 
+namespace theory {
+class QuantifiersEngine;
+}
+
 namespace smt {
 
 class Assertions;
@@ -119,6 +123,8 @@ class SmtSolver
   TheoryEngine* getTheoryEngine();
   /** Get a pointer to the PropEngine owned by this solver. */
   prop::PropEngine* getPropEngine();
+  /** Get a pointer to the QuantifiersEngine owned by this solver. */
+  theory::QuantifiersEngine* getQuantifiersEngine();
   /** Get a pointer to the preprocessor */
   Preprocessor* getPreprocessor();
   //------------------------------------------ end access methods

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -230,7 +230,7 @@ bool SygusSolver::getSynthSolutions(std::map<Node, Node>& sol_map)
   std::map<Node, std::map<Node, Node>> sol_mapn;
   // fail if the theory engine does not have synthesis solutions
   QuantifiersEngine* qe = d_smtSolver.getQuantifiersEngine();
-  if (qe==nullptr || !qe->getSynthSolutions(sol_mapn))
+  if (qe == nullptr || !qe->getSynthSolutions(sol_mapn))
   {
     return false;
   }

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -22,9 +22,9 @@
 #include "smt/preprocessor.h"
 #include "smt/smt_solver.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
-#include "theory/quantifiers_engine.h"
 #include "theory/quantifiers/sygus/sygus_grammar_cons.h"
 #include "theory/quantifiers/sygus/sygus_utils.h"
+#include "theory/quantifiers_engine.h"
 #include "theory/smt_engine_subsolver.h"
 
 using namespace CVC4::theory;
@@ -248,10 +248,11 @@ bool SygusSolver::getSynthSolutions(std::map<Node, Node>& sol_map)
 void SygusSolver::printSynthSolution(std::ostream& out)
 {
   QuantifiersEngine* qe = d_smtSolver.getQuantifiersEngine();
-  if(qe == nullptr)
+  if (qe == nullptr)
   {
     InternalError()
-        << "SygusSolver::printSynthSolution(): Cannot print synth solution in the current logic, which does not include quantifiers";
+        << "SygusSolver::printSynthSolution(): Cannot print synth solution in "
+           "the current logic, which does not include quantifiers";
   }
   qe->printSynthSolution(out);
 }
@@ -264,7 +265,7 @@ void SygusSolver::checkSynthSolution(Assertions& as)
   std::map<Node, std::map<Node, Node>> sol_map;
   // Get solutions and build auxiliary vectors for substituting
   QuantifiersEngine* qe = d_smtSolver.getQuantifiersEngine();
-  if (qe==nullptr || !qe->getSynthSolutions(sol_map))
+  if (qe == nullptr || !qe->getSynthSolutions(sol_map))
   {
     InternalError()
         << "SygusSolver::checkSynthSolution(): No solution to check!";

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -230,8 +230,7 @@ bool SygusSolver::getSynthSolutions(std::map<Node, Node>& sol_map)
   std::map<Node, std::map<Node, Node>> sol_mapn;
   // fail if the theory engine does not have synthesis solutions
   QuantifiersEngine* qe = d_smtSolver.getQuantifiersEngine();
-  Assert(qe != nullptr);
-  if (!qe->getSynthSolutions(sol_mapn))
+  if (qe==nullptr || !qe->getSynthSolutions(sol_mapn))
   {
     return false;
   }

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -230,7 +230,9 @@ bool SygusSolver::getSynthSolutions(std::map<Node, Node>& sol_map)
   // fail if the theory engine does not have synthesis solutions
   TheoryEngine* te = d_smtSolver.getTheoryEngine();
   Assert(te != nullptr);
-  if (!te->getSynthSolutions(sol_mapn))
+  QuantifiersEngine* qe = te->getQuantifiersEngine();
+  Assert(qe != nullptr);
+  if (!qe->getSynthSolutions(sol_mapn))
   {
     return false;
   }
@@ -242,6 +244,15 @@ bool SygusSolver::getSynthSolutions(std::map<Node, Node>& sol_map)
     }
   }
   return true;
+}
+
+void SygusSolver::printSynthSolution(std::ostream& out)
+{
+  TheoryEngine* te = getTheoryEngine();
+  Assert(te != nullptr);
+  QuantifiersEngine* qe = te->getQuantifiersEngine();
+  Assert(qe != nullptr);
+  qe->printSynthSolution(out);
 }
 
 void SygusSolver::checkSynthSolution(Assertions& as)

--- a/src/smt/sygus_solver.h
+++ b/src/smt/sygus_solver.h
@@ -141,6 +141,7 @@ class SygusSolver
    * instantiation module.
    */
   void printSynthSolution(std::ostream& out);
+
  private:
   /**
    * Check that a solution to a synthesis conjecture is indeed a solution.

--- a/src/smt/sygus_solver.h
+++ b/src/smt/sygus_solver.h
@@ -136,7 +136,11 @@ class SygusSolver
    * is a valid formula.
    */
   bool getSynthSolutions(std::map<Node, Node>& sol_map);
-
+  /**
+   * Print solution for synthesis conjectures found by counter-example guided
+   * instantiation module.
+   */
+  void printSynthSolution(std::ostream& out);
  private:
   /**
    * Check that a solution to a synthesis conjecture is indeed a solution.

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -693,17 +693,6 @@ bool TheoryEngine::buildModel()
   return d_tc->buildModel();
 }
 
-bool TheoryEngine::getSynthSolutions(
-    std::map<Node, std::map<Node, Node>>& sol_map)
-{
-  if (d_quantEngine)
-  {
-    return d_quantEngine->getSynthSolutions(sol_map);
-  }
-  // we are not in a quantified logic, there is no synthesis solution
-  return false;
-}
-
 bool TheoryEngine::presolve() {
   // Reset the interrupt flag
   d_interrupted = false;
@@ -1173,15 +1162,6 @@ Node TheoryEngine::getPreprocessedTerm(TNode n)
 {
   Node rewritten = Rewriter::rewrite(n);
   return d_propEngine->getPreprocessedTerm(rewritten);
-}
-
-void TheoryEngine::printSynthSolution( std::ostream& out ) {
-  if( d_quantEngine ){
-    d_quantEngine->printSynthSolution( out );
-  }else{
-    out << "Internal error : synth solution not available when quantifiers are not present." << std::endl;
-    Assert(false);
-  }
 }
 
 TrustNode TheoryEngine::getExplanation(TNode node)

--- a/src/theory/theory_engine.h
+++ b/src/theory/theory_engine.h
@@ -586,22 +586,6 @@ class TheoryEngine {
    */
   void setEagerModelBuilding() { d_eager_model_building = true; }
 
-  /** get synth solutions
-   *
-   * This method returns true if there is a synthesis solution available. This
-   * is the case if the last call to check satisfiability originated in a
-   * check-synth call, and the synthesis solver successfully found a solution
-   * for all active synthesis conjectures.
-   *
-   * This method adds entries to sol_map that map functions-to-synthesize with
-   * their solutions, for all active conjectures. This should be called
-   * immediately after the solver answers unsat for sygus input.
-   *
-   * For details on what is added to sol_map, see
-   * SynthConjecture::getSynthSolutions.
-   */
-  bool getSynthSolutions(std::map<Node, std::map<Node, Node> >& sol_map);
-
   /**
    * Get the theory associated to a given Node.
    *
@@ -662,10 +646,6 @@ class TheoryEngine {
    * if preprocessing n involves introducing new skolems.
    */
   Node getPreprocessedTerm(TNode n);
-  /**
-   * Print solution for synthesis conjectures found by ce_guided_instantiation module
-   */
-  void printSynthSolution( std::ostream& out );
 
   /**
    * Forwards an entailment check according to the given theoryOfMode.


### PR DESCRIPTION
This reorganizes calls to QuantifiersEngine from SmtEngine.  Our policy has changed recently that the SmtEngine layer is allowed to make calls directly to QuantifiersEngine, which eliminates the need for TheoryEngine to have forwarding calls.  This PR makes this policy more consistent.

This also makes quantifier-specific calls more safe by throwing modal exceptions in the cases where quantifiers are present.

Marking "major" since we currently segfault when e.g. dumping instantiations in non-quantified logics.  This PR makes it so that we throw a modal exception.