### PR TITLE
Add missing includes for statistics

### DIFF
--- a/src/prop/cadical.h
+++ b/src/prop/cadical.h
@@ -22,6 +22,7 @@
 #ifdef CVC4_USE_CADICAL
 
 #include "prop/sat_solver.h"
+#include "util/stats_timer.h"
 
 #include <cadical.hpp>
 

--- a/src/prop/cryptominisat.h
+++ b/src/prop/cryptominisat.h
@@ -22,6 +22,7 @@
 #ifdef CVC4_USE_CRYPTOMINISAT
 
 #include "prop/sat_solver.h"
+#include "util/stats_timer.h"
 
 // Cryptominisat has name clashes with the other Minisat implementations since
 // the Minisat implementations export var_Undef, l_True, ... as macro whereas

--- a/src/prop/kissat.h
+++ b/src/prop/kissat.h
@@ -22,6 +22,7 @@
 #ifdef CVC4_USE_KISSAT
 
 #include "prop/sat_solver.h"
+#include "util/stats_timer.h"
 
 extern "C" {
 #include <kissat/kissat.h>


### PR DESCRIPTION
The recent cleanup removed necessary includes for statistics in optional modules (cadical, cryptominisat, kissat). This PR adds these includes (and should fix the nightly builds).
Fixes #6130.