### PR TITLE
Move ExprManager::isNAryKind to NodeManager.

### DIFF
--- a/src/api/cvc4cpp.cpp
+++ b/src/api/cvc4cpp.cpp
@@ -726,7 +726,7 @@ uint32_t minArity(Kind k)
 {
   Assert(isDefinedKind(k));
   Assert(isDefinedIntKind(extToIntKind(k)));
-  uint32_t min = CVC4::kind::metakind::getLowerBoundForKind(extToIntKind(k));
+  uint32_t min = CVC4::kind::metakind::getMinArityForKind(extToIntKind(k));
 
   // At the API level, we treat functions/constructors/selectors/testers as
   // normal terms instead of making them part of the operator
@@ -742,7 +742,7 @@ uint32_t maxArity(Kind k)
 {
   Assert(isDefinedKind(k));
   Assert(isDefinedIntKind(extToIntKind(k)));
-  uint32_t max = CVC4::kind::metakind::getUpperBoundForKind(extToIntKind(k));
+  uint32_t max = CVC4::kind::metakind::getMaxArityForKind(extToIntKind(k));
 
   // At the API level, we treat functions/constructors/selectors/testers as
   // normal terms instead of making them part of the operator

--- a/src/expr/expr_manager_template.cpp
+++ b/src/expr/expr_manager_template.cpp
@@ -812,11 +812,11 @@ Expr ExprManager::mkChain(Kind kind, const std::vector<Expr>& children)
 }
 
 unsigned ExprManager::minArity(Kind kind) {
-  return metakind::getLowerBoundForKind(kind);
+  return metakind::getMinArityForKind(kind);
 }
 
 unsigned ExprManager::maxArity(Kind kind) {
-  return metakind::getUpperBoundForKind(kind);
+  return metakind::getMaxArityForKind(kind);
 }
 
 bool ExprManager::isNAryKind(Kind fun)

--- a/src/expr/metakind_template.cpp
+++ b/src/expr/metakind_template.cpp
@@ -147,7 +147,8 @@ ${metakind_constDeleters}
 // re-enable the strict-aliasing warning
 # pragma GCC diagnostic warning "-Wstrict-aliasing"
 
-unsigned getLowerBoundForKind(::CVC4::Kind k) {
+uint32_t getMinArityForKind(::CVC4::Kind k)
+{
   static const unsigned lbs[] = {
     0, /* NULL_EXPR */
 ${metakind_lbchildren}
@@ -158,7 +159,8 @@ ${metakind_lbchildren}
   return lbs[k];
 }
 
-unsigned getUpperBoundForKind(::CVC4::Kind k) {
+uint32_t getMaxArityForKind(::CVC4::Kind k)
+{
   static const unsigned ubs[] = {
     0, /* NULL_EXPR */
 ${metakind_ubchildren}
@@ -168,8 +170,7 @@ ${metakind_ubchildren}
 
   return ubs[k];
 }
-
-}/* CVC4::metakind namespace */
+}  // namespace metakind
 
 /**
  * Map a kind of the operator to the kind of the enclosing expression. For

--- a/src/expr/metakind_template.h
+++ b/src/expr/metakind_template.h
@@ -187,8 +187,10 @@ struct NodeValueConstPrinter {
  */
 void deleteNodeValueConstant(::CVC4::expr::NodeValue* nv);
 
-unsigned getLowerBoundForKind(::CVC4::Kind k);
-unsigned getUpperBoundForKind(::CVC4::Kind k);
+/** Return the minimum arity of the given kind. */
+uint32_t getMinArityForKind(::CVC4::Kind k);
+/** Return the maximum arity of the given kind. */
+uint32_t getMaxArityForKind(::CVC4::Kind k);
 
 }/* CVC4::kind::metakind namespace */
 

--- a/src/expr/node_builder.h
+++ b/src/expr/node_builder.h
@@ -957,15 +957,15 @@ expr::NodeValue* NodeBuilder<nchild_thresh>::constructNV() {
   // check that there are the right # of children for this kind
   Assert(getMetaKind() != kind::metakind::CONSTANT)
       << "Cannot make Nodes with NodeBuilder that have CONSTANT-kinded kinds";
-  Assert(getNumChildren() >= kind::metakind::getLowerBoundForKind(getKind()))
+  Assert(getNumChildren() >= kind::metakind::getMinArityForKind(getKind()))
       << "Nodes with kind " << getKind() << " must have at least "
-      << kind::metakind::getLowerBoundForKind(getKind())
+      << kind::metakind::getMinArityForKind(getKind())
       << " children (the one under "
          "construction has "
       << getNumChildren() << ")";
-  Assert(getNumChildren() <= kind::metakind::getUpperBoundForKind(getKind()))
+  Assert(getNumChildren() <= kind::metakind::getMaxArityForKind(getKind()))
       << "Nodes with kind " << getKind() << " must have at most "
-      << kind::metakind::getUpperBoundForKind(getKind())
+      << kind::metakind::getMaxArityForKind(getKind())
       << " children (the one under "
          "construction has "
       << getNumChildren() << ")";
@@ -1132,15 +1132,15 @@ expr::NodeValue* NodeBuilder<nchild_thresh>::constructNV() const {
   // check that there are the right # of children for this kind
   Assert(getMetaKind() != kind::metakind::CONSTANT)
       << "Cannot make Nodes with NodeBuilder that have CONSTANT-kinded kinds";
-  Assert(getNumChildren() >= kind::metakind::getLowerBoundForKind(getKind()))
+  Assert(getNumChildren() >= kind::metakind::getMinArityForKind(getKind()))
       << "Nodes with kind " << getKind() << " must have at least "
-      << kind::metakind::getLowerBoundForKind(getKind())
+      << kind::metakind::getMinArityForKind(getKind())
       << " children (the one under "
          "construction has "
       << getNumChildren() << ")";
-  Assert(getNumChildren() <= kind::metakind::getUpperBoundForKind(getKind()))
+  Assert(getNumChildren() <= kind::metakind::getMaxArityForKind(getKind()))
       << "Nodes with kind " << getKind() << " must have at most "
-      << kind::metakind::getUpperBoundForKind(getKind())
+      << kind::metakind::getMaxArityForKind(getKind())
       << " children (the one under "
          "construction has "
       << getNumChildren() << ")";

--- a/src/expr/node_manager.cpp
+++ b/src/expr/node_manager.cpp
@@ -27,6 +27,7 @@
 #include "expr/bound_var_manager.h"
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
+#include "expr/metakind.h"
 #include "expr/node_manager_attributes.h"
 #include "expr/skolem_manager.h"
 #include "expr/type_checker.h"
@@ -106,6 +107,11 @@ NodeManager::NodeManager(ExprManager* exprManager)
       d_skolemCounter(0)
 {
   init();
+}
+
+bool NodeManager::isNAryKind(Kind k)
+{
+  return kind::metakind::getMaxArityForKind(k) == expr::NodeValue::MAX_CHILDREN;
 }
 
 TypeNode NodeManager::booleanType()
@@ -965,7 +971,7 @@ Node NodeManager::mkAssociative(Kind kind, const std::vector<Node>& children)
 {
   AlwaysAssert(kind::isAssociative(kind)) << "Illegal kind in mkAssociative";
 
-  const unsigned int max = kind::metakind::getUpperBoundForKind(kind);
+  const unsigned int max = kind::metakind::getMaxArityForKind(kind);
   size_t numChildren = children.size();
 
   /* If the number of children is within bounds, then there's nothing to do. */
@@ -973,7 +979,7 @@ Node NodeManager::mkAssociative(Kind kind, const std::vector<Node>& children)
   {
     return mkNode(kind, children);
   }
-  const unsigned int min = kind::metakind::getLowerBoundForKind(kind);
+  const unsigned int min = kind::metakind::getMinArityForKind(kind);
 
   std::vector<Node>::const_iterator it = children.begin();
   std::vector<Node>::const_iterator end = children.end();

--- a/src/expr/node_manager.h
+++ b/src/expr/node_manager.h
@@ -98,6 +98,15 @@ class NodeManager
   friend class NodeBuilder;
   friend class NodeManagerScope;
 
+ public:
+  /**
+   * Return true if given kind is n-ary. The test is based on n-ary kinds
+   * having their maximal arity as the maximal possible number of children
+   * of a node.
+   */
+  static bool isNAryKind(Kind k);
+
+ private:
   /** Predicate for use with STL algorithms */
   struct NodeValueReferenceCountNonZero {
     bool operator()(expr::NodeValue* nv) { return nv->d_rc > 0; }

--- a/src/smt_util/nary_builder.cpp
+++ b/src/smt_util/nary_builder.cpp
@@ -23,14 +23,20 @@ using namespace std;
 namespace CVC4 {
 namespace util {
 
-Node NaryBuilder::mkAssoc(Kind kind, const std::vector<Node>& children){
-  if(children.size() == 0){
+Node NaryBuilder::mkAssoc(Kind kind, const std::vector<Node>& children)
+{
+  if (children.size() == 0)
+  {
     return zeroArity(kind);
-  }else if(children.size() == 1){
+  }
+  else if (children.size() == 1)
+  {
     return children[0];
-  }else{
-    const unsigned int max = kind::metakind::getMaxArityForKind(kind);
-    const unsigned int min = kind::metakind::getMinArityForKind(kind);
+  }
+  else
+  {
+    const uint32_t max = kind::metakind::getMaxArityForKind(kind);
+    const uint32_t min = kind::metakind::getMinArityForKind(kind);
 
     Assert(min <= children.size());
 

--- a/src/smt_util/nary_builder.cpp
+++ b/src/smt_util/nary_builder.cpp
@@ -29,8 +29,8 @@ Node NaryBuilder::mkAssoc(Kind kind, const std::vector<Node>& children){
   }else if(children.size() == 1){
     return children[0];
   }else{
-    const unsigned int max = kind::metakind::getUpperBoundForKind(kind);
-    const unsigned int min = kind::metakind::getLowerBoundForKind(kind);
+    const unsigned int max = kind::metakind::getMaxArityForKind(kind);
+    const unsigned int min = kind::metakind::getMinArityForKind(kind);
 
     Assert(min <= children.size());
 

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -184,9 +184,10 @@ Node ExtendedRewriter::extendedRewrite(Node n)
         // we may have subsumed children down to one
         ret = children[0];
       }
-      else if (isAssoc && children.size() > kind::metakind::getUpperBoundForKind(k))
+      else if (isAssoc
+               && children.size() > kind::metakind::getMaxArityForKind(k))
       {
-        Assert(kind::metakind::getUpperBoundForKind(k) >= 2);
+        Assert(kind::metakind::getMaxArityForKind(k) >= 2);
         // kind may require binary construction
         ret = children[0];
         for (unsigned i = 1, nchild = children.size(); i < nchild; i++)

--- a/src/theory/uf/eq_proof.cpp
+++ b/src/theory/uf/eq_proof.cpp
@@ -1182,7 +1182,7 @@ Node EqProof::addToProof(
   // use (= t1 t2) as a premise and rely on a symmetry step to justify it.
   unsigned arity = d_node[0].getNumChildren();
   Kind k = d_node[0].getKind();
-  bool isNary = ExprManager::isNAryKind(k);
+  bool isNary = NodeManager::isNAryKind(k);
 
   // N-ary operators are fun. The following proof is a valid EqProof
   //

--- a/src/theory/uf/equality_engine.cpp
+++ b/src/theory/uf/equality_engine.cpp
@@ -1029,7 +1029,7 @@ void EqualityEngine::buildEqConclusion(EqualityNodeId id1,
   if ((d_isInternal[id1] || d_isInternal[id2])
       && (k1 != k2 || k1 == kind::APPLY_UF || k1 == kind::APPLY_CONSTRUCTOR
           || k1 == kind::APPLY_SELECTOR || k1 == kind::APPLY_TESTER
-          || !ExprManager::isNAryKind(k1)))
+          || !NodeManager::isNAryKind(k1)))
   {
     return;
   }

--- a/test/unit/expr/node_black.cpp
+++ b/test/unit/expr/node_black.cpp
@@ -442,16 +442,16 @@ TEST_F(TestNodeBlackNode, getNumChildren)
 #ifdef CVC4_ASSERTIONS
   ASSERT_DEATH(testNaryExpForSize(AND, 0),
                "getNumChildren\\(\\) >= "
-               "kind::metakind::getLowerBoundForKind\\(getKind\\(\\)\\)");
+               "kind::metakind::getMinArityForKind\\(getKind\\(\\)\\)");
   ASSERT_DEATH(testNaryExpForSize(AND, 1),
                "getNumChildren\\(\\) >= "
-               "kind::metakind::getLowerBoundForKind\\(getKind\\(\\)\\)");
+               "kind::metakind::getMinArityForKind\\(getKind\\(\\)\\)");
   ASSERT_DEATH(testNaryExpForSize(NOT, 0),
                "getNumChildren\\(\\) >= "
-               "kind::metakind::getLowerBoundForKind\\(getKind\\(\\)\\)");
+               "kind::metakind::getMinArityForKind\\(getKind\\(\\)\\)");
   ASSERT_DEATH(testNaryExpForSize(NOT, 2),
                "getNumChildren\\(\\) <= "
-               "kind::metakind::getUpperBoundForKind\\(getKind\\(\\)\\)");
+               "kind::metakind::getMaxArityForKind\\(getKind\\(\\)\\)");
 #endif /* CVC4_ASSERTIONS */
 }
 

--- a/test/unit/expr/node_manager_black.cpp
+++ b/test/unit/expr/node_manager_black.cpp
@@ -314,7 +314,7 @@ TEST_F(TestNodeBlackNodeManager, mkNode_too_many_children)
 {
 #ifdef CVC4_ASSERTIONS
   std::vector<Node> vars;
-  const unsigned int max = metakind::getUpperBoundForKind(AND);
+  const uint32_t max = metakind::getMaxArityForKind(AND);
   TypeNode boolType = d_nodeManager->booleanType();
   Node skolem_i = d_nodeManager->mkSkolem("i", boolType);
   Node skolem_j = d_nodeManager->mkSkolem("j", boolType);


### PR DESCRIPTION
This also renames metakind::getLowerBoundForKind and
metakind::getUpperBoundForKind for consistency.

Note that the NodeManager class needs to be reordered to comply to our
style guidelines. This PR does not reorder but introduces a public block
at the top (where the rest of the public interface of the class should
go eventually).