### PR TITLE
cmake: Do not link against main object library.

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -38,7 +38,6 @@ endif()
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
-target_include_directories(main PRIVATE cvc4)
 
 # main-test library is only used for linking against api and unit tests so
 # that we don't have to include all object files of main into each api/unit

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -38,12 +38,12 @@ endif()
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
-get_target_property(GMP_INCLUDES GMP INTERFACE_INCLUDE_DIRECTORIES)
-message(STATUS "GMP INCLUDES: ${GMP_INCLUDES}")
 if(USE_CLN)
-  target_include_directories(main PUBLIC CLN)
+  get_target_property(CLN_INCLUDES CLN INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(main PRIVATE ${CLN_INCLUDES})
 endif()
-target_include_directories(main PUBLIC GMP)
+get_target_property(GMP_INCLUDES GMP INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(main PRIVATE ${GMP_INCLUDES})
 
 # main-test library is only used for linking against api and unit tests so
 # that we don't have to include all object files of main into each api/unit

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -38,10 +38,12 @@ endif()
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
+get_target_property(GMP_INCLUDES GMP INCLUDE_DIRECTORIES)
+message(STATUS "GMP INCLUDES: ${GMP_INCLUDES}")
 if(USE_CLN)
-  target_include_directories(main PRIVATE CLN)
+  target_include_directories(main PUBLIC CLN)
 endif()
-target_include_directories(main PRIVATE GMP)
+target_include_directories(main PUBLIC GMP)
 
 # main-test library is only used for linking against api and unit tests so
 # that we don't have to include all object files of main into each api/unit

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -38,8 +38,11 @@ endif()
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
-get_target_property(LIBCVC4_INCLUDES cvc4 INCLUDE_DIRECTORIES)
-target_include_directories(main PRIVATE ${LIBCVC4_INCLUDES})
+target_include_directories(main PRIVATE cvc4)
+target_include_directories(main PRIVATE GMP)
+if(USE_CLN)
+  target_include_directories(main PRIVATE CLN)
+endif()
 
 # main-test library is only used for linking against api and unit tests so
 # that we don't have to include all object files of main into each api/unit

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -61,6 +61,10 @@ set_target_properties(cvc4-bin
     OUTPUT_NAME cvc4
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 target_link_libraries(cvc4-bin PUBLIC cvc4 cvc4parser)
+if(USE_CLN)
+  target_link_libraries(cvc4-bin PUBLIC CLN)
+endif()
+target_link_libraries(cvc4-bin PUBLIC GMP)
 
 if(PROGRAM_PREFIX)
   install(PROGRAMS

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -23,8 +23,8 @@ set(libmain_src_files
 )
 
 #-----------------------------------------------------------------------------#
-# Build object library since we will use the object files for cvc4-bin,
-# pcvc4-bin, and main-test library.
+# Build object library since we will use the object files for cvc4-bin and
+# main-test library.
 
 add_library(main OBJECT ${libmain_src_files})
 target_compile_definitions(main PRIVATE -D__BUILDING_CVC4DRIVER)
@@ -39,10 +39,6 @@ endif()
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
 target_include_directories(main PRIVATE cvc4)
-target_include_directories(main PUBLIC GMP)
-if(USE_CLN)
-  target_include_directories(main PUBLIC CLN)
-endif()
 
 # main-test library is only used for linking against api and unit tests so
 # that we don't have to include all object files of main into each api/unit
@@ -65,10 +61,7 @@ set_target_properties(cvc4-bin
     OUTPUT_NAME cvc4
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 target_link_libraries(cvc4-bin PUBLIC cvc4 cvc4parser)
-if(USE_CLN)
-  target_link_libraries(cvc4-bin PUBLIC CLN)
-endif()
-target_link_libraries(cvc4-bin PUBLIC GMP)
+
 if(PROGRAM_PREFIX)
   install(PROGRAMS
     $<TARGET_FILE:cvc4-bin>

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -39,9 +39,9 @@ endif()
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
 target_include_directories(main PRIVATE cvc4)
-target_include_directories(main PRIVATE GMP)
+target_include_directories(main PUBLIC GMP)
 if(USE_CLN)
-  target_include_directories(main PRIVATE CLN)
+  target_include_directories(main PUBLIC CLN)
 endif()
 
 # main-test library is only used for linking against api and unit tests so

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -38,6 +38,10 @@ endif()
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
+if(USE_CLN)
+  target_include_directories(main PRIVATE CLN)
+endif()
+target_include_directories(main PRIVATE GMP)
 
 # main-test library is only used for linking against api and unit tests so
 # that we don't have to include all object files of main into each api/unit

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -38,6 +38,10 @@ endif()
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
+
+# Note: This should not be required anymore as soon as we get rid of the
+#       smt_engine.h include in src/main. smt_engine.h has transitive includes
+#       of GMP and CLN via sexpr.h and therefore needs GMP/CLN headers.
 if(USE_CLN)
   get_target_property(CLN_INCLUDES CLN INTERFACE_INCLUDE_DIRECTORIES)
   target_include_directories(main PRIVATE ${CLN_INCLUDES})

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -32,18 +32,14 @@ if(ENABLE_SHARED)
   set_target_properties(main PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
-# We can't use target_link_libraries(...) here since this is only supported for
-# cmake version >= 3.12. Hence, we have to manually add the library
-# dependencies for main. As a consequence, include directories from
+# We can't use target_link_libraries(main ...) here since this is only
+# supported for cmake version >= 3.12. Hence, we have to manually add the
+# library dependencies for main. As a consequence, include directories from
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
 get_target_property(LIBCVC4_INCLUDES cvc4 INCLUDE_DIRECTORIES)
 target_include_directories(main PRIVATE ${LIBCVC4_INCLUDES})
-if(USE_CLN)
-  target_link_libraries(main PUBLIC CLN)
-endif()
-target_link_libraries(main PUBLIC GMP)
 
 # main-test library is only used for linking against api and unit tests so
 # that we don't have to include all object files of main into each api/unit

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 # dependencies are not propagated and we need to manually add the include
 # directories of libcvc4 to main.
 add_dependencies(main cvc4 cvc4parser gen-tokens)
-get_target_property(GMP_INCLUDES GMP INCLUDE_DIRECTORIES)
+get_target_property(GMP_INCLUDES GMP INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "GMP INCLUDES: ${GMP_INCLUDES}")
 if(USE_CLN)
   target_include_directories(main PUBLIC CLN)

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -18,6 +18,7 @@
 #  include <sys/resource.h>
 #endif /* ! __WIN32__ */
 
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/src/main/command_executor.cpp
+++ b/src/main/command_executor.cpp
@@ -25,6 +25,7 @@
 
 #include "main/main.h"
 #include "smt/command.h"
+#include "smt/smt_engine.h"
 
 namespace cvc5 {
 namespace main {

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -21,7 +21,6 @@
 #include "api/cvc4cpp.h"
 #include "expr/symbol_manager.h"
 #include "options/options.h"
-#include "util/statistics_registry.h"
 
 namespace cvc5 {
 

--- a/src/main/command_executor.h
+++ b/src/main/command_executor.h
@@ -21,12 +21,15 @@
 #include "api/cvc4cpp.h"
 #include "expr/symbol_manager.h"
 #include "options/options.h"
-#include "smt/smt_engine.h"
 #include "util/statistics_registry.h"
 
 namespace cvc5 {
 
 class Command;
+
+namespace smt {
+class SmtEngine;
+}
 
 namespace main {
 

--- a/src/main/driver_unified.cpp
+++ b/src/main/driver_unified.cpp
@@ -23,11 +23,10 @@
 #include <memory>
 #include <new>
 
-#include "cvc4autoconfig.h"
-
 #include "api/cvc4cpp.h"
 #include "base/configuration.h"
 #include "base/output.h"
+#include "cvc4autoconfig.h"
 #include "main/command_executor.h"
 #include "main/interactive_shell.h"
 #include "main/main.h"
@@ -38,6 +37,7 @@
 #include "parser/parser.h"
 #include "parser/parser_builder.h"
 #include "smt/command.h"
+#include "smt/smt_engine.h"
 #include "util/result.h"
 
 using namespace std;

--- a/src/main/signal_handlers.cpp
+++ b/src/main/signal_handlers.cpp
@@ -38,7 +38,6 @@
 #include "main/command_executor.h"
 #include "main/main.h"
 #include "options/options.h"
-#include "smt/smt_engine.h"
 #include "util/safe_print.h"
 
 using cvc5::Exception;


### PR DESCRIPTION
CMake 3.10.2 (default on Ubuntu 18.04) does not allow `target_link_libraries` on object libraries.