### PR TITLE
Add an option to explicitly not use Ninja #6223

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -237,6 +237,7 @@ do
     --arm64) arm64=ON;;
 
     --ninja) ninja=ON;;
+    --no-ninja) ninja=OFF;;
 
     --glpk) glpk=ON;;
     --no-glpk) glpk=OFF;;
@@ -376,7 +377,8 @@ cmake_opts=""
   && cmake_opts="$cmake_opts -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-mingw64.cmake"
 [ $arm64 != default ] \
   && cmake_opts="$cmake_opts -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-aarch64.cmake"
-[ $ninja != default ] && cmake_opts="$cmake_opts -G Ninja"
+[ $ninja != "OFF" ] \
+  && cmake_opts="$cmake_opts -G Ninja"
 [ $muzzle != default ] \
   && cmake_opts="$cmake_opts -DENABLE_MUZZLE=$muzzle"
 [ $shared != default ] \


### PR DESCRIPTION
This adds an option to `./configure.sh` to *not* use Ninja.

Note, most other `./configure.sh` options pass `-D<OPTION>=$var` to CMake -- this won't work for `-G Ninja`, so I've had to check `!= OFF`.

This works if, e.g., you have `export CMAKE_GENERATOR=Ninja` set but don't want to use Ninja.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>