### PR TITLE
Make most methods of TheoryInferenceManager expect an InferenceId.

### DIFF
--- a/src/theory/arith/arith_preprocess.cpp
+++ b/src/theory/arith/arith_preprocess.cpp
@@ -49,7 +49,7 @@ bool ArithPreprocess::reduceAssertion(TNode atom)
   // tn is of kind REWRITE, turn this into a LEMMA here
   TrustNode tlem = TrustNode::mkTrustLemma(tn.getProven(), tn.getGenerator());
   // must preprocess
-  d_im.trustedLemma(InferenceId::UNKNOWN, tlem);
+  d_im.trustedLemma(tlem, InferenceId::UNKNOWN);
   // mark the atom as reduced
   d_reduced[atom] = true;
   return true;

--- a/src/theory/arith/arith_preprocess.cpp
+++ b/src/theory/arith/arith_preprocess.cpp
@@ -49,7 +49,7 @@ bool ArithPreprocess::reduceAssertion(TNode atom)
   // tn is of kind REWRITE, turn this into a LEMMA here
   TrustNode tlem = TrustNode::mkTrustLemma(tn.getProven(), tn.getGenerator());
   // must preprocess
-  d_im.trustedLemma(tlem);
+  d_im.trustedLemma(InferenceId::UNKNOWN, tlem);
   // mark the atom as reduced
   d_reduced[atom] = true;
   return true;

--- a/src/theory/arrays/inference_manager.cpp
+++ b/src/theory/arrays/inference_manager.cpp
@@ -53,9 +53,9 @@ bool InferenceManager::assertInference(TNode atom,
     std::vector<Node> args;
     // convert to proof rule application
     convert(id, fact, reason, children, args);
-    return assertInternalFact(InferenceId::UNKNOWN, atom, polarity, id, children, args);
+    return assertInternalFact(atom, polarity, InferenceId::UNKNOWN, id, children, args);
   }
-  return assertInternalFact(InferenceId::UNKNOWN, atom, polarity, reason);
+  return assertInternalFact(atom, polarity, InferenceId::UNKNOWN, reason);
 }
 
 bool InferenceManager::arrayLemma(
@@ -72,11 +72,11 @@ bool InferenceManager::arrayLemma(
     convert(id, conc, exp, children, args);
     // make the trusted lemma based on the eager proof generator and send
     TrustNode tlem = d_lemmaPg->mkTrustNode(conc, id, children, args);
-    return trustedLemma(InferenceId::UNKNOWN,tlem, p, doCache);
+    return trustedLemma(tlem, InferenceId::UNKNOWN, p, doCache);
   }
   // send lemma without proofs
   Node lem = nm->mkNode(IMPLIES, exp, conc);
-  return lemma(InferenceId::UNKNOWN, lem, p, doCache);
+  return lemma(lem, InferenceId::UNKNOWN, p, doCache);
 }
 
 void InferenceManager::convert(PfRule& id,

--- a/src/theory/arrays/inference_manager.cpp
+++ b/src/theory/arrays/inference_manager.cpp
@@ -53,9 +53,9 @@ bool InferenceManager::assertInference(TNode atom,
     std::vector<Node> args;
     // convert to proof rule application
     convert(id, fact, reason, children, args);
-    return assertInternalFact(atom, polarity, id, children, args);
+    return assertInternalFact(InferenceId::UNKNOWN, atom, polarity, id, children, args);
   }
-  return assertInternalFact(atom, polarity, reason);
+  return assertInternalFact(InferenceId::UNKNOWN, atom, polarity, reason);
 }
 
 bool InferenceManager::arrayLemma(
@@ -72,11 +72,11 @@ bool InferenceManager::arrayLemma(
     convert(id, conc, exp, children, args);
     // make the trusted lemma based on the eager proof generator and send
     TrustNode tlem = d_lemmaPg->mkTrustNode(conc, id, children, args);
-    return trustedLemma(tlem, p, doCache);
+    return trustedLemma(InferenceId::UNKNOWN,tlem, p, doCache);
   }
   // send lemma without proofs
   Node lem = nm->mkNode(IMPLIES, exp, conc);
-  return lemma(lem, p, doCache);
+  return lemma(InferenceId::UNKNOWN, lem, p, doCache);
 }
 
 void InferenceManager::convert(PfRule& id,

--- a/src/theory/bags/infer_info.cpp
+++ b/src/theory/bags/infer_info.cpp
@@ -37,7 +37,7 @@ bool InferInfo::process(TheoryInferenceManager* im, bool asLemma)
   if (asLemma)
   {
     TrustNode trustedLemma = TrustNode::mkTrustLemma(lemma, nullptr);
-    im->trustedLemma(trustedLemma);
+    im->trustedLemma(getId(), trustedLemma);
   }
   else
   {
@@ -47,7 +47,7 @@ bool InferInfo::process(TheoryInferenceManager* im, bool asLemma)
   {
     Node n = pair.first.eqNode(pair.second);
     TrustNode trustedLemma = TrustNode::mkTrustLemma(n, nullptr);
-    im->trustedLemma(trustedLemma);
+    im->trustedLemma(getId(), trustedLemma);
   }
 
   Trace("bags::InferInfo::process") << (*this) << std::endl;

--- a/src/theory/bags/infer_info.cpp
+++ b/src/theory/bags/infer_info.cpp
@@ -37,7 +37,7 @@ bool InferInfo::process(TheoryInferenceManager* im, bool asLemma)
   if (asLemma)
   {
     TrustNode trustedLemma = TrustNode::mkTrustLemma(lemma, nullptr);
-    im->trustedLemma(getId(), trustedLemma);
+    im->trustedLemma(trustedLemma, getId());
   }
   else
   {
@@ -47,7 +47,7 @@ bool InferInfo::process(TheoryInferenceManager* im, bool asLemma)
   {
     Node n = pair.first.eqNode(pair.second);
     TrustNode trustedLemma = TrustNode::mkTrustLemma(n, nullptr);
-    im->trustedLemma(getId(), trustedLemma);
+    im->trustedLemma(trustedLemma, getId());
   }
 
   Trace("bags::InferInfo::process") << (*this) << std::endl;

--- a/src/theory/bv/bitblast/lazy_bitblaster.cpp
+++ b/src/theory/bv/bitblast/lazy_bitblaster.cpp
@@ -416,9 +416,9 @@ void TLazyBitblaster::MinisatNotify::notify(prop::SatClause& clause) {
       lemmab << d_cnf->getNode(clause[i]);
     }
     Node lemma = lemmab;
-    d_bv->d_inferManager.lemma(lemma);
+    d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, lemma);
   } else {
-    d_bv->d_inferManager.lemma(d_cnf->getNode(clause[0]));
+    d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, d_cnf->getNode(clause[0]));
   }
 }
 

--- a/src/theory/bv/bitblast/lazy_bitblaster.cpp
+++ b/src/theory/bv/bitblast/lazy_bitblaster.cpp
@@ -416,9 +416,9 @@ void TLazyBitblaster::MinisatNotify::notify(prop::SatClause& clause) {
       lemmab << d_cnf->getNode(clause[i]);
     }
     Node lemma = lemmab;
-    d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, lemma);
+    d_bv->d_inferManager.lemma(lemma, InferenceId::UNKNOWN);
   } else {
-    d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, d_cnf->getNode(clause[0]));
+    d_bv->d_inferManager.lemma(d_cnf->getNode(clause[0]), InferenceId::UNKNOWN);
   }
 }
 

--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -97,7 +97,7 @@ void BVSolverBitblast::postCheck(Theory::Effort level)
     }
 
     NodeManager* nm = NodeManager::currentNM();
-    d_inferManager.conflict(nm->mkAnd(conflict));
+    d_inferManager.conflict(InferenceId::UNKNOWN, nm->mkAnd(conflict));
   }
 }
 

--- a/src/theory/bv/bv_solver_bitblast.cpp
+++ b/src/theory/bv/bv_solver_bitblast.cpp
@@ -97,7 +97,7 @@ void BVSolverBitblast::postCheck(Theory::Effort level)
     }
 
     NodeManager* nm = NodeManager::currentNM();
-    d_inferManager.conflict(InferenceId::UNKNOWN, nm->mkAnd(conflict));
+    d_inferManager.conflict(nm->mkAnd(conflict), InferenceId::UNKNOWN);
   }
 }
 

--- a/src/theory/bv/bv_solver_lazy.cpp
+++ b/src/theory/bv/bv_solver_lazy.cpp
@@ -196,7 +196,7 @@ void BVSolverLazy::sendConflict()
   {
     Debug("bitvector") << indent() << "BVSolverLazy::check(): conflict "
                        << d_conflictNode << std::endl;
-    d_inferManager.conflict(InferenceId::UNKNOWN, d_conflictNode);
+    d_inferManager.conflict(d_conflictNode, InferenceId::UNKNOWN);
     d_statistics.d_avgConflictSize.addEntry(d_conflictNode.getNumChildren());
     d_conflictNode = Node::null();
   }
@@ -287,11 +287,11 @@ void BVSolverLazy::check(Theory::Effort e)
     {
       if (assertions.size() == 1)
       {
-        d_inferManager.conflict(InferenceId::UNKNOWN, assertions[0]);
+        d_inferManager.conflict(assertions[0], InferenceId::UNKNOWN);
         return;
       }
       Node conflict = utils::mkAnd(assertions);
-      d_inferManager.conflict(InferenceId::UNKNOWN, conflict);
+      d_inferManager.conflict(conflict, InferenceId::UNKNOWN);
       return;
     }
     return;

--- a/src/theory/bv/bv_solver_lazy.cpp
+++ b/src/theory/bv/bv_solver_lazy.cpp
@@ -196,7 +196,7 @@ void BVSolverLazy::sendConflict()
   {
     Debug("bitvector") << indent() << "BVSolverLazy::check(): conflict "
                        << d_conflictNode << std::endl;
-    d_inferManager.conflict(d_conflictNode);
+    d_inferManager.conflict(InferenceId::UNKNOWN, d_conflictNode);
     d_statistics.d_avgConflictSize.addEntry(d_conflictNode.getNumChildren());
     d_conflictNode = Node::null();
   }
@@ -287,11 +287,11 @@ void BVSolverLazy::check(Theory::Effort e)
     {
       if (assertions.size() == 1)
       {
-        d_inferManager.conflict(assertions[0]);
+        d_inferManager.conflict(InferenceId::UNKNOWN, assertions[0]);
         return;
       }
       Node conflict = utils::mkAnd(assertions);
-      d_inferManager.conflict(conflict);
+      d_inferManager.conflict(InferenceId::UNKNOWN, conflict);
       return;
     }
     return;

--- a/src/theory/bv/bv_solver_lazy.h
+++ b/src/theory/bv/bv_solver_lazy.h
@@ -203,7 +203,7 @@ class BVSolverLazy : public BVSolver
 
   void lemma(TNode node)
   {
-    d_inferManager.lemma(InferenceId::UNKNOWN, node);
+    d_inferManager.lemma(node, InferenceId::UNKNOWN);
     d_lemmasAdded = true;
   }
 

--- a/src/theory/bv/bv_solver_lazy.h
+++ b/src/theory/bv/bv_solver_lazy.h
@@ -203,7 +203,7 @@ class BVSolverLazy : public BVSolver
 
   void lemma(TNode node)
   {
-    d_inferManager.lemma(node);
+    d_inferManager.lemma(InferenceId::UNKNOWN, node);
     d_lemmasAdded = true;
   }
 

--- a/src/theory/bv/bv_solver_simple.cpp
+++ b/src/theory/bv/bv_solver_simple.cpp
@@ -93,12 +93,12 @@ void BVSolverSimple::addBBLemma(TNode fact)
 
   if (d_epg == nullptr)
   {
-    d_inferManager.lemma(lemma);
+    d_inferManager.lemma(InferenceId::UNKNOWN, lemma);
   }
   else
   {
     TrustNode tlem = d_epg->mkTrustNode(lemma, PfRule::BV_BITBLAST, {}, {fact});
-    d_inferManager.trustedLemma(tlem);
+    d_inferManager.trustedLemma(InferenceId::UNKNOWN, tlem);
   }
 }
 
@@ -123,13 +123,13 @@ bool BVSolverSimple::preNotifyFact(
 
     if (d_epg == nullptr)
     {
-      d_inferManager.lemma(lemma);
+      d_inferManager.lemma(InferenceId::UNKNOWN, lemma);
     }
     else
     {
       TrustNode tlem =
           d_epg->mkTrustNode(lemma, PfRule::BV_EAGER_ATOM, {}, {fact});
-      d_inferManager.trustedLemma(tlem);
+      d_inferManager.trustedLemma(InferenceId::UNKNOWN, tlem);
     }
 
     std::unordered_set<Node, NodeHashFunction> bv_atoms;

--- a/src/theory/bv/bv_solver_simple.cpp
+++ b/src/theory/bv/bv_solver_simple.cpp
@@ -93,12 +93,12 @@ void BVSolverSimple::addBBLemma(TNode fact)
 
   if (d_epg == nullptr)
   {
-    d_inferManager.lemma(InferenceId::UNKNOWN, lemma);
+    d_inferManager.lemma(lemma, InferenceId::UNKNOWN);
   }
   else
   {
     TrustNode tlem = d_epg->mkTrustNode(lemma, PfRule::BV_BITBLAST, {}, {fact});
-    d_inferManager.trustedLemma(InferenceId::UNKNOWN, tlem);
+    d_inferManager.trustedLemma(tlem, InferenceId::UNKNOWN);
   }
 }
 
@@ -123,13 +123,13 @@ bool BVSolverSimple::preNotifyFact(
 
     if (d_epg == nullptr)
     {
-      d_inferManager.lemma(InferenceId::UNKNOWN, lemma);
+      d_inferManager.lemma(lemma, InferenceId::UNKNOWN);
     }
     else
     {
       TrustNode tlem =
           d_epg->mkTrustNode(lemma, PfRule::BV_EAGER_ATOM, {}, {fact});
-      d_inferManager.trustedLemma(InferenceId::UNKNOWN, tlem);
+      d_inferManager.trustedLemma(tlem, InferenceId::UNKNOWN);
     }
 
     std::unordered_set<Node, NodeHashFunction> bv_atoms;

--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -560,7 +560,7 @@ bool CoreSolver::doExtfInferences(std::vector<Node>& terms)
                               nm->mkNode(kind::LT, n, max));
         Trace("bv-extf-lemma")
             << "BV extf lemma (range) : " << lem << std::endl;
-        d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, lem);
+        d_bv->d_inferManager.lemma(lem, InferenceId::UNKNOWN);
         sentLemma = true;
       }
     }
@@ -609,7 +609,7 @@ bool CoreSolver::doExtfInferences(std::vector<Node>& terms)
           //   (bv2nat ((_ int2bv w) x)) == x + k*2^w for some k
           Trace("bv-extf-lemma")
               << "BV extf lemma (collapse) : " << lem << std::endl;
-          d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, lem);
+          d_bv->d_inferManager.lemma(lem, InferenceId::UNKNOWN);
           sentLemma = true;
         }
       }

--- a/src/theory/bv/bv_subtheory_core.cpp
+++ b/src/theory/bv/bv_subtheory_core.cpp
@@ -560,7 +560,7 @@ bool CoreSolver::doExtfInferences(std::vector<Node>& terms)
                               nm->mkNode(kind::LT, n, max));
         Trace("bv-extf-lemma")
             << "BV extf lemma (range) : " << lem << std::endl;
-        d_bv->d_inferManager.lemma(lem);
+        d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, lem);
         sentLemma = true;
       }
     }
@@ -609,7 +609,7 @@ bool CoreSolver::doExtfInferences(std::vector<Node>& terms)
           //   (bv2nat ((_ int2bv w) x)) == x + k*2^w for some k
           Trace("bv-extf-lemma")
               << "BV extf lemma (collapse) : " << lem << std::endl;
-          d_bv->d_inferManager.lemma(lem);
+          d_bv->d_inferManager.lemma(InferenceId::UNKNOWN, lem);
           sentLemma = true;
         }
       }

--- a/src/theory/datatypes/inference_manager.cpp
+++ b/src/theory/datatypes/inference_manager.cpp
@@ -87,7 +87,7 @@ void InferenceManager::sendDtLemma(Node lem,
     return;
   }
   // otherwise send as a normal lemma
-  if (lemma(id, lem, p, doCache))
+  if (lemma(lem, id, p, doCache))
   {
     d_inferenceLemmas << id;
   }
@@ -109,7 +109,7 @@ bool InferenceManager::sendLemmas(const std::vector<Node>& lemmas)
   bool ret = false;
   for (const Node& lem : lemmas)
   {
-    if (lemma(InferenceId::UNKNOWN, lem))
+    if (lemma(lem, InferenceId::UNKNOWN))
     {
       ret = true;
     }
@@ -154,7 +154,7 @@ bool InferenceManager::processDtLemma(
   }
   // use trusted lemma
   TrustNode tlem = TrustNode::mkTrustLemma(lem, d_lemPg.get());
-  if (!trustedLemma(id, tlem))
+  if (!trustedLemma(tlem, id))
   {
     Trace("dt-lemma-debug") << "...duplicate lemma" << std::endl;
     return false;
@@ -176,12 +176,12 @@ bool InferenceManager::processDtFact(Node conc, Node exp, InferenceId id)
     {
       expv.push_back(exp);
     }
-    assertInternalFact(id, atom, polarity, expv, d_ipc.get());
+    assertInternalFact(atom, polarity, id, expv, d_ipc.get());
   }
   else
   {
     // use version without proofs
-    assertInternalFact(id, atom, polarity, exp);
+    assertInternalFact(atom, polarity, id, exp);
   }
   d_inferenceFacts << id;
   return true;

--- a/src/theory/datatypes/inference_manager.cpp
+++ b/src/theory/datatypes/inference_manager.cpp
@@ -87,7 +87,7 @@ void InferenceManager::sendDtLemma(Node lem,
     return;
   }
   // otherwise send as a normal lemma
-  if (lemma(lem, p, doCache))
+  if (lemma(id, lem, p, doCache))
   {
     d_inferenceLemmas << id;
   }
@@ -100,7 +100,7 @@ void InferenceManager::sendDtConflict(const std::vector<Node>& conf, InferenceId
     Node exp = NodeManager::currentNM()->mkAnd(conf);
     prepareDtInference(d_false, exp, id, d_ipc.get());
   }
-  conflictExp(conf, d_ipc.get());
+  conflictExp(id, conf, d_ipc.get());
   d_inferenceConflicts << id;
 }
 
@@ -109,7 +109,7 @@ bool InferenceManager::sendLemmas(const std::vector<Node>& lemmas)
   bool ret = false;
   for (const Node& lem : lemmas)
   {
-    if (lemma(lem))
+    if (lemma(InferenceId::UNKNOWN, lem))
     {
       ret = true;
     }
@@ -154,7 +154,7 @@ bool InferenceManager::processDtLemma(
   }
   // use trusted lemma
   TrustNode tlem = TrustNode::mkTrustLemma(lem, d_lemPg.get());
-  if (!trustedLemma(tlem))
+  if (!trustedLemma(id, tlem))
   {
     Trace("dt-lemma-debug") << "...duplicate lemma" << std::endl;
     return false;
@@ -176,12 +176,12 @@ bool InferenceManager::processDtFact(Node conc, Node exp, InferenceId id)
     {
       expv.push_back(exp);
     }
-    assertInternalFact(atom, polarity, expv, d_ipc.get());
+    assertInternalFact(id, atom, polarity, expv, d_ipc.get());
   }
   else
   {
     // use version without proofs
-    assertInternalFact(atom, polarity, exp);
+    assertInternalFact(id, atom, polarity, exp);
   }
   d_inferenceFacts << id;
   return true;

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -252,7 +252,7 @@ void TheoryDatatypes::postCheck(Effort level)
                     assumptions.push_back(assumption);
                     Node lemma = assumptions.size()==1 ? assumptions[0] : NodeManager::currentNM()->mkNode( OR, assumptions );
                     Trace("dt-singleton") << "*************Singleton equality lemma " << lemma << std::endl;
-                    d_im.lemma(lemma);
+                    d_im.lemma(InferenceId::UNKNOWN, lemma);
                   }
                 }
               }else{
@@ -318,7 +318,7 @@ void TheoryDatatypes::postCheck(Effort level)
                     NodeBuilder<> nb(kind::OR);
                     nb << test << test.notNode();
                     Node lemma = nb;
-                    d_im.lemma(lemma);
+                    d_im.lemma(InferenceId::UNKNOWN, lemma);
                     d_out->requirePhase( test, true );
                   }else{
                     Trace("dt-split") << "*************Split for constructors on " << n <<  endl;
@@ -1415,7 +1415,7 @@ Node TheoryDatatypes::getSingletonLemma( TypeNode tn, bool pol ) {
       Node v2 = NodeManager::currentNM()->mkSkolem( "k2", tn );
       a = v1.eqNode( v2 ).negate();
       //send out immediately as lemma
-      d_im.lemma(a);
+      d_im.lemma(InferenceId::UNKNOWN, a);
       Trace("dt-singleton") << "******** assert " << a << " to avoid singleton cardinality for type " << tn << std::endl;
     }
     d_singleton_lemma[index][tn] = a;

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -252,7 +252,7 @@ void TheoryDatatypes::postCheck(Effort level)
                     assumptions.push_back(assumption);
                     Node lemma = assumptions.size()==1 ? assumptions[0] : NodeManager::currentNM()->mkNode( OR, assumptions );
                     Trace("dt-singleton") << "*************Singleton equality lemma " << lemma << std::endl;
-                    d_im.lemma(InferenceId::UNKNOWN, lemma);
+                    d_im.lemma(lemma, InferenceId::UNKNOWN);
                   }
                 }
               }else{
@@ -318,7 +318,7 @@ void TheoryDatatypes::postCheck(Effort level)
                     NodeBuilder<> nb(kind::OR);
                     nb << test << test.notNode();
                     Node lemma = nb;
-                    d_im.lemma(InferenceId::UNKNOWN, lemma);
+                    d_im.lemma(lemma, InferenceId::UNKNOWN);
                     d_out->requirePhase( test, true );
                   }else{
                     Trace("dt-split") << "*************Split for constructors on " << n <<  endl;
@@ -1415,7 +1415,7 @@ Node TheoryDatatypes::getSingletonLemma( TypeNode tn, bool pol ) {
       Node v2 = NodeManager::currentNM()->mkSkolem( "k2", tn );
       a = v1.eqNode( v2 ).negate();
       //send out immediately as lemma
-      d_im.lemma(InferenceId::UNKNOWN, a);
+      d_im.lemma(a, InferenceId::UNKNOWN);
       Trace("dt-singleton") << "******** assert " << a << " to avoid singleton cardinality for type " << tn << std::endl;
     }
     d_singleton_lemma[index][tn] = a;

--- a/src/theory/sep/theory_sep.cpp
+++ b/src/theory/sep/theory_sep.cpp
@@ -1787,7 +1787,7 @@ void TheorySep::sendLemma( std::vector< Node >& ant, Node conc, const char * c, 
       if( conc==d_false ){
         Trace("sep-lemma") << "Sep::Conflict: " << ant << " by " << c
                            << std::endl;
-        d_im.conflictExp(ant, nullptr);
+        d_im.conflictExp(InferenceId::UNKNOWN, ant, nullptr);
       }else{
         Trace("sep-lemma") << "Sep::Lemma: " << conc << " from " << ant
                            << " by " << c << std::endl;

--- a/src/theory/sets/inference_manager.cpp
+++ b/src/theory/sets/inference_manager.cpp
@@ -57,7 +57,7 @@ bool InferenceManager::assertFactRec(Node fact, Node exp, int inferType)
     if (fact == d_false)
     {
       Trace("sets-lemma") << "Conflict : " << exp << std::endl;
-      conflict(InferenceId::UNKNOWN, exp);
+      conflict(exp, InferenceId::UNKNOWN);
       return true;
     }
     return false;
@@ -90,7 +90,7 @@ bool InferenceManager::assertFactRec(Node fact, Node exp, int inferType)
       || (atom.getKind() == EQUAL && atom[0].getType().isSet()))
   {
     // send to equality engine
-    if (assertInternalFact(InferenceId::UNKNOWN, atom, polarity, exp))
+    if (assertInternalFact(atom, polarity, InferenceId::UNKNOWN, exp))
     {
       // return true if this wasn't redundant
       return true;
@@ -164,7 +164,7 @@ void InferenceManager::split(Node n, int reqPol)
   n = Rewriter::rewrite(n);
   Node lem = NodeManager::currentNM()->mkNode(OR, n, n.negate());
   // send the lemma
-  lemma(InferenceId::UNKNOWN, lem);
+  lemma(lem, InferenceId::UNKNOWN);
   Trace("sets-lemma") << "Sets::Lemma split : " << lem << std::endl;
   if (reqPol != 0)
   {

--- a/src/theory/sets/inference_manager.cpp
+++ b/src/theory/sets/inference_manager.cpp
@@ -57,7 +57,7 @@ bool InferenceManager::assertFactRec(Node fact, Node exp, int inferType)
     if (fact == d_false)
     {
       Trace("sets-lemma") << "Conflict : " << exp << std::endl;
-      conflict(exp);
+      conflict(InferenceId::UNKNOWN, exp);
       return true;
     }
     return false;
@@ -90,7 +90,7 @@ bool InferenceManager::assertFactRec(Node fact, Node exp, int inferType)
       || (atom.getKind() == EQUAL && atom[0].getType().isSet()))
   {
     // send to equality engine
-    if (assertInternalFact(atom, polarity, exp))
+    if (assertInternalFact(InferenceId::UNKNOWN, atom, polarity, exp))
     {
       // return true if this wasn't redundant
       return true;
@@ -164,7 +164,7 @@ void InferenceManager::split(Node n, int reqPol)
   n = Rewriter::rewrite(n);
   Node lem = NodeManager::currentNM()->mkNode(OR, n, n.negate());
   // send the lemma
-  lemma(lem);
+  lemma(InferenceId::UNKNOWN, lem);
   Trace("sets-lemma") << "Sets::Lemma split : " << lem << std::endl;
   if (reqPol != 0)
   {

--- a/src/theory/sets/term_registry.cpp
+++ b/src/theory/sets/term_registry.cpp
@@ -53,13 +53,13 @@ Node TermRegistry::getProxy(Node n)
   d_proxy_to_term[k] = n;
   Node eq = k.eqNode(n);
   Trace("sets-lemma") << "Sets::Lemma : " << eq << " by proxy" << std::endl;
-  d_im.lemma(eq, LemmaProperty::NONE, false);
+  d_im.lemma(InferenceId::UNKNOWN, eq, LemmaProperty::NONE, false);
   if (nk == SINGLETON)
   {
     Node slem = nm->mkNode(MEMBER, n[0], k);
     Trace("sets-lemma") << "Sets::Lemma : " << slem << " by singleton"
                         << std::endl;
-    d_im.lemma(slem, LemmaProperty::NONE, false);
+    d_im.lemma(InferenceId::UNKNOWN, slem, LemmaProperty::NONE, false);
   }
   return k;
 }
@@ -104,7 +104,7 @@ Node TermRegistry::getUnivSet(TypeNode tn)
       Node ulem = nm->mkNode(SUBSET, n1, n2);
       Trace("sets-lemma") << "Sets::Lemma : " << ulem << " by univ-type"
                           << std::endl;
-      d_im.lemma(ulem, LemmaProperty::NONE, false);
+      d_im.lemma(InferenceId::UNKNOWN, ulem, LemmaProperty::NONE, false);
     }
   }
   d_univset[tn] = n;

--- a/src/theory/sets/term_registry.cpp
+++ b/src/theory/sets/term_registry.cpp
@@ -53,13 +53,13 @@ Node TermRegistry::getProxy(Node n)
   d_proxy_to_term[k] = n;
   Node eq = k.eqNode(n);
   Trace("sets-lemma") << "Sets::Lemma : " << eq << " by proxy" << std::endl;
-  d_im.lemma(InferenceId::UNKNOWN, eq, LemmaProperty::NONE, false);
+  d_im.lemma(eq, InferenceId::UNKNOWN, LemmaProperty::NONE, false);
   if (nk == SINGLETON)
   {
     Node slem = nm->mkNode(MEMBER, n[0], k);
     Trace("sets-lemma") << "Sets::Lemma : " << slem << " by singleton"
                         << std::endl;
-    d_im.lemma(InferenceId::UNKNOWN, slem, LemmaProperty::NONE, false);
+    d_im.lemma(slem, InferenceId::UNKNOWN, LemmaProperty::NONE, false);
   }
   return k;
 }
@@ -104,7 +104,7 @@ Node TermRegistry::getUnivSet(TypeNode tn)
       Node ulem = nm->mkNode(SUBSET, n1, n2);
       Trace("sets-lemma") << "Sets::Lemma : " << ulem << " by univ-type"
                           << std::endl;
-      d_im.lemma(InferenceId::UNKNOWN, ulem, LemmaProperty::NONE, false);
+      d_im.lemma(ulem, InferenceId::UNKNOWN, LemmaProperty::NONE, false);
     }
   }
   d_univset[tn] = n;

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -104,7 +104,7 @@ void TheorySetsPrivate::eqNotifyMerge(TNode t1, TNode t2)
             // infer equality between elements of singleton
             Node exp = s1.eqNode(s2);
             Node eq = s1[0].eqNode(s2[0]);
-            d_im.assertInternalFact(InferenceId::UNKNOWN, eq, true, exp);
+            d_im.assertInternalFact(eq, true, InferenceId::UNKNOWN, exp);
           }
           else
           {
@@ -137,7 +137,7 @@ void TheorySetsPrivate::eqNotifyMerge(TNode t1, TNode t2)
       Assert(facts.size() == 1);
       Trace("sets-prop") << "Propagate eq-mem conflict : " << facts[0]
                          << std::endl;
-      d_im.conflict(InferenceId::UNKNOWN, facts[0]);
+      d_im.conflict(facts[0], InferenceId::UNKNOWN);
       return;
     }
     for (const Node& f : facts)
@@ -145,7 +145,7 @@ void TheorySetsPrivate::eqNotifyMerge(TNode t1, TNode t2)
       Assert(f.getKind() == kind::IMPLIES);
       Trace("sets-prop") << "Propagate eq-mem eq inference : " << f[0] << " => "
                          << f[1] << std::endl;
-      d_im.assertInternalFact(InferenceId::UNKNOWN, f[1], true, f[0]);
+      d_im.assertInternalFact(f[1], true, InferenceId::UNKNOWN, f[0]);
     }
   }
 }
@@ -764,7 +764,7 @@ void TheorySetsPrivate::checkReduceComprehensions()
         nm->mkNode(FORALL, nm->mkNode(BOUND_VAR_LIST, v), body.eqNode(mem));
     Trace("sets-comprehension")
         << "Comprehension reduction: " << lem << std::endl;
-    d_im.lemma(InferenceId::UNKNOWN, lem);
+    d_im.lemma(lem, InferenceId::UNKNOWN);
   }
 }
 
@@ -818,14 +818,14 @@ void TheorySetsPrivate::notifyFact(TNode atom, bool polarity, TNode fact)
             Trace("sets-prop") << "Propagate mem-eq : " << pexp << std::endl;
             Node eq = s[0].eqNode(atom[0]);
             // triggers an internal inference
-            d_im.assertInternalFact(InferenceId::UNKNOWN, eq, true, pexp);
+            d_im.assertInternalFact(eq, true, InferenceId::UNKNOWN, pexp);
           }
         }
         else
         {
           Trace("sets-prop")
               << "Propagate mem-eq conflict : " << pexp << std::endl;
-          d_im.conflict(InferenceId::UNKNOWN, pexp);
+          d_im.conflict(pexp, InferenceId::UNKNOWN);
         }
       }
     }

--- a/src/theory/sets/theory_sets_private.cpp
+++ b/src/theory/sets/theory_sets_private.cpp
@@ -104,7 +104,7 @@ void TheorySetsPrivate::eqNotifyMerge(TNode t1, TNode t2)
             // infer equality between elements of singleton
             Node exp = s1.eqNode(s2);
             Node eq = s1[0].eqNode(s2[0]);
-            d_im.assertInternalFact(eq, true, exp);
+            d_im.assertInternalFact(InferenceId::UNKNOWN, eq, true, exp);
           }
           else
           {
@@ -137,7 +137,7 @@ void TheorySetsPrivate::eqNotifyMerge(TNode t1, TNode t2)
       Assert(facts.size() == 1);
       Trace("sets-prop") << "Propagate eq-mem conflict : " << facts[0]
                          << std::endl;
-      d_im.conflict(facts[0]);
+      d_im.conflict(InferenceId::UNKNOWN, facts[0]);
       return;
     }
     for (const Node& f : facts)
@@ -145,7 +145,7 @@ void TheorySetsPrivate::eqNotifyMerge(TNode t1, TNode t2)
       Assert(f.getKind() == kind::IMPLIES);
       Trace("sets-prop") << "Propagate eq-mem eq inference : " << f[0] << " => "
                          << f[1] << std::endl;
-      d_im.assertInternalFact(f[1], true, f[0]);
+      d_im.assertInternalFact(InferenceId::UNKNOWN, f[1], true, f[0]);
     }
   }
 }
@@ -764,7 +764,7 @@ void TheorySetsPrivate::checkReduceComprehensions()
         nm->mkNode(FORALL, nm->mkNode(BOUND_VAR_LIST, v), body.eqNode(mem));
     Trace("sets-comprehension")
         << "Comprehension reduction: " << lem << std::endl;
-    d_im.lemma(lem);
+    d_im.lemma(InferenceId::UNKNOWN, lem);
   }
 }
 
@@ -818,14 +818,14 @@ void TheorySetsPrivate::notifyFact(TNode atom, bool polarity, TNode fact)
             Trace("sets-prop") << "Propagate mem-eq : " << pexp << std::endl;
             Node eq = s[0].eqNode(atom[0]);
             // triggers an internal inference
-            d_im.assertInternalFact(eq, true, pexp);
+            d_im.assertInternalFact(InferenceId::UNKNOWN, eq, true, pexp);
           }
         }
         else
         {
           Trace("sets-prop")
               << "Propagate mem-eq conflict : " << pexp << std::endl;
-          d_im.conflict(pexp);
+          d_im.conflict(InferenceId::UNKNOWN, pexp);
         }
       }
     }

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -299,7 +299,7 @@ void InferenceManager::processConflict(const InferInfo& ii)
   Trace("strings-assert") << "(assert (not " << tconf.getNode()
                           << ")) ; conflict " << ii.getId() << std::endl;
   // send the trusted conflict
-  trustedConflict(ii.getId(), tconf);
+  trustedConflict(tconf, ii.getId());
 }
 
 bool InferenceManager::processFact(InferInfo& ii)
@@ -342,13 +342,13 @@ bool InferenceManager::processFact(InferInfo& ii)
       // current SAT context
       d_ipc->notifyFact(ii);
       // now, assert the internal fact with d_ipc as proof generator
-      curRet = assertInternalFact(ii.getId(), atom, polarity, exp, d_ipc.get());
+      curRet = assertInternalFact(atom, polarity, ii.getId(), exp, d_ipc.get());
     }
     else
     {
       Node cexp = utils::mkAnd(exp);
       // without proof generator
-      curRet = assertInternalFact(ii.getId(), atom, polarity, cexp);
+      curRet = assertInternalFact(atom, polarity, ii.getId(), cexp);
     }
     ret = ret || curRet;
     // may be in conflict
@@ -420,7 +420,7 @@ bool InferenceManager::processLemma(InferInfo& ii)
   ++(d_statistics.d_lemmasInfer);
 
   // call the trusted lemma, without caching
-  return trustedLemma(ii.getId(), tlem, p, false);
+  return trustedLemma(tlem, ii.getId(), p, false);
 }
 
 }  // namespace strings

--- a/src/theory/strings/inference_manager.cpp
+++ b/src/theory/strings/inference_manager.cpp
@@ -299,7 +299,7 @@ void InferenceManager::processConflict(const InferInfo& ii)
   Trace("strings-assert") << "(assert (not " << tconf.getNode()
                           << ")) ; conflict " << ii.getId() << std::endl;
   // send the trusted conflict
-  trustedConflict(tconf);
+  trustedConflict(ii.getId(), tconf);
 }
 
 bool InferenceManager::processFact(InferInfo& ii)
@@ -342,13 +342,13 @@ bool InferenceManager::processFact(InferInfo& ii)
       // current SAT context
       d_ipc->notifyFact(ii);
       // now, assert the internal fact with d_ipc as proof generator
-      curRet = assertInternalFact(atom, polarity, exp, d_ipc.get());
+      curRet = assertInternalFact(ii.getId(), atom, polarity, exp, d_ipc.get());
     }
     else
     {
       Node cexp = utils::mkAnd(exp);
       // without proof generator
-      curRet = assertInternalFact(atom, polarity, cexp);
+      curRet = assertInternalFact(ii.getId(), atom, polarity, cexp);
     }
     ret = ret || curRet;
     // may be in conflict
@@ -420,7 +420,7 @@ bool InferenceManager::processLemma(InferInfo& ii)
   ++(d_statistics.d_lemmasInfer);
 
   // call the trusted lemma, without caching
-  return trustedLemma(tlem, p, false);
+  return trustedLemma(ii.getId(), tlem, p, false);
 }
 
 }  // namespace strings

--- a/src/theory/theory_inference.cpp
+++ b/src/theory/theory_inference.cpp
@@ -34,7 +34,7 @@ bool SimpleTheoryLemma::process(TheoryInferenceManager* im, bool asLemma)
   Assert(!d_node.isNull());
   Assert(asLemma);
   // send (trusted) lemma on the output channel with property p
-  return im->trustedLemma(getId(), TrustNode::mkTrustLemma(d_node, d_pg), d_property);
+  return im->trustedLemma(TrustNode::mkTrustLemma(d_node, d_pg), getId(), d_property);
 }
 
 SimpleTheoryInternalFact::SimpleTheoryInternalFact(InferenceId id,
@@ -54,11 +54,11 @@ bool SimpleTheoryInternalFact::process(TheoryInferenceManager* im, bool asLemma)
   Assert(atom.getKind() != NOT && atom.getKind() != AND);
   if (d_pg != nullptr)
   {
-    im->assertInternalFact(getId(), atom, polarity, {d_exp}, d_pg);
+    im->assertInternalFact(atom, polarity, getId(), {d_exp}, d_pg);
   }
   else
   {
-    im->assertInternalFact(getId(), atom, polarity, d_exp);
+    im->assertInternalFact(atom, polarity, getId(), d_exp);
   }
   return true;
 }

--- a/src/theory/theory_inference.cpp
+++ b/src/theory/theory_inference.cpp
@@ -34,7 +34,7 @@ bool SimpleTheoryLemma::process(TheoryInferenceManager* im, bool asLemma)
   Assert(!d_node.isNull());
   Assert(asLemma);
   // send (trusted) lemma on the output channel with property p
-  return im->trustedLemma(TrustNode::mkTrustLemma(d_node, d_pg), d_property);
+  return im->trustedLemma(getId(), TrustNode::mkTrustLemma(d_node, d_pg), d_property);
 }
 
 SimpleTheoryInternalFact::SimpleTheoryInternalFact(InferenceId id,
@@ -54,11 +54,11 @@ bool SimpleTheoryInternalFact::process(TheoryInferenceManager* im, bool asLemma)
   Assert(atom.getKind() != NOT && atom.getKind() != AND);
   if (d_pg != nullptr)
   {
-    im->assertInternalFact(atom, polarity, {d_exp}, d_pg);
+    im->assertInternalFact(getId(), atom, polarity, {d_exp}, d_pg);
   }
   else
   {
-    im->assertInternalFact(atom, polarity, d_exp);
+    im->assertInternalFact(getId(), atom, polarity, d_exp);
   }
   return true;
 }

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -85,7 +85,7 @@ void TheoryInferenceManager::conflictEqConstantMerge(TNode a, TNode b)
   }
 }
 
-void TheoryInferenceManager::conflict(InferenceId id, TNode conf)
+void TheoryInferenceManager::conflict(TNode conf, InferenceId id)
 {
   if (!d_theoryState.isInConflict())
   {
@@ -95,7 +95,7 @@ void TheoryInferenceManager::conflict(InferenceId id, TNode conf)
   }
 }
 
-void TheoryInferenceManager::trustedConflict(InferenceId id, TrustNode tconf)
+void TheoryInferenceManager::trustedConflict(TrustNode tconf, InferenceId id)
 {
   if (!d_theoryState.isInConflict())
   {
@@ -113,7 +113,7 @@ void TheoryInferenceManager::conflictExp(InferenceId id, PfRule pfr,
     // make the trust node
     TrustNode tconf = mkConflictExp(pfr, exp, args);
     // send it on the output channel
-    trustedConflict(id, tconf);
+    trustedConflict(tconf, id);
   }
 }
 
@@ -139,7 +139,7 @@ void TheoryInferenceManager::conflictExp(InferenceId id, const std::vector<Node>
     // make the trust node
     TrustNode tconf = mkConflictExp(exp, pg);
     // send it on the output channel
-    trustedConflict(id, tconf);
+    trustedConflict(tconf, id);
   }
 }
 
@@ -207,13 +207,14 @@ TrustNode TheoryInferenceManager::explainConflictEqConstantMerge(TNode a,
                   << " mkTrustedConflictEqConstantMerge";
 }
 
-bool TheoryInferenceManager::lemma(InferenceId id, TNode lem, LemmaProperty p, bool doCache)
+bool TheoryInferenceManager::lemma(TNode lem, InferenceId id, LemmaProperty p, bool doCache)
 {
   TrustNode tlem = TrustNode::mkTrustLemma(lem, nullptr);
-  return trustedLemma(id, tlem, p, doCache);
+  return trustedLemma(tlem, id, p, doCache);
 }
 
-bool TheoryInferenceManager::trustedLemma(InferenceId id, const TrustNode& tlem,
+bool TheoryInferenceManager::trustedLemma(const TrustNode& tlem,
+                                          InferenceId id,
                                           LemmaProperty p,
                                           bool doCache)
 {
@@ -229,7 +230,8 @@ bool TheoryInferenceManager::trustedLemma(InferenceId id, const TrustNode& tlem,
   return true;
 }
 
-bool TheoryInferenceManager::lemmaExp(InferenceId id, Node conc,
+bool TheoryInferenceManager::lemmaExp(Node conc,
+                                      InferenceId id,
                                       PfRule pfr,
                                       const std::vector<Node>& exp,
                                       const std::vector<Node>& noExplain,
@@ -240,7 +242,7 @@ bool TheoryInferenceManager::lemmaExp(InferenceId id, Node conc,
   // make the trust node
   TrustNode trn = mkLemmaExp(conc, pfr, exp, noExplain, args);
   // send it on the output channel
-  return trustedLemma(id, trn, p, doCache);
+  return trustedLemma(trn, id, p, doCache);
 }
 
 TrustNode TheoryInferenceManager::mkLemmaExp(Node conc,
@@ -260,7 +262,8 @@ TrustNode TheoryInferenceManager::mkLemmaExp(Node conc,
   return TrustNode::mkTrustLemma(lem, nullptr);
 }
 
-bool TheoryInferenceManager::lemmaExp(InferenceId id, Node conc,
+bool TheoryInferenceManager::lemmaExp(Node conc,
+                                      InferenceId id,
                                       const std::vector<Node>& exp,
                                       const std::vector<Node>& noExplain,
                                       ProofGenerator* pg,
@@ -270,7 +273,7 @@ bool TheoryInferenceManager::lemmaExp(InferenceId id, Node conc,
   // make the trust node
   TrustNode trn = mkLemmaExp(conc, exp, noExplain, pg);
   // send it on the output channel
-  return trustedLemma(id, trn, p, doCache);
+  return trustedLemma(trn, id, p, doCache);
 }
 
 TrustNode TheoryInferenceManager::mkLemmaExp(Node conc,
@@ -305,13 +308,14 @@ bool TheoryInferenceManager::hasSentLemma() const
   return d_numCurrentLemmas != 0;
 }
 
-bool TheoryInferenceManager::assertInternalFact(InferenceId id, TNode atom, bool pol, TNode exp)
+bool TheoryInferenceManager::assertInternalFact(TNode atom, bool pol, InferenceId id, TNode exp)
 {
   return processInternalFact(atom, pol, PfRule::UNKNOWN, {exp}, {}, nullptr);
 }
 
-bool TheoryInferenceManager::assertInternalFact(InferenceId id, TNode atom,
+bool TheoryInferenceManager::assertInternalFact(TNode atom,
                                                 bool pol,
+                                                InferenceId id,
                                                 PfRule pfr,
                                                 const std::vector<Node>& exp,
                                                 const std::vector<Node>& args)
@@ -320,8 +324,9 @@ bool TheoryInferenceManager::assertInternalFact(InferenceId id, TNode atom,
   return processInternalFact(atom, pol, pfr, exp, args, nullptr);
 }
 
-bool TheoryInferenceManager::assertInternalFact(InferenceId id, TNode atom,
+bool TheoryInferenceManager::assertInternalFact(TNode atom,
                                                 bool pol,
+                                                InferenceId id,
                                                 const std::vector<Node>& exp,
                                                 ProofGenerator* pg)
 {

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -104,7 +104,8 @@ void TheoryInferenceManager::trustedConflict(TrustNode tconf, InferenceId id)
   }
 }
 
-void TheoryInferenceManager::conflictExp(InferenceId id, PfRule pfr,
+void TheoryInferenceManager::conflictExp(InferenceId id,
+                                         PfRule pfr,
                                          const std::vector<Node>& exp,
                                          const std::vector<Node>& args)
 {
@@ -131,7 +132,8 @@ TrustNode TheoryInferenceManager::mkConflictExp(PfRule id,
   return TrustNode::mkTrustConflict(conf, nullptr);
 }
 
-void TheoryInferenceManager::conflictExp(InferenceId id, const std::vector<Node>& exp,
+void TheoryInferenceManager::conflictExp(InferenceId id,
+                                         const std::vector<Node>& exp,
                                          ProofGenerator* pg)
 {
   if (!d_theoryState.isInConflict())
@@ -207,7 +209,10 @@ TrustNode TheoryInferenceManager::explainConflictEqConstantMerge(TNode a,
                   << " mkTrustedConflictEqConstantMerge";
 }
 
-bool TheoryInferenceManager::lemma(TNode lem, InferenceId id, LemmaProperty p, bool doCache)
+bool TheoryInferenceManager::lemma(TNode lem,
+                                   InferenceId id,
+                                   LemmaProperty p,
+                                   bool doCache)
 {
   TrustNode tlem = TrustNode::mkTrustLemma(lem, nullptr);
   return trustedLemma(tlem, id, p, doCache);
@@ -308,7 +313,10 @@ bool TheoryInferenceManager::hasSentLemma() const
   return d_numCurrentLemmas != 0;
 }
 
-bool TheoryInferenceManager::assertInternalFact(TNode atom, bool pol, InferenceId id, TNode exp)
+bool TheoryInferenceManager::assertInternalFact(TNode atom,
+                                                bool pol,
+                                                InferenceId id,
+                                                TNode exp)
 {
   return processInternalFact(atom, pol, PfRule::UNKNOWN, {exp}, {}, nullptr);
 }

--- a/src/theory/theory_inference_manager.cpp
+++ b/src/theory/theory_inference_manager.cpp
@@ -85,7 +85,7 @@ void TheoryInferenceManager::conflictEqConstantMerge(TNode a, TNode b)
   }
 }
 
-void TheoryInferenceManager::conflict(TNode conf)
+void TheoryInferenceManager::conflict(InferenceId id, TNode conf)
 {
   if (!d_theoryState.isInConflict())
   {
@@ -95,7 +95,7 @@ void TheoryInferenceManager::conflict(TNode conf)
   }
 }
 
-void TheoryInferenceManager::trustedConflict(TrustNode tconf)
+void TheoryInferenceManager::trustedConflict(InferenceId id, TrustNode tconf)
 {
   if (!d_theoryState.isInConflict())
   {
@@ -104,16 +104,16 @@ void TheoryInferenceManager::trustedConflict(TrustNode tconf)
   }
 }
 
-void TheoryInferenceManager::conflictExp(PfRule id,
+void TheoryInferenceManager::conflictExp(InferenceId id, PfRule pfr,
                                          const std::vector<Node>& exp,
                                          const std::vector<Node>& args)
 {
   if (!d_theoryState.isInConflict())
   {
     // make the trust node
-    TrustNode tconf = mkConflictExp(id, exp, args);
+    TrustNode tconf = mkConflictExp(pfr, exp, args);
     // send it on the output channel
-    trustedConflict(tconf);
+    trustedConflict(id, tconf);
   }
 }
 
@@ -131,7 +131,7 @@ TrustNode TheoryInferenceManager::mkConflictExp(PfRule id,
   return TrustNode::mkTrustConflict(conf, nullptr);
 }
 
-void TheoryInferenceManager::conflictExp(const std::vector<Node>& exp,
+void TheoryInferenceManager::conflictExp(InferenceId id, const std::vector<Node>& exp,
                                          ProofGenerator* pg)
 {
   if (!d_theoryState.isInConflict())
@@ -139,7 +139,7 @@ void TheoryInferenceManager::conflictExp(const std::vector<Node>& exp,
     // make the trust node
     TrustNode tconf = mkConflictExp(exp, pg);
     // send it on the output channel
-    trustedConflict(tconf);
+    trustedConflict(id, tconf);
   }
 }
 
@@ -207,13 +207,13 @@ TrustNode TheoryInferenceManager::explainConflictEqConstantMerge(TNode a,
                   << " mkTrustedConflictEqConstantMerge";
 }
 
-bool TheoryInferenceManager::lemma(TNode lem, LemmaProperty p, bool doCache)
+bool TheoryInferenceManager::lemma(InferenceId id, TNode lem, LemmaProperty p, bool doCache)
 {
   TrustNode tlem = TrustNode::mkTrustLemma(lem, nullptr);
-  return trustedLemma(tlem, p, doCache);
+  return trustedLemma(id, tlem, p, doCache);
 }
 
-bool TheoryInferenceManager::trustedLemma(const TrustNode& tlem,
+bool TheoryInferenceManager::trustedLemma(InferenceId id, const TrustNode& tlem,
                                           LemmaProperty p,
                                           bool doCache)
 {
@@ -229,8 +229,8 @@ bool TheoryInferenceManager::trustedLemma(const TrustNode& tlem,
   return true;
 }
 
-bool TheoryInferenceManager::lemmaExp(Node conc,
-                                      PfRule id,
+bool TheoryInferenceManager::lemmaExp(InferenceId id, Node conc,
+                                      PfRule pfr,
                                       const std::vector<Node>& exp,
                                       const std::vector<Node>& noExplain,
                                       const std::vector<Node>& args,
@@ -238,9 +238,9 @@ bool TheoryInferenceManager::lemmaExp(Node conc,
                                       bool doCache)
 {
   // make the trust node
-  TrustNode trn = mkLemmaExp(conc, id, exp, noExplain, args);
+  TrustNode trn = mkLemmaExp(conc, pfr, exp, noExplain, args);
   // send it on the output channel
-  return trustedLemma(trn, p, doCache);
+  return trustedLemma(id, trn, p, doCache);
 }
 
 TrustNode TheoryInferenceManager::mkLemmaExp(Node conc,
@@ -260,7 +260,7 @@ TrustNode TheoryInferenceManager::mkLemmaExp(Node conc,
   return TrustNode::mkTrustLemma(lem, nullptr);
 }
 
-bool TheoryInferenceManager::lemmaExp(Node conc,
+bool TheoryInferenceManager::lemmaExp(InferenceId id, Node conc,
                                       const std::vector<Node>& exp,
                                       const std::vector<Node>& noExplain,
                                       ProofGenerator* pg,
@@ -270,7 +270,7 @@ bool TheoryInferenceManager::lemmaExp(Node conc,
   // make the trust node
   TrustNode trn = mkLemmaExp(conc, exp, noExplain, pg);
   // send it on the output channel
-  return trustedLemma(trn, p, doCache);
+  return trustedLemma(id, trn, p, doCache);
 }
 
 TrustNode TheoryInferenceManager::mkLemmaExp(Node conc,
@@ -305,22 +305,22 @@ bool TheoryInferenceManager::hasSentLemma() const
   return d_numCurrentLemmas != 0;
 }
 
-bool TheoryInferenceManager::assertInternalFact(TNode atom, bool pol, TNode exp)
+bool TheoryInferenceManager::assertInternalFact(InferenceId id, TNode atom, bool pol, TNode exp)
 {
   return processInternalFact(atom, pol, PfRule::UNKNOWN, {exp}, {}, nullptr);
 }
 
-bool TheoryInferenceManager::assertInternalFact(TNode atom,
+bool TheoryInferenceManager::assertInternalFact(InferenceId id, TNode atom,
                                                 bool pol,
-                                                PfRule id,
+                                                PfRule pfr,
                                                 const std::vector<Node>& exp,
                                                 const std::vector<Node>& args)
 {
-  Assert(id != PfRule::UNKNOWN);
-  return processInternalFact(atom, pol, id, exp, args, nullptr);
+  Assert(pfr != PfRule::UNKNOWN);
+  return processInternalFact(atom, pol, pfr, exp, args, nullptr);
 }
 
-bool TheoryInferenceManager::assertInternalFact(TNode atom,
+bool TheoryInferenceManager::assertInternalFact(InferenceId id, TNode atom,
                                                 bool pol,
                                                 const std::vector<Node>& exp,
                                                 ProofGenerator* pg)

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -132,12 +132,12 @@ class TheoryInferenceManager
    * Raise conflict conf (of any form), without proofs. This method should
    * only be called if there is not yet proof support in the given theory.
    */
-  void conflict(InferenceId id, TNode conf);
+  void conflict(TNode conf, InferenceId id);
   /**
    * Raise trusted conflict tconf (of any form) where a proof generator has
    * been provided (as part of the trust node) in a custom way.
    */
-  void trustedConflict(InferenceId id, TrustNode tconf);
+  void trustedConflict(TrustNode tconf, InferenceId id);
   /**
    * Explain and send conflict from contradictory facts. This method is called
    * when the proof rule id with premises exp and arguments args concludes
@@ -181,14 +181,14 @@ class TheoryInferenceManager
    * cached (see cacheLemma), and add it to the cache during this call.
    * @return true if the lemma was sent on the output channel.
    */
-  bool trustedLemma(InferenceId id, const TrustNode& tlem,
+  bool trustedLemma(const TrustNode& tlem, InferenceId id,
                     LemmaProperty p = LemmaProperty::NONE,
                     bool doCache = true);
   /**
    * Send lemma lem with property p on the output channel. Same as above, with
    * a node instead of a trust node.
    */
-  bool lemma(InferenceId id, TNode lem,
+  bool lemma(TNode lem, InferenceId id,
              LemmaProperty p = LemmaProperty::NONE,
              bool doCache = true);
   /**
@@ -214,7 +214,8 @@ class TheoryInferenceManager
    * @param doCache Whether to check and add the lemma to the cache
    * @return true if the lemma was sent on the output channel.
    */
-  bool lemmaExp(InferenceId id, Node conc,
+  bool lemmaExp(Node conc,
+                InferenceId id,
                 PfRule pfr,
                 const std::vector<Node>& exp,
                 const std::vector<Node>& noExplain,
@@ -245,7 +246,8 @@ class TheoryInferenceManager
    * @param doCache Whether to check and add the lemma to the cache
    * @return true if the lemma was sent on the output channel.
    */
-  bool lemmaExp(InferenceId id, Node conc,
+  bool lemmaExp(Node conc,
+                InferenceId id,
                 const std::vector<Node>& exp,
                 const std::vector<Node>& noExplain,
                 ProofGenerator* pg = nullptr,
@@ -286,7 +288,7 @@ class TheoryInferenceManager
    * @return true if the fact was processed, i.e. it was asserted to the
    * equality engine or preNotifyFact returned true.
    */
-  bool assertInternalFact(InferenceId id, TNode atom, bool pol, TNode exp);
+  bool assertInternalFact(TNode atom, bool pol, InferenceId id, TNode exp);
   /**
    * Assert internal fact, with a proof step justification. Notice that if
    * proofs are not enabled in this inference manager, then this asserts
@@ -300,8 +302,9 @@ class TheoryInferenceManager
    * @return true if the fact was processed, i.e. it was asserted to the
    * equality engine or preNotifyFact returned true.
    */
-  bool assertInternalFact(InferenceId id, TNode atom,
+  bool assertInternalFact(TNode atom,
                           bool pol,
+                          InferenceId id,
                           PfRule pfr,
                           const std::vector<Node>& exp,
                           const std::vector<Node>& args);
@@ -318,8 +321,9 @@ class TheoryInferenceManager
    * @return true if the fact was processed, i.e. it was asserted to the
    * equality engine or preNotifyFact returned true.
    */
-  bool assertInternalFact(InferenceId id, TNode atom,
+  bool assertInternalFact(TNode atom,
                           bool pol,
+                          InferenceId id,
                           const std::vector<Node>& exp,
                           ProofGenerator* pg);
   /** The number of internal facts we have added since the last call to reset */

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -145,7 +145,8 @@ class TheoryInferenceManager
    * equality engine's explanation of literals in exp, with the proof equality
    * engine as the proof generator (if it exists).
    */
-  void conflictExp(InferenceId id, PfRule pfr,
+  void conflictExp(InferenceId id,
+                   PfRule pfr,
                    const std::vector<Node>& exp,
                    const std::vector<Node>& args);
   /**
@@ -164,7 +165,9 @@ class TheoryInferenceManager
    * engine as the proof generator (if it exists), where pg provides the
    * final step(s) of this proof during this call.
    */
-  void conflictExp(InferenceId id, const std::vector<Node>& exp, ProofGenerator* pg);
+  void conflictExp(InferenceId id,
+                   const std::vector<Node>& exp,
+                   ProofGenerator* pg);
   /**
    * Make the trust node corresponding to the conflict of the above form. It is
    * the responsibility of the caller to subsequently call trustedConflict with
@@ -181,14 +184,16 @@ class TheoryInferenceManager
    * cached (see cacheLemma), and add it to the cache during this call.
    * @return true if the lemma was sent on the output channel.
    */
-  bool trustedLemma(const TrustNode& tlem, InferenceId id,
+  bool trustedLemma(const TrustNode& tlem,
+                    InferenceId id,
                     LemmaProperty p = LemmaProperty::NONE,
                     bool doCache = true);
   /**
    * Send lemma lem with property p on the output channel. Same as above, with
    * a node instead of a trust node.
    */
-  bool lemma(TNode lem, InferenceId id,
+  bool lemma(TNode lem,
+             InferenceId id,
              LemmaProperty p = LemmaProperty::NONE,
              bool doCache = true);
   /**
@@ -331,7 +336,7 @@ class TheoryInferenceManager
   /** Have we added a internal fact since the last call to reset? */
   bool hasSentFact() const;
   //--------------------------------------- phase requirements
-  /** 
+  /**
    * Set that literal n has SAT phase requirement pol, that is, it should be
    * decided with polarity pol, for details see OutputChannel::requirePhase.
    */

--- a/src/theory/theory_inference_manager.h
+++ b/src/theory/theory_inference_manager.h
@@ -132,12 +132,12 @@ class TheoryInferenceManager
    * Raise conflict conf (of any form), without proofs. This method should
    * only be called if there is not yet proof support in the given theory.
    */
-  void conflict(TNode conf);
+  void conflict(InferenceId id, TNode conf);
   /**
    * Raise trusted conflict tconf (of any form) where a proof generator has
    * been provided (as part of the trust node) in a custom way.
    */
-  void trustedConflict(TrustNode tconf);
+  void trustedConflict(InferenceId id, TrustNode tconf);
   /**
    * Explain and send conflict from contradictory facts. This method is called
    * when the proof rule id with premises exp and arguments args concludes
@@ -145,7 +145,7 @@ class TheoryInferenceManager
    * equality engine's explanation of literals in exp, with the proof equality
    * engine as the proof generator (if it exists).
    */
-  void conflictExp(PfRule id,
+  void conflictExp(InferenceId id, PfRule pfr,
                    const std::vector<Node>& exp,
                    const std::vector<Node>& args);
   /**
@@ -153,7 +153,7 @@ class TheoryInferenceManager
    * the responsibility of the caller to subsequently call trustedConflict with
    * the returned trust node.
    */
-  TrustNode mkConflictExp(PfRule id,
+  TrustNode mkConflictExp(PfRule pfr,
                           const std::vector<Node>& exp,
                           const std::vector<Node>& args);
   /**
@@ -164,7 +164,7 @@ class TheoryInferenceManager
    * engine as the proof generator (if it exists), where pg provides the
    * final step(s) of this proof during this call.
    */
-  void conflictExp(const std::vector<Node>& exp, ProofGenerator* pg);
+  void conflictExp(InferenceId id, const std::vector<Node>& exp, ProofGenerator* pg);
   /**
    * Make the trust node corresponding to the conflict of the above form. It is
    * the responsibility of the caller to subsequently call trustedConflict with
@@ -181,14 +181,14 @@ class TheoryInferenceManager
    * cached (see cacheLemma), and add it to the cache during this call.
    * @return true if the lemma was sent on the output channel.
    */
-  bool trustedLemma(const TrustNode& tlem,
+  bool trustedLemma(InferenceId id, const TrustNode& tlem,
                     LemmaProperty p = LemmaProperty::NONE,
                     bool doCache = true);
   /**
    * Send lemma lem with property p on the output channel. Same as above, with
    * a node instead of a trust node.
    */
-  bool lemma(TNode lem,
+  bool lemma(InferenceId id, TNode lem,
              LemmaProperty p = LemmaProperty::NONE,
              bool doCache = true);
   /**
@@ -214,8 +214,8 @@ class TheoryInferenceManager
    * @param doCache Whether to check and add the lemma to the cache
    * @return true if the lemma was sent on the output channel.
    */
-  bool lemmaExp(Node conc,
-                PfRule id,
+  bool lemmaExp(InferenceId id, Node conc,
+                PfRule pfr,
                 const std::vector<Node>& exp,
                 const std::vector<Node>& noExplain,
                 const std::vector<Node>& args,
@@ -245,7 +245,7 @@ class TheoryInferenceManager
    * @param doCache Whether to check and add the lemma to the cache
    * @return true if the lemma was sent on the output channel.
    */
-  bool lemmaExp(Node conc,
+  bool lemmaExp(InferenceId id, Node conc,
                 const std::vector<Node>& exp,
                 const std::vector<Node>& noExplain,
                 ProofGenerator* pg = nullptr,
@@ -286,7 +286,7 @@ class TheoryInferenceManager
    * @return true if the fact was processed, i.e. it was asserted to the
    * equality engine or preNotifyFact returned true.
    */
-  bool assertInternalFact(TNode atom, bool pol, TNode exp);
+  bool assertInternalFact(InferenceId id, TNode atom, bool pol, TNode exp);
   /**
    * Assert internal fact, with a proof step justification. Notice that if
    * proofs are not enabled in this inference manager, then this asserts
@@ -300,9 +300,9 @@ class TheoryInferenceManager
    * @return true if the fact was processed, i.e. it was asserted to the
    * equality engine or preNotifyFact returned true.
    */
-  bool assertInternalFact(TNode atom,
+  bool assertInternalFact(InferenceId id, TNode atom,
                           bool pol,
-                          PfRule id,
+                          PfRule pfr,
                           const std::vector<Node>& exp,
                           const std::vector<Node>& args);
   /**
@@ -318,7 +318,7 @@ class TheoryInferenceManager
    * @return true if the fact was processed, i.e. it was asserted to the
    * equality engine or preNotifyFact returned true.
    */
-  bool assertInternalFact(TNode atom,
+  bool assertInternalFact(InferenceId id, TNode atom,
                           bool pol,
                           const std::vector<Node>& exp,
                           ProofGenerator* pg);

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1037,7 +1037,7 @@ int SortModel::addSplit(Region* r)
     //split on the equality s
     Node lem = NodeManager::currentNM()->mkNode( kind::OR, ss, ss.negate() );
     // send lemma, with caching
-    if (d_im.lemma(lem))
+    if (d_im.lemma(InferenceId::UNKNOWN, lem))
     {
       Trace("uf-ss-lemma") << "*** Split on " << s << std::endl;
       //tell the sat solver to explore the equals branch first
@@ -1070,7 +1070,7 @@ void SortModel::addCliqueLemma(std::vector<Node>& clique)
   eqs.push_back(d_cardinality_literal[d_cardinality].notNode());
   Node lem = NodeManager::currentNM()->mkNode(OR, eqs);
   // send lemma, with caching
-  if (d_im.lemma(lem))
+  if (d_im.lemma(InferenceId::UNKNOWN, lem))
   {
     Trace("uf-ss-lemma") << "*** Add clique lemma " << lem << std::endl;
     ++(d_thss->d_statistics.d_clique_lemmas);
@@ -1082,7 +1082,7 @@ void SortModel::simpleCheckCardinality() {
     Node lem = NodeManager::currentNM()->mkNode( AND, getCardinalityLiteral( d_cardinality.get() ),
                                                       getCardinalityLiteral( d_maxNegCard.get() ).negate() );
     Trace("uf-ss-lemma") << "*** Simple cardinality conflict : " << lem << std::endl;
-    d_im.conflict(lem);
+    d_im.conflict(InferenceId::UNKNOWN, lem);
   }
 }
 
@@ -1179,7 +1179,7 @@ bool SortModel::checkLastCall()
         Node lem = NodeManager::currentNM()->mkNode(
             OR, cl, NodeManager::currentNM()->mkAnd(force_cl));
         Trace("uf-ss-lemma") << "*** Enforce negative cardinality constraint lemma : " << lem << std::endl;
-        d_im.lemma(lem, LemmaProperty::NONE, false);
+        d_im.lemma(InferenceId::UNKNOWN, lem, LemmaProperty::NONE, false);
         return false;
       }
     }
@@ -1399,7 +1399,7 @@ void CardinalityExtension::assertNode(Node n, bool isDecision)
           Node eqv_lit = NodeManager::currentNM()->mkNode( CARDINALITY_CONSTRAINT, ct, lit[1] );
           eqv_lit = lit.eqNode( eqv_lit );
           Trace("uf-ss-lemma") << "*** Cardinality equiv lemma : " << eqv_lit << std::endl;
-          d_im.lemma(eqv_lit, LemmaProperty::NONE, false);
+          d_im.lemma(InferenceId::UNKNOWN, eqv_lit, LemmaProperty::NONE, false);
           d_card_assertions_eqv_lemma[lit] = true;
         }
       }
@@ -1528,7 +1528,7 @@ void CardinalityExtension::check(Theory::Effort level)
                     Node eq = Rewriter::rewrite( a.eqNode( b ) );
                     Node lem = NodeManager::currentNM()->mkNode( kind::OR, eq, eq.negate() );
                     Trace("uf-ss-lemma") << "*** Split (no-minimal) : " << lem << std::endl;
-                    d_im.lemma(lem, LemmaProperty::NONE, false);
+                    d_im.lemma(InferenceId::UNKNOWN, lem, LemmaProperty::NONE, false);
                     d_im.requirePhase(eq, true);
                     type_proc[tn] = true;
                     break;
@@ -1707,7 +1707,7 @@ void CardinalityExtension::checkCombinedCardinality()
                              << " : " << cf << std::endl;
         Trace("uf-ss-com-card") << "*** Combined monotone cardinality conflict"
                                 << " : " << cf << std::endl;
-        d_im.conflict(cf);
+        d_im.conflict(InferenceId::UNKNOWN, cf);
         return;
       }
     }
@@ -1745,7 +1745,7 @@ void CardinalityExtension::checkCombinedCardinality()
                            << std::endl;
       Trace("uf-ss-com-card") << "*** Combined cardinality conflict : " << cf
                               << std::endl;
-      d_im.conflict(cf);
+      d_im.conflict(InferenceId::UNKNOWN, cf);
     }
   }
 }

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -1037,7 +1037,7 @@ int SortModel::addSplit(Region* r)
     //split on the equality s
     Node lem = NodeManager::currentNM()->mkNode( kind::OR, ss, ss.negate() );
     // send lemma, with caching
-    if (d_im.lemma(InferenceId::UNKNOWN, lem))
+    if (d_im.lemma(lem, InferenceId::UNKNOWN))
     {
       Trace("uf-ss-lemma") << "*** Split on " << s << std::endl;
       //tell the sat solver to explore the equals branch first
@@ -1070,7 +1070,7 @@ void SortModel::addCliqueLemma(std::vector<Node>& clique)
   eqs.push_back(d_cardinality_literal[d_cardinality].notNode());
   Node lem = NodeManager::currentNM()->mkNode(OR, eqs);
   // send lemma, with caching
-  if (d_im.lemma(InferenceId::UNKNOWN, lem))
+  if (d_im.lemma(lem, InferenceId::UNKNOWN))
   {
     Trace("uf-ss-lemma") << "*** Add clique lemma " << lem << std::endl;
     ++(d_thss->d_statistics.d_clique_lemmas);
@@ -1082,7 +1082,7 @@ void SortModel::simpleCheckCardinality() {
     Node lem = NodeManager::currentNM()->mkNode( AND, getCardinalityLiteral( d_cardinality.get() ),
                                                       getCardinalityLiteral( d_maxNegCard.get() ).negate() );
     Trace("uf-ss-lemma") << "*** Simple cardinality conflict : " << lem << std::endl;
-    d_im.conflict(InferenceId::UNKNOWN, lem);
+    d_im.conflict(lem, InferenceId::UNKNOWN);
   }
 }
 
@@ -1179,7 +1179,7 @@ bool SortModel::checkLastCall()
         Node lem = NodeManager::currentNM()->mkNode(
             OR, cl, NodeManager::currentNM()->mkAnd(force_cl));
         Trace("uf-ss-lemma") << "*** Enforce negative cardinality constraint lemma : " << lem << std::endl;
-        d_im.lemma(InferenceId::UNKNOWN, lem, LemmaProperty::NONE, false);
+        d_im.lemma(lem, InferenceId::UNKNOWN, LemmaProperty::NONE, false);
         return false;
       }
     }
@@ -1399,7 +1399,7 @@ void CardinalityExtension::assertNode(Node n, bool isDecision)
           Node eqv_lit = NodeManager::currentNM()->mkNode( CARDINALITY_CONSTRAINT, ct, lit[1] );
           eqv_lit = lit.eqNode( eqv_lit );
           Trace("uf-ss-lemma") << "*** Cardinality equiv lemma : " << eqv_lit << std::endl;
-          d_im.lemma(InferenceId::UNKNOWN, eqv_lit, LemmaProperty::NONE, false);
+          d_im.lemma(eqv_lit, InferenceId::UNKNOWN, LemmaProperty::NONE, false);
           d_card_assertions_eqv_lemma[lit] = true;
         }
       }
@@ -1528,7 +1528,7 @@ void CardinalityExtension::check(Theory::Effort level)
                     Node eq = Rewriter::rewrite( a.eqNode( b ) );
                     Node lem = NodeManager::currentNM()->mkNode( kind::OR, eq, eq.negate() );
                     Trace("uf-ss-lemma") << "*** Split (no-minimal) : " << lem << std::endl;
-                    d_im.lemma(InferenceId::UNKNOWN, lem, LemmaProperty::NONE, false);
+                    d_im.lemma(lem, InferenceId::UNKNOWN, LemmaProperty::NONE, false);
                     d_im.requirePhase(eq, true);
                     type_proc[tn] = true;
                     break;
@@ -1707,7 +1707,7 @@ void CardinalityExtension::checkCombinedCardinality()
                              << " : " << cf << std::endl;
         Trace("uf-ss-com-card") << "*** Combined monotone cardinality conflict"
                                 << " : " << cf << std::endl;
-        d_im.conflict(InferenceId::UNKNOWN, cf);
+        d_im.conflict(cf, InferenceId::UNKNOWN);
         return;
       }
     }
@@ -1745,7 +1745,7 @@ void CardinalityExtension::checkCombinedCardinality()
                            << std::endl;
       Trace("uf-ss-com-card") << "*** Combined cardinality conflict : " << cf
                               << std::endl;
-      d_im.conflict(InferenceId::UNKNOWN, cf);
+      d_im.conflict(cf, InferenceId::UNKNOWN);
     }
   }
 }

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -107,7 +107,7 @@ unsigned HoExtension::applyExtensionality(TNode deq)
     Node lem = NodeManager::currentNM()->mkNode(OR, deq[0], conc);
     Trace("uf-ho-lemma") << "uf-ho-lemma : extensionality : " << lem
                          << std::endl;
-    d_im.lemma(InferenceId::UNKNOWN, lem);
+    d_im.lemma(lem, InferenceId::UNKNOWN);
     return 1;
   }
   return 0;
@@ -167,7 +167,7 @@ Node HoExtension::getApplyUfForHoApply(Node node)
       Trace("uf-ho-lemma")
           << "uf-ho-lemma : Skolem definition for apply-conversion : " << lem
           << std::endl;
-      d_im.lemma(InferenceId::UNKNOWN, lem);
+      d_im.lemma(lem, InferenceId::UNKNOWN);
       d_uf_std_skolem[f] = new_f;
     }
     else
@@ -256,7 +256,7 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
               Node lem = nm->mkNode(OR, deq.negate(), eq);
               Trace("uf-ho") << "HoExtension: cmi extensionality lemma " << lem
                              << std::endl;
-              d_im.lemma(InferenceId::UNKNOWN, lem);
+              d_im.lemma(lem, InferenceId::UNKNOWN);
               return 1;
             }
           }
@@ -284,7 +284,7 @@ unsigned HoExtension::applyAppCompletion(TNode n)
     Node eq = n.eqNode(ret);
     Trace("uf-ho-lemma") << "uf-ho-lemma : infer, by apply-expand : " << eq
                          << std::endl;
-    d_im.assertInternalFact(InferenceId::UNKNOWN, eq, true, PfRule::HO_APP_ENCODE, {}, {n});
+    d_im.assertInternalFact(eq, true, InferenceId::UNKNOWN, PfRule::HO_APP_ENCODE, {}, {n});
     return 1;
   }
   Trace("uf-ho-debug") << "    ...already have " << ret << " == " << n << "."
@@ -441,7 +441,7 @@ bool HoExtension::collectModelInfoHoTerm(Node n, TheoryModel* m)
       Node eq = n.eqNode(hn);
       Trace("uf-ho") << "HoExtension: cmi app completion lemma " << eq
                      << std::endl;
-      d_im.lemma(InferenceId::UNKNOWN, eq);
+      d_im.lemma(eq, InferenceId::UNKNOWN);
       return false;
     }
   }

--- a/src/theory/uf/ho_extension.cpp
+++ b/src/theory/uf/ho_extension.cpp
@@ -107,7 +107,7 @@ unsigned HoExtension::applyExtensionality(TNode deq)
     Node lem = NodeManager::currentNM()->mkNode(OR, deq[0], conc);
     Trace("uf-ho-lemma") << "uf-ho-lemma : extensionality : " << lem
                          << std::endl;
-    d_im.lemma(lem);
+    d_im.lemma(InferenceId::UNKNOWN, lem);
     return 1;
   }
   return 0;
@@ -167,7 +167,7 @@ Node HoExtension::getApplyUfForHoApply(Node node)
       Trace("uf-ho-lemma")
           << "uf-ho-lemma : Skolem definition for apply-conversion : " << lem
           << std::endl;
-      d_im.lemma(lem);
+      d_im.lemma(InferenceId::UNKNOWN, lem);
       d_uf_std_skolem[f] = new_f;
     }
     else
@@ -256,7 +256,7 @@ unsigned HoExtension::checkExtensionality(TheoryModel* m)
               Node lem = nm->mkNode(OR, deq.negate(), eq);
               Trace("uf-ho") << "HoExtension: cmi extensionality lemma " << lem
                              << std::endl;
-              d_im.lemma(lem);
+              d_im.lemma(InferenceId::UNKNOWN, lem);
               return 1;
             }
           }
@@ -284,7 +284,7 @@ unsigned HoExtension::applyAppCompletion(TNode n)
     Node eq = n.eqNode(ret);
     Trace("uf-ho-lemma") << "uf-ho-lemma : infer, by apply-expand : " << eq
                          << std::endl;
-    d_im.assertInternalFact(eq, true, PfRule::HO_APP_ENCODE, {}, {n});
+    d_im.assertInternalFact(InferenceId::UNKNOWN, eq, true, PfRule::HO_APP_ENCODE, {}, {n});
     return 1;
   }
   Trace("uf-ho-debug") << "    ...already have " << ret << " == " << n << "."
@@ -441,7 +441,7 @@ bool HoExtension::collectModelInfoHoTerm(Node n, TheoryModel* m)
       Node eq = n.eqNode(hn);
       Trace("uf-ho") << "HoExtension: cmi app completion lemma " << eq
                      << std::endl;
-      d_im.lemma(eq);
+      d_im.lemma(InferenceId::UNKNOWN, eq);
       return false;
     }
   }

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -315,7 +315,7 @@ void TheoryUF::presolve() {
         ++i) {
       Debug("uf") << "uf: generating a lemma: " << *i << std::endl;
       // no proof generator provided
-      d_im.lemma(InferenceId::UNKNOWN, *i);
+      d_im.lemma(*i, InferenceId::UNKNOWN);
     }
   }
   if( d_thss ){

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -315,7 +315,7 @@ void TheoryUF::presolve() {
         ++i) {
       Debug("uf") << "uf: generating a lemma: " << *i << std::endl;
       // no proof generator provided
-      d_im.lemma(*i);
+      d_im.lemma(InferenceId::UNKNOWN, *i);
     }
   }
   if( d_thss ){


### PR DESCRIPTION
This PR makes most methods of the TheoryInferenceManager expect an InferenceId.
All classes that inherit from TheoryInferenceManager are adapted accordingly and InferenceIds are passed everywhere.
In some cases, there are no appropriate InferenceIds yet. We use InferenceId::UNKNOWN for the time being and introduce proper values in future PRs.
The InferenceIds are not yet used, but will be used for statistics and debug output.