### PR TITLE
(proof-new) Add new arithmetic kind INDEXED_ROOT_PREDICATE.

### DIFF
--- a/src/printer/smt2/smt2_printer.cpp
+++ b/src/printer/smt2/smt2_printer.cpp
@@ -665,6 +665,12 @@ void Smt2Printer::toStream(std::ostream& out,
     out << "(_ divisible " << n.getOperator().getConst<Divisible>().k << ")";
     stillNeedToPrintParams = false;
     break;
+  case kind::INDEXED_ROOT_PREDICATE_OP:
+  {
+    const IndexedRootPredicate& irp = n.getConst<IndexedRootPredicate>();
+    out << "(_ root_predicate " << irp.d_index << ")";
+    break;
+  }
 
     // arrays theory
   case kind::SELECT:

--- a/src/theory/arith/kinds
+++ b/src/theory/arith/kinds
@@ -80,6 +80,7 @@ operator LEQ 2 "less than or equal, x <= y"
 operator GT 2 "greater than, x > y"
 operator GEQ 2 "greater than or equal, x >= y"
 
+# represents an indexed root predicate. See util/indexed_root_predicate.h for more documentation.
 constant INDEXED_ROOT_PREDICATE_OP \
 	::CVC4::IndexedRootPredicate \
 	::CVC4::IndexedRootPredicateHashFunction \

--- a/src/theory/arith/kinds
+++ b/src/theory/arith/kinds
@@ -80,9 +80,16 @@ operator LEQ 2 "less than or equal, x <= y"
 operator GT 2 "greater than, x > y"
 operator GEQ 2 "greater than or equal, x >= y"
 
-operator IS_INTEGER   1 "term-is-integer predicate (parameter is a real-sorted term)"
-operator TO_INTEGER   1 "convert term to integer by the floor function (parameter is a real-sorted term)"
-operator TO_REAL      1 "cast term to real (parameter is an integer-sorted term; this is a no-op in CVC4, as integer is a subtype of real)"
+constant INDEXED_ROOT_PREDICATE_OP \
+	::CVC4::IndexedRootPredicate \
+	::CVC4::IndexedRootPredicateHashFunction \
+	"util/arith.h" \
+	"operator for the indexed root predicate; payload is an instance of the CVC4::IndexedRootPredicate class"
+parameterized INDEXED_ROOT_PREDICATE INDEXED_ROOT_PREDICATE_OP 2 "indexed root predicate; first parameter is a INDEXED_ROOT_PREDICATE_OP, second is a real variable compared to zero, third is a polynomial"
+
+operator IS_INTEGER 1 "term-is-integer predicate (parameter is a real-sorted term)"
+operator TO_INTEGER 1 "convert term to integer by the floor function (parameter is a real-sorted term)"
+operator TO_REAL 1 "cast term to real (parameter is an integer-sorted term; this is a no-op in CVC4, as integer is a subtype of real)"
 
 # CAST_TO_REAL is added to distinguish between integers casted to reals internally, and
 # integers casted to reals or using the API \
@@ -106,10 +113,13 @@ typerule LEQ "SimpleTypeRule<RBool, AReal, AReal>"
 typerule GT "SimpleTypeRule<RBool, AReal, AReal>"
 typerule GEQ "SimpleTypeRule<RBool, AReal, AReal>"
 
-typerule TO_REAL      ::CVC4::theory::arith::ArithOperatorTypeRule
+typerule INDEXED_ROOT_PREDICATE_OP "SimpleTypeRule<RBuiltinOperator>"
+typerule INDEXED_ROOT_PREDICATE ::CVC4::theory::arith::IndexedRootPredicateTypeRule
+
+typerule TO_REAL ::CVC4::theory::arith::ArithOperatorTypeRule
 typerule CAST_TO_REAL ::CVC4::theory::arith::ArithOperatorTypeRule
-typerule TO_INTEGER   ::CVC4::theory::arith::ArithOperatorTypeRule
-typerule IS_INTEGER   "SimpleTypeRule<RBool, AReal>"
+typerule TO_INTEGER ::CVC4::theory::arith::ArithOperatorTypeRule
+typerule IS_INTEGER "SimpleTypeRule<RBool, AReal>"
 
 typerule ABS "SimpleTypeRule<RInteger, AInteger>"
 typerule INTS_DIVISION "SimpleTypeRule<RInteger, AInteger, AInteger>"

--- a/src/theory/arith/kinds
+++ b/src/theory/arith/kinds
@@ -83,7 +83,7 @@ operator GEQ 2 "greater than or equal, x >= y"
 constant INDEXED_ROOT_PREDICATE_OP \
 	::CVC4::IndexedRootPredicate \
 	::CVC4::IndexedRootPredicateHashFunction \
-	"util/arith.h" \
+	"util/indexed_root_predicate.h" \
 	"operator for the indexed root predicate; payload is an instance of the CVC4::IndexedRootPredicate class"
 parameterized INDEXED_ROOT_PREDICATE INDEXED_ROOT_PREDICATE_OP 2 "indexed root predicate; first parameter is a INDEXED_ROOT_PREDICATE_OP, second is a real variable compared to zero, third is a polynomial"
 

--- a/src/theory/arith/theory_arith_type_rules.h
+++ b/src/theory/arith/theory_arith_type_rules.h
@@ -131,6 +131,35 @@ class IAndTypeRule
   }
 }; /* class BitVectorConversionTypeRule */
 
+class IndexedRootPredicateTypeRule
+{
+ public:
+  inline static TypeNode computeType(NodeManager* nodeManager,
+                                     TNode n,
+                                     bool check)
+  {
+    IndexedRootPredicate info =
+        n.getOperator().getConst<IndexedRootPredicate>();
+
+    if (check)
+    {
+      TypeNode t1 = n[0].getType(check);
+      if (!t1.isBoolean())
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "expecting boolean term as first argument");
+      }
+      TypeNode t2 = n[1].getType(check);
+      if (!t2.isReal())
+      {
+        throw TypeCheckingExceptionPrivate(
+            n, "expecting polynomial as second argument");
+      }
+    }
+    return nodeManager->booleanType();
+  }
+}; /* class IndexedRootPredicateTypeRule */
+
 }/* CVC4::theory::arith namespace */
 }/* CVC4::theory namespace */
 }/* CVC4 namespace */

--- a/src/theory/arith/theory_arith_type_rules.h
+++ b/src/theory/arith/theory_arith_type_rules.h
@@ -138,9 +138,6 @@ class IndexedRootPredicateTypeRule
                                      TNode n,
                                      bool check)
   {
-    IndexedRootPredicate info =
-        n.getOperator().getConst<IndexedRootPredicate>();
-
     if (check)
     {
       TypeNode t1 = n[0].getType(check);

--- a/src/util/arith.h
+++ b/src/util/arith.h
@@ -1,0 +1,58 @@
+/*********************                                                        */
+/*! \file arith.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Aina Niemetz, Andres Noetzli, Dejan Jovanovic
+ ** This file is part of the CVC4 project.
+ ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory and their institutional affiliations.
+ ** All rights reserved.  See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief Utils for arithmetic kinds.
+ **
+ ** Some utils for arithmetic kinds, for example indexed root predicates.
+ **/
+
+#include "cvc4_public.h"
+
+#ifndef CVC4__UTIL__ARITH_H
+#define CVC4__UTIL__ARITH_H
+
+namespace CVC4 {
+
+/**
+ * The structure representing a root predicate.
+ */
+struct CVC4_PUBLIC IndexedRootPredicate
+{
+  /** The index of the root */
+  unsigned d_index;
+
+  IndexedRootPredicate(unsigned index) : d_index(index) {}
+
+  bool operator==(const IndexedRootPredicate& irp) const
+  {
+    return d_index == irp.d_index;
+  }
+}; /* struct IndexedRootPredicate */
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const IndexedRootPredicate& irp) CVC4_PUBLIC;
+inline std::ostream& operator<<(std::ostream& os,
+                                const IndexedRootPredicate& irp)
+{
+  return os << "k=" << irp.d_index;
+}
+
+struct CVC4_PUBLIC IndexedRootPredicateHashFunction
+{
+  std::size_t operator()(const IndexedRootPredicate& irp) const
+  {
+    return irp.d_index;
+  }
+}; /* struct IndexedRootPredicateHashFunction */
+
+}  // namespace CVC4
+
+#endif

--- a/src/util/indexed_root_predicate.h
+++ b/src/util/indexed_root_predicate.h
@@ -27,7 +27,7 @@ namespace CVC4 {
 struct CVC4_PUBLIC IndexedRootPredicate
 {
   /** The index of the root */
-  unsigned d_index;
+  std::uint64_t d_index;
 
   IndexedRootPredicate(unsigned index) : d_index(index) {}
 

--- a/src/util/indexed_root_predicate.h
+++ b/src/util/indexed_root_predicate.h
@@ -22,7 +22,23 @@
 namespace CVC4 {
 
 /**
- * The structure representing a root predicate.
+ * The structure representing the index of a root predicate.
+ * An indexed root predicate has the form
+ *   IRP_k(x ~ 0, p)
+ * where k is a positive integer (d_index), x is a real variable,
+ * ~ an arithmetic relation symbol and p a (possibly multivariate polynomial).
+ * The evaluation of the predicate is obtained by comparing the k'th root of p
+ * (as polynomial in x) to the value of x according to the relation symbol ~.
+ * Note that p may be multivariate: in this case we can only evaluate with
+ * respect to a (partial) variable assignment, that (at least) contains values
+ * for all variables from p except x.
+ *
+ * Some examples:
+ *  IRP_1(x > 0, x)  <=>  x > 0
+ *  IRP_1(x < 0, x*x-1)  <=>  x < -1
+ *  IRP_2(x < 0, x*x-1)  <=>  x < 1
+ *  IRP_1(x = 0, x*x-2)  <=>  x = -sqrt(2)
+ *  IRP_1(x = 0, x*x-y), y=3  <=>  x = -sqrt(3)
  */
 struct CVC4_PUBLIC IndexedRootPredicate
 {

--- a/src/util/indexed_root_predicate.h
+++ b/src/util/indexed_root_predicate.h
@@ -1,23 +1,23 @@
 /*********************                                                        */
-/*! \file arith.h
+/*! \file indexed_root_predicate.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Aina Niemetz, Andres Noetzli, Dejan Jovanovic
+ **   Gereon Kremer
  ** This file is part of the CVC4 project.
  ** Copyright (c) 2009-2020 by the authors listed in the file AUTHORS
  ** in the top-level source directory and their institutional affiliations.
  ** All rights reserved.  See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** \brief Utils for arithmetic kinds.
+ ** \brief Utils for indexed root predicates.
  **
- ** Some utils for arithmetic kinds, for example indexed root predicates.
+ ** Some utils for indexed root predicates.
  **/
 
 #include "cvc4_public.h"
 
-#ifndef CVC4__UTIL__ARITH_H
-#define CVC4__UTIL__ARITH_H
+#ifndef CVC4__UTIL__INDEXED_ROOT_PREDICATE_H
+#define CVC4__UTIL__INDEXED_ROOT_PREDICATE_H
 
 namespace CVC4 {
 


### PR DESCRIPTION
This PR introduces a new arithmetic kind for indexed root predicates.
An indexed root predicate compares a real variable to the k'th root of a given polynomial as follows:
Let `IRP_k(x ~ 0, p)` an indexed root predicate with `k` a non-negative number, `x` some real variable, `~` an arithmetic relation (e.g. `=`, `<`, ...), and `p` a polynomial over `x` (and possibly other variables).
If `p` contains variables apart from `x`, we can only evaluate the expression over a suitable assignment for at least these variables.
The evaluation of this expression is equivalent to computing the k'th real root of `p` in `x` (with all other variables evaluated over a given assignment) and comparing this real root to zero (according to the relation symbol `~`).

Note that we currently do not intend to use this structure for solving, but require it for representing and printing CAD proofs.