### PR TITLE
contrib: Do not use HOST env variable for cross-compilation host target.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -361,12 +361,12 @@ done
 
 if [ "$arm64" == "ON" ]; then
   echo "Setting up dependencies for ARM 64-bit build"
-  HOST="aarch64-linux-gnu" contrib/get-antlr-3.4 || exit 1
-  HOST="aarch64-linux-gnu" contrib/get-gmp-dev || exit 1
+  contrib/get-antlr-3.4 --host=aarch64-linux-gnu || exit 1
+  contrib/get-gmp-dev --host=aarch64-linux-gnu || exit 1
 elif [ "$win64" == "ON" ]; then
   echo "Setting up dependencies for Windows 64-bit build"
-  HOST="x86_64-w64-mingw32" contrib/get-antlr-3.4 || exit 1
-  HOST="x86_64-w64-mingw32" contrib/get-gmp-dev || exit 1
+  contrib/get-antlr-3.4 --host=x86_64-w64-mingw32 || exit 1
+  contrib/get-gmp-dev --host=x86_64-w64-mingw32 || exit 1
 fi
 
 #--------------------------------------------------------------------------#

--- a/contrib/get-antlr-3.4
+++ b/contrib/get-antlr-3.4
@@ -4,31 +4,26 @@ source "$(dirname "$0")/get-script-header.sh"
 ANTLR_HOME_DIR="$DEPS_DIR/antlr-3.4"
 rm -rf "$ANTLR_HOME_DIR"
 
-[ -z "${BUILD_TYPE}" ] && BUILD_TYPE="--disable-shared --enable-static"
-if [ -n "$HOST" ]; then
-  ANTLR_CONFIGURE_ARGS="--host=$HOST"
-  MACHINE_TYPE="$(echo "$HOST" | cut -d '-' -f 1)"
-  echo "Using MACHINE_TYPE=$MACHINE_TYPE for HOST=$HOST"
-fi
+while :; do
+  case $1 in
+    --host=?*)
+      host=${1#*=}
+      ANTLR_CONFIGURE_ARGS="--host=$host"
+      MACHINE_TYPE="$(echo "$host" | cut -d '-' -f 1)"
+      echo "Using MACHINE_TYPE=$MACHINE_TYPE for --host=$host"
+      ;;
+    --host=)
+      echo "Error: empty --host="
+      exit 1
+      ;;
+    *)
+      break
+  esac
+  shift
+done
 
-if [ -z "${MACHINE_TYPE}" ]; then
-  CONFIG_GUESS_SCRIPT="$ANTLR_HOME_DIR/config.guess"
-  if ! [ -e "${CONFIG_GUESS_SCRIPT}" ]; then
-    mkdir -p "$ANTLR_HOME_DIR"
-    # Attempt to download once
-    webget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' $CONFIG_GUESS_SCRIPT
-    if [ -e "$CONFIG_GUESS_SCRIPT" ]; then
-     chmod +x "$CONFIG_GUESS_SCRIPT"
-   else
-     echo "$(basename $0): I need the file config/config.guess to tell MACHINE_TYPE" >&2
-     echo "Try running ./autogen.sh, or set the MACHINE_TYPE environment variable" >&2
-     echo "(e.g., \"export MACHINE_TYPE=x86_64\")." >&2
-     exit 1
-    fi
-  fi
-  # get first nibble from config.guess (x86_64, i686, ...)
-  MACHINE_TYPE=$(${CONFIG_GUESS_SCRIPT} | sed 's,-.*,,')
-fi
+[ -z "${BUILD_TYPE}" ] && BUILD_TYPE="--disable-shared --enable-static"
+[ -z "${MACHINE_TYPE}" ] && MACHINE_TYPE="$(uname -m)"
 
 mkdir -p "$INSTALL_DIR/share/java"
 webget \
@@ -48,6 +43,10 @@ setup_dep \
   "https://www.antlr3.org/download/C/libantlr3c-3.4.tar.gz" \
   "$ANTLR_HOME_DIR/libantlr3c-3.4"
 cd "$ANTLR_HOME_DIR/libantlr3c-3.4" || exit 1
+
+# Update config.guess for libantlr3c
+webget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' config.guess.new
+[ -f "config.guess.new" ] && mv config.guess.new config.guess
 
 # Add aarch64 architecture
 sed 's/avr32 \\$/avr32 | aarch64 \\/' config.sub > config.sub.new

--- a/contrib/get-gmp-dev
+++ b/contrib/get-gmp-dev
@@ -11,9 +11,25 @@
 
 source "$(dirname "$0")/get-script-header.sh"
 
-[ -z "${BUILD_TYPE}" ] && BUILD_TYPE="--enable-shared --enable-static"
-[ -n "$HOST" ] && HOST="--host=$HOST"
-[ -z "$GMPVERSION" ] && GMPVERSION=6.2.0
+CONFIG=
+while :; do
+  case $1 in
+    --host=?*)
+      host=${1#*=}
+      CONFIG="--host=$host"
+      ;;
+    --host=)
+      echo "Error: empty --host="
+      exit 1
+      ;;
+    *)
+      break
+  esac
+  shift
+done
+
+[ -z "${BUILD_TYPE}" ] && BUILD_TYPE="--disable-shared --enable-static"
+[ -z "$GMPVERSION" ] && GMPVERSION=6.2.1
 
 GMP_DIR="$DEPS_DIR/gmp-$GMPVERSION"
 rm -rf "$GMP_DIR"
@@ -35,7 +51,7 @@ echo "Setting up GMP $GMPVERSION..."
 echo
 setup_dep "https://gmplib.org/download/gmp/gmp-$GMPVERSION.tar.bz2" "$GMP_DIR"
 cd "$GMP_DIR"
-./configure ${HOST} --prefix="$INSTALL_DIR" --enable-cxx ${BUILD_TYPE}
+./configure ${CONFIG} --prefix="$INSTALL_DIR" --enable-cxx ${BUILD_TYPE}
 make \
   CFLAGS="${MAKE_CFLAGS}" \
   CXXFLAGS="${MAKE_CXXFLAGS}" \


### PR DESCRIPTION
On some systems HOST is set by default to the host name. This commit adds a `--host` option for the get-antlr-3.4 and get-gmp-dev scripts. It further simplifies the machine type check in get-antlr-3.4 and updates the GMP version to 6.2.1.