### PR TITLE
Remove Theory::setOutputChannel()

### DIFF
--- a/src/theory/theory.h
+++ b/src/theory/theory.h
@@ -456,13 +456,6 @@ class Theory {
   }
 
   /**
-   * Set the output channel associated to this theory.
-   */
-  void setOutputChannel(OutputChannel& out) {
-    d_out = &out;
-  }
-
-  /**
    * Get the output channel associated to this theory.
    */
   OutputChannel& getOutputChannel() {


### PR DESCRIPTION
`Theory::setOutputChannel()` is not used throughout our code base.