### PR TITLE
Avoid spurious shadowing check for free variables computation in terms with WITNESS subterms

### DIFF
--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -345,8 +345,15 @@ bool getFreeVariablesScope(TNode n,
   {
     cur = visit.back();
     visit.pop_back();
-    // can skip if it doesn't have a bound variable
-    if (!hasBoundVar(cur))
+    Kind k = cur.getKind();
+    // can skip if it doesn't have a bound variable or if it's a witness terms,
+    // since neither have free variables and it's spurious to consider
+    // them. Moreover, witness terms are problematic to traverse because they
+    // main contain shadowing declarations, since they replace skolem terms
+    // *without* the use of a non-capture-avoiding substitution, which is not an
+    // issue for solving (since we don't solved based on witness forms) but it's
+    // an issue for the assertion below that checks shadowing.
+    if (!hasBoundVar(cur) || k == kind::WITNESS)
     {
       continue;
     }
@@ -355,7 +362,6 @@ bool getFreeVariablesScope(TNode n,
     if (itv == visited.end())
     {
       visited.insert(cur);
-      Kind k = cur.getKind();
       if (k == kind::BOUND_VARIABLE)
       {
         if (scope.find(cur) == scope.end())
@@ -370,12 +376,7 @@ bool getFreeVariablesScope(TNode n,
           }
         }
       }
-      // witness terms do not have free variables, so it's spurious to consider
-      // them. Moreover, they main contain shadowing declarations, since they
-      // replace skolem terms *without* the use of a non-capture-avoiding
-      // substitution, which is not an issue for solving (since we don't solved
-      // based on witness forms) but it's an issue for the assertion below
-      else if (cur.isClosure() && k != kind::WITNESS)
+      else if (cur.isClosure())
       {
         // add to scope
         for (const TNode& cn : cur[0])

--- a/src/expr/node_algorithm.cpp
+++ b/src/expr/node_algorithm.cpp
@@ -355,7 +355,8 @@ bool getFreeVariablesScope(TNode n,
     if (itv == visited.end())
     {
       visited.insert(cur);
-      if (cur.getKind() == kind::BOUND_VARIABLE)
+      Kind k = cur.getKind();
+      if (k == kind::BOUND_VARIABLE)
       {
         if (scope.find(cur) == scope.end())
         {
@@ -369,7 +370,12 @@ bool getFreeVariablesScope(TNode n,
           }
         }
       }
-      else if (cur.isClosure())
+      // witness terms do not have free variables, so it's spurious to consider
+      // them. Moreover, they main contain shadowing declarations, since they
+      // replace skolem terms *without* the use of a non-capture-avoiding
+      // substitution, which is not an issue for solving (since we don't solved
+      // based on witness forms) but it's an issue for the assertion below
+      else if (cur.isClosure() && k != kind::WITNESS)
       {
         // add to scope
         for (const TNode& cn : cur[0])


### PR DESCRIPTION
Achieved by not traversing witness terms when computing free variables.