### PR TITLE
fp: Use setBit instead of bv or in conversion from Real.

### DIFF
--- a/src/util/floatingpoint.cpp
+++ b/src/util/floatingpoint.cpp
@@ -254,7 +254,7 @@ FloatingPoint::FloatingPoint(const FloatingPointSize& size,
 
       if (mid <= rabs)
       {
-        sig = sig | one;
+        sig = sig.setBit(0, true);
         workingSig = mid;
       }
 
@@ -268,7 +268,7 @@ FloatingPoint::FloatingPoint(const FloatingPointSize& size,
 
     if (!remainder.isZero())
     {
-      sig = sig | one;
+      sig = sig.setBit(0, true);
     }
 
     // Build an exact float


### PR DESCRIPTION
This is a minor optimization that goes into effect as soon as #6176 goes
in.