### PR TITLE
Add proper define for libpoly usage

### DIFF
--- a/cmake/ConfigureCVC4.cmake
+++ b/cmake/ConfigureCVC4.cmake
@@ -95,5 +95,7 @@ check_c_source_compiles(
 set(CVC4_CLN_IMP ${CVC4_USE_CLN_IMP})
 # Defined if using the GMP multi-precision arithmetic library.
 set(CVC4_GMP_IMP ${CVC4_USE_GMP_IMP})
+# Defined if using the libpoly polynomial library.
+set(CVC4_POLY_IMP ${CVC4_USE_POLY_IMP})
 # Define the full name of this package.
 set(CVC4_PACKAGE_NAME "${PROJECT_NAME}")

--- a/cvc4autoconfig.h.in
+++ b/cvc4autoconfig.h.in
@@ -28,6 +28,9 @@
 /* Define to use the GMP multi-precision arithmetic library. */
 #cmakedefine CVC4_GMP_IMP
 
+/* Define to use the libpoly polynomial library. */
+#cmakedefine CVC4_POLY_IMP
+
 /* Define to 1 if Boost threading library has support for thread attributes. */
 #cmakedefine01 BOOST_HAS_THREAD_ATTR
 

--- a/src/theory/arith/nl/cad/cdcac.h
+++ b/src/theory/arith/nl/cad/cdcac.h
@@ -20,8 +20,6 @@
 #ifndef CVC4__THEORY__ARITH__NL__CAD__CDCAC_H
 #define CVC4__THEORY__ARITH__NL__CAD__CDCAC_H
 
-#include "util/real_algebraic_number.h"
-
 #ifdef CVC4_POLY_IMP
 
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/cad/cdcac_utils.h
+++ b/src/theory/arith/nl/cad/cdcac_utils.h
@@ -19,8 +19,6 @@
 #ifndef CVC4__THEORY__ARITH__NL__CAD__CDCAC_UTILS_H
 #define CVC4__THEORY__ARITH__NL__CAD__CDCAC_UTILS_H
 
-#include "util/real_algebraic_number.h"
-
 #ifdef CVC4_POLY_IMP
 
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/cad/constraints.h
+++ b/src/theory/arith/nl/cad/constraints.h
@@ -19,8 +19,6 @@
 #ifndef CVC4__THEORY__ARITH__NL__CAD__CONSTRAINTS_H
 #define CVC4__THEORY__ARITH__NL__CAD__CONSTRAINTS_H
 
-#include "util/real_algebraic_number.h"
-
 #ifdef CVC4_POLY_IMP
 
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/cad/projections.h
+++ b/src/theory/arith/nl/cad/projections.h
@@ -19,8 +19,6 @@
 #ifndef CVC4__THEORY__ARITH__NL__CAD_PROJECTIONS_H
 #define CVC4__THEORY__ARITH__NL__CAD_PROJECTIONS_H
 
-#include "util/real_algebraic_number.h"
-
 #ifdef CVC4_USE_POLY
 
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/cad/proof_generator.h
+++ b/src/theory/arith/nl/cad/proof_generator.h
@@ -17,8 +17,6 @@
 #ifndef CVC4__THEORY__ARITH__NL__CAD__PROOF_GENERATOR_H
 #define CVC4__THEORY__ARITH__NL__CAD__PROOF_GENERATOR_H
 
-#include "util/real_algebraic_number.h"
-
 #ifdef CVC4_POLY_IMP
 
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/cad/variable_ordering.h
+++ b/src/theory/arith/nl/cad/variable_ordering.h
@@ -19,8 +19,6 @@
 #ifndef CVC4__THEORY__ARITH__NL__CAD__VARIABLE_ORDERING_H
 #define CVC4__THEORY__ARITH__NL__CAD__VARIABLE_ORDERING_H
 
-#include "util/real_algebraic_number.h"
-
 #ifdef CVC4_POLY_IMP
 
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/cad_solver.h
+++ b/src/theory/arith/nl/cad_solver.h
@@ -21,7 +21,6 @@
 #include "expr/node.h"
 #include "theory/arith/nl/cad/cdcac.h"
 #include "theory/arith/nl/cad/proof_checker.h"
-#include "util/real_algebraic_number.h"
 
 namespace CVC4 {
 namespace theory {

--- a/src/theory/arith/nl/icp/candidate.h
+++ b/src/theory/arith/nl/icp/candidate.h
@@ -15,7 +15,7 @@
 #ifndef CVC4__THEORY__ARITH__ICP__CANDIDATE_H
 #define CVC4__THEORY__ARITH__ICP__CANDIDATE_H
 
-#include "util/real_algebraic_number.h"
+#include "cvc4_private.h"
 
 #ifdef CVC4_POLY_IMP
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/icp/icp_solver.h
+++ b/src/theory/arith/nl/icp/icp_solver.h
@@ -15,7 +15,7 @@
 #ifndef CVC4__THEORY__ARITH__ICP__ICP_SOLVER_H
 #define CVC4__THEORY__ARITH__ICP__ICP_SOLVER_H
 
-#include "util/real_algebraic_number.h"
+#include "cvc4_private.h"
 
 #ifdef CVC4_POLY_IMP
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/icp/intersection.h
+++ b/src/theory/arith/nl/icp/intersection.h
@@ -15,9 +15,12 @@
 #ifndef CVC4__THEORY__ARITH__ICP__INTERSECTION_H
 #define CVC4__THEORY__ARITH__ICP__INTERSECTION_H
 
-#include "util/real_algebraic_number.h"
+#include "cvc4_private.h"
 
 #ifdef CVC4_POLY_IMP
+
+#include <cstddef>
+
 namespace poly {
   class Interval;
 }

--- a/src/theory/arith/nl/icp/interval.h
+++ b/src/theory/arith/nl/icp/interval.h
@@ -15,7 +15,7 @@
 #ifndef CVC4__THEORY__ARITH__ICP__INTERVAL_H
 #define CVC4__THEORY__ARITH__ICP__INTERVAL_H
 
-#include "util/real_algebraic_number.h"
+#include "cvc4_private.h"
 
 #ifdef CVC4_POLY_IMP
 #include <poly/polyxx.h>

--- a/src/theory/arith/nl/poly_conversion.h
+++ b/src/theory/arith/nl/poly_conversion.h
@@ -17,7 +17,7 @@
 #ifndef CVC4__THEORY__ARITH__NL__POLY_CONVERSION_H
 #define CVC4__THEORY__ARITH__NL__POLY_CONVERSION_H
 
-#include "util/real_algebraic_number.h"
+#include "cvc4_private.h"
 
 #ifdef CVC4_POLY_IMP
 
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "expr/node.h"
+#include "util/real_algebraic_number.h"
 
 namespace CVC4 {
 namespace theory {


### PR DESCRIPTION
When adding libpoly, we forgot to add a proper define to cvc4autoconfig and included `real_algebraic_number.h` everywhere to get this define. This PR introduces the `CVC4_POLY_IMP` define and removes all obsolete includes to `real_algebraic_number.h`.