### PR TITLE
Optimizations for Theory::theoryOf

### DIFF
--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -146,8 +146,9 @@ struct TheoryOfTypeTag
 struct TheoryOfTermTag
 {
 };
-/** Attribute true for expressions with bound variables in them */
+/** Attribute caching the result of theoryOf, type based */
 typedef expr::Attribute<TheoryOfTypeTag, uint32_t> TheoryOfTypeAttr;
+/** Attribute caching the result of theoryOf, term based */
 typedef expr::Attribute<TheoryOfTermTag, uint32_t> TheoryOfTermAttr;
 
 TheoryId Theory::theoryOf(options::TheoryOfMode mode, TNode node)

--- a/src/theory/theory.cpp
+++ b/src/theory/theory.cpp
@@ -288,7 +288,6 @@ TheoryId Theory::theoryOf(options::TheoryOfMode mode, TNode node)
   default:
     Unreachable();
   }
-  return THEORY_BUILTIN;
 }
 
 void Theory::notifySharedTerm(TNode n)

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -351,15 +351,14 @@ class Theory {
    * Return the ID of the theory responsible for the given type.
    */
   static inline TheoryId theoryOf(TypeNode typeNode) {
-    Trace("theory::internal") << "theoryOf(" << typeNode << ")" << std::endl;
     TheoryId id;
-    if (typeNode.getKind() == kind::TYPE_CONSTANT) {
-      id = typeConstantToTheoryId(typeNode.getConst<TypeConstant>());
-    } else {
-      id = kindToTheoryId(typeNode.getKind());
+    Kind k = typeNode.getKind();
+    if (k == kind::TYPE_CONSTANT)
+    {
+      return typeConstantToTheoryId(typeNode.getConst<TypeConstant>());
     }
+    id = kindToTheoryId(k);
     if (id == THEORY_BUILTIN) {
-      Trace("theory::internal") << "theoryOf(" << typeNode << ") == " << s_uninterpretedSortOwner << std::endl;
       return s_uninterpretedSortOwner;
     }
     return id;

--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -355,6 +355,7 @@ class Theory {
     Kind k = typeNode.getKind();
     if (k == kind::TYPE_CONSTANT)
     {
+      // type constants, e.g. Int, always belong to given theory (not builtin)
       return typeConstantToTheoryId(typeNode.getConst<TypeConstant>());
     }
     id = kindToTheoryId(k);


### PR DESCRIPTION
These methods commonly take 10-15% of runtime.  This PR caches the result of this method. It also removes traces from the method, which can contribute around 2% of runtime on trace enabled builds (even when the trace is disabled).