### PR TITLE
More cleanup of includes to reduce compilation times

### DIFF
--- a/src/base/exception.cpp
+++ b/src/base/exception.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <sstream>
 #include <string>
 
 #include "base/check.h"
@@ -27,6 +28,13 @@
 using namespace std;
 
 namespace CVC4 {
+
+std::string Exception::toString() const
+  {
+    std::stringstream ss;
+    toStream(ss);
+    return ss.str();
+  }
 
 thread_local LastExceptionBuffer* LastExceptionBuffer::s_currentBuffer = nullptr;
 

--- a/src/base/exception.cpp
+++ b/src/base/exception.cpp
@@ -30,11 +30,11 @@ using namespace std;
 namespace CVC4 {
 
 std::string Exception::toString() const
-  {
-    std::stringstream ss;
-    toStream(ss);
-    return ss.str();
-  }
+{
+  std::stringstream ss;
+  toStream(ss);
+  return ss.str();
+}
 
 thread_local LastExceptionBuffer* LastExceptionBuffer::s_currentBuffer = nullptr;
 

--- a/src/base/exception.h
+++ b/src/base/exception.h
@@ -19,12 +19,8 @@
 #ifndef CVC4__EXCEPTION_H
 #define CVC4__EXCEPTION_H
 
-#include <cstdarg>
-#include <cstdlib>
 #include <exception>
 #include <iosfwd>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 
 namespace CVC4 {
@@ -61,12 +57,7 @@ class CVC4_PUBLIC Exception : public std::exception {
    * toString(), there is no stream, so the parameters are default
    * and you'll get exprs and types printed using the AST language.
    */
-  std::string toString() const
-  {
-    std::stringstream ss;
-    toStream(ss);
-    return ss.str();
-  }
+  std::string toString() const;
 
   /**
    * Printing: feel free to redefine toStream().  When overridden in

--- a/src/base/listener.cpp
+++ b/src/base/listener.cpp
@@ -16,10 +16,6 @@
 
 #include "base/listener.h"
 
-#include <list>
-
-#include "base/check.h"
-
 namespace CVC4 {
 
 Listener::Listener(){}

--- a/src/decision/decision_engine.cpp
+++ b/src/decision/decision_engine.cpp
@@ -20,6 +20,7 @@
 #include "expr/node.h"
 #include "options/decision_options.h"
 #include "options/smt_options.h"
+#include "util/resource_manager.h"
 
 using namespace std;
 

--- a/src/decision/decision_engine.h
+++ b/src/decision/decision_engine.h
@@ -26,6 +26,7 @@
 #include "prop/cnf_stream.h"
 #include "prop/sat_solver.h"
 #include "prop/sat_solver_types.h"
+#include "util/result.h"
 
 using namespace CVC4::prop;
 using namespace CVC4::decision;

--- a/src/decision/decision_engine.h
+++ b/src/decision/decision_engine.h
@@ -20,9 +20,11 @@
 #define CVC4__DECISION__DECISION_ENGINE_H
 
 #include "base/output.h"
+#include "context/cdo.h"
 #include "decision/decision_strategy.h"
 #include "expr/node.h"
 #include "prop/cnf_stream.h"
+#include "prop/sat_solver.h"
 #include "prop/sat_solver_types.h"
 
 using namespace CVC4::prop;

--- a/src/decision/decision_engine.h
+++ b/src/decision/decision_engine.h
@@ -19,18 +19,12 @@
 #ifndef CVC4__DECISION__DECISION_ENGINE_H
 #define CVC4__DECISION__DECISION_ENGINE_H
 
-#include <vector>
-
 #include "base/output.h"
 #include "decision/decision_strategy.h"
 #include "expr/node.h"
 #include "prop/cnf_stream.h"
-#include "prop/prop_engine.h"
 #include "prop/sat_solver_types.h"
-#include "smt/smt_engine_scope.h"
-#include "smt/term_formula_removal.h"
 
-using namespace std;
 using namespace CVC4::prop;
 using namespace CVC4::decision;
 

--- a/src/decision/justification_heuristic.cpp
+++ b/src/decision/justification_heuristic.cpp
@@ -18,14 +18,14 @@
  **/
 #include "justification_heuristic.h"
 
-#include "decision/decision_engine.h"
 #include "decision/decision_attributes.h"
+#include "decision/decision_engine.h"
 #include "expr/kind.h"
 #include "expr/node_manager.h"
 #include "options/decision_options.h"
-#include "theory/rewriter.h"
-#include "smt/term_formula_removal.h"
 #include "smt/smt_statistics_registry.h"
+#include "smt/term_formula_removal.h"
+#include "theory/rewriter.h"
 #include "util/random.h"
 
 namespace CVC4 {
@@ -70,8 +70,10 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNext(bool &stopSearch)
 {
   if(options::decisionThreshold() > 0) {
     bool stopSearchTmp = false;
-    prop::SatLiteral lit = getNextThresh(stopSearchTmp, options::decisionThreshold());
-    if(lit != prop::undefSatLiteral) {
+    prop::SatLiteral lit =
+        getNextThresh(stopSearchTmp, options::decisionThreshold());
+    if (lit != prop::undefSatLiteral)
+    {
       Assert(stopSearchTmp == false);
       return lit;
     }
@@ -91,8 +93,9 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNextThresh(bool &stopSearch, D
     for(JustifiedSet::key_iterator i = d_justified.key_begin();
         i != d_justified.key_end(); ++i) {
       TNode n = *i;
-      prop::SatLiteral l = d_decisionEngine->hasSatLiteral(n) ?
-        d_decisionEngine->getSatLiteral(n) : -1;
+      prop::SatLiteral l = d_decisionEngine->hasSatLiteral(n)
+                               ? d_decisionEngine->getSatLiteral(n)
+                               : -1;
       prop::SatValue v = tryGetSatValue(n);
       Trace("justified") <<"{ "<<l<<"}" << n <<": "<<v << std::endl;
     }
@@ -110,7 +113,8 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNextThresh(bool &stopSearch, D
 
     litDecision = findSplitter(d_assertions[i], desiredVal);
 
-    if(litDecision != prop::undefSatLiteral) {
+    if (litDecision != prop::undefSatLiteral)
+    {
       setPrvsIndex(i);
       Trace("decision") << "jh: splitting on " << litDecision << std::endl;
       ++d_helpfulness;
@@ -139,23 +143,24 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNextThresh(bool &stopSearch, D
 
   // SAT solver can stop...
   stopSearch = true;
-  if(d_curThreshold == 0)
-    d_decisionEngine->setResult(prop::SAT_VALUE_TRUE);
+  if (d_curThreshold == 0) d_decisionEngine->setResult(prop::SAT_VALUE_TRUE);
   return prop::undefSatLiteral;
 }
 
-
-inline void computeXorIffDesiredValues
-(Kind k, prop::SatValue desiredVal, prop::SatValue &desiredVal1, prop::SatValue &desiredVal2)
+inline void computeXorIffDesiredValues(Kind k,
+                                       prop::SatValue desiredVal,
+                                       prop::SatValue& desiredVal1,
+                                       prop::SatValue& desiredVal2)
 {
   Assert(k == kind::EQUAL || k == kind::XOR);
 
   bool shouldInvert =
-    (desiredVal == prop::SAT_VALUE_TRUE && k == kind::EQUAL) ||
-    (desiredVal == prop::SAT_VALUE_FALSE && k == kind::XOR);
+      (desiredVal == prop::SAT_VALUE_TRUE && k == kind::EQUAL)
+      || (desiredVal == prop::SAT_VALUE_FALSE && k == kind::XOR);
 
-  if(desiredVal1 == prop::SAT_VALUE_UNKNOWN &&
-     desiredVal2 == prop::SAT_VALUE_UNKNOWN) {
+  if (desiredVal1 == prop::SAT_VALUE_UNKNOWN
+      && desiredVal2 == prop::SAT_VALUE_UNKNOWN)
+  {
     // CHOICE: pick one of them arbitarily
     desiredVal1 = prop::SAT_VALUE_FALSE;
   }
@@ -217,9 +222,9 @@ bool JustificationHeuristic::checkJustified(TNode n)
 
 DecisionWeight JustificationHeuristic::getExploredThreshold(TNode n)
 {
-  return
-    d_exploredThreshold.find(n) == d_exploredThreshold.end() ?
-    std::numeric_limits<DecisionWeight>::max() : d_exploredThreshold[n];
+  return d_exploredThreshold.find(n) == d_exploredThreshold.end()
+             ? std::numeric_limits<DecisionWeight>::max()
+             : d_exploredThreshold[n];
 }
 
 void JustificationHeuristic::setExploredThreshold(TNode n)
@@ -279,9 +284,9 @@ DecisionWeight JustificationHeuristic::getWeightPolarized(TNode n, bool polarity
         }
       } else if(k == kind::IMPLIES) {
         dW1 = std::min(getWeightPolarized(n[0], false),
-                  getWeightPolarized(n[1], true));
+                       getWeightPolarized(n[1], true));
         dW2 = std::max(getWeightPolarized(n[0], true),
-                  getWeightPolarized(n[1], false));
+                       getWeightPolarized(n[1], false));
       } else if(k == kind::NOT) {
         dW1 = getWeightPolarized(n[0], false);
         dW2 = getWeightPolarized(n[0], true);

--- a/src/decision/justification_heuristic.cpp
+++ b/src/decision/justification_heuristic.cpp
@@ -18,6 +18,8 @@
  **/
 #include "justification_heuristic.h"
 
+#include "decision/decision_engine.h"
+#include "decision/decision_attributes.h"
 #include "expr/kind.h"
 #include "expr/node_manager.h"
 #include "options/decision_options.h"
@@ -27,6 +29,7 @@
 #include "util/random.h"
 
 namespace CVC4 {
+namespace decision {
 
 JustificationHeuristic::JustificationHeuristic(CVC4::DecisionEngine* de,
                                                context::UserContext* uc,
@@ -67,8 +70,8 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNext(bool &stopSearch)
 {
   if(options::decisionThreshold() > 0) {
     bool stopSearchTmp = false;
-    SatLiteral lit = getNextThresh(stopSearchTmp, options::decisionThreshold());
-    if(lit != undefSatLiteral) {
+    prop::SatLiteral lit = getNextThresh(stopSearchTmp, options::decisionThreshold());
+    if(lit != prop::undefSatLiteral) {
       Assert(stopSearchTmp == false);
       return lit;
     }
@@ -88,9 +91,9 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNextThresh(bool &stopSearch, D
     for(JustifiedSet::key_iterator i = d_justified.key_begin();
         i != d_justified.key_end(); ++i) {
       TNode n = *i;
-      SatLiteral l = d_decisionEngine->hasSatLiteral(n) ?
+      prop::SatLiteral l = d_decisionEngine->hasSatLiteral(n) ?
         d_decisionEngine->getSatLiteral(n) : -1;
-      SatValue v = tryGetSatValue(n);
+      prop::SatValue v = tryGetSatValue(n);
       Trace("justified") <<"{ "<<l<<"}" << n <<": "<<v << std::endl;
     }
   }
@@ -102,12 +105,12 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNextThresh(bool &stopSearch, D
     // Commenting out. See bug 374. In short, to do with how CNF stream works.
     // Assert( tryGetSatValue(d_assertions[i]) != SAT_VALUE_FALSE);
 
-    SatValue desiredVal = SAT_VALUE_TRUE;
-    SatLiteral litDecision;
+    prop::SatValue desiredVal = prop::SAT_VALUE_TRUE;
+    prop::SatLiteral litDecision;
 
     litDecision = findSplitter(d_assertions[i], desiredVal);
 
-    if(litDecision != undefSatLiteral) {
+    if(litDecision != prop::undefSatLiteral) {
       setPrvsIndex(i);
       Trace("decision") << "jh: splitting on " << litDecision << std::endl;
       ++d_helpfulness;
@@ -137,24 +140,24 @@ CVC4::prop::SatLiteral JustificationHeuristic::getNextThresh(bool &stopSearch, D
   // SAT solver can stop...
   stopSearch = true;
   if(d_curThreshold == 0)
-    d_decisionEngine->setResult(SAT_VALUE_TRUE);
+    d_decisionEngine->setResult(prop::SAT_VALUE_TRUE);
   return prop::undefSatLiteral;
 }
 
 
 inline void computeXorIffDesiredValues
-(Kind k, SatValue desiredVal, SatValue &desiredVal1, SatValue &desiredVal2)
+(Kind k, prop::SatValue desiredVal, prop::SatValue &desiredVal1, prop::SatValue &desiredVal2)
 {
   Assert(k == kind::EQUAL || k == kind::XOR);
 
   bool shouldInvert =
-    (desiredVal == SAT_VALUE_TRUE && k == kind::EQUAL) ||
-    (desiredVal == SAT_VALUE_FALSE && k == kind::XOR);
+    (desiredVal == prop::SAT_VALUE_TRUE && k == kind::EQUAL) ||
+    (desiredVal == prop::SAT_VALUE_FALSE && k == kind::XOR);
 
-  if(desiredVal1 == SAT_VALUE_UNKNOWN &&
-     desiredVal2 == SAT_VALUE_UNKNOWN) {
+  if(desiredVal1 == prop::SAT_VALUE_UNKNOWN &&
+     desiredVal2 == prop::SAT_VALUE_UNKNOWN) {
     // CHOICE: pick one of them arbitarily
-    desiredVal1 = SAT_VALUE_FALSE;
+    desiredVal1 = prop::SAT_VALUE_FALSE;
   }
 
   if(desiredVal2 == SAT_VALUE_UNKNOWN) {
@@ -216,7 +219,7 @@ DecisionWeight JustificationHeuristic::getExploredThreshold(TNode n)
 {
   return
     d_exploredThreshold.find(n) == d_exploredThreshold.end() ?
-    numeric_limits<DecisionWeight>::max() : d_exploredThreshold[n];
+    std::numeric_limits<DecisionWeight>::max() : d_exploredThreshold[n];
 }
 
 void JustificationHeuristic::setExploredThreshold(TNode n)
@@ -263,21 +266,21 @@ DecisionWeight JustificationHeuristic::getWeightPolarized(TNode n, bool polarity
     } else {
 
       if(k == kind::OR) {
-        dW1 = numeric_limits<DecisionWeight>::max(), dW2 = 0;
+        dW1 = std::numeric_limits<DecisionWeight>::max(), dW2 = 0;
         for(TNode::iterator i=n.begin(); i != n.end(); ++i) {
-          dW1 = min(dW1, getWeightPolarized(*i, true));
-          dW2 = max(dW2, getWeightPolarized(*i, false));
+          dW1 = std::min(dW1, getWeightPolarized(*i, true));
+          dW2 = std::max(dW2, getWeightPolarized(*i, false));
         }
       } else if(k == kind::AND) {
-        dW1 = 0, dW2 = numeric_limits<DecisionWeight>::max();
+        dW1 = 0, dW2 = std::numeric_limits<DecisionWeight>::max();
         for(TNode::iterator i=n.begin(); i != n.end(); ++i) {
-          dW1 = max(dW1, getWeightPolarized(*i, true));
-          dW2 = min(dW2, getWeightPolarized(*i, false));
+          dW1 = std::max(dW1, getWeightPolarized(*i, true));
+          dW2 = std::min(dW2, getWeightPolarized(*i, false));
         }
       } else if(k == kind::IMPLIES) {
-        dW1 = min(getWeightPolarized(n[0], false),
+        dW1 = std::min(getWeightPolarized(n[0], false),
                   getWeightPolarized(n[1], true));
-        dW2 = max(getWeightPolarized(n[0], true),
+        dW2 = std::max(getWeightPolarized(n[0], true),
                   getWeightPolarized(n[1], false));
       } else if(k == kind::NOT) {
         dW1 = getWeightPolarized(n[0], false);
@@ -285,14 +288,14 @@ DecisionWeight JustificationHeuristic::getWeightPolarized(TNode n, bool polarity
       } else {
         dW1 = 0;
         for(TNode::iterator i=n.begin(); i != n.end(); ++i) {
-          dW1 = max(dW1, getWeightPolarized(*i, true));
-          dW1 = max(dW1, getWeightPolarized(*i, false));
+          dW1 = std::max(dW1, getWeightPolarized(*i, true));
+          dW1 = std::max(dW1, getWeightPolarized(*i, false));
         }
         dW2 = dW1;
       }
 
     }
-    d_weightCache[n] = make_pair(dW1, dW2);
+    d_weightCache[n] = std::make_pair(dW1, dW2);
   }
   return polarity ? d_weightCache[n].get().first : d_weightCache[n].get().second;
 }
@@ -315,7 +318,7 @@ DecisionWeight JustificationHeuristic::getWeight(TNode n) {
     {
       DecisionWeight dW = 0;
       for (TNode::iterator i = n.begin(); i != n.end(); ++i)
-        dW = max(dW, getWeight(*i));
+        dW = std::max(dW, getWeight(*i));
       n.setAttribute(DecisionWeightAttr(), dW);
     }
     else if (combiningFn == options::DecisionWeightInternal::SUM
@@ -323,7 +326,7 @@ DecisionWeight JustificationHeuristic::getWeight(TNode n) {
     {
       DecisionWeight dW = 0;
       for (TNode::iterator i = n.begin(); i != n.end(); ++i)
-        dW = max(dW, getWeight(*i));
+        dW = std::max(dW, getWeight(*i));
       n.setAttribute(DecisionWeightAttr(), dW);
     }
     else
@@ -334,7 +337,7 @@ DecisionWeight JustificationHeuristic::getWeight(TNode n) {
   return n.getAttribute(DecisionWeightAttr());
 }
 
-typedef vector<TNode> ChildList;
+typedef std::vector<TNode> ChildList;
 TNode JustificationHeuristic::getChildByWeight(TNode n, int i, bool polarity) {
   if(options::decisionUseWeight()) {
     // TODO: Optimize storing & access
@@ -389,7 +392,7 @@ void JustificationHeuristic::computeSkolems(TNode n, SkolemList& l)
     SkolemMap::iterator it2 = d_skolemAssertions.find(n[i]);
     if (it2 != d_skolemAssertions.end())
     {
-      l.push_back(make_pair(n[i], (*it2).second));
+      l.push_back(std::make_pair(n[i], (*it2).second));
       Assert(n[i].getNumChildren() == 0);
     }
     if (d_visitedComputeSkolems.find(n[i]) == d_visitedComputeSkolems.end())
@@ -610,8 +613,8 @@ JustificationHeuristic::SearchResult JustificationHeuristic::handleBinaryEasy(TN
 {
   if(options::decisionUseWeight() &&
      getWeightPolarized(node1, desiredVal1) > getWeightPolarized(node2, desiredVal2)) {
-    swap(node1, node2);
-    swap(desiredVal1, desiredVal2);
+    std::swap(node1, node2);
+    std::swap(desiredVal1, desiredVal2);
   }
 
   if ( tryGetSatValue(node1) != invertValue(desiredVal1) ) {
@@ -635,8 +638,8 @@ JustificationHeuristic::SearchResult JustificationHeuristic::handleBinaryHard(TN
 {
   if(options::decisionUseWeight() &&
      getWeightPolarized(node1, desiredVal1) > getWeightPolarized(node2, desiredVal2)) {
-    swap(node1, node2);
-    swap(desiredVal1, desiredVal2);
+    std::swap(node1, node2);
+    std::swap(desiredVal1, desiredVal2);
   }
 
   bool noSplitter = true;
@@ -722,4 +725,5 @@ JustificationHeuristic::handleEmbeddedSkolems(TNode node)
   return noSplitter ? NO_SPLITTER : DONT_KNOW;
 }
 
+} /* namespace decision */
 } /* namespace CVC4 */

--- a/src/decision/justification_heuristic.h
+++ b/src/decision/justification_heuristic.h
@@ -31,8 +31,8 @@
 #include "context/cdlist.h"
 #include "context/cdo.h"
 #include "decision/decision_strategy.h"
-#include "options/decision_weight.h"
 #include "expr/node.h"
+#include "options/decision_weight.h"
 #include "prop/sat_solver_types.h"
 #include "util/statistics_registry.h"
 
@@ -46,9 +46,14 @@ class JustificationHeuristic : public ITEDecisionStrategy {
   typedef std::vector<std::pair<TNode, TNode> > SkolemList;
   typedef context::CDHashMap<TNode, SkolemList, TNodeHashFunction> SkolemCache;
   typedef std::vector<TNode> ChildList;
-  typedef context::CDHashMap<TNode,std::pair<ChildList,ChildList>,TNodeHashFunction> ChildCache;
+  typedef context::
+      CDHashMap<TNode, std::pair<ChildList, ChildList>, TNodeHashFunction>
+          ChildCache;
   typedef context::CDHashMap<TNode,TNode,TNodeHashFunction> SkolemMap;
-  typedef context::CDHashMap<TNode,std::pair<DecisionWeight,DecisionWeight>,TNodeHashFunction> WeightCache;
+  typedef context::CDHashMap<TNode,
+                             std::pair<DecisionWeight, DecisionWeight>,
+                             TNodeHashFunction>
+      WeightCache;
 
   // being 'justified' is monotonic with respect to decisions
   typedef context::CDHashSet<Node,NodeHashFunction> JustifiedSet;
@@ -179,10 +184,14 @@ public:
 
   SearchResult handleAndOrEasy(TNode node, prop::SatValue desiredVal);
   SearchResult handleAndOrHard(TNode node, prop::SatValue desiredVal);
-  SearchResult handleBinaryEasy(TNode node1, prop::SatValue desiredVal1,
-                        TNode node2, prop::SatValue desiredVal2);
-  SearchResult handleBinaryHard(TNode node1, prop::SatValue desiredVal1,
-                        TNode node2, prop::SatValue desiredVal2);
+  SearchResult handleBinaryEasy(TNode node1,
+                                prop::SatValue desiredVal1,
+                                TNode node2,
+                                prop::SatValue desiredVal2);
+  SearchResult handleBinaryHard(TNode node1,
+                                prop::SatValue desiredVal1,
+                                TNode node2,
+                                prop::SatValue desiredVal2);
   SearchResult handleITE(TNode node, prop::SatValue desiredVal);
   SearchResult handleEmbeddedSkolems(TNode node);
 };/* class JustificationHeuristic */

--- a/src/decision/justification_heuristic.h
+++ b/src/decision/justification_heuristic.h
@@ -24,15 +24,15 @@
 #define CVC4__DECISION__JUSTIFICATION_HEURISTIC
 
 #include <unordered_set>
+#include <utility>
 
 #include "context/cdhashmap.h"
 #include "context/cdhashset.h"
 #include "context/cdlist.h"
-#include "decision/decision_attributes.h"
-#include "decision/decision_engine.h"
+#include "context/cdo.h"
 #include "decision/decision_strategy.h"
+#include "options/decision_weight.h"
 #include "expr/node.h"
-#include "preprocessing/assertion_pipeline.h"
 #include "prop/sat_solver_types.h"
 
 namespace CVC4 {
@@ -42,12 +42,12 @@ class JustificationHeuristic : public ITEDecisionStrategy {
   //                   TRUE           FALSE         MEH
   enum SearchResult {FOUND_SPLITTER, NO_SPLITTER, DONT_KNOW};
 
-  typedef std::vector<pair<TNode, TNode> > SkolemList;
+  typedef std::vector<std::pair<TNode, TNode> > SkolemList;
   typedef context::CDHashMap<TNode, SkolemList, TNodeHashFunction> SkolemCache;
   typedef std::vector<TNode> ChildList;
-  typedef context::CDHashMap<TNode,pair<ChildList,ChildList>,TNodeHashFunction> ChildCache;
+  typedef context::CDHashMap<TNode,std::pair<ChildList,ChildList>,TNodeHashFunction> ChildCache;
   typedef context::CDHashMap<TNode,TNode,TNodeHashFunction> SkolemMap;
-  typedef context::CDHashMap<TNode,pair<DecisionWeight,DecisionWeight>,TNodeHashFunction> WeightCache;
+  typedef context::CDHashMap<TNode,std::pair<DecisionWeight,DecisionWeight>,TNodeHashFunction> WeightCache;
 
   // being 'justified' is monotonic with respect to decisions
   typedef context::CDHashSet<Node,NodeHashFunction> JustifiedSet;
@@ -91,7 +91,7 @@ class JustificationHeuristic : public ITEDecisionStrategy {
   std::unordered_set<TNode, TNodeHashFunction> d_visitedComputeSkolems;
 
   /** current decision for the recursive call */
-  SatLiteral d_curDecision;
+  prop::SatLiteral d_curDecision;
   /** current threshold for the recursive call */
   DecisionWeight d_curThreshold;
 
@@ -136,12 +136,12 @@ public:
   /* getNext with an option to specify threshold */
   prop::SatLiteral getNextThresh(bool &stopSearch, DecisionWeight threshold);
 
-  SatLiteral findSplitter(TNode node, SatValue desiredVal);
+  prop::SatLiteral findSplitter(TNode node, prop::SatValue desiredVal);
 
   /**
    * Do all the hard work.
    */
-  SearchResult findSplitterRec(TNode node, SatValue value);
+  SearchResult findSplitterRec(TNode node, prop::SatValue value);
 
   /* Helper functions */
   void setJustified(TNode);
@@ -151,7 +151,7 @@ public:
   void setPrvsIndex(int);
   int  getPrvsIndex();
   DecisionWeight getWeightPolarized(TNode n, bool polarity);
-  DecisionWeight getWeightPolarized(TNode n, SatValue);
+  DecisionWeight getWeightPolarized(TNode n, prop::SatValue);
   static DecisionWeight getWeight(TNode);
   bool compareByWeightFalse(TNode, TNode);
   bool compareByWeightTrue(TNode, TNode);
@@ -159,7 +159,7 @@ public:
 
   /* If literal exists corresponding to the node return
      that. Otherwise an UNKNOWN */
-  SatValue tryGetSatValue(Node n);
+  prop::SatValue tryGetSatValue(Node n);
 
   /* Get list of all term-ITEs for the atomic formula v */
   JustificationHeuristic::SkolemList getSkolems(TNode n);
@@ -176,13 +176,13 @@ public:
   /* Compute all term-removal skolems in a node recursively */
   void computeSkolems(TNode n, SkolemList& l);
 
-  SearchResult handleAndOrEasy(TNode node, SatValue desiredVal);
-  SearchResult handleAndOrHard(TNode node, SatValue desiredVal);
-  SearchResult handleBinaryEasy(TNode node1, SatValue desiredVal1,
-                        TNode node2, SatValue desiredVal2);
-  SearchResult handleBinaryHard(TNode node1, SatValue desiredVal1,
-                        TNode node2, SatValue desiredVal2);
-  SearchResult handleITE(TNode node, SatValue desiredVal);
+  SearchResult handleAndOrEasy(TNode node, prop::SatValue desiredVal);
+  SearchResult handleAndOrHard(TNode node, prop::SatValue desiredVal);
+  SearchResult handleBinaryEasy(TNode node1, prop::SatValue desiredVal1,
+                        TNode node2, prop::SatValue desiredVal2);
+  SearchResult handleBinaryHard(TNode node1, prop::SatValue desiredVal1,
+                        TNode node2, prop::SatValue desiredVal2);
+  SearchResult handleITE(TNode node, prop::SatValue desiredVal);
   SearchResult handleEmbeddedSkolems(TNode node);
 };/* class JustificationHeuristic */
 

--- a/src/decision/justification_heuristic.h
+++ b/src/decision/justification_heuristic.h
@@ -34,6 +34,7 @@
 #include "options/decision_weight.h"
 #include "expr/node.h"
 #include "prop/sat_solver_types.h"
+#include "util/statistics_registry.h"
 
 namespace CVC4 {
 namespace decision {

--- a/src/expr/buffered_proof_generator.h
+++ b/src/expr/buffered_proof_generator.h
@@ -19,11 +19,11 @@
 
 #include "context/cdhashmap.h"
 #include "expr/proof_generator.h"
-#include "expr/proof_step_buffer.h"
 
 namespace CVC4 {
 
 class ProofNodeManager;
+class ProofStep;
 
 /**
  * The proof generator for buffered steps. This class is a context-dependent

--- a/src/expr/dtype.cpp
+++ b/src/expr/dtype.cpp
@@ -13,6 +13,8 @@
  **/
 #include "expr/dtype.h"
 
+#include <sstream>
+
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"
 #include "expr/type_matcher.h"

--- a/src/expr/kind_template.cpp
+++ b/src/expr/kind_template.cpp
@@ -15,9 +15,9 @@
  ** \todo document this file
  **/
 
-#include "expr/kind.h"
-
 #include <sstream>
+
+#include "expr/kind.h"
 
 namespace CVC4 {
 namespace kind {

--- a/src/expr/kind_template.cpp
+++ b/src/expr/kind_template.cpp
@@ -17,6 +17,8 @@
 
 #include "expr/kind.h"
 
+#include <sstream>
+
 namespace CVC4 {
 namespace kind {
 

--- a/src/expr/lazy_proof.cpp
+++ b/src/expr/lazy_proof.cpp
@@ -15,6 +15,7 @@
 #include "expr/lazy_proof.h"
 
 #include "expr/proof_ensure_closed.h"
+#include "expr/proof_node.h"
 #include "expr/proof_node_manager.h"
 
 using namespace CVC4::kind;

--- a/src/expr/lazy_proof.h
+++ b/src/expr/lazy_proof.h
@@ -17,14 +17,11 @@
 #ifndef CVC4__EXPR__LAZY_PROOF_H
 #define CVC4__EXPR__LAZY_PROOF_H
 
-#include <unordered_map>
-#include <vector>
-
 #include "expr/proof.h"
-#include "expr/proof_generator.h"
 
 namespace CVC4 {
 
+class ProofGenerator;
 class ProofNodeManager;
 
 /**

--- a/src/expr/lazy_proof_chain.cpp
+++ b/src/expr/lazy_proof_chain.cpp
@@ -16,6 +16,7 @@
 
 #include "expr/proof.h"
 #include "expr/proof_ensure_closed.h"
+#include "expr/proof_node.h"
 #include "expr/proof_node_algorithm.h"
 #include "expr/proof_node_manager.h"
 #include "options/proof_options.h"

--- a/src/expr/lazy_proof_chain.h
+++ b/src/expr/lazy_proof_chain.h
@@ -17,7 +17,6 @@
 #ifndef CVC4__EXPR__LAZY_PROOF_CHAIN_H
 #define CVC4__EXPR__LAZY_PROOF_CHAIN_H
 
-#include <unordered_map>
 #include <vector>
 
 #include "context/cdhashmap.h"

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <cstring>
+#include <sstream>
 
 #include "base/exception.h"
 #include "base/output.h"

--- a/src/expr/node.cpp
+++ b/src/expr/node.cpp
@@ -15,8 +15,8 @@
  **/
 #include "expr/node.h"
 
-#include <iostream>
 #include <cstring>
+#include <iostream>
 #include <sstream>
 
 #include "base/exception.h"

--- a/src/expr/proof.cpp
+++ b/src/expr/proof.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/proof.h"
 
+#include "expr/proof_checker.h"
+#include "expr/proof_node.h"
 #include "expr/proof_node_manager.h"
 
 using namespace CVC4::kind;

--- a/src/expr/proof.h
+++ b/src/expr/proof.h
@@ -17,17 +17,16 @@
 #ifndef CVC4__EXPR__PROOF_H
 #define CVC4__EXPR__PROOF_H
 
-#include <map>
 #include <vector>
 
 #include "context/cdhashmap.h"
 #include "expr/node.h"
 #include "expr/proof_generator.h"
-#include "expr/proof_node.h"
 #include "expr/proof_step_buffer.h"
 
 namespace CVC4 {
 
+class ProofNode;
 class ProofNodeManager;
 
 /**

--- a/src/expr/proof_checker.cpp
+++ b/src/expr/proof_checker.cpp
@@ -14,6 +14,7 @@
 
 #include "expr/proof_checker.h"
 
+#include "expr/proof_node.h"
 #include "expr/skolem_manager.h"
 #include "options/proof_options.h"
 #include "smt/smt_statistics_registry.h"

--- a/src/expr/proof_checker.h
+++ b/src/expr/proof_checker.h
@@ -20,12 +20,13 @@
 #include <map>
 
 #include "expr/node.h"
-#include "expr/proof_node.h"
+#include "expr/proof_rule.h"
 #include "util/statistics_registry.h"
 
 namespace CVC4 {
 
 class ProofChecker;
+class ProofNode;
 
 /** A virtual base class for checking a proof rule */
 class ProofRuleChecker

--- a/src/expr/proof_ensure_closed.cpp
+++ b/src/expr/proof_ensure_closed.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/proof_ensure_closed.h"
 
+#include <sstream>
+
 #include "expr/proof_generator.h"
 #include "expr/proof_node.h"
 #include "expr/proof_node_algorithm.h"

--- a/src/expr/proof_ensure_closed.cpp
+++ b/src/expr/proof_ensure_closed.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/proof_ensure_closed.h"
 
+#include "expr/proof_generator.h"
+#include "expr/proof_node.h"
 #include "expr/proof_node_algorithm.h"
 #include "options/proof_options.h"
 #include "options/smt_options.h"

--- a/src/expr/proof_ensure_closed.h
+++ b/src/expr/proof_ensure_closed.h
@@ -18,10 +18,11 @@
 #define CVC4__EXPR__PROOF_ENSURE_CLOSED_H
 
 #include "expr/node.h"
-#include "expr/proof_generator.h"
-#include "expr/proof_node.h"
 
 namespace CVC4 {
+
+class ProofGenerator;
+class ProofNode;
 
 /**
  * Debug check closed on Trace c. Context ctx is string for debugging.

--- a/src/expr/proof_generator.cpp
+++ b/src/expr/proof_generator.cpp
@@ -15,6 +15,7 @@
 #include "expr/proof_generator.h"
 
 #include "expr/proof.h"
+#include "expr/proof_node.h"
 #include "expr/proof_node_algorithm.h"
 #include "options/smt_options.h"
 

--- a/src/expr/proof_generator.cpp
+++ b/src/expr/proof_generator.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/proof_generator.h"
 
+#include <sstream>
+
 #include "expr/proof.h"
 #include "expr/proof_node.h"
 #include "expr/proof_node_algorithm.h"

--- a/src/expr/proof_generator.h
+++ b/src/expr/proof_generator.h
@@ -18,11 +18,11 @@
 #define CVC4__EXPR__PROOF_GENERATOR_H
 
 #include "expr/node.h"
-#include "expr/proof_node.h"
 
 namespace CVC4 {
 
 class CDProof;
+class ProofNode;
 
 /** An overwrite policy for CDProof */
 enum class CDPOverwrite : uint32_t

--- a/src/expr/proof_node_algorithm.cpp
+++ b/src/expr/proof_node_algorithm.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/proof_node_algorithm.h"
 
+#include "expr/proof_node.h"
+
 namespace CVC4 {
 namespace expr {
 

--- a/src/expr/proof_node_algorithm.h
+++ b/src/expr/proof_node_algorithm.h
@@ -20,9 +20,11 @@
 #include <vector>
 
 #include "expr/node.h"
-#include "expr/proof_node.h"
 
 namespace CVC4 {
+
+class ProofNode;
+
 namespace expr {
 
 /**

--- a/src/expr/proof_node_manager.cpp
+++ b/src/expr/proof_node_manager.cpp
@@ -15,6 +15,8 @@
 #include "expr/proof_node_manager.h"
 
 #include "expr/proof.h"
+#include "expr/proof_checker.h"
+#include "expr/proof_node.h"
 #include "expr/proof_node_algorithm.h"
 #include "options/proof_options.h"
 #include "theory/rewriter.h"

--- a/src/expr/proof_node_manager.h
+++ b/src/expr/proof_node_manager.h
@@ -19,10 +19,13 @@
 
 #include <vector>
 
-#include "expr/proof_checker.h"
-#include "expr/proof_node.h"
+#include "expr/node.h"
+#include "expr/proof_rule.h"
 
 namespace CVC4 {
+
+class ProofChecker;
+class ProofNode;
 
 /**
  * A manager for proof node objects. This is a trusted interface for creating

--- a/src/expr/proof_node_to_sexpr.cpp
+++ b/src/expr/proof_node_to_sexpr.cpp
@@ -16,6 +16,7 @@
 
 #include <iostream>
 
+#include "expr/proof_node.h"
 #include "options/proof_options.h"
 
 using namespace CVC4::kind;

--- a/src/expr/proof_node_to_sexpr.cpp
+++ b/src/expr/proof_node_to_sexpr.cpp
@@ -15,6 +15,7 @@
 #include "expr/proof_node_to_sexpr.h"
 
 #include <iostream>
+#include <sstream>
 
 #include "expr/proof_node.h"
 #include "options/proof_options.h"

--- a/src/expr/proof_node_to_sexpr.h
+++ b/src/expr/proof_node_to_sexpr.h
@@ -20,9 +20,11 @@
 #include <map>
 
 #include "expr/node.h"
-#include "expr/proof_node.h"
+#include "expr/proof_rule.h"
 
 namespace CVC4 {
+
+class ProofNode;
 
 /** A class to convert ProofNode objects to s-expressions */
 class ProofNodeToSExpr

--- a/src/expr/proof_node_updater.cpp
+++ b/src/expr/proof_node_updater.cpp
@@ -15,6 +15,7 @@
 #include "expr/proof_node_updater.h"
 
 #include "expr/lazy_proof.h"
+#include "expr/proof_node_manager.h"
 #include "expr/proof_ensure_closed.h"
 #include "expr/proof_node_algorithm.h"
 

--- a/src/expr/proof_node_updater.cpp
+++ b/src/expr/proof_node_updater.cpp
@@ -15,9 +15,9 @@
 #include "expr/proof_node_updater.h"
 
 #include "expr/lazy_proof.h"
-#include "expr/proof_node_manager.h"
 #include "expr/proof_ensure_closed.h"
 #include "expr/proof_node_algorithm.h"
+#include "expr/proof_node_manager.h"
 
 namespace CVC4 {
 

--- a/src/expr/proof_node_updater.h
+++ b/src/expr/proof_node_updater.h
@@ -18,13 +18,16 @@
 #define CVC4__EXPR__PROOF_NODE_UPDATER_H
 
 #include <map>
-#include <unordered_set>
+#include <memory>
 
-#include "expr/proof.h"
+#include "expr/node.h"
 #include "expr/proof_node.h"
-#include "expr/proof_node_manager.h"
 
 namespace CVC4 {
+
+class CDProof;
+class ProofNode;
+class ProofNodeManager;
 
 /**
  * A virtual callback class for updating ProofNode. An example use case of this

--- a/src/expr/proof_step_buffer.cpp
+++ b/src/expr/proof_step_buffer.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/proof_step_buffer.h"
 
+#include "expr/proof_checker.h"
+
 using namespace CVC4::kind;
 
 namespace CVC4 {

--- a/src/expr/proof_step_buffer.h
+++ b/src/expr/proof_step_buffer.h
@@ -20,10 +20,11 @@
 #include <vector>
 
 #include "expr/node.h"
-#include "expr/proof_checker.h"
 #include "expr/proof_rule.h"
 
 namespace CVC4 {
+
+class ProofChecker;
 
 /**
  * Information for constructing a step in a CDProof. Notice that the conclusion

--- a/src/expr/record.h
+++ b/src/expr/record.h
@@ -19,7 +19,6 @@
 #ifndef CVC4__RECORD_H
 #define CVC4__RECORD_H
 
-#include <functional>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/expr/sequence.cpp
+++ b/src/expr/sequence.cpp
@@ -14,6 +14,7 @@
 
 #include "expr/sequence.h"
 
+#include <sstream>
 #include <vector>
 
 #include "expr/node.h"

--- a/src/expr/subs.cpp
+++ b/src/expr/subs.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/subs.h"
 
+#include <sstream>
+
 #include "theory/rewriter.h"
 
 namespace CVC4 {

--- a/src/expr/sygus_datatype.cpp
+++ b/src/expr/sygus_datatype.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/sygus_datatype.h"
 
+#include <sstream>
+
 using namespace CVC4::kind;
 
 namespace CVC4 {

--- a/src/expr/symbol_manager.h
+++ b/src/expr/symbol_manager.h
@@ -19,7 +19,6 @@
 
 #include <map>
 #include <memory>
-#include <set>
 #include <string>
 
 #include "api/cvc4cpp.h"

--- a/src/expr/tconv_seq_proof_generator.cpp
+++ b/src/expr/tconv_seq_proof_generator.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/tconv_seq_proof_generator.h"
 
+#include <sstream>
+
 #include "expr/proof_node_manager.h"
 
 namespace CVC4 {

--- a/src/expr/tconv_seq_proof_generator.cpp
+++ b/src/expr/tconv_seq_proof_generator.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/tconv_seq_proof_generator.h"
 
+#include "expr/proof_node_manager.h"
+
 namespace CVC4 {
 
 TConvSeqProofGenerator::TConvSeqProofGenerator(

--- a/src/expr/tconv_seq_proof_generator.h
+++ b/src/expr/tconv_seq_proof_generator.h
@@ -20,10 +20,11 @@
 #include "context/cdhashmap.h"
 #include "expr/node.h"
 #include "expr/proof_generator.h"
-#include "expr/proof_node_manager.h"
 #include "theory/trust_node.h"
 
 namespace CVC4 {
+
+class ProofNodeManager;
 
 /**
  * The term conversion sequence proof generator. This is used for maintaining

--- a/src/expr/term_canonize.cpp
+++ b/src/expr/term_canonize.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/term_canonize.h"
 
+#include <sstream>
+
 // TODO #1216: move the code in this include
 #include "theory/quantifiers/term_util.h"
 

--- a/src/expr/term_context_node.cpp
+++ b/src/expr/term_context_node.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/term_context_node.h"
 
+#include <sstream>
+
 #include "expr/term_context.h"
 
 namespace CVC4 {

--- a/src/expr/term_context_node.cpp
+++ b/src/expr/term_context_node.cpp
@@ -14,8 +14,6 @@
 
 #include "expr/term_context_node.h"
 
-#include <sstream>
-
 #include "expr/term_context.h"
 
 namespace CVC4 {

--- a/src/expr/term_context_node.h
+++ b/src/expr/term_context_node.h
@@ -18,11 +18,11 @@
 #define CVC4__EXPR__TERM_CONTEXT_NODE_H
 
 #include "expr/node.h"
-#include "expr/term_context.h"
 
 namespace CVC4 {
 
 class TCtxStack;
+class TermContext;
 
 /**
  * A (term-context) sensitive term. This is a wrapper around a Node that

--- a/src/expr/term_context_stack.cpp
+++ b/src/expr/term_context_stack.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/term_context_stack.h"
 
+#include "expr/term_context.h"
+
 namespace CVC4 {
 
 TCtxStack::TCtxStack(const TermContext* tctx) : d_tctx(tctx) {}

--- a/src/expr/term_conversion_proof_generator.cpp
+++ b/src/expr/term_conversion_proof_generator.cpp
@@ -14,6 +14,9 @@
 
 #include "expr/term_conversion_proof_generator.h"
 
+#include "expr/proof_checker.h"
+#include "expr/proof_node.h"
+#include "expr/term_context.h"
 #include "expr/term_context_stack.h"
 
 using namespace CVC4::kind;

--- a/src/expr/term_conversion_proof_generator.h
+++ b/src/expr/term_conversion_proof_generator.h
@@ -20,10 +20,11 @@
 #include "context/cdhashmap.h"
 #include "expr/lazy_proof.h"
 #include "expr/proof_generator.h"
-#include "expr/proof_node_manager.h"
-#include "expr/term_context.h"
 
 namespace CVC4 {
+
+class ProofNodeManager;
+class TermContext;
 
 /** A policy for how rewrite steps are applied in TConvProofGenerator */
 enum class TConvPolicy : uint32_t

--- a/src/expr/type.cpp
+++ b/src/expr/type.cpp
@@ -16,6 +16,7 @@
 #include "expr/type.h"
 
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/src/expr/type_checker_template.cpp
+++ b/src/expr/type_checker_template.cpp
@@ -14,6 +14,8 @@
  ** TypeChecker implementation.
  **/
 
+#include <sstream>
+
 #include "expr/node_manager.h"
 #include "expr/node_manager_attributes.h"
 #include "expr/type_checker.h"

--- a/src/expr/type_checker_util.h
+++ b/src/expr/type_checker_util.h
@@ -19,6 +19,8 @@
 
 #include "cvc4_private.h"
 
+#include <sstream>
+
 #include "expr/kind.h"
 #include "expr/node.h"
 #include "expr/node_manager.h"

--- a/src/expr/type_matcher.h
+++ b/src/expr/type_matcher.h
@@ -19,7 +19,6 @@
 
 #include <vector>
 
-#include "expr/node.h"
 #include "expr/type_node.h"
 
 namespace CVC4 {

--- a/src/options/language.cpp
+++ b/src/options/language.cpp
@@ -16,6 +16,11 @@
 
 #include "options/language.h"
 
+#include <sstream>
+
+#include "base/exception.h"
+#include "options/option_exception.h"
+
 namespace CVC4 {
 namespace language {
 

--- a/src/options/language.h
+++ b/src/options/language.h
@@ -179,9 +179,9 @@ bool isInputLang_smt2(InputLanguage lang) CVC4_PUBLIC;
 bool isOutputLang_smt2(OutputLanguage lang) CVC4_PUBLIC;
 
 /**
-  * Is the language smtlib 2.5 or above? If exact=true, then this method returns
-  * false if the input language is not exactly SMT-LIB 2.5.
-  */
+ * Is the language smtlib 2.5 or above? If exact=true, then this method returns
+ * false if the input language is not exactly SMT-LIB 2.5.
+ */
 bool isInputLang_smt2_5(InputLanguage lang, bool exact = false) CVC4_PUBLIC;
 bool isOutputLang_smt2_5(OutputLanguage lang, bool exact = false) CVC4_PUBLIC;
 /**

--- a/src/options/language.h
+++ b/src/options/language.h
@@ -19,11 +19,8 @@
 #ifndef CVC4__LANGUAGE_H
 #define CVC4__LANGUAGE_H
 
-#include <sstream>
+#include <ostream>
 #include <string>
-
-#include "base/exception.h"
-#include "options/option_exception.h"
 
 namespace CVC4 {
 namespace language {
@@ -183,7 +180,7 @@ bool isOutputLang_smt2(OutputLanguage lang) CVC4_PUBLIC;
 
 /**
   * Is the language smtlib 2.5 or above? If exact=true, then this method returns
-  * false if the input language is not exactly SMT-LIB 2.6.
+  * false if the input language is not exactly SMT-LIB 2.5.
   */
 bool isInputLang_smt2_5(InputLanguage lang, bool exact = false) CVC4_PUBLIC;
 bool isOutputLang_smt2_5(OutputLanguage lang, bool exact = false) CVC4_PUBLIC;

--- a/src/options/open_ostream.h
+++ b/src/options/open_ostream.h
@@ -21,11 +21,9 @@
 #define CVC4__OPEN_OSTREAM_H
 
 #include <map>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <utility>
-
-#include "options/option_exception.h"
 
 namespace CVC4 {
 

--- a/src/options/open_ostream.h
+++ b/src/options/open_ostream.h
@@ -20,8 +20,8 @@
 #ifndef CVC4__OPEN_OSTREAM_H
 #define CVC4__OPEN_OSTREAM_H
 
-#include <map>
 #include <iosfwd>
+#include <map>
 #include <string>
 #include <utility>
 

--- a/src/options/options_handler.h
+++ b/src/options/options_handler.h
@@ -22,17 +22,18 @@
 #include <ostream>
 #include <string>
 
-#include "base/modal_exception.h"
 #include "options/base_handlers.h"
 #include "options/bv_options.h"
 #include "options/decision_options.h"
 #include "options/language.h"
 #include "options/option_exception.h"
-#include "options/options.h"
 #include "options/printer_modes.h"
 #include "options/quantifiers_options.h"
 
 namespace CVC4 {
+
+class Options;
+
 namespace options {
 
 /**

--- a/src/preprocessing/assertion_pipeline.cpp
+++ b/src/preprocessing/assertion_pipeline.cpp
@@ -18,6 +18,7 @@
 #include "expr/node_manager.h"
 #include "options/smt_options.h"
 #include "proof/proof_manager.h"
+#include "smt/preprocess_proof_generator.h"
 #include "theory/builtin/proof_checker.h"
 #include "theory/rewriter.h"
 

--- a/src/preprocessing/assertion_pipeline.h
+++ b/src/preprocessing/assertion_pipeline.h
@@ -21,13 +21,15 @@
 #include <vector>
 
 #include "expr/node.h"
-#include "expr/proof_generator.h"
-#include "expr/proof_node_manager.h"
-#include "smt/preprocess_proof_generator.h"
-#include "smt/term_formula_removal.h"
 #include "theory/trust_node.h"
 
 namespace CVC4 {
+
+class ProofGenerator;
+namespace smt {
+class PreprocessProofGenerator;
+}
+
 namespace preprocessing {
 
 using IteSkolemMap = std::unordered_map<size_t, Node>;

--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -197,7 +197,7 @@ size_t getBVSkolemSize(size_t capacity)
  * a sufficient bit-vector size.
  * Populate usVarsToBVVars so that it maps variables with uninterpreted sort to
  * the fresh skolem BV variables. variables */
-void collectUSortsToBV(const unordered_set<TNode, TNodeHashFunction>& vars,
+void collectUSortsToBV(const std::unordered_set<TNode, TNodeHashFunction>& vars,
                        const USortToBVSizeMap& usortCardinality,
                        SubstitutionMap& usVarsToBVVars)
 {

--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -27,6 +27,8 @@
 #include "expr/node_algorithm.h"
 #include "options/options.h"
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
 
 using namespace CVC4;
 using namespace CVC4::theory;

--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -22,7 +22,9 @@
  **/
 
 #include "preprocessing/passes/ackermann.h"
+
 #include <cmath>
+
 #include "base/check.h"
 #include "expr/node_algorithm.h"
 #include "options/options.h"

--- a/src/preprocessing/passes/ackermann.h
+++ b/src/preprocessing/passes/ackermann.h
@@ -27,9 +27,11 @@
 #define CVC4__PREPROCESSING__PASSES__ACKERMANN_H
 
 #include <unordered_map>
+
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
+#include "theory/logic_info.h"
+#include "theory/substitutions.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/apply_substs.cpp
+++ b/src/preprocessing/passes/apply_substs.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/apply_substs.h"
 
 #include "context/cdo.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "theory/rewriter.h"
 #include "theory/substitutions.h"

--- a/src/preprocessing/passes/apply_substs.cpp
+++ b/src/preprocessing/passes/apply_substs.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/apply_substs.h"
 
 #include "context/cdo.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/rewriter.h"
 #include "theory/substitutions.h"
 

--- a/src/preprocessing/passes/apply_substs.h
+++ b/src/preprocessing/passes/apply_substs.h
@@ -21,10 +21,12 @@
 #define CVC4__PREPROCESSING__PASSES__APPLY_SUBSTS_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {
+
+class PreprocessingPassContext;
+
 namespace passes {
 
 class ApplySubsts : public PreprocessingPass

--- a/src/preprocessing/passes/bool_to_bv.cpp
+++ b/src/preprocessing/passes/bool_to_bv.cpp
@@ -19,7 +19,9 @@
 
 #include "base/map_util.h"
 #include "expr/node.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
+#include "theory/bv/theory_bv_utils.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
 

--- a/src/preprocessing/passes/bool_to_bv.cpp
+++ b/src/preprocessing/passes/bool_to_bv.cpp
@@ -19,6 +19,7 @@
 
 #include "base/map_util.h"
 #include "expr/node.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/bv/theory_bv_utils.h"

--- a/src/preprocessing/passes/bool_to_bv.h
+++ b/src/preprocessing/passes/bool_to_bv.h
@@ -20,8 +20,6 @@
 
 #include "options/bv_options.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
-#include "theory/bv/theory_bv_utils.h"
 #include "util/statistics_registry.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/bool_to_bv.h
+++ b/src/preprocessing/passes/bool_to_bv.h
@@ -18,6 +18,7 @@
 #ifndef CVC4__PREPROCESSING__PASSES__BOOL_TO_BV_H
 #define CVC4__PREPROCESSING__PASSES__BOOL_TO_BV_H
 
+#include "expr/node.h"
 #include "options/bv_options.h"
 #include "preprocessing/preprocessing_pass.h"
 #include "util/statistics_registry.h"

--- a/src/preprocessing/passes/bv_abstraction.cpp
+++ b/src/preprocessing/passes/bv_abstraction.cpp
@@ -26,8 +26,11 @@
 #include <vector>
 
 #include "options/bv_options.h"
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/bv/theory_bv.h"
 #include "theory/rewriter.h"
+#include "theory/theory_engine.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_abstraction.h
+++ b/src/preprocessing/passes/bv_abstraction.h
@@ -27,7 +27,6 @@
 #define CVC4__PREPROCESSING__PASSES__BV_ABSTRACTION_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_eager_atoms.cpp
+++ b/src/preprocessing/passes/bv_eager_atoms.cpp
@@ -18,6 +18,9 @@
 
 #include "preprocessing/passes/bv_eager_atoms.h"
 
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
+#include "theory/theory_engine.h"
 #include "theory/theory_model.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/bv_eager_atoms.h
+++ b/src/preprocessing/passes/bv_eager_atoms.h
@@ -21,7 +21,6 @@
 #define CVC4__PREPROCESSING__PASSES__BV_EAGER_ATOMS_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_gauss.cpp
+++ b/src/preprocessing/passes/bv_gauss.cpp
@@ -17,6 +17,9 @@
 
 #include "preprocessing/passes/bv_gauss.h"
 
+#include <unordered_map>
+#include <vector>
+
 #include "expr/node.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
@@ -24,10 +27,6 @@
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/rewriter.h"
 #include "util/bitvector.h"
-
-#include <unordered_map>
-#include <vector>
-
 
 using namespace CVC4;
 using namespace CVC4::theory;

--- a/src/preprocessing/passes/bv_gauss.cpp
+++ b/src/preprocessing/passes/bv_gauss.cpp
@@ -18,6 +18,8 @@
 #include "preprocessing/passes/bv_gauss.h"
 
 #include "expr/node.h"
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/bv/theory_bv_rewrite_rules_normalization.h"
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/bv_gauss.h
+++ b/src/preprocessing/passes/bv_gauss.h
@@ -20,8 +20,8 @@
 #ifndef CVC4__PREPROCESSING__PASSES__BV_GAUSS_ELIM_H
 #define CVC4__PREPROCESSING__PASSES__BV_GAUSS_ELIM_H
 
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_intro_pow2.cpp
+++ b/src/preprocessing/passes/bv_intro_pow2.cpp
@@ -20,6 +20,8 @@
 
 #include <unordered_map>
 
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/bv/theory_bv_rewrite_rules_simplification.h"
 #include "theory/rewriter.h"
 

--- a/src/preprocessing/passes/bv_intro_pow2.h
+++ b/src/preprocessing/passes/bv_intro_pow2.h
@@ -22,7 +22,6 @@
 #define CVC4__PREPROCESSING__PASSES__BV_INTRO_POW2_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_to_bool.cpp
+++ b/src/preprocessing/passes/bv_to_bool.cpp
@@ -23,10 +23,12 @@
 
 #include "expr/node.h"
 #include "expr/node_visitor.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
+#include "theory/bv/theory_bv_utils.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_to_bool.cpp
+++ b/src/preprocessing/passes/bv_to_bool.cpp
@@ -23,6 +23,7 @@
 
 #include "expr/node.h"
 #include "expr/node_visitor.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"

--- a/src/preprocessing/passes/bv_to_bool.cpp
+++ b/src/preprocessing/passes/bv_to_bool.cpp
@@ -26,9 +26,9 @@
 #include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
+#include "theory/bv/theory_bv_utils.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
-#include "theory/bv/theory_bv_utils.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/bv_to_bool.h
+++ b/src/preprocessing/passes/bv_to_bool.h
@@ -19,9 +19,8 @@
 #ifndef CVC4__PREPROCESSING__PASSES__BV_TO_BOOL_H
 #define CVC4__PREPROCESSING__PASSES__BV_TO_BOOL_H
 
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
-#include "theory/bv/theory_bv_utils.h"
 #include "util/statistics_registry.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/bv_to_int.h"
 
 #include <cmath>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -34,6 +34,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 using namespace CVC4::theory::bv;
 

--- a/src/preprocessing/passes/bv_to_int.cpp
+++ b/src/preprocessing/passes/bv_to_int.cpp
@@ -26,6 +26,8 @@
 #include "expr/node_traversal.h"
 #include "options/smt_options.h"
 #include "options/uf_options.h"
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/bv/theory_bv_rewrite_rules_operator_elimination.h"
 #include "theory/bv/theory_bv_rewrite_rules_simplification.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/bv_to_int.h
+++ b/src/preprocessing/passes/bv_to_int.h
@@ -104,7 +104,7 @@ class BVToInt : public PreprocessingPass
    * @return a node representing the shift.
    *
    */
-  Node createShiftNode(vector<Node> children,
+  Node createShiftNode(std::vector<Node> children,
                        uint64_t bvsize,
                        bool isLeftShift);
 
@@ -209,7 +209,7 @@ class BVToInt : public PreprocessingPass
    */
   Node reconstructNode(Node originalNode,
                        TypeNode resultType,
-                       const vector<Node>& translated_children);
+                       const std::vector<Node>& translated_children);
 
   /**
    * A useful utility function.
@@ -247,7 +247,7 @@ class BVToInt : public PreprocessingPass
    * that have children.
    */
   Node translateWithChildren(Node original,
-                             const vector<Node>& translated_children);
+                             const std::vector<Node>& translated_children);
 
   /**
    * Performs the actual translation to integers for nodes

--- a/src/preprocessing/passes/bv_to_int.h
+++ b/src/preprocessing/passes/bv_to_int.h
@@ -69,10 +69,8 @@
 #define __CVC4__PREPROCESSING__PASSES__BV_TO_INT_H
 
 #include "context/cdhashmap.h"
-#include "context/cdo.h"
-#include "context/context.h"
+#include "context/cdhashset.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/arith/nl/iand_utils.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/extended_rewriter_pass.cpp
+++ b/src/preprocessing/passes/extended_rewriter_pass.cpp
@@ -17,6 +17,8 @@
 #include "preprocessing/passes/extended_rewriter_pass.h"
 
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/quantifiers/extended_rewrite.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/extended_rewriter_pass.h
+++ b/src/preprocessing/passes/extended_rewriter_pass.h
@@ -20,7 +20,6 @@
 #define CVC4__PREPROCESSING__PASSES__EXTENDED_REWRITER_PASS_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/foreign_theory_rewrite.cpp
+++ b/src/preprocessing/passes/foreign_theory_rewrite.cpp
@@ -17,6 +17,9 @@
 #include "preprocessing/passes/foreign_theory_rewrite.h"
 
 #include "expr/node_traversal.h"
+#include "preprocessing/assertion_pipeline.h"
+#include "preprocessing/preprocessing_pass_context.h"
+#include "theory/rewriter.h"
 #include "theory/strings/arith_entail.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/foreign_theory_rewrite.h
+++ b/src/preprocessing/passes/foreign_theory_rewrite.h
@@ -57,7 +57,7 @@ class ForeignTheoryRewrite : public PreprocessingPass
   /** construct a node with the same operator as originalNode whose children are
    * processedChildren
    */
-  static Node reconstructNode(Node originalNode, vector<Node> newChildren);
+  static Node reconstructNode(Node originalNode, std::vector<Node> newChildren);
   /** A cache to store the simplified nodes */
   CDNodeMap d_cache;
 };

--- a/src/preprocessing/passes/foreign_theory_rewrite.h
+++ b/src/preprocessing/passes/foreign_theory_rewrite.h
@@ -20,10 +20,8 @@
 #define CVC4__PREPROCESSING__PASSES__FOREIGN_THEORY_REWRITE_H
 
 #include "context/cdhashmap.h"
-#include "context/cdo.h"
-#include "context/context.h"
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/fun_def_fmf.cpp
+++ b/src/preprocessing/passes/fun_def_fmf.cpp
@@ -15,10 +15,12 @@
 #include "preprocessing/passes/fun_def_fmf.h"
 
 #include "options/smt_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "proof/proof_manager.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/term_database.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/rewriter.h"
 
 using namespace std;
 using namespace CVC4::kind;

--- a/src/preprocessing/passes/fun_def_fmf.cpp
+++ b/src/preprocessing/passes/fun_def_fmf.cpp
@@ -14,6 +14,8 @@
 
 #include "preprocessing/passes/fun_def_fmf.h"
 
+#include <sstream>
+
 #include "options/smt_options.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"

--- a/src/preprocessing/passes/fun_def_fmf.cpp
+++ b/src/preprocessing/passes/fun_def_fmf.cpp
@@ -15,6 +15,7 @@
 #include "preprocessing/passes/fun_def_fmf.h"
 
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "proof/proof_manager.h"
 #include "theory/quantifiers/quantifiers_attributes.h"

--- a/src/preprocessing/passes/fun_def_fmf.h
+++ b/src/preprocessing/passes/fun_def_fmf.h
@@ -16,7 +16,6 @@
 #define CVC4__PREPROCESSING__PASSES__FUN_DEF_FMF_H
 
 #include <map>
-#include <string>
 #include <vector>
 
 #include "context/cdlist.h"

--- a/src/preprocessing/passes/fun_def_fmf.h
+++ b/src/preprocessing/passes/fun_def_fmf.h
@@ -19,9 +19,9 @@
 #include <string>
 #include <vector>
 
+#include "context/cdlist.h"
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/global_negate.cpp
+++ b/src/preprocessing/passes/global_negate.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "expr/node.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/rewriter.h"
 
 using namespace std;

--- a/src/preprocessing/passes/global_negate.h
+++ b/src/preprocessing/passes/global_negate.h
@@ -26,7 +26,6 @@
 #define CVC4__PREPROCESSING__PASSES__GLOBAL_NEGATE_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/global_negate.h
+++ b/src/preprocessing/passes/global_negate.h
@@ -25,6 +25,7 @@
 #ifndef CVC4__PREPROCESSING__PASSES__GLOBAL_NEGATE_H
 #define CVC4__PREPROCESSING__PASSES__GLOBAL_NEGATE_H
 
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/ho_elim.cpp
+++ b/src/preprocessing/passes/ho_elim.cpp
@@ -18,6 +18,7 @@
 
 #include "expr/node_algorithm.h"
 #include "options/quantifiers_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/rewriter.h"
 #include "theory/uf/theory_uf_rewriter.h"
 

--- a/src/preprocessing/passes/ho_elim.h
+++ b/src/preprocessing/passes/ho_elim.h
@@ -19,6 +19,11 @@
 #ifndef __CVC4__PREPROCESSING__PASSES__HO_ELIM_PASS_H
 #define __CVC4__PREPROCESSING__PASSES__HO_ELIM_PASS_H
 
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/ho_elim.h
+++ b/src/preprocessing/passes/ho_elim.h
@@ -20,7 +20,6 @@
 #define __CVC4__PREPROCESSING__PASSES__HO_ELIM_PASS_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/int_to_bv.cpp
+++ b/src/preprocessing/passes/int_to_bv.cpp
@@ -25,6 +25,7 @@
 #include "expr/node.h"
 #include "expr/node_traversal.h"
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"
 

--- a/src/preprocessing/passes/int_to_bv.cpp
+++ b/src/preprocessing/passes/int_to_bv.cpp
@@ -32,6 +32,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 
 using NodeMap = std::unordered_map<Node, Node, NodeHashFunction>;

--- a/src/preprocessing/passes/int_to_bv.h
+++ b/src/preprocessing/passes/int_to_bv.h
@@ -22,7 +22,6 @@
 #define CVC4__PREPROCESSING__PASSES__INT_TO_BV_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/ite_removal.cpp
+++ b/src/preprocessing/passes/ite_removal.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/ite_removal.h"
 
 #include "options/smt_options.h"
+#include "prop/prop_engine.h"
 #include "theory/rewriter.h"
 #include "theory/theory_preprocessor.h"
 

--- a/src/preprocessing/passes/ite_removal.cpp
+++ b/src/preprocessing/passes/ite_removal.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/ite_removal.h"
 
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "prop/prop_engine.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/ite_removal.cpp
+++ b/src/preprocessing/passes/ite_removal.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/ite_removal.h"
 
 #include "options/smt_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "prop/prop_engine.h"
 #include "theory/rewriter.h"
 #include "theory/theory_preprocessor.h"

--- a/src/preprocessing/passes/ite_removal.cpp
+++ b/src/preprocessing/passes/ite_removal.cpp
@@ -20,6 +20,7 @@
 #include "options/smt_options.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
+#include "proof/proof_manager.h"
 #include "prop/prop_engine.h"
 #include "theory/rewriter.h"
 #include "theory/theory_preprocessor.h"

--- a/src/preprocessing/passes/ite_removal.h
+++ b/src/preprocessing/passes/ite_removal.h
@@ -20,11 +20,7 @@
 #ifndef CVC4__PREPROCESSING__PASSES__ITE_REMOVAL_H
 #define CVC4__PREPROCESSING__PASSES__ITE_REMOVAL_H
 
-#include <unordered_set>
-#include <vector>
-
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/ite_simp.cpp
+++ b/src/preprocessing/passes/ite_simp.cpp
@@ -17,11 +17,13 @@
 #include <vector>
 
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "smt_util/nary_builder.h"
 #include "theory/arith/arith_ite_utils.h"
 #include "theory/rewriter.h"
+#include "theory/theory_engine.h"
 
 using namespace std;
 using namespace CVC4;

--- a/src/preprocessing/passes/ite_simp.cpp
+++ b/src/preprocessing/passes/ite_simp.cpp
@@ -17,9 +17,11 @@
 #include <vector>
 
 #include "options/smt_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "smt_util/nary_builder.h"
 #include "theory/arith/arith_ite_utils.h"
+#include "theory/rewriter.h"
 
 using namespace std;
 using namespace CVC4;

--- a/src/preprocessing/passes/ite_simp.cpp
+++ b/src/preprocessing/passes/ite_simp.cpp
@@ -21,6 +21,7 @@
 #include "smt_util/nary_builder.h"
 #include "theory/arith/arith_ite_utils.h"
 
+using namespace std;
 using namespace CVC4;
 using namespace CVC4::theory;
 

--- a/src/preprocessing/passes/ite_simp.h
+++ b/src/preprocessing/passes/ite_simp.h
@@ -18,7 +18,7 @@
 #define CVC4__PREPROCESSING__PASSES__ITE_SIMP_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
+#include "preprocessing/util/ite_utilities.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/miplib_trick.cpp
+++ b/src/preprocessing/passes/miplib_trick.cpp
@@ -15,6 +15,7 @@
 
 #include "preprocessing/passes/miplib_trick.h"
 
+#include <sstream>
 #include <vector>
 
 #include "expr/node_self_iterator.h"

--- a/src/preprocessing/passes/miplib_trick.cpp
+++ b/src/preprocessing/passes/miplib_trick.cpp
@@ -20,9 +20,11 @@
 #include "expr/node_self_iterator.h"
 #include "options/arith_options.h"
 #include "options/smt_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "smt_util/boolean_simplification.h"
 #include "theory/booleans/circuit_propagator.h"
+#include "theory/theory_engine.h"
 #include "theory/theory_model.h"
 #include "theory/trust_substitutions.h"
 

--- a/src/preprocessing/passes/miplib_trick.cpp
+++ b/src/preprocessing/passes/miplib_trick.cpp
@@ -20,6 +20,7 @@
 #include "expr/node_self_iterator.h"
 #include "options/arith_options.h"
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "smt_util/boolean_simplification.h"

--- a/src/preprocessing/passes/miplib_trick.cpp
+++ b/src/preprocessing/passes/miplib_trick.cpp
@@ -30,6 +30,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 
 namespace {

--- a/src/preprocessing/passes/miplib_trick.h
+++ b/src/preprocessing/passes/miplib_trick.h
@@ -18,6 +18,7 @@
 #ifndef CVC4__PREPROCESSING__PASSES__MIPLIB_TRICK_H
 #define CVC4__PREPROCESSING__PASSES__MIPLIB_TRICK_H
 
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/miplib_trick.h
+++ b/src/preprocessing/passes/miplib_trick.h
@@ -19,7 +19,6 @@
 #define CVC4__PREPROCESSING__PASSES__MIPLIB_TRICK_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/nl_ext_purify.cpp
+++ b/src/preprocessing/passes/nl_ext_purify.cpp
@@ -21,6 +21,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 
 Node NlExtPurify::purifyNlTerms(TNode n,

--- a/src/preprocessing/passes/nl_ext_purify.cpp
+++ b/src/preprocessing/passes/nl_ext_purify.cpp
@@ -16,6 +16,7 @@
 
 #include "preprocessing/passes/nl_ext_purify.h"
 
+#include "theory/rewriter.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/nl_ext_purify.cpp
+++ b/src/preprocessing/passes/nl_ext_purify.cpp
@@ -16,6 +16,7 @@
 
 #include "preprocessing/passes/nl_ext_purify.h"
 
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/rewriter.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/nl_ext_purify.h
+++ b/src/preprocessing/passes/nl_ext_purify.h
@@ -25,7 +25,6 @@
 
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -289,7 +289,7 @@ PreprocessingPassResult NonClausalSimp::applyInternal(
       << "Resize non-clausal learned literals to " << j << std::endl;
   learned_literals.resize(j);
 
-  unordered_set<TNode, TNodeHashFunction> s;
+  std::unordered_set<TNode, TNodeHashFunction> s;
   for (size_t i = 0, size = assertionsToPreprocess->size(); i < size; ++i)
   {
     Node assertion = (*assertionsToPreprocess)[i];

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -20,7 +20,10 @@
 
 #include "context/cdo.h"
 #include "options/smt_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
+#include "smt/preprocess_proof_generator.h"
 #include "smt/smt_statistics_registry.h"
+#include "theory/theory.h"
 #include "theory/theory_model.h"
 #include "theory/trust_substitutions.h"
 

--- a/src/preprocessing/passes/non_clausal_simp.cpp
+++ b/src/preprocessing/passes/non_clausal_simp.cpp
@@ -20,10 +20,13 @@
 
 #include "context/cdo.h"
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/preprocess_proof_generator.h"
 #include "smt/smt_statistics_registry.h"
+#include "theory/booleans/circuit_propagator.h"
 #include "theory/theory.h"
+#include "theory/theory_engine.h"
 #include "theory/theory_model.h"
 #include "theory/trust_substitutions.h"
 

--- a/src/preprocessing/passes/non_clausal_simp.h
+++ b/src/preprocessing/passes/non_clausal_simp.h
@@ -17,16 +17,23 @@
 #ifndef CVC4__PREPROCESSING__PASSES__NON_CLAUSAL_SIMP_H
 #define CVC4__PREPROCESSING__PASSES__NON_CLAUSAL_SIMP_H
 
-#include <vector>
-
-#include "expr/lazy_proof.h"
+#include "context/cdlist.h"
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
-#include "smt/preprocess_proof_generator.h"
 #include "theory/trust_node.h"
 
 namespace CVC4 {
+
+class LazyCDProof;
+class ProofNodeManager;
+
+namespace smt {
+class PreprocessProofGenerator;
+}
+namespace theory {
+class TrustSubstitutionMap;
+}
+
 namespace preprocessing {
 namespace passes {
 

--- a/src/preprocessing/passes/pseudo_boolean_processor.cpp
+++ b/src/preprocessing/passes/pseudo_boolean_processor.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/pseudo_boolean_processor.h"
 
 #include "base/output.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/arith/arith_utilities.h"
 #include "theory/arith/normal_form.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/pseudo_boolean_processor.cpp
+++ b/src/preprocessing/passes/pseudo_boolean_processor.cpp
@@ -18,6 +18,7 @@
 #include "preprocessing/passes/pseudo_boolean_processor.h"
 
 #include "base/output.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "theory/arith/arith_utilities.h"
 #include "theory/arith/normal_form.h"

--- a/src/preprocessing/passes/pseudo_boolean_processor.h
+++ b/src/preprocessing/passes/pseudo_boolean_processor.h
@@ -25,10 +25,8 @@
 
 #include "context/cdhashmap.h"
 #include "context/cdo.h"
-#include "context/context.h"
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/substitutions.h"
 #include "util/maybe.h"
 #include "util/rational.h"

--- a/src/preprocessing/passes/quantifier_macros.cpp
+++ b/src/preprocessing/passes/quantifier_macros.cpp
@@ -20,6 +20,7 @@
 
 #include "options/quantifiers_options.h"
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "proof/proof_manager.h"
 #include "smt/smt_engine.h"
@@ -31,6 +32,7 @@
 #include "theory/quantifiers/term_util.h"
 #include "theory/quantifiers_engine.h"
 #include "theory/rewriter.h"
+#include "theory/theory_engine.h"
 
 using namespace std;
 using namespace CVC4::theory;

--- a/src/preprocessing/passes/quantifier_macros.cpp
+++ b/src/preprocessing/passes/quantifier_macros.cpp
@@ -20,6 +20,8 @@
 
 #include "options/quantifiers_options.h"
 #include "options/smt_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
+#include "proof/proof_manager.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
 #include "theory/arith/arith_msum.h"

--- a/src/preprocessing/passes/quantifier_macros.h
+++ b/src/preprocessing/passes/quantifier_macros.h
@@ -18,12 +18,9 @@
 #define CVC4__PREPROCESSING__PASSES__QUANTIFIER_MACROS_H
 
 #include <map>
-#include <string>
 #include <vector>
 #include "expr/node.h"
-#include "expr/type_node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/quantifiers_preprocess.cpp
+++ b/src/preprocessing/passes/quantifiers_preprocess.cpp
@@ -27,6 +27,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 
 QuantifiersPreprocess::QuantifiersPreprocess(PreprocessingPassContext* preprocContext)

--- a/src/preprocessing/passes/quantifiers_preprocess.cpp
+++ b/src/preprocessing/passes/quantifiers_preprocess.cpp
@@ -20,6 +20,7 @@
 #include "preprocessing/passes/quantifiers_preprocess.h"
 
 #include "base/output.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/quantifiers/quantifiers_rewriter.h"
 #include "theory/rewriter.h"
 

--- a/src/preprocessing/passes/quantifiers_preprocess.h
+++ b/src/preprocessing/passes/quantifiers_preprocess.h
@@ -23,7 +23,6 @@
 #define CVC4__PREPROCESSING__PASSES__QUANTIFIERS_PREPROCESS_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/real_to_int.cpp
+++ b/src/preprocessing/passes/real_to_int.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "theory/arith/arith_msum.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/real_to_int.cpp
+++ b/src/preprocessing/passes/real_to_int.cpp
@@ -26,6 +26,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 
 Node RealToInt::realToIntInternal(TNode n, NodeMap& cache, std::vector<Node>& var_eq)

--- a/src/preprocessing/passes/real_to_int.cpp
+++ b/src/preprocessing/passes/real_to_int.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/arith/arith_msum.h"
 #include "theory/rewriter.h"
 #include "theory/theory_model.h"

--- a/src/preprocessing/passes/real_to_int.h
+++ b/src/preprocessing/passes/real_to_int.h
@@ -19,12 +19,10 @@
 #ifndef CVC4__PREPROCESSING__PASSES__REAL_TO_INT_H
 #define CVC4__PREPROCESSING__PASSES__REAL_TO_INT_H
 
-#include <unordered_map>
 #include <vector>
 
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/rewrite.cpp
+++ b/src/preprocessing/passes/rewrite.cpp
@@ -16,6 +16,7 @@
 
 #include "preprocessing/passes/rewrite.h"
 
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/rewriter.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/rewrite.h
+++ b/src/preprocessing/passes/rewrite.h
@@ -20,7 +20,6 @@
 #define CVC4__PREPROCESSING__PASSES__REWRITE_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/sep_skolem_emp.cpp
+++ b/src/preprocessing/passes/sep_skolem_emp.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "expr/node.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/quantifiers/quant_util.h"
 #include "theory/rewriter.h"
 #include "theory/theory.h"

--- a/src/preprocessing/passes/sep_skolem_emp.cpp
+++ b/src/preprocessing/passes/sep_skolem_emp.cpp
@@ -28,6 +28,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 
 namespace {

--- a/src/preprocessing/passes/sep_skolem_emp.h
+++ b/src/preprocessing/passes/sep_skolem_emp.h
@@ -19,7 +19,6 @@
 #define CVC4__PREPROCESSING__PASSES__SEP_SKOLEM_EMP_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -16,11 +16,13 @@
 
 #include "options/smt_options.h"
 #include "options/uf_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/dump_manager.h"
 #include "smt/smt_engine_scope.h"
 #include "theory/rewriter.h"
 #include "theory/sort_inference.h"
+#include "theory/theory_engine.h"
 
 using namespace std;
 

--- a/src/preprocessing/passes/sort_infer.cpp
+++ b/src/preprocessing/passes/sort_infer.cpp
@@ -16,7 +16,9 @@
 
 #include "options/smt_options.h"
 #include "options/uf_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/dump_manager.h"
+#include "smt/smt_engine_scope.h"
 #include "theory/rewriter.h"
 #include "theory/sort_inference.h"
 

--- a/src/preprocessing/passes/sort_infer.h
+++ b/src/preprocessing/passes/sort_infer.h
@@ -15,13 +15,7 @@
 #ifndef CVC4__PREPROCESSING__PASSES__SORT_INFERENCE_PASS_H_
 #define CVC4__PREPROCESSING__PASSES__SORT_INFERENCE_PASS_H_
 
-#include <map>
-#include <string>
-#include <vector>
-
-#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/static_learning.cpp
+++ b/src/preprocessing/passes/static_learning.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "expr/node.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/rewriter.h"
 
 namespace CVC4 {

--- a/src/preprocessing/passes/static_learning.cpp
+++ b/src/preprocessing/passes/static_learning.cpp
@@ -18,8 +18,10 @@
 #include <string>
 
 #include "expr/node.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "theory/rewriter.h"
+#include "theory/theory_engine.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/static_learning.h
+++ b/src/preprocessing/passes/static_learning.h
@@ -19,7 +19,6 @@
 #define CVC4__PREPROCESSING__PASSES__STATIC_LEARNING_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/strings_eager_pp.cpp
+++ b/src/preprocessing/passes/strings_eager_pp.cpp
@@ -14,6 +14,7 @@
 
 #include "preprocessing/passes/strings_eager_pp.h"
 
+#include "preprocessing/assertion_pipeline.h"
 #include "theory/strings/theory_strings_preprocess.h"
 #include "theory/rewriter.h"
 

--- a/src/preprocessing/passes/strings_eager_pp.cpp
+++ b/src/preprocessing/passes/strings_eager_pp.cpp
@@ -15,8 +15,8 @@
 #include "preprocessing/passes/strings_eager_pp.h"
 
 #include "preprocessing/assertion_pipeline.h"
-#include "theory/strings/theory_strings_preprocess.h"
 #include "theory/rewriter.h"
+#include "theory/strings/theory_strings_preprocess.h"
 
 using namespace CVC4::theory;
 

--- a/src/preprocessing/passes/strings_eager_pp.h
+++ b/src/preprocessing/passes/strings_eager_pp.h
@@ -18,7 +18,6 @@
 #define CVC4__PREPROCESSING__PASSES__STRINGS_EAGER_PP_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/sygus_inference.cpp
+++ b/src/preprocessing/passes/sygus_inference.cpp
@@ -14,6 +14,7 @@
 
 #include "preprocessing/passes/sygus_inference.h"
 
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
@@ -22,6 +23,7 @@
 #include "theory/quantifiers/quantifiers_rewriter.h"
 #include "theory/quantifiers/sygus/sygus_grammar_cons.h"
 #include "theory/quantifiers/sygus/sygus_utils.h"
+#include "theory/rewriter.h"
 #include "theory/smt_engine_subsolver.h"
 
 using namespace std;

--- a/src/preprocessing/passes/sygus_inference.cpp
+++ b/src/preprocessing/passes/sygus_inference.cpp
@@ -14,6 +14,7 @@
 
 #include "preprocessing/passes/sygus_inference.h"
 
+#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
 #include "smt/smt_statistics_registry.h"

--- a/src/preprocessing/passes/sygus_inference.h
+++ b/src/preprocessing/passes/sygus_inference.h
@@ -15,13 +15,10 @@
 #ifndef CVC4__PREPROCESSING__PASSES__SYGUS_INFERENCE_H_
 #define CVC4__PREPROCESSING__PASSES__SYGUS_INFERENCE_H_
 
-#include <map>
-#include <string>
 #include <vector>
 #include "expr/node.h"
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -19,6 +19,7 @@
 #include "expr/term_canonize.h"
 #include "options/base_options.h"
 #include "options/quantifiers_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "printer/printer.h"
 #include "theory/quantifiers/candidate_rewrite_database.h"
 #include "theory/quantifiers/quantifiers_attributes.h"

--- a/src/preprocessing/passes/synth_rew_rules.cpp
+++ b/src/preprocessing/passes/synth_rew_rules.cpp
@@ -15,6 +15,8 @@
 
 #include "preprocessing/passes/synth_rew_rules.h"
 
+#include <sstream>
+
 #include "expr/sygus_datatype.h"
 #include "expr/term_canonize.h"
 #include "options/base_options.h"

--- a/src/preprocessing/passes/synth_rew_rules.h
+++ b/src/preprocessing/passes/synth_rew_rules.h
@@ -17,7 +17,6 @@
 #define CVC4__PREPROCESSING__PASSES__SYNTH_REW_RULES_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/theory_preprocess.cpp
+++ b/src/preprocessing/passes/theory_preprocess.cpp
@@ -17,6 +17,7 @@
 #include "preprocessing/passes/theory_preprocess.h"
 
 #include "options/smt_options.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "prop/prop_engine.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/theory_preprocess.cpp
+++ b/src/preprocessing/passes/theory_preprocess.cpp
@@ -17,6 +17,7 @@
 #include "preprocessing/passes/theory_preprocess.h"
 
 #include "options/smt_options.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "prop/prop_engine.h"
 #include "theory/rewriter.h"
 #include "theory/theory_engine.h"
@@ -36,7 +37,7 @@ PreprocessingPassResult TheoryPreprocess::applyInternal(
   d_preprocContext->spendResource(ResourceManager::Resource::PreprocessStep);
 
   IteSkolemMap& imap = assertions->getIteSkolemMap();
-  PropEngine* propEngine = d_preprocContext->getPropEngine();
+  prop::PropEngine* propEngine = d_preprocContext->getPropEngine();
   // Remove all of the ITE occurrences and normalize
   for (unsigned i = 0, size = assertions->size(); i < size; ++i)
   {

--- a/src/preprocessing/passes/theory_preprocess.cpp
+++ b/src/preprocessing/passes/theory_preprocess.cpp
@@ -17,6 +17,7 @@
 #include "preprocessing/passes/theory_preprocess.h"
 
 #include "options/smt_options.h"
+#include "prop/prop_engine.h"
 #include "theory/rewriter.h"
 #include "theory/theory_engine.h"
 

--- a/src/preprocessing/passes/theory_preprocess.cpp
+++ b/src/preprocessing/passes/theory_preprocess.cpp
@@ -19,6 +19,7 @@
 #include "options/smt_options.h"
 #include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
+#include "proof/proof_manager.h"
 #include "prop/prop_engine.h"
 #include "theory/rewriter.h"
 #include "theory/theory_engine.h"

--- a/src/preprocessing/passes/theory_preprocess.h
+++ b/src/preprocessing/passes/theory_preprocess.h
@@ -20,7 +20,6 @@
 #define CVC4__PREPROCESSING__PASSES__THEORY_PREPROCESS_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/theory_rewrite_eq.cpp
+++ b/src/preprocessing/passes/theory_rewrite_eq.cpp
@@ -14,6 +14,7 @@
 
 #include "preprocessing/passes/theory_rewrite_eq.h"
 
+#include "preprocessing/preprocessing_pass_context.h"
 #include "theory/theory_engine.h"
 
 using namespace CVC4::theory;

--- a/src/preprocessing/passes/theory_rewrite_eq.cpp
+++ b/src/preprocessing/passes/theory_rewrite_eq.cpp
@@ -14,6 +14,7 @@
 
 #include "preprocessing/passes/theory_rewrite_eq.h"
 
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "theory/theory_engine.h"
 

--- a/src/preprocessing/passes/theory_rewrite_eq.h
+++ b/src/preprocessing/passes/theory_rewrite_eq.h
@@ -17,7 +17,9 @@
 #ifndef CVC4__PREPROCESSING__PASSES__THEORY_REWRITE_EQ_H
 #define CVC4__PREPROCESSING__PASSES__THEORY_REWRITE_EQ_H
 
+#include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
+#include "theory/trust_node.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/theory_rewrite_eq.h
+++ b/src/preprocessing/passes/theory_rewrite_eq.h
@@ -18,8 +18,6 @@
 #define CVC4__PREPROCESSING__PASSES__THEORY_REWRITE_EQ_H
 
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
-#include "theory/trust_node.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/passes/unconstrained_simplifier.cpp
+++ b/src/preprocessing/passes/unconstrained_simplifier.cpp
@@ -19,7 +19,9 @@
 #include "preprocessing/passes/unconstrained_simplifier.h"
 
 #include "expr/dtype.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
+#include "smt/logic_exception.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/logic_info.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/unconstrained_simplifier.cpp
+++ b/src/preprocessing/passes/unconstrained_simplifier.cpp
@@ -19,6 +19,7 @@
 #include "preprocessing/passes/unconstrained_simplifier.h"
 
 #include "expr/dtype.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/logic_info.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/passes/unconstrained_simplifier.cpp
+++ b/src/preprocessing/passes/unconstrained_simplifier.cpp
@@ -27,6 +27,7 @@ namespace CVC4 {
 namespace preprocessing {
 namespace passes {
 
+using namespace std;
 using namespace CVC4::theory;
 
 UnconstrainedSimplifier::UnconstrainedSimplifier(

--- a/src/preprocessing/passes/unconstrained_simplifier.h
+++ b/src/preprocessing/passes/unconstrained_simplifier.h
@@ -31,7 +31,7 @@
 
 namespace CVC4 {
 namespace context {
-  class Context;
+class Context;
 }
 namespace preprocessing {
 namespace passes {

--- a/src/preprocessing/passes/unconstrained_simplifier.h
+++ b/src/preprocessing/passes/unconstrained_simplifier.h
@@ -24,13 +24,15 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "context/context.h"
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
 #include "theory/substitutions.h"
 #include "util/statistics_registry.h"
 
 namespace CVC4 {
+namespace context {
+  class Context;
+}
 namespace preprocessing {
 namespace passes {
 

--- a/src/preprocessing/passes/unconstrained_simplifier.h
+++ b/src/preprocessing/passes/unconstrained_simplifier.h
@@ -23,13 +23,10 @@
 
 #include <unordered_map>
 #include <unordered_set>
-#include <vector>
 
 #include "context/context.h"
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
-#include "preprocessing/preprocessing_pass_context.h"
-#include "theory/logic_info.h"
 #include "theory/substitutions.h"
 #include "util/statistics_registry.h"
 

--- a/src/preprocessing/preprocessing_pass.cpp
+++ b/src/preprocessing/preprocessing_pass.cpp
@@ -16,6 +16,7 @@
 
 #include "preprocessing/preprocessing_pass.h"
 
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "printer/printer.h"
 #include "smt/dump.h"

--- a/src/preprocessing/preprocessing_pass.cpp
+++ b/src/preprocessing/preprocessing_pass.cpp
@@ -16,9 +16,12 @@
 
 #include "preprocessing/preprocessing_pass.h"
 
-#include "smt/dump.h"
-#include "smt/smt_statistics_registry.h"
+#include "preprocessing/preprocessing_pass_context.h"
 #include "printer/printer.h"
+#include "smt/dump.h"
+#include "smt/output_manager.h"
+#include "smt/smt_engine_scope.h"
+#include "smt/smt_statistics_registry.h"
 
 namespace CVC4 {
 namespace preprocessing {

--- a/src/preprocessing/preprocessing_pass.h
+++ b/src/preprocessing/preprocessing_pass.h
@@ -34,12 +34,12 @@
 #include <string>
 
 #include "preprocessing/assertion_pipeline.h"
-#include "preprocessing/preprocessing_pass_context.h"
-#include "smt/smt_engine_scope.h"
-#include "theory/logic_info.h"
+#include "util/statistics_registry.h"
 
 namespace CVC4 {
 namespace preprocessing {
+
+class PreprocessingPassContext;
 
 /**
  * Preprocessing passes return a result which indicates whether a conflict has

--- a/src/preprocessing/preprocessing_pass.h
+++ b/src/preprocessing/preprocessing_pass.h
@@ -33,12 +33,12 @@
 
 #include <string>
 
-#include "preprocessing/assertion_pipeline.h"
 #include "util/statistics_registry.h"
 
 namespace CVC4 {
 namespace preprocessing {
 
+class AssertionPipeline;
 class PreprocessingPassContext;
 
 /**

--- a/src/preprocessing/preprocessing_pass_context.h
+++ b/src/preprocessing/preprocessing_pass_context.h
@@ -27,13 +27,13 @@
 #include "util/resource_manager.h"
 
 namespace CVC4 {
-  class SmtEngine;
-  class TheoryEngine;
+class SmtEngine;
+class TheoryEngine;
 namespace theory::booleans {
-  class CircuitPropagator;
+class CircuitPropagator;
 }
 namespace prop {
-  class PropEngine;
+class PropEngine;
 }
 namespace preprocessing {
 

--- a/src/preprocessing/preprocessing_pass_context.h
+++ b/src/preprocessing/preprocessing_pass_context.h
@@ -21,12 +21,9 @@
 #ifndef CVC4__PREPROCESSING__PREPROCESSING_PASS_CONTEXT_H
 #define CVC4__PREPROCESSING__PREPROCESSING_PASS_CONTEXT_H
 
-#include "context/cdo.h"
 #include "context/context.h"
-#include "decision/decision_engine.h"
 #include "preprocessing/util/ite_utilities.h"
 #include "smt/smt_engine.h"
-#include "smt/term_formula_removal.h"
 #include "theory/booleans/circuit_propagator.h"
 #include "theory/theory_engine.h"
 #include "theory/trust_substitutions.h"

--- a/src/preprocessing/preprocessing_pass_context.h
+++ b/src/preprocessing/preprocessing_pass_context.h
@@ -21,15 +21,20 @@
 #ifndef CVC4__PREPROCESSING__PREPROCESSING_PASS_CONTEXT_H
 #define CVC4__PREPROCESSING__PREPROCESSING_PASS_CONTEXT_H
 
-#include "context/context.h"
-#include "preprocessing/util/ite_utilities.h"
+#include "context/cdhashset.h"
 #include "smt/smt_engine.h"
-#include "theory/booleans/circuit_propagator.h"
-#include "theory/theory_engine.h"
 #include "theory/trust_substitutions.h"
 #include "util/resource_manager.h"
 
 namespace CVC4 {
+  class SmtEngine;
+  class TheoryEngine;
+namespace theory::booleans {
+  class CircuitPropagator;
+}
+namespace prop {
+  class PropEngine;
+}
 namespace preprocessing {
 
 class PreprocessingPassContext

--- a/src/preprocessing/preprocessing_pass_registry.h
+++ b/src/preprocessing/preprocessing_pass_registry.h
@@ -19,15 +19,14 @@
 #ifndef CVC4__PREPROCESSING__PREPROCESSING_PASS_REGISTRY_H
 #define CVC4__PREPROCESSING__PREPROCESSING_PASS_REGISTRY_H
 
-#include <memory>
+#include <functional>
 #include <string>
 #include <unordered_map>
-
-#include "preprocessing/preprocessing_pass.h"
 
 namespace CVC4 {
 namespace preprocessing {
 
+class PreprocessingPass;
 class PreprocessingPassContext;
 
 /**

--- a/src/preprocessing/util/ite_utilities.cpp
+++ b/src/preprocessing/util/ite_utilities.cpp
@@ -21,6 +21,7 @@
 
 #include <utility>
 
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/passes/rewrite.h"
 #include "smt/smt_statistics_registry.h"
 #include "theory/rewriter.h"

--- a/src/preprocessing/util/ite_utilities.h
+++ b/src/preprocessing/util/ite_utilities.h
@@ -27,16 +27,16 @@
 #include <vector>
 
 #include "expr/node.h"
-#include "preprocessing/assertion_pipeline.h"
 #include "util/hash.h"
 #include "util/statistics_registry.h"
 
 namespace CVC4 {
 namespace preprocessing {
+
+class AssertionPipeline;
+
 namespace util {
 
-class IncomingArcCounter;
-class TermITEHeightCounter;
 class ITECompressor;
 class ITESimplifier;
 class ITECareSimplifier;

--- a/src/printer/let_binding.h
+++ b/src/printer/let_binding.h
@@ -17,7 +17,6 @@
 #ifndef CVC4__PRINTER__LET_BINDING_H
 #define CVC4__PRINTER__LET_BINDING_H
 
-#include <map>
 #include <vector>
 
 #include "context/cdhashmap.h"

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -19,7 +19,6 @@
 #ifndef CVC4__PRINTER__PRINTER_H
 #define CVC4__PRINTER__PRINTER_H
 
-#include <map>
 #include <string>
 
 #include "expr/node.h"

--- a/src/proof/cnf_proof.h
+++ b/src/proof/cnf_proof.h
@@ -21,14 +21,12 @@
 #ifndef CVC4__CNF_PROOF_H
 #define CVC4__CNF_PROOF_H
 
-#include <iosfwd>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "context/cdhashmap.h"
 #include "proof/clause_id.h"
-#include "proof/sat_proof.h"
-#include "util/maybe.h"
+#include "proof/proof_manager.h"
 
 namespace CVC4 {
 namespace prop {

--- a/src/proof/proof_manager.h
+++ b/src/proof/proof_manager.h
@@ -19,7 +19,6 @@
 #ifndef CVC4__PROOF_MANAGER_H
 #define CVC4__PROOF_MANAGER_H
 
-#include <iosfwd>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -28,7 +27,6 @@
 #include "context/cdhashset.h"
 #include "expr/node.h"
 #include "proof/clause_id.h"
-#include "util/statistics_registry.h"
 
 namespace CVC4 {
 

--- a/src/prop/bvminisat/simp/SimpSolver.h
+++ b/src/prop/bvminisat/simp/SimpSolver.h
@@ -21,13 +21,16 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef BVMinisat_SimpSolver_h
 #define BVMinisat_SimpSolver_h
 
-#include "context/context.h"
 #include "proof/clause_id.h"
 #include "prop/bvminisat/core/Solver.h"
 #include "prop/bvminisat/mtl/Queue.h"
-#include "util/statistics_registry.h"
 
 namespace CVC4 {
+
+namespace context {
+class Context;
+}
+
 namespace BVMinisat {
 
 //=================================================================================================

--- a/src/prop/cnf_stream.h
+++ b/src/prop/cnf_stream.h
@@ -32,7 +32,7 @@
 #include "proof/proof_manager.h"
 #include "prop/proof_cnf_stream.h"
 #include "prop/registrar.h"
-#include "prop/theory_proxy.h"
+#include "prop/sat_solver_types.h"
 
 namespace CVC4 {
 
@@ -41,6 +41,8 @@ class OutputManager;
 namespace prop {
 
 class ProofCnfStream;
+class PropEngine;
+class SatSolver;
 
 /** A policy for how literals for formulas are handled in cnf_stream */
 enum class FormulaLitPolicy : uint32_t

--- a/src/prop/minisat/core/Solver.h
+++ b/src/prop/minisat/core/Solver.h
@@ -36,6 +36,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include "prop/minisat/utils/Options.h"
 #include "prop/sat_proof_manager.h"
 #include "theory/theory.h"
+#include "util/resource_manager.h"
 
 namespace CVC4 {
 template <class Solver> class TSatProof;

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -42,8 +42,6 @@
 #include "util/resource_manager.h"
 #include "util/result.h"
 
-using namespace std;
-
 namespace CVC4 {
 namespace prop {
 
@@ -86,7 +84,7 @@ PropEngine::PropEngine(TheoryEngine* te,
       d_resourceManager(rm),
       d_outMgr(outMgr)
 {
-  Debug("prop") << "Constructing the PropEngine" << endl;
+  Debug("prop") << "Constructing the PropEngine" << std::endl;
 
   d_decisionEngine.reset(new DecisionEngine(satContext, userContext, rm));
   d_decisionEngine->init();  // enable appropriate strategies
@@ -149,7 +147,7 @@ void PropEngine::finishInit()
 }
 
 PropEngine::~PropEngine() {
-  Debug("prop") << "Destructing the PropEngine" << endl;
+  Debug("prop") << "Destructing the PropEngine" << std::endl;
   d_decisionEngine->shutdown();
   d_decisionEngine.reset(nullptr);
   delete d_cnfStream;
@@ -182,7 +180,7 @@ void PropEngine::notifyPreprocessedAssertions(
 
 void PropEngine::assertFormula(TNode node) {
   Assert(!d_inCheckSat) << "Sat solver in solve()!";
-  Debug("prop") << "assertFormula(" << node << ")" << endl;
+  Debug("prop") << "assertFormula(" << node << ")" << std::endl;
   d_decisionEngine->addAssertion(node);
   assertInternal(node, false, false, true);
 }
@@ -190,7 +188,7 @@ void PropEngine::assertFormula(TNode node) {
 void PropEngine::assertSkolemDefinition(TNode node, TNode skolem)
 {
   Assert(!d_inCheckSat) << "Sat solver in solve()!";
-  Debug("prop") << "assertFormula(" << node << ")" << endl;
+  Debug("prop") << "assertFormula(" << node << ")" << std::endl;
   d_decisionEngine->addSkolemDefinition(node, skolem);
   assertInternal(node, false, false, true);
 }
@@ -238,7 +236,7 @@ void PropEngine::assertTrustedLemmaInternal(theory::TrustNode trn,
                                             bool removable)
 {
   Node node = trn.getNode();
-  Debug("prop::lemmas") << "assertLemma(" << node << ")" << endl;
+  Debug("prop::lemmas") << "assertLemma(" << node << ")" << std::endl;
   bool negated = trn.getKind() == theory::TrustNodeKind::CONFLICT;
   Assert(!isProofEnabled() || trn.getGenerator() != nullptr);
   assertInternal(trn.getNode(), negated, removable, false, trn.getGenerator());
@@ -295,7 +293,7 @@ void PropEngine::assertLemmasInternal(
 }
 
 void PropEngine::requirePhase(TNode n, bool phase) {
-  Debug("prop") << "requirePhase(" << n << ", " << phase << ")" << endl;
+  Debug("prop") << "requirePhase(" << n << ", " << phase << ")" << std::endl;
 
   Assert(n.getType().isBoolean());
   SatLiteral lit = d_cnfStream->getLiteral(n);
@@ -310,26 +308,26 @@ bool PropEngine::isDecision(Node lit) const {
 void PropEngine::printSatisfyingAssignment(){
   const CnfStream::NodeToLiteralMap& transCache =
     d_cnfStream->getTranslationCache();
-  Debug("prop-value") << "Literal | Value | Expr" << endl
+  Debug("prop-value") << "Literal | Value | Expr" << std::endl
                       << "----------------------------------------"
-                      << "-----------------" << endl;
+                      << "-----------------" << std::endl;
   for(CnfStream::NodeToLiteralMap::const_iterator i = transCache.begin(),
       end = transCache.end();
       i != end;
       ++i) {
-    pair<Node, SatLiteral> curr = *i;
+    std::pair<Node, SatLiteral> curr = *i;
     SatLiteral l = curr.second;
     if(!l.isNegated()) {
       Node n = curr.first;
       SatValue value = d_satSolver->modelValue(l);
-      Debug("prop-value") << "'" << l << "' " << value << " " << n << endl;
+      Debug("prop-value") << "'" << l << "' " << value << " " << n << std::endl;
     }
   }
 }
 
 Result PropEngine::checkSat() {
   Assert(!d_inCheckSat) << "Sat solver in solve()!";
-  Debug("prop") << "PropEngine::checkSat()" << endl;
+  Debug("prop") << "PropEngine::checkSat()" << std::endl;
 
   // Mark that we are in the checkSat
   ScopedBool scopedBool(d_inCheckSat);
@@ -363,7 +361,7 @@ Result PropEngine::checkSat() {
     printSatisfyingAssignment();
   }
 
-  Debug("prop") << "PropEngine::checkSat() => " << result << endl;
+  Debug("prop") << "PropEngine::checkSat() => " << result << std::endl;
   if(result == SAT_VALUE_TRUE && d_theoryEngine->isIncomplete()) {
     return Result(Result::SAT_UNKNOWN, Result::INCOMPLETE);
   }
@@ -494,20 +492,20 @@ void PropEngine::push()
 {
   Assert(!d_inCheckSat) << "Sat solver in solve()!";
   d_satSolver->push();
-  Debug("prop") << "push()" << endl;
+  Debug("prop") << "push()" << std::endl;
 }
 
 void PropEngine::pop()
 {
   Assert(!d_inCheckSat) << "Sat solver in solve()!";
   d_satSolver->pop();
-  Debug("prop") << "pop()" << endl;
+  Debug("prop") << "pop()" << std::endl;
 }
 
 void PropEngine::resetTrail()
 {
   d_satSolver->resetTrail();
-  Debug("prop") << "resetTrail()" << endl;
+  Debug("prop") << "resetTrail()" << std::endl;
 }
 
 unsigned PropEngine::getAssertionLevel() const
@@ -525,7 +523,7 @@ void PropEngine::interrupt()
 
   d_interrupted = true;
   d_satSolver->interrupt();
-  Debug("prop") << "interrupt()" << endl;
+  Debug("prop") << "interrupt()" << std::endl;
 }
 
 void PropEngine::spendResource(ResourceManager::Resource r)

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -32,6 +32,7 @@
 #include "proof/proof_manager.h"
 #include "prop/cnf_stream.h"
 #include "prop/minisat/minisat.h"
+#include "prop/prop_proof_manager.h"
 #include "prop/sat_solver.h"
 #include "prop/sat_solver_factory.h"
 #include "prop/theory_proxy.h"

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -41,6 +41,8 @@
 #include "util/resource_manager.h"
 #include "util/result.h"
 
+using namespace std;
+
 namespace CVC4 {
 namespace prop {
 

--- a/src/prop/prop_engine.h
+++ b/src/prop/prop_engine.h
@@ -21,22 +21,11 @@
 #ifndef CVC4__PROP_ENGINE_H
 #define CVC4__PROP_ENGINE_H
 
-#include <sys/time.h>
-
-#include "base/modal_exception.h"
+#include "context/cdlist.h"
 #include "expr/node.h"
-#include "options/options.h"
-#include "proof/proof_manager.h"
-#include "prop/minisat/core/Solver.h"
-#include "prop/minisat/minisat.h"
-#include "prop/proof_cnf_stream.h"
-#include "prop/prop_proof_manager.h"
-#include "prop/sat_solver_types.h"
+#include "theory/output_channel.h"
 #include "theory/trust_node.h"
-#include "theory/theory_inference_manager.h"
-#include "util/resource_manager.h"
 #include "util/result.h"
-#include "util/unsafe_interrupt_exception.h"
 
 namespace CVC4 {
 
@@ -45,16 +34,12 @@ class DecisionEngine;
 class OutputManager;
 class TheoryEngine;
 
-namespace theory {
-  class TheoryRegistrar;
-}/* CVC4::theory namespace */
-
 namespace prop {
 
 class CnfStream;
 class CDCLTSatSolverInterface;
-
-class PropEngine;
+class ProofCnfStream;
+class PropPfManager;
 
 /**
  * PropEngine is the abstraction of a Sat Solver, providing methods for

--- a/src/prop/prop_proof_manager.cpp
+++ b/src/prop/prop_proof_manager.cpp
@@ -16,6 +16,8 @@
 
 #include "expr/proof_ensure_closed.h"
 #include "expr/proof_node_algorithm.h"
+#include "prop/prop_proof_manager.h"
+#include "prop/sat_solver.h"
 
 namespace CVC4 {
 namespace prop {

--- a/src/prop/prop_proof_manager.h
+++ b/src/prop/prop_proof_manager.h
@@ -27,6 +27,8 @@ namespace CVC4 {
 
 namespace prop {
 
+class CDCLTSatSolverInterface;
+
 /**
  * This class is responsible for managing the proof output of PropEngine, both
  * building and checking it.

--- a/src/prop/sat_proof_manager.h
+++ b/src/prop/sat_proof_manager.h
@@ -21,10 +21,7 @@
 #include "expr/buffered_proof_generator.h"
 #include "expr/lazy_proof_chain.h"
 #include "expr/node.h"
-#include "expr/proof.h"
-#include "expr/proof_node_manager.h"
 #include "prop/minisat/core/SolverTypes.h"
-#include "prop/cnf_stream.h"
 #include "prop/sat_solver_types.h"
 
 namespace Minisat {
@@ -32,7 +29,12 @@ class Solver;
 }
 
 namespace CVC4 {
+
+class ProofNodeManager;
+
 namespace prop {
+
+class CnfStream;
 
 /**
  * This class is responsible for managing the proof production of the SAT

--- a/src/prop/theory_proxy.h
+++ b/src/prop/theory_proxy.h
@@ -23,19 +23,16 @@
 // Optional blocks below will be unconditionally included
 #define CVC4_USE_MINISAT
 
-#include <iosfwd>
 #include <unordered_set>
 
-#include "context/cdhashmap.h"
 #include "context/cdqueue.h"
 #include "expr/node.h"
 #include "prop/registrar.h"
-#include "prop/sat_solver.h"
+#include "prop/sat_solver_types.h"
 #include "theory/theory.h"
 #include "theory/theory_preprocessor.h"
 #include "theory/trust_node.h"
 #include "util/resource_manager.h"
-#include "util/statistics_registry.h"
 
 namespace CVC4 {
 

--- a/src/smt/abduction_solver.cpp
+++ b/src/smt/abduction_solver.cpp
@@ -14,6 +14,8 @@
 
 #include "smt/abduction_solver.h"
 
+#include <sstream>
+
 #include "options/smt_options.h"
 #include "smt/smt_engine.h"
 #include "theory/quantifiers/quantifiers_attributes.h"

--- a/src/smt/assertions.cpp
+++ b/src/smt/assertions.cpp
@@ -19,6 +19,7 @@
 #include "options/language.h"
 #include "options/smt_options.h"
 #include "proof/proof_manager.h"
+#include "smt/abstract_values.h"
 #include "smt/smt_engine.h"
 
 using namespace CVC4::theory;

--- a/src/smt/assertions.h
+++ b/src/smt/assertions.h
@@ -20,13 +20,13 @@
 #include <vector>
 
 #include "context/cdlist.h"
-#include "context/context.h"
 #include "expr/node.h"
 #include "preprocessing/assertion_pipeline.h"
-#include "smt/abstract_values.h"
 
 namespace CVC4 {
 namespace smt {
+
+class AbstractValues;
 
 /**
  * Contains all information pertaining to the assertions of an SMT engine.

--- a/src/smt/check_models.cpp
+++ b/src/smt/check_models.cpp
@@ -15,8 +15,10 @@
 #include "smt/check_models.h"
 
 #include "options/smt_options.h"
+#include "smt/model.h"
 #include "smt/node_command.h"
 #include "smt/preprocessor.h"
+#include "smt/smt_solver.h"
 #include "theory/rewriter.h"
 #include "theory/substitutions.h"
 #include "theory/theory_engine.h"

--- a/src/smt/check_models.h
+++ b/src/smt/check_models.h
@@ -19,11 +19,12 @@
 
 #include "context/cdlist.h"
 #include "expr/node.h"
-#include "smt/model.h"
-#include "smt/smt_solver.h"
 
 namespace CVC4 {
 namespace smt {
+
+class Model;
+class SmtSolver;
 
 /**
  * This utility is responsible for checking the current model.

--- a/src/smt/command.h
+++ b/src/smt/command.h
@@ -23,7 +23,6 @@
 #define CVC4__COMMAND_H
 
 #include <iosfwd>
-#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -40,8 +39,6 @@ class Term;
 }  // namespace api
 
 class SymbolManager;
-class UnsatCore;
-class SmtEngine;
 class Command;
 class CommandStatus;
 

--- a/src/smt/dump_manager.h
+++ b/src/smt/dump_manager.h
@@ -18,8 +18,9 @@
 #define CVC4__SMT__DUMP_MANAGER_H
 
 #include <memory>
+#include <vector>
 
-#include "context/cdlist.h"
+#include "context/context.h"
 #include "expr/node.h"
 
 namespace CVC4 {

--- a/src/smt/dump_manager.h
+++ b/src/smt/dump_manager.h
@@ -18,7 +18,6 @@
 #define CVC4__SMT__DUMP_MANAGER_H
 
 #include <memory>
-#include <vector>
 
 #include "context/cdlist.h"
 #include "expr/node.h"
@@ -26,6 +25,10 @@
 namespace CVC4 {
 
 class NodeCommand;
+
+namespace context {
+class UserContext;
+}
 
 namespace smt {
 

--- a/src/smt/expand_definitions.cpp
+++ b/src/smt/expand_definitions.cpp
@@ -18,8 +18,10 @@
 #include <utility>
 
 #include "expr/node_manager_attributes.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "smt/defined_function.h"
 #include "smt/smt_engine.h"
+#include "smt/smt_engine_stats.h"
 #include "theory/theory_engine.h"
 
 using namespace CVC4::preprocessing;

--- a/src/smt/expand_definitions.h
+++ b/src/smt/expand_definitions.h
@@ -20,16 +20,22 @@
 #include <unordered_map>
 
 #include "expr/node.h"
-#include "expr/term_conversion_proof_generator.h"
-#include "preprocessing/assertion_pipeline.h"
-#include "smt/smt_engine_stats.h"
-#include "util/resource_manager.h"
+#include "theory/trust_node.h"
 
 namespace CVC4 {
 
+class ProofNodeManager;
+class ResourceManager;
 class SmtEngine;
+class TConvProofGenerator;
+
+namespace preprocessing {
+class AssertionPipeline;
+}
 
 namespace smt {
+
+struct SmtEngineStatistics;
 
 /**
  * Module in charge of expanding definitions for an SMT engine.

--- a/src/smt/interpolation_solver.cpp
+++ b/src/smt/interpolation_solver.cpp
@@ -14,6 +14,8 @@
 
 #include "smt/interpolation_solver.h"
 
+#include <sstream>
+
 #include "options/smt_options.h"
 #include "smt/smt_engine.h"
 #include "theory/quantifiers/quantifiers_attributes.h"

--- a/src/smt/managed_ostreams.h
+++ b/src/smt/managed_ostreams.h
@@ -22,10 +22,9 @@
 
 #include <ostream>
 
-#include "options/open_ostream.h"
-#include "smt/update_ostream.h"
-
 namespace CVC4 {
+
+class OstreamOpener;
 
 /** This abstracts the management of ostream memory and initialization. */
 class ManagedOstream {

--- a/src/smt/model.h
+++ b/src/smt/model.h
@@ -27,7 +27,7 @@ namespace CVC4 {
 class SmtEngine;
 
 namespace theory {
-  class TheoryModel;
+class TheoryModel;
 }
 
 namespace smt {

--- a/src/smt/model.h
+++ b/src/smt/model.h
@@ -21,12 +21,14 @@
 #include <vector>
 
 #include "expr/node.h"
-#include "theory/theory_model.h"
-#include "util/cardinality.h"
 
 namespace CVC4 {
 
 class SmtEngine;
+
+namespace theory {
+  class TheoryModel;
+}
 
 namespace smt {
 

--- a/src/smt/model_blocker.cpp
+++ b/src/smt/model_blocker.cpp
@@ -18,6 +18,8 @@
 #include "expr/node.h"
 #include "expr/node_algorithm.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/rewriter.h"
+#include "theory/theory_model.h"
 
 using namespace CVC4::kind;
 

--- a/src/smt/model_blocker.h
+++ b/src/smt/model_blocker.h
@@ -21,9 +21,12 @@
 
 #include "expr/node.h"
 #include "options/smt_options.h"
-#include "theory/theory_model.h"
 
 namespace CVC4 {
+
+namespace theory {
+class TheoryModel;
+}
 
 /**
  * A utility for blocking the current model.

--- a/src/smt/node_command.cpp
+++ b/src/smt/node_command.cpp
@@ -16,6 +16,8 @@
 
 #include "smt/node_command.h"
 
+#include <sstream>
+
 #include "printer/printer.h"
 
 namespace CVC4 {

--- a/src/smt/options_manager.h
+++ b/src/smt/options_manager.h
@@ -15,15 +15,15 @@
 #ifndef CVC4__SMT__OPTIONS_MANAGER_H
 #define CVC4__SMT__OPTIONS_MANAGER_H
 
-#include "options/options.h"
 #include "options/options_listener.h"
 #include "smt/managed_ostreams.h"
 
 namespace CVC4 {
 
-class SmtEngine;
 class LogicInfo;
+class Options;
 class ResourceManager;
+class SmtEngine;
 
 namespace smt {
 

--- a/src/smt/preprocess_proof_generator.cpp
+++ b/src/smt/preprocess_proof_generator.cpp
@@ -17,6 +17,7 @@
 
 #include "expr/proof.h"
 #include "expr/proof_checker.h"
+#include "expr/proof_node.h"
 #include "options/proof_options.h"
 #include "theory/rewriter.h"
 

--- a/src/smt/preprocess_proof_generator.cpp
+++ b/src/smt/preprocess_proof_generator.cpp
@@ -16,6 +16,7 @@
 #include "smt/preprocess_proof_generator.h"
 
 #include "expr/proof.h"
+#include "expr/proof_checker.h"
 #include "options/proof_options.h"
 #include "theory/rewriter.h"
 

--- a/src/smt/preprocess_proof_generator.h
+++ b/src/smt/preprocess_proof_generator.h
@@ -20,12 +20,10 @@
 #include <map>
 
 #include "context/cdhashmap.h"
-#include "context/cdlist.h"
 #include "expr/lazy_proof.h"
 #include "expr/proof_set.h"
 #include "expr/proof_generator.h"
 #include "expr/proof_node_manager.h"
-#include "theory/eager_proof_generator.h"
 #include "theory/trust_node.h"
 
 namespace CVC4 {

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -19,6 +19,7 @@
 #include "smt/abstract_values.h"
 #include "smt/assertions.h"
 #include "smt/dump.h"
+#include "smt/preprocess_proof_generator.h"
 #include "smt/smt_engine.h"
 
 using namespace std;

--- a/src/smt/preprocessor.cpp
+++ b/src/smt/preprocessor.cpp
@@ -21,6 +21,7 @@
 #include "smt/dump.h"
 #include "smt/smt_engine.h"
 
+using namespace std;
 using namespace CVC4::theory;
 using namespace CVC4::kind;
 

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -25,7 +25,7 @@
 
 namespace CVC4 {
 namespace preprocessing {
-  class PreprocessingPassContext;
+class PreprocessingPassContext;
 }
 namespace smt {
 

--- a/src/smt/preprocessor.h
+++ b/src/smt/preprocessor.h
@@ -17,14 +17,16 @@
 #ifndef CVC4__SMT__PREPROCESSOR_H
 #define CVC4__SMT__PREPROCESSOR_H
 
-#include <vector>
+#include <memory>
 
-#include "preprocessing/preprocessing_pass_context.h"
 #include "smt/expand_definitions.h"
 #include "smt/process_assertions.h"
 #include "theory/booleans/circuit_propagator.h"
 
 namespace CVC4 {
+namespace preprocessing {
+  class PreprocessingPassContext;
+}
 namespace smt {
 
 class AbstractValues;

--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -31,7 +31,9 @@
 #include "printer/printer.h"
 #include "smt/defined_function.h"
 #include "smt/dump.h"
+#include "smt/expand_definitions.h"
 #include "smt/smt_engine.h"
+#include "smt/smt_engine_stats.h"
 #include "theory/logic_info.h"
 #include "theory/theory_engine.h"
 

--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -35,6 +35,7 @@
 #include "theory/logic_info.h"
 #include "theory/theory_engine.h"
 
+using namespace std;
 using namespace CVC4::preprocessing;
 using namespace CVC4::theory;
 using namespace CVC4::kind;

--- a/src/smt/process_assertions.h
+++ b/src/smt/process_assertions.h
@@ -54,7 +54,7 @@ class ProcessAssertions
 {
   /** The types for the recursive function definitions */
   typedef context::CDList<Node> NodeList;
-  typedef unordered_map<Node, bool, NodeHashFunction> NodeToBoolHashMap;
+  typedef std::unordered_map<Node, bool, NodeHashFunction> NodeToBoolHashMap;
 
  public:
   ProcessAssertions(SmtEngine& smt,

--- a/src/smt/process_assertions.h
+++ b/src/smt/process_assertions.h
@@ -17,17 +17,14 @@
 #ifndef CVC4__SMT__PROCESS_ASSERTIONS_H
 #define CVC4__SMT__PROCESS_ASSERTIONS_H
 
-#include <map>
+#include <unordered_map>
 
-#include "context/cdhashmap.h"
 #include "context/cdlist.h"
 #include "expr/node.h"
 #include "expr/type_node.h"
 #include "preprocessing/preprocessing_pass.h"
 #include "preprocessing/preprocessing_pass_context.h"
 #include "smt/assertions.h"
-#include "smt/expand_definitions.h"
-#include "smt/smt_engine_stats.h"
 #include "util/resource_manager.h"
 
 namespace CVC4 {
@@ -35,6 +32,9 @@ namespace CVC4 {
 class SmtEngine;
 
 namespace smt {
+
+class ExpandDefs;
+struct SmtEngineStatistics;
 
 /**
  * Module in charge of processing assertions for an SMT engine.

--- a/src/smt/proof_manager.cpp
+++ b/src/smt/proof_manager.cpp
@@ -14,11 +14,15 @@
 
 #include "smt/proof_manager.h"
 
+#include "expr/proof_checker.h"
 #include "expr/proof_node_algorithm.h"
+#include "expr/proof_node_manager.h"
 #include "options/base_options.h"
 #include "options/proof_options.h"
 #include "smt/assertions.h"
 #include "smt/defined_function.h"
+#include "smt/preprocess_proof_generator.h"
+#include "smt/proof_post_processor.h"
 
 namespace CVC4 {
 namespace smt {

--- a/src/smt/proof_manager.h
+++ b/src/smt/proof_manager.h
@@ -18,22 +18,21 @@
 #define CVC4__SMT__PROOF_MANAGER_H
 
 #include "context/cdhashmap.h"
-#include "context/cdlist.h"
 #include "expr/node.h"
-#include "expr/proof_checker.h"
-#include "expr/proof_node.h"
-#include "expr/proof_node_manager.h"
-#include "smt/preprocess_proof_generator.h"
-#include "smt/proof_post_processor.h"
 
 namespace CVC4 {
 
+class ProofChecker;
+class ProofNode;
+class ProofNodeManager;
 class SmtEngine;
 
 namespace smt {
 
 class Assertions;
 class DefinedFunction;
+class PreprocessProofGenerator;
+class ProofPostproccess;
 
 /**
  * This class is responsible for managing the proof output of SmtEngine, as

--- a/src/smt/proof_post_processor.cpp
+++ b/src/smt/proof_post_processor.cpp
@@ -14,6 +14,7 @@
 
 #include "smt/proof_post_processor.h"
 
+#include "expr/proof_node_manager.h"
 #include "expr/skolem_manager.h"
 #include "options/proof_options.h"
 #include "options/smt_options.h"

--- a/src/smt/proof_post_processor.h
+++ b/src/smt/proof_post_processor.h
@@ -22,6 +22,7 @@
 
 #include "expr/proof_node_updater.h"
 #include "smt/witness_form.h"
+#include "util/statistics_registry.h"
 
 namespace CVC4 {
 

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -34,6 +34,7 @@
 #include "printer/printer.h"
 #include "proof/proof_manager.h"
 #include "proof/unsat_core.h"
+#include "prop/prop_engine.h"
 #include "smt/abduction_solver.h"
 #include "smt/abstract_values.h"
 #include "smt/assertions.h"

--- a/src/smt/smt_engine.cpp
+++ b/src/smt/smt_engine.cpp
@@ -40,6 +40,7 @@
 #include "smt/assertions.h"
 #include "smt/check_models.h"
 #include "smt/defined_function.h"
+#include "smt/dump.h"
 #include "smt/dump_manager.h"
 #include "smt/interpolation_solver.h"
 #include "smt/listeners.h"

--- a/src/smt/smt_engine.h
+++ b/src/smt/smt_engine.h
@@ -888,8 +888,6 @@ class CVC4_PUBLIC SmtEngine
   /* .......................................................................  */
  private:
   /* .......................................................................  */
-  /** The type of our internal assertion list */
-  typedef context::CDList<Node> AssertionList;
 
   // disallow copy/assignment
   SmtEngine(const SmtEngine&) = delete;

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -69,12 +69,12 @@ void SmtSolver::finishInit(const LogicInfo& logicInfo)
    * are unregistered by the obsolete PropEngine object before registered
    * again by the new PropEngine object */
   d_propEngine.reset(nullptr);
-  d_propEngine.reset(new PropEngine(d_theoryEngine.get(),
-                                    d_smt.getContext(),
-                                    d_smt.getUserContext(),
-                                    d_rm,
-                                    d_smt.getOutputManager(),
-                                    d_pnm));
+  d_propEngine.reset(new prop::PropEngine(d_theoryEngine.get(),
+                                          d_smt.getContext(),
+                                          d_smt.getUserContext(),
+                                          d_rm,
+                                          d_smt.getOutputManager(),
+                                          d_pnm));
 
   Trace("smt-debug") << "Setting up theory engine..." << std::endl;
   d_theoryEngine->setPropEngine(getPropEngine());
@@ -90,12 +90,12 @@ void SmtSolver::resetAssertions()
    * statistics are unregistered by the obsolete PropEngine object before
    * registered again by the new PropEngine object */
   d_propEngine.reset(nullptr);
-  d_propEngine.reset(new PropEngine(d_theoryEngine.get(),
-                                    d_smt.getContext(),
-                                    d_smt.getUserContext(),
-                                    d_rm,
-                                    d_smt.getOutputManager(),
-                                    d_pnm));
+  d_propEngine.reset(new prop::PropEngine(d_theoryEngine.get(),
+                                          d_smt.getContext(),
+                                          d_smt.getUserContext(),
+                                          d_rm,
+                                          d_smt.getOutputManager(),
+                                          d_pnm));
   d_theoryEngine->setPropEngine(getPropEngine());
   // Notice that we do not reset TheoryEngine, nor does it require calling
   // finishInit again. In particular, TheoryEngine::finishInit does not

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -23,6 +23,8 @@
 #include "theory/theory_engine.h"
 #include "theory/theory_traits.h"
 
+using namespace std;
+
 namespace CVC4 {
 namespace smt {
 

--- a/src/smt/smt_solver.cpp
+++ b/src/smt/smt_solver.cpp
@@ -20,6 +20,7 @@
 #include "smt/preprocessor.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_state.h"
+#include "smt/smt_engine_stats.h"
 #include "theory/theory_engine.h"
 #include "theory/theory_traits.h"
 

--- a/src/smt/term_formula_removal.cpp
+++ b/src/smt/term_formula_removal.cpp
@@ -18,8 +18,11 @@
 #include <vector>
 
 #include "expr/attribute.h"
+#include "expr/lazy_proof.h"
 #include "expr/node_algorithm.h"
 #include "expr/skolem_manager.h"
+#include "expr/term_context_stack.h"
+#include "expr/term_conversion_proof_generator.h"
 #include "options/smt_options.h"
 #include "proof/proof_manager.h"
 

--- a/src/smt/term_formula_removal.h
+++ b/src/smt/term_formula_removal.h
@@ -25,6 +25,7 @@
 #include "context/context.h"
 #include "expr/lazy_proof.h"
 #include "expr/node.h"
+#include "expr/term_context.h"
 #include "expr/term_context_stack.h"
 #include "expr/term_conversion_proof_generator.h"
 #include "theory/eager_proof_generator.h"

--- a/src/smt/term_formula_removal.h
+++ b/src/smt/term_formula_removal.h
@@ -26,7 +26,6 @@
 #include "expr/node.h"
 #include "expr/term_context.h"
 #include "theory/trust_node.h"
-#include "util/bool.h"
 #include "util/hash.h"
 
 namespace CVC4 {

--- a/src/smt/term_formula_removal.h
+++ b/src/smt/term_formula_removal.h
@@ -18,22 +18,22 @@
 
 #pragma once
 
-#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "context/cdinsert_hashmap.h"
 #include "context/context.h"
-#include "expr/lazy_proof.h"
 #include "expr/node.h"
 #include "expr/term_context.h"
-#include "expr/term_context_stack.h"
-#include "expr/term_conversion_proof_generator.h"
-#include "theory/eager_proof_generator.h"
 #include "theory/trust_node.h"
 #include "util/bool.h"
 #include "util/hash.h"
 
 namespace CVC4 {
+
+class LazyCDProof;
+class ProofNodeManager;
+class TConvProofGenerator;
 
 class RemoveTermFormulas {
  public:

--- a/src/theory/arith/delta_rational.cpp
+++ b/src/theory/arith/delta_rational.cpp
@@ -18,6 +18,8 @@
 
 #include "theory/arith/delta_rational.h"
 
+#include <sstream>
+
 using namespace std;
 
 namespace CVC4 {

--- a/src/theory/arith/nl/iand_solver.cpp
+++ b/src/theory/arith/nl/iand_solver.cpp
@@ -22,6 +22,7 @@
 #include "theory/arith/arith_utilities.h"
 #include "theory/arith/inference_manager.h"
 #include "theory/arith/nl/nl_model.h"
+#include "theory/rewriter.h"
 #include "util/iand.h"
 
 using namespace CVC4::kind;

--- a/src/theory/booleans/proof_circuit_propagator.cpp
+++ b/src/theory/booleans/proof_circuit_propagator.cpp
@@ -16,6 +16,8 @@
 
 #include "theory/booleans/proof_circuit_propagator.h"
 
+#include <sstream>
+
 #include "expr/proof_node_manager.h"
 
 namespace CVC4 {

--- a/src/theory/bv/bitblast/bitblaster.h
+++ b/src/theory/bv/bitblast/bitblaster.h
@@ -31,6 +31,7 @@
 #include "prop/sat_solver_types.h"
 #include "smt/smt_engine_scope.h"
 #include "theory/bv/bitblast/bitblast_strategies_template.h"
+#include "theory/theory.h"
 #include "theory/valuation.h"
 #include "util/resource_manager.h"
 

--- a/src/theory/bv/bv_solver_bitblast.h
+++ b/src/theory/bv/bv_solver_bitblast.h
@@ -21,6 +21,7 @@
 
 #include <unordered_map>
 
+#include "context/cdqueue.h"
 #include "prop/cnf_stream.h"
 #include "prop/sat_solver.h"
 #include "theory/bv/bitblast/simple_bitblaster.h"

--- a/src/theory/datatypes/sygus_datatype_utils.cpp
+++ b/src/theory/datatypes/sygus_datatype_utils.cpp
@@ -16,6 +16,8 @@
 
 #include "theory/datatypes/sygus_datatype_utils.h"
 
+#include <sstream>
+
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"

--- a/src/theory/datatypes/theory_datatypes.cpp
+++ b/src/theory/datatypes/theory_datatypes.cpp
@@ -16,6 +16,7 @@
 #include "theory/datatypes/theory_datatypes.h"
 
 #include <map>
+#include <sstream>
 
 #include "base/check.h"
 #include "expr/dtype.h"

--- a/src/theory/inference_id.cpp
+++ b/src/theory/inference_id.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/inference_id.h"
 
+#include <iostream>
+
 namespace CVC4 {
 namespace theory {
 

--- a/src/theory/lazy_tree_proof_generator.cpp
+++ b/src/theory/lazy_tree_proof_generator.cpp
@@ -18,6 +18,7 @@
 
 #include "expr/node.h"
 #include "expr/proof_generator.h"
+#include "expr/proof_node.h"
 #include "expr/proof_node_manager.h"
 
 namespace CVC4 {

--- a/src/theory/quantifiers/single_inv_partition.cpp
+++ b/src/theory/quantifiers/single_inv_partition.cpp
@@ -14,6 +14,8 @@
  **/
 #include "theory/quantifiers/single_inv_partition.h"
 
+#include <sstream>
+
 #include "expr/node_algorithm.h"
 #include "theory/quantifiers/term_util.h"
 #include "theory/rewriter.h"

--- a/src/theory/quantifiers/sygus/cegis_core_connective.h
+++ b/src/theory/quantifiers/sygus/cegis_core_connective.h
@@ -18,9 +18,9 @@
 #define CVC4__THEORY__QUANTIFIERS__CEGIS_CORE_CONNECTIVE_H
 
 #include <unordered_set>
+
 #include "expr/node.h"
 #include "expr/node_trie.h"
-
 #include "theory/evaluator.h"
 #include "theory/quantifiers/sygus/cegis.h"
 #include "util/result.h"

--- a/src/theory/quantifiers/sygus/cegis_core_connective.h
+++ b/src/theory/quantifiers/sygus/cegis_core_connective.h
@@ -23,6 +23,7 @@
 
 #include "theory/evaluator.h"
 #include "theory/quantifiers/sygus/cegis.h"
+#include "util/result.h"
 
 namespace CVC4 {
 namespace theory {

--- a/src/theory/quantifiers/sygus/sygus_abduct.cpp
+++ b/src/theory/quantifiers/sygus/sygus_abduct.cpp
@@ -15,6 +15,8 @@
 
 #include "theory/quantifiers/sygus/sygus_abduct.h"
 
+#include <sstream>
+
 #include "expr/dtype.h"
 #include "expr/node_algorithm.h"
 #include "expr/sygus_datatype.h"

--- a/src/theory/quantifiers/sygus/sygus_interpol.cpp
+++ b/src/theory/quantifiers/sygus/sygus_interpol.cpp
@@ -16,6 +16,8 @@
 
 #include "theory/quantifiers/sygus/sygus_interpol.h"
 
+#include <sstream>
+
 #include "expr/dtype.h"
 #include "expr/node_algorithm.h"
 #include "options/smt_options.h"

--- a/src/theory/quantifiers/sygus/sygus_utils.cpp
+++ b/src/theory/quantifiers/sygus/sygus_utils.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/quantifiers/sygus/sygus_utils.h"
 
+#include <sstream>
+
 #include "expr/node_algorithm.h"
 #include "theory/quantifiers/quantifiers_attributes.h"
 #include "theory/quantifiers/sygus/sygus_grammar_cons.h"

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -26,6 +26,7 @@
 #include "theory/quantifiers/quantifiers_inference_manager.h"
 #include "theory/quantifiers/quantifiers_state.h"
 #include "theory/quantifiers/term_util.h"
+#include "theory/rewriter.h"
 
 using namespace CVC4::kind;
 

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -23,6 +23,7 @@
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"
 #include "theory/quantifiers/lazy_trie.h"
+#include "theory/rewriter.h"
 #include "util/bitvector.h"
 #include "util/random.h"
 #include "util/sampler.h"

--- a/src/theory/strings/regexp_operation.cpp
+++ b/src/theory/strings/regexp_operation.cpp
@@ -16,6 +16,8 @@
 
 #include "theory/strings/regexp_operation.h"
 
+#include <sstream>
+
 #include "expr/node_algorithm.h"
 #include "options/strings_options.h"
 #include "theory/rewriter.h"

--- a/src/theory/strings/theory_strings_utils.cpp
+++ b/src/theory/strings/theory_strings_utils.cpp
@@ -16,6 +16,8 @@
 
 #include "theory/strings/theory_strings_utils.h"
 
+#include <sstream>
+
 #include "options/strings_options.h"
 #include "theory/rewriter.h"
 #include "theory/strings/arith_entail.h"

--- a/src/theory/theory_engine.cpp
+++ b/src/theory/theory_engine.cpp
@@ -16,6 +16,8 @@
 
 #include "theory/theory_engine.h"
 
+#include <sstream>
+
 #include "base/map_util.h"
 #include "decision/decision_engine.h"
 #include "expr/attribute.h"

--- a/src/theory/theory_engine_proof_generator.cpp
+++ b/src/theory/theory_engine_proof_generator.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/theory_engine_proof_generator.h"
 
+#include "expr/proof_node.h"
+
 using namespace CVC4::kind;
 
 namespace CVC4 {

--- a/src/theory/theory_engine_proof_generator.cpp
+++ b/src/theory/theory_engine_proof_generator.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/theory_engine_proof_generator.h"
 
+#include <sstream>
+
 #include "expr/proof_node.h"
 
 using namespace CVC4::kind;

--- a/src/theory/theory_id.cpp
+++ b/src/theory/theory_id.cpp
@@ -17,6 +17,8 @@
 
 #include "theory/theory_id.h"
 
+#include <sstream>
+
 #include "base/check.h"
 #include "lib/ffs.h"
 

--- a/src/theory/uf/cardinality_extension.cpp
+++ b/src/theory/uf/cardinality_extension.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/uf/cardinality_extension.h"
 
+#include <sstream>
+
 #include "options/smt_options.h"
 #include "options/uf_options.h"
 #include "theory/quantifiers/term_database.h"

--- a/src/theory/uf/eq_proof.cpp
+++ b/src/theory/uf/eq_proof.cpp
@@ -17,6 +17,7 @@
 
 #include "base/configuration.h"
 #include "expr/proof.h"
+#include "expr/proof_checker.h"
 #include "options/uf_options.h"
 
 namespace CVC4 {

--- a/src/theory/uf/theory_uf.cpp
+++ b/src/theory/uf/theory_uf.cpp
@@ -18,6 +18,7 @@
 #include "theory/uf/theory_uf.h"
 
 #include <memory>
+#include <sstream>
 
 #include "expr/node_algorithm.h"
 #include "expr/proof_node_manager.h"

--- a/src/util/bitvector.h
+++ b/src/util/bitvector.h
@@ -20,6 +20,7 @@
 #define CVC4__BITVECTOR_H
 
 #include <iosfwd>
+#include <iostream>
 
 #include "util/integer.h"
 

--- a/src/util/bitvector.h
+++ b/src/util/bitvector.h
@@ -22,6 +22,7 @@
 #include <iosfwd>
 #include <iostream>
 
+#include "base/exception.h"
 #include "util/integer.h"
 
 namespace CVC4 {

--- a/src/util/cardinality.cpp
+++ b/src/util/cardinality.cpp
@@ -17,6 +17,7 @@
 #include "util/cardinality.h"
 
 #include <ostream>
+#include <sstream>
 
 #include "base/check.h"
 #include "base/exception.h"

--- a/src/util/integer_gmp_imp.h
+++ b/src/util/integer_gmp_imp.h
@@ -21,11 +21,8 @@
 #define CVC4__INTEGER_H
 
 #include <iosfwd>
-#include <limits>
 #include <string>
-
-#include "base/exception.h"
-#include "util/gmp_util.h"
+#include <gmpxx.h>
 
 namespace CVC4 {
 

--- a/src/util/integer_gmp_imp.h
+++ b/src/util/integer_gmp_imp.h
@@ -20,9 +20,10 @@
 #ifndef CVC4__INTEGER_H
 #define CVC4__INTEGER_H
 
+#include <gmpxx.h>
+
 #include <iosfwd>
 #include <string>
-#include <gmpxx.h>
 
 namespace CVC4 {
 

--- a/src/util/poly_util.cpp
+++ b/src/util/poly_util.cpp
@@ -27,6 +27,7 @@
 #include <poly/polyxx.h>
 
 #include <map>
+#include <sstream>
 
 #include "base/check.h"
 #include "maybe.h"

--- a/src/util/rational_gmp_imp.h
+++ b/src/util/rational_gmp_imp.h
@@ -24,9 +24,9 @@
 
 #include <string>
 
-#include "base/exception.h"
 #include "util/integer.h"
 #include "util/maybe.h"
+#include "util/gmp_util.h"
 
 namespace CVC4 {
 

--- a/src/util/rational_gmp_imp.h
+++ b/src/util/rational_gmp_imp.h
@@ -24,9 +24,9 @@
 
 #include <string>
 
+#include "util/gmp_util.h"
 #include "util/integer.h"
 #include "util/maybe.h"
-#include "util/gmp_util.h"
 
 namespace CVC4 {
 

--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cctype>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "base/check.h"

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -19,10 +19,9 @@
 #ifndef CVC4__RESULT_H
 #define CVC4__RESULT_H
 
-#include <iostream>
+#include <iosfwd>
 #include <string>
 
-#include "base/exception.h"
 #include "options/language.h"
 
 namespace CVC4 {

--- a/src/util/safe_print.cpp
+++ b/src/util/safe_print.cpp
@@ -20,6 +20,8 @@
 
 #include "safe_print.h"
 
+#include <cstdlib>
+#include <time.h>
 #include <unistd.h>
 
 /* Size of buffers used */

--- a/src/util/safe_print.cpp
+++ b/src/util/safe_print.cpp
@@ -20,9 +20,10 @@
 
 #include "safe_print.h"
 
-#include <cstdlib>
 #include <time.h>
 #include <unistd.h>
+
+#include <cstdlib>
 
 /* Size of buffers used */
 #define BUFFER_SIZE 20

--- a/src/util/safe_print.h
+++ b/src/util/safe_print.h
@@ -37,13 +37,9 @@
 #ifndef CVC4__SAFE_PRINT_H
 #define CVC4__SAFE_PRINT_H
 
-#include <unistd.h>
-
 #include <cstring>
-#include <type_traits>
-
-#include "lib/clock_gettime.h"
-#include "util/result.h"
+#include <string>
+#include <unistd.h>
 
 namespace CVC4 {
 

--- a/src/util/safe_print.h
+++ b/src/util/safe_print.h
@@ -37,9 +37,10 @@
 #ifndef CVC4__SAFE_PRINT_H
 #define CVC4__SAFE_PRINT_H
 
+#include <unistd.h>
+
 #include <cstring>
 #include <string>
-#include <unistd.h>
 
 namespace CVC4 {
 

--- a/src/util/sampler.cpp
+++ b/src/util/sampler.cpp
@@ -21,6 +21,7 @@
 
 #include "base/check.h"
 #include "util/bitvector.h"
+#include "util/random.h"
 
 namespace CVC4 {
 

--- a/src/util/sampler.cpp
+++ b/src/util/sampler.cpp
@@ -17,6 +17,8 @@
 
 #include "util/sampler.h"
 
+#include <sstream>
+
 #include "base/check.h"
 #include "util/bitvector.h"
 

--- a/src/util/sampler.h
+++ b/src/util/sampler.h
@@ -21,7 +21,6 @@
 #define CVC4__UTIL_FLOATINGPOINT_SAMPLER_H
 
 #include "util/floatingpoint.h"
-#include "util/random.h"
 
 namespace CVC4 {
 

--- a/src/util/sexpr.h
+++ b/src/util/sexpr.h
@@ -26,12 +26,10 @@
 #ifndef CVC4__SEXPR_H
 #define CVC4__SEXPR_H
 
-#include <iomanip>
 #include <iosfwd>
 #include <string>
 #include <vector>
 
-#include "base/exception.h"
 #include "options/language.h"
 #include "util/integer.h"
 #include "util/rational.h"

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -17,8 +17,7 @@
 #ifndef CVC4__UTIL__STRING_H
 #define CVC4__UTIL__STRING_H
 
-#include <functional>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <vector>
 #include "util/rational.h"

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -20,6 +20,7 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
+
 #include "util/rational.h"
 
 namespace CVC4 {

--- a/test/unit/preprocessing/pass_bv_gauss_white.cpp
+++ b/test/unit/preprocessing/pass_bv_gauss_white.cpp
@@ -20,6 +20,7 @@
 #include "context/context.h"
 #include "expr/node.h"
 #include "expr/node_manager.h"
+#include "preprocessing/assertion_pipeline.h"
 #include "preprocessing/passes/bv_gauss.h"
 #include "smt/smt_engine.h"
 #include "smt/smt_engine_scope.h"

--- a/test/unit/prop/cnf_stream_white.cpp
+++ b/test/unit/prop/cnf_stream_white.cpp
@@ -19,6 +19,7 @@
 #include "prop/cnf_stream.h"
 #include "prop/prop_engine.h"
 #include "prop/registrar.h"
+#include "prop/sat_solver.h"
 #include "prop/theory_proxy.h"
 #include "test_smt.h"
 #include "theory/arith/theory_arith.h"

--- a/test/unit/util/cardinality_black.cpp
+++ b/test/unit/util/cardinality_black.cpp
@@ -17,8 +17,8 @@
 #include <sstream>
 #include <string>
 
-#include "test.h"
 #include "base/exception.h"
+#include "test.h"
 #include "util/cardinality.h"
 #include "util/integer.h"
 

--- a/test/unit/util/cardinality_black.cpp
+++ b/test/unit/util/cardinality_black.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "test.h"
+#include "base/exception.h"
 #include "util/cardinality.h"
 #include "util/integer.h"
 

--- a/test/unit/util/integer_black.cpp
+++ b/test/unit/util/integer_black.cpp
@@ -17,8 +17,8 @@
 #include <limits>
 #include <sstream>
 
-#include "test.h"
 #include "base/exception.h"
+#include "test.h"
 #include "util/integer.h"
 
 namespace CVC4 {

--- a/test/unit/util/integer_black.cpp
+++ b/test/unit/util/integer_black.cpp
@@ -18,6 +18,7 @@
 #include <sstream>
 
 #include "test.h"
+#include "base/exception.h"
 #include "util/integer.h"
 
 namespace CVC4 {


### PR DESCRIPTION
Similar to #6031, this PR implements suggestions from iwyu to reduce the number of includes in header files by introducing forward declarations and moving includes to source files.