### PR TITLE
Fix two issues in preprocessing

### DIFF
--- a/src/smt/process_assertions.cpp
+++ b/src/smt/process_assertions.cpp
@@ -340,10 +340,8 @@ bool ProcessAssertions::apply(Assertions& as)
   d_passes["theory-rewrite-eq"]->apply(&assertions);
   // apply theory preprocess, which includes ITE removal
   d_passes["theory-preprocess"]->apply(&assertions);
-  // This is needed because when solving incrementally, removeITEs may
-  // introduce skolems that were solved for earlier and thus appear in the
-  // substitution map.
-  d_passes["apply-substs"]->apply(&assertions);
+  // notice that we do not apply substitutions as a last step here, since
+  // the range of substitutions is not theory-preprocessed.
 
   if (options::bitblastMode() == options::BitblastMode::EAGER)
   {

--- a/src/theory/arith/theory_arith_private.cpp
+++ b/src/theory/arith/theory_arith_private.cpp
@@ -1419,7 +1419,7 @@ void TheoryArithPrivate::setupPolynomial(const Polynomial& poly) {
 }
 
 void TheoryArithPrivate::setupAtom(TNode atom) {
-  Assert(isRelationOperator(atom.getKind()));
+  Assert(isRelationOperator(atom.getKind())) << atom;
   Assert(Comparison::isNormalAtom(atom));
   Assert(!isSetup(atom));
   Assert(!d_constraintDatabase.hasLiteral(atom));

--- a/src/theory/shared_solver.cpp
+++ b/src/theory/shared_solver.cpp
@@ -42,6 +42,7 @@ bool SharedSolver::needsEqualityEngine(theory::EeSetupInfo& esi)
 
 void SharedSolver::preRegister(TNode atom)
 {
+  Trace("theory") << "SharedSolver::preRegister atom " << atom << std::endl;
   // This method uses two different implementations for preregistering terms,
   // which depends on whether sharing is enabled.
   // If sharing is disabled, we use PreRegisterVisitor, which keeps a global
@@ -66,6 +67,7 @@ void SharedSolver::preRegister(TNode atom)
     // Theory::preRegisterTerm possibly multiple times.
     NodeVisitor<PreRegisterVisitor>::run(d_preRegistrationVisitor, atom);
   }
+  Trace("theory") << "SharedSolver::preRegister atom finished" << std::endl;
 }
 
 void SharedSolver::preNotifySharedFact(TNode atom)

--- a/src/theory/shared_solver.cpp
+++ b/src/theory/shared_solver.cpp
@@ -31,7 +31,7 @@ SharedSolver::SharedSolver(TheoryEngine& te, ProofNodeManager* pnm)
       d_logicInfo(te.getLogicInfo()),
       d_sharedTerms(&d_te, d_te.getSatContext(), d_te.getUserContext(), pnm),
       d_preRegistrationVisitor(&te, d_te.getSatContext()),
-      d_sharedTermsVisitor(&te, d_sharedTerms)
+      d_sharedTermsVisitor(&te, d_sharedTerms, d_te.getSatContext())
 {
 }
 

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -174,7 +174,7 @@ void PreRegisterVisitor::preRegisterWithTheory(TheoryEngine* te,
     // already pregregistered
     return;
   }
-  visitedTheories = TheoryIdSetUtil::setInsert(id, visitedTheories);
+  preregTheories = TheoryIdSetUtil::setInsert(id, preregTheories);
   if (Configuration::isAssertionBuild())
   {
     Debug("register::internal")

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -167,13 +167,14 @@ void PreRegisterVisitor::preRegisterWithTheory(TheoryEngine* te,
     // already visited
     return;
   }
+  bool isPreregistered = TheoryIdSetUtil::setContains(id, preregTheories);
   visitedTheories = TheoryIdSetUtil::setInsert(id, visitedTheories);
-  if (TheoryIdSetUtil::setContains(id, preregTheories))
+  if (isPreregistered)
   {
     // already pregregistered
     return;
   }
-  preregTheories = TheoryIdSetUtil::setInsert(id, preregTheories);
+  visitedTheories = TheoryIdSetUtil::setInsert(id, visitedTheories);
   if (Configuration::isAssertionBuild())
   {
     Debug("register::internal")

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -133,13 +133,15 @@ void PreRegisterVisitor::preRegister(TheoryEngine* te,
 {
   // Preregister with the current theory, if necessary
   TheoryId currentTheoryId = Theory::theoryOf(current);
-  preRegisterWithTheory(te, visitedTheories, currentTheoryId, current, parent, preregTheories);
+  preRegisterWithTheory(
+      te, visitedTheories, currentTheoryId, current, parent, preregTheories);
 
   if (current != parent)
   {
     // preregister with parent theory, if necessary
     TheoryId parentTheoryId = Theory::theoryOf(parent);
-    preRegisterWithTheory(te, visitedTheories, parentTheoryId, current, parent, preregTheories);
+    preRegisterWithTheory(
+        te, visitedTheories, parentTheoryId, current, parent, preregTheories);
 
     // Note that if enclosed by different theories it's shared, for example,
     // in read(a, f(a)), f(a) should be shared with integers.
@@ -148,7 +150,8 @@ void PreRegisterVisitor::preRegister(TheoryEngine* te,
     {
       // preregister with the type's theory, if necessary
       TheoryId typeTheoryId = Theory::theoryOf(type);
-      preRegisterWithTheory(te, visitedTheories, typeTheoryId, current, parent, preregTheories);
+      preRegisterWithTheory(
+          te, visitedTheories, typeTheoryId, current, parent, preregTheories);
     }
   }
 }
@@ -157,7 +160,7 @@ void PreRegisterVisitor::preRegisterWithTheory(TheoryEngine* te,
                                                TheoryId id,
                                                TNode current,
                                                TNode parent,
-                                     TheoryIdSet& preregTheories)
+                                               TheoryIdSet& preregTheories)
 {
   if (TheoryIdSetUtil::setContains(id, visitedTheories))
   {
@@ -251,7 +254,8 @@ void SharedTermsVisitor::visit(TNode current, TNode parent) {
 
   // preregister the term with the current, parent or type theories, as needed
   TheoryIdSet preregTheories = d_preregistered[current];
-  PreRegisterVisitor::preRegister(d_engine, visitedTheories, current, parent, preregTheories);
+  PreRegisterVisitor::preRegister(
+      d_engine, visitedTheories, current, parent, preregTheories);
   d_preregistered[current] = preregTheories;
 
   // Record the new theories that we visited

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -173,6 +173,7 @@ void PreRegisterVisitor::preRegisterWithTheory(TheoryEngine* te,
     // already pregregistered
     return;
   }
+  preregTheories = TheoryIdSetUtil::setInsert(id, preregTheories);
   if (Configuration::isAssertionBuild())
   {
     Debug("register::internal")

--- a/src/theory/term_registration_visitor.cpp
+++ b/src/theory/term_registration_visitor.cpp
@@ -260,9 +260,10 @@ void SharedTermsVisitor::visit(TNode current, TNode parent) {
 
   // Record the new theories that we visited
   d_visited[current] = visitedTheories;
-  
+
   // add visited theories to those who have preregistered
-  d_preregistered[current] = TheoryIdSetUtil::setUnion(preregTheories, visitedTheories);
+  d_preregistered[current] =
+      TheoryIdSetUtil::setUnion(preregTheories, visitedTheories);
 
   // If there is more than two theories and a new one has been added notify the shared terms database
   TheoryId currentTheoryId = Theory::theoryOf(current);

--- a/src/theory/term_registration_visitor.h
+++ b/src/theory/term_registration_visitor.h
@@ -125,8 +125,10 @@ class PreRegisterVisitor {
  * been visited already, we need to visit it again, since we need to associate it with both atoms.
  */
 class SharedTermsVisitor {
-  using TNodeVisitedMap = std::unordered_map<TNode, theory::TheoryIdSet, TNodeHashFunction>;
-  using TNodeToTheorySetMap = context::CDHashMap<TNode, theory::TheoryIdSet, TNodeHashFunction>;
+  using TNodeVisitedMap =
+      std::unordered_map<TNode, theory::TheoryIdSet, TNodeHashFunction>;
+  using TNodeToTheorySetMap =
+      context::CDHashMap<TNode, theory::TheoryIdSet, TNodeHashFunction>;
   /**
    * String representation of the visited map, for debugging purposes.
    */
@@ -141,7 +143,9 @@ class SharedTermsVisitor {
   /** required to instantiate template for NodeVisitor */
   using return_type = void;
 
-  SharedTermsVisitor(TheoryEngine* te, SharedTermsDatabase& sharedTerms, context::Context* c)
+  SharedTermsVisitor(TheoryEngine* te,
+                     SharedTermsDatabase& sharedTerms,
+                     context::Context* c)
       : d_engine(te), d_sharedTerms(sharedTerms), d_preregistered(c)
   {
   }

--- a/src/theory/term_registration_visitor.h
+++ b/src/theory/term_registration_visitor.h
@@ -182,7 +182,7 @@ class SharedTermsVisitor {
   SharedTermsDatabase& d_sharedTerms;
   /** Cache of nodes we have visited in this traversal */
   TNodeVisitedMap d_visited;
-  /** Cache of nodes we have preregistered */
+  /** (Global) cache of nodes we have preregistered in this SAT context */
   TNodeToTheorySetMap d_preregistered;
 };
 

--- a/src/theory/term_registration_visitor.h
+++ b/src/theory/term_registration_visitor.h
@@ -98,12 +98,15 @@ class PreRegisterVisitor {
    * @param visitedTheories The theories that have already preregistered current
    * @param current The term to preregister
    * @param parent The parent term of current
+   * @param preregTheories The theories that have already preregistered current.
+   * If there is no theory sharing, this coincides with visitedTheories.
+   * Otherwise, visitedTheories may be a subset of preregTheories.
    */
   static void preRegister(TheoryEngine* te,
                           theory::TheoryIdSet& visitedTheories,
                           TNode current,
                           TNode parent,
-                          theory::TheoryIdSet& preregTheories);
+                          theory::TheoryIdSet preregTheories);
 
  private:
   /**
@@ -115,7 +118,7 @@ class PreRegisterVisitor {
                                     theory::TheoryId id,
                                     TNode current,
                                     TNode parent,
-                                    theory::TheoryIdSet& preregTheories);
+                                    theory::TheoryIdSet preregTheories);
 };
 
 

--- a/src/theory/term_registration_visitor.h
+++ b/src/theory/term_registration_visitor.h
@@ -59,8 +59,8 @@ class PreRegisterVisitor {
   /** required to instantiate template for NodeVisitor */
   using return_type = void;
 
-  PreRegisterVisitor(TheoryEngine* engine, context::Context* context)
-      : d_engine(engine), d_visited(context)
+  PreRegisterVisitor(TheoryEngine* engine, context::Context* c)
+      : d_engine(engine), d_visited(c)
   {
   }
 
@@ -102,7 +102,8 @@ class PreRegisterVisitor {
   static void preRegister(TheoryEngine* te,
                           theory::TheoryIdSet& visitedTheories,
                           TNode current,
-                          TNode parent);
+                          TNode parent,
+                          theory::TheoryIdSet& preregTheories);
 
  private:
   /**
@@ -113,7 +114,8 @@ class PreRegisterVisitor {
                                     theory::TheoryIdSet& visitedTheories,
                                     theory::TheoryId id,
                                     TNode current,
-                                    TNode parent);
+                                    TNode parent,
+                                    theory::TheoryIdSet& preregTheories);
 };
 
 
@@ -123,14 +125,8 @@ class PreRegisterVisitor {
  * been visited already, we need to visit it again, since we need to associate it with both atoms.
  */
 class SharedTermsVisitor {
-
-  /**
-   * Cache from preprocessing of atoms.
-   */
-  typedef std::unordered_map<TNode, theory::TheoryIdSet, TNodeHashFunction>
-      TNodeVisitedMap;
-  TNodeVisitedMap d_visited;
-
+  using TNodeVisitedMap = std::unordered_map<TNode, theory::TheoryIdSet, TNodeHashFunction>;
+  using TNodeToTheorySetMap = context::CDHashMap<TNode, theory::TheoryIdSet, TNodeHashFunction>;
   /**
    * String representation of the visited map, for debugging purposes.
    */
@@ -145,8 +141,8 @@ class SharedTermsVisitor {
   /** required to instantiate template for NodeVisitor */
   using return_type = void;
 
-  SharedTermsVisitor(TheoryEngine* te, SharedTermsDatabase& sharedTerms)
-      : d_engine(te), d_sharedTerms(sharedTerms)
+  SharedTermsVisitor(TheoryEngine* te, SharedTermsDatabase& sharedTerms, context::Context* c)
+      : d_engine(te), d_sharedTerms(sharedTerms), d_preregistered(c)
   {
   }
 
@@ -180,6 +176,10 @@ class SharedTermsVisitor {
   TheoryEngine* d_engine;
   /** The shared terms database */
   SharedTermsDatabase& d_sharedTerms;
+  /** Cache of nodes we have visited in this traversal */
+  TNodeVisitedMap d_visited;
+  /** Cache of nodes we have preregistered */
+  TNodeToTheorySetMap d_preregistered;
 };
 
 

--- a/test/regress/regress1/strings/issue6071-arith-prereg-i.smt2
+++ b/test/regress/regress1/strings/issue6071-arith-prereg-i.smt2
@@ -1,0 +1,13 @@
+; COMMAND-LINE: -i
+; EXPECT: sat
+(set-logic ALL)
+(set-option :strings-lazy-pp false)
+(declare-fun ufbi4 (Bool Bool Bool Bool) Int)
+(declare-fun str0 () String)
+(declare-fun str8 () String)
+(declare-fun i16 () Int)
+(assert (= (str.to_int str0) (ufbi4 false true false (= 0 i16))))
+(push)
+(assert (= str8 (str.from_int (str.to_int str0))))
+(push)
+(check-sat)


### PR DESCRIPTION
This fixes two issues for preprocessing:
(1) The term preregistration visitor was calling preRegister on terms multiple times in a SAT context, which the linear arithmetic solver is sensitive to.
(2) It was possible for non-preprocessed terms to appear in assertions if they were on the RHS of substitutions learned by non-clausal simplification, and substituted into assertions post-theory-preprocessing.

To fix (1), the term registration visitor is update to track which theories has preregistered each term, as is done in the PreRegisterVisitor.  To fix (2), we no longer apply-subst after theory preprocessing.

These two fixes are required to fix #6071.