### PR TITLE
parsekinds: Remove DEFAULT_HEADER.

### DIFF
--- a/src/api/java/genkinds.py
+++ b/src/api/java/genkinds.py
@@ -97,8 +97,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser('Read a kinds header file and generate a '
                                      'corresponding java file')
     parser.add_argument('--kinds-header', metavar='<KINDS_HEADER>',
-                        help='The header file to read kinds from',
-                        default=DEFAULT_HEADER)
+                        help='The header file to read kinds from')
     parser.add_argument('--kinds-file-prefix', metavar='<KIND_FILE_PREFIX>',
                         help='The prefix for the generated .java file',
                         default=DEFAULT_PREFIX)

--- a/src/api/parsekinds.py
+++ b/src/api/parsekinds.py
@@ -21,9 +21,6 @@ handle nested '#if 0' pairs.
 
 from collections import OrderedDict
 
-#################### Default Filenames ################
-DEFAULT_HEADER = 'cvc4cppkind.h'
-
 ##################### Useful Constants ################
 OCB = '{'
 CCB = '}'

--- a/src/api/python/genkinds.py.in
+++ b/src/api/python/genkinds.py.in
@@ -132,8 +132,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser('Read a kinds header file and generate a '
                          'corresponding pxd file, with simplified kind names.')
     parser.add_argument('--kinds-header', metavar='<KINDS_HEADER>',
-                        help='The header file to read kinds from',
-                        default=DEFAULT_HEADER)
+                        help='The header file to read kinds from')
     parser.add_argument('--kinds-file-prefix', metavar='<KIND_FILE_PREFIX>',
                         help='The prefix for the .pxd and .pxi files to write '
                         'the Cython declarations to.',


### PR DESCRIPTION
`DEFAULT_HEADER` in `src/api/parsekinds.py` is essentially unused since both `genkinds.py` scripts pass the kinds header to the script. The current value of `DEFAULT_HEADER` does not work for the scripts since the working directory for genkinds.py is in `src/api/{java,python}`.