### PR TITLE
Fix datatypes inference manager when proofs are enabled

### DIFF
--- a/src/theory/datatypes/inference_manager.cpp
+++ b/src/theory/datatypes/inference_manager.cpp
@@ -74,10 +74,11 @@ void InferenceManager::sendDtLemma(Node lem, InferenceId id, LemmaProperty p)
 {
   if (isProofEnabled())
   {
-    processDtLemma(lem, Node::null(), id);
+    TrustNode trn = processDtLemma(lem, Node::null(), id);
+    trustedLemma(trn, id);
     return;
   }
-  // otherwise send as a normal lemma
+  // otherwise send as a normal lemma directly
   lemma(lem, id, p);
 }
 


### PR DESCRIPTION
Accidentally was not sending lemmas in one interface when proofs are enabled due to recent refactoring.