### PR TITLE
Compute fact or lemma in datatypes prior to buffering

### DIFF
--- a/src/theory/datatypes/inference.cpp
+++ b/src/theory/datatypes/inference.cpp
@@ -65,7 +65,7 @@ bool DatatypesInference::process(TheoryInferenceManager* im, bool asLemma)
 {
   // Check to see if we have to communicate it to the rest of the system.
   // The flag asLemma is true when the inference was marked that it must be
-  // sent as a lemma in addPendingInference below.
+  // sent as a lemma.
   if (asLemma)
   {
     return d_im->processDtLemma(d_conc, d_exp, getId());

--- a/src/theory/datatypes/inference.cpp
+++ b/src/theory/datatypes/inference.cpp
@@ -66,7 +66,7 @@ bool DatatypesInference::process(TheoryInferenceManager* im, bool asLemma)
   // Check to see if we have to communicate it to the rest of the system.
   // The flag asLemma is true when the inference was marked that it must be
   // sent as a lemma in addPendingInference below.
-  if (asLemma || mustCommunicateFact(d_conc, d_exp))
+  if (asLemma)
   {
     return d_im->processDtLemma(d_conc, d_exp, getId());
   }

--- a/src/theory/datatypes/inference_manager.cpp
+++ b/src/theory/datatypes/inference_manager.cpp
@@ -58,6 +58,9 @@ void InferenceManager::addPendingInference(Node conc,
                                            bool forceLemma,
                                            InferenceId i)
 {
+  // if we are forcing the inference to be processed as a lemma, or if the
+  // inference must be sent as a lemma based on the policy in
+  // mustCommunicateFact.
   if (forceLemma || DatatypesInference::mustCommunicateFact(conc, exp))
   {
     d_pendingLem.emplace_back(new DatatypesInference(this, conc, exp, i));

--- a/src/theory/datatypes/inference_manager.cpp
+++ b/src/theory/datatypes/inference_manager.cpp
@@ -58,7 +58,7 @@ void InferenceManager::addPendingInference(Node conc,
                                            bool forceLemma,
                                            InferenceId i)
 {
-  if (forceLemma)
+  if (forceLemma || DatatypesInference::mustCommunicateFact(conc, exp))
   {
     d_pendingLem.emplace_back(new DatatypesInference(this, conc, exp, i));
   }


### PR DESCRIPTION
This is necessary for the planned refactoring of TheoryInference::process. This forces datatypes to decide lemma vs. fact prior to buffering inferences.

FYI @yoni206 