### PR TITLE
Simplify interface for preprocessor

### DIFF
--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -80,12 +80,10 @@ bool Preprocessor::process(Assertions& as)
   }
 
   // process the assertions, return true if no conflict is discovered
-  return d_processor.apply(as);
-}
+  bool noConflict = d_processor.apply(as);
 
-void Preprocessor::postprocess(Assertions& as)
-{
-  preprocessing::AssertionPipeline& ap = as.getAssertionPipeline();
+  // now, post-process the assertions
+
   // if incremental, compute which variables are assigned
   if (options::incrementalSolving())
   {
@@ -94,6 +92,8 @@ void Preprocessor::postprocess(Assertions& as)
 
   // mark that we've processed assertions
   d_assertionsProcessed = true;
+
+  return noConflict;
 }
 
 void Preprocessor::clearLearnedLiterals()

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -56,12 +56,6 @@ class Preprocessor
    */
   bool process(Assertions& as);
   /**
-   * Postprocess assertions, called after the SmtEngine has finished
-   * giving the assertions to the SMT solver and before the assertions are
-   * cleared.
-   */
-  void postprocess(Assertions& as);
-  /**
    * Clear learned literals from the Boolean propagator.
    */
   void clearLearnedLiterals();

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -236,8 +236,6 @@ void SmtSolver::processAssertions(Assertions& as)
   // end: INVARIANT to maintain: no reordering of assertions or
   // introducing new ones
 
-  d_pp.postprocess(as);
-
   // Push the formula to SAT
   {
     Chat() << "converting to CNF..." << endl;


### PR DESCRIPTION
This does a minor simplification to the interface for preprocessor.  It has a `postProcess` call that is called after another unrelated call at the `SmtSolver` level (notifyPreprocessedAssertions) is made.  This makes it so that `Preprocessor::postProcess` is inlined as the last step of `process`.