### PR TITLE
[proof-new] Fix dangling pointer in SAT proof generation

### DIFF
--- a/src/prop/sat_proof_manager.cpp
+++ b/src/prop/sat_proof_manager.cpp
@@ -352,9 +352,9 @@ void SatProofManager::explainLit(
     printClause(reason);
     Trace("sat-proof") << "\n";
   }
+#ifdef CVC4_ASSERTIONS
   // pedantically check that the negation of the literal to explain *does not*
   // occur in the reason, otherwise we will loop forever
-#ifdef CVC4_ASSERTIONS
   for (unsigned i = 0; i < size; ++i)
   {
     AlwaysAssert(~MinisatSatSolver::toSatLiteral(reason[i]) != lit)
@@ -373,8 +373,8 @@ void SatProofManager::explainLit(
   Trace("sat-proof") << push;
   for (unsigned i = 0; i < size; ++i)
   {
-    // pedantically make sure that the reason stays the same
 #ifdef CVC4_ASSERTIONS
+    // pedantically make sure that the reason stays the same
     const Minisat::Clause& reloadedReason = d_solver->ca[reasonRef];
     AlwaysAssert(size == static_cast<unsigned>(reloadedReason.size()));
     AlwaysAssert(children[0] == getClauseNode(reloadedReason));

--- a/src/prop/sat_proof_manager.cpp
+++ b/src/prop/sat_proof_manager.cpp
@@ -331,9 +331,9 @@ void SatProofManager::processRedundantLit(
 void SatProofManager::explainLit(
     SatLiteral lit, std::unordered_set<TNode, TNodeHashFunction>& premises)
 {
+  Trace("sat-proof") << push << "SatProofManager::explainLit: Lit: " << lit;
   Node litNode = getClauseNode(lit);
-  Trace("sat-proof") << push << "SatProofManager::explainLit: Lit: " << lit
-                     << " [" << litNode << "]\n";
+  Trace("sat-proof") << " [" << litNode << "]\n";
   Minisat::Solver::TCRef reasonRef =
       d_solver->reason(Minisat::var(MinisatSatSolver::toMinisatLit(lit)));
   if (reasonRef == Minisat::Solver::TCRef_Undef)
@@ -367,7 +367,12 @@ void SatProofManager::explainLit(
   Trace("sat-proof") << push;
   for (unsigned i = 0; i < size; ++i)
   {
-    SatLiteral curr_lit = MinisatSatSolver::toSatLiteral(reason[i]);
+    // Since explainLit calls can reallocate memory in the
+    // SAT solver's, we need to reload the reason ptr each time.
+    const Minisat::Clause& reloadedReason = d_solver->ca[reasonRef];
+    Assert(size == static_cast<unsigned>(reloadedReason.size()));
+    Assert(children[0] == getClauseNode(reloadedReason));
+    SatLiteral curr_lit = MinisatSatSolver::toSatLiteral(reloadedReason[i]);
     // ignore the lit we are trying to explain...
     if (curr_lit == lit)
     {


### PR DESCRIPTION
When a clause is being explained, the negation of each of its literals, other than the one it propagates, needs to be explained. This process may lead to the creation of new clauses in the SAT solver (because if a literal being explained was propagated and an explanation was not yet given, it will then be computed and added). This may lead to changes in the memory where clauses are, which may break the reference to the original clause being explained. To avoid this issue we store the literals in the reason before we start explaining their negations. We then iterate over them rather than over the clause, as before.