### PR TITLE
Add missing includes.

### DIFF
--- a/src/expr/proof_node_manager.cpp
+++ b/src/expr/proof_node_manager.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/proof_node_manager.h"
 
+#include <sstream>
+
 #include "expr/proof.h"
 #include "expr/proof_checker.h"
 #include "expr/proof_node.h"

--- a/src/expr/term_conversion_proof_generator.cpp
+++ b/src/expr/term_conversion_proof_generator.cpp
@@ -14,6 +14,8 @@
 
 #include "expr/term_conversion_proof_generator.h"
 
+#include <sstream>
+
 #include "expr/proof_checker.h"
 #include "expr/proof_node.h"
 #include "expr/term_context.h"

--- a/src/preprocessing/passes/ho_elim.cpp
+++ b/src/preprocessing/passes/ho_elim.cpp
@@ -16,6 +16,8 @@
 
 #include "preprocessing/passes/ho_elim.h"
 
+#include <sstream>
+
 #include "expr/node_algorithm.h"
 #include "options/quantifiers_options.h"
 #include "preprocessing/assertion_pipeline.h"

--- a/src/smt/preprocess_proof_generator.cpp
+++ b/src/smt/preprocess_proof_generator.cpp
@@ -15,6 +15,8 @@
 
 #include "smt/preprocess_proof_generator.h"
 
+#include <sstream>
+
 #include "expr/proof.h"
 #include "expr/proof_checker.h"
 #include "expr/proof_node.h"

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -14,6 +14,8 @@
 
 #include "smt/set_defaults.h"
 
+#include <sstream>
+
 #include "base/output.h"
 #include "options/arith_options.h"
 #include "options/arrays_options.h"

--- a/src/smt/sygus_solver.cpp
+++ b/src/smt/sygus_solver.cpp
@@ -14,6 +14,8 @@
 
 #include "smt/sygus_solver.h"
 
+#include <sstream>
+
 #include "expr/dtype.h"
 #include "options/quantifiers_options.h"
 #include "options/smt_options.h"

--- a/src/theory/arith/arith_rewriter.cpp
+++ b/src/theory/arith/arith_rewriter.cpp
@@ -16,6 +16,7 @@
  **/
 
 #include <set>
+#include <sstream>
 #include <stack>
 #include <vector>
 

--- a/src/theory/arith/cut_log.cpp
+++ b/src/theory/arith/cut_log.cpp
@@ -16,6 +16,7 @@
  **/
 
 #include <cmath>
+#include <iomanip>
 #include <limits.h>
 #include <map>
 #include <math.h>

--- a/src/theory/arith/operator_elim.cpp
+++ b/src/theory/arith/operator_elim.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/arith/operator_elim.h"
 
+#include <sstream>
+
 #include "expr/attribute.h"
 #include "expr/bound_var_manager.h"
 #include "expr/skolem_manager.h"

--- a/src/theory/quantifiers/extended_rewrite.cpp
+++ b/src/theory/quantifiers/extended_rewrite.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/quantifiers/extended_rewrite.h"
 
+#include <sstream>
+
 #include "theory/arith/arith_msum.h"
 #include "theory/bv/theory_bv_utils.h"
 #include "theory/datatypes/datatypes_rewriter.h"

--- a/src/theory/quantifiers/query_generator.cpp
+++ b/src/theory/quantifiers/query_generator.cpp
@@ -16,6 +16,7 @@
 #include "theory/quantifiers/query_generator.h"
 
 #include <fstream>
+#include <sstream>
 
 #include "options/quantifiers_options.h"
 #include "smt/smt_engine.h"

--- a/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_cons.cpp
@@ -14,6 +14,7 @@
  **/
 #include "theory/quantifiers/sygus/sygus_grammar_cons.h"
 
+#include <sstream>
 #include <stack>
 
 #include "expr/dtype_cons.h"

--- a/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
+++ b/src/theory/quantifiers/sygus/sygus_grammar_norm.cpp
@@ -15,6 +15,8 @@
 
 #include "theory/quantifiers/sygus/sygus_grammar_norm.h"
 
+#include <sstream>
+
 #include "expr/dtype_cons.h"
 #include "expr/node_manager_attributes.h"  // for VarNameAttr
 #include "options/quantifiers_options.h"

--- a/src/theory/quantifiers/sygus/sygus_process_conj.cpp
+++ b/src/theory/quantifiers/sygus/sygus_process_conj.cpp
@@ -14,6 +14,7 @@
  **/
 #include "theory/quantifiers/sygus/sygus_process_conj.h"
 
+#include <sstream>
 #include <stack>
 
 #include "options/quantifiers_options.h"

--- a/src/theory/quantifiers/sygus/term_database_sygus.cpp
+++ b/src/theory/quantifiers/sygus/term_database_sygus.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/quantifiers/sygus/term_database_sygus.h"
 
+#include <sstream>
+
 #include "base/check.h"
 #include "expr/dtype_cons.h"
 #include "expr/sygus_datatype.h"

--- a/src/theory/quantifiers/sygus_sampler.cpp
+++ b/src/theory/quantifiers/sygus_sampler.cpp
@@ -14,6 +14,8 @@
 
 #include "theory/quantifiers/sygus_sampler.h"
 
+#include <sstream>
+
 #include "expr/dtype.h"
 #include "expr/dtype_cons.h"
 #include "expr/node_algorithm.h"

--- a/src/theory/sort_inference.cpp
+++ b/src/theory/sort_inference.cpp
@@ -21,6 +21,7 @@
 
 #include "theory/sort_inference.h"
 
+#include <sstream>
 #include <vector>
 
 #include "options/quantifiers_options.h"


### PR DESCRIPTION
This PR adds includes that are missing from source files, but currently provided by other includes.
This mostly concerns `<sstream>` which is currently included by the statistics, which will change in the future.