### PR TITLE
cmake: Do not always regenerate cvc4kinds.{pxi,pxd}.

### DIFF
--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -17,19 +17,17 @@ endif()
 find_package(PythonExtensions REQUIRED)
 find_package(Cython 0.29 REQUIRED)
 
-include_directories(${PYTHON_INCLUDE_DIRS})
-include_directories(${CMAKE_CURRENT_LIST_DIR})         # cvc4kinds.pxd
-include_directories(${PROJECT_SOURCE_DIR}/src)
-include_directories(${PROJECT_SOURCE_DIR}/src/include)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-# TEMP: Only needed while expr/kind.h is public in the C++ api
-include_directories("${CMAKE_BINARY_DIR}/src/")
-
 # Generate cvc4kinds.{pxd,pyx}
 configure_file(genkinds.py.in genkinds.py)
-add_custom_target(
-  gen-pycvc4-kinds
-  ALL
+set(GENERATED_FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/cvc4kinds.pxd"
+  "${CMAKE_CURRENT_BINARY_DIR}/cvc4kinds.pxi"
+)
+add_custom_command(
+  OUTPUT
+    ${GENERATED_FILES}
+  BYPRODUCTS
+    ${GENERATED_FILES}
   COMMAND
     "${PYTHON_EXECUTABLE}"
     "${CMAKE_CURRENT_BINARY_DIR}/genkinds.py"
@@ -37,15 +35,25 @@ add_custom_target(
     --kinds-file-prefix "${CMAKE_CURRENT_BINARY_DIR}/cvc4kinds"
   DEPENDS
     "${CMAKE_CURRENT_BINARY_DIR}/genkinds.py"
-  COMMENT
-    "Generate cvc4kinds.{pxd,pyx}"
+    "${PROJECT_SOURCE_DIR}/src/api/cpp/cvc5_kind.h"
 )
 
+add_custom_target(cvc4kinds DEPENDS ${GENERATED_FILES})
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})   # for cvc4kinds.pxi
 add_cython_target(pycvc4 CXX)
 
 add_library(pycvc4
             MODULE
             ${pycvc4})
+add_dependencies(pycvc4 cvc4kinds)
+
+target_include_directories(pycvc4
+  PRIVATE
+  ${PYTHON_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src       # for API headers in src/api/cpp
+  ${CMAKE_BINARY_DIR}/src         # for cvc4_export.h
+)
 
 target_link_libraries(pycvc4 cvc4 ${PYTHON_LIBRARIES})
 
@@ -86,7 +94,8 @@ execute_process(OUTPUT_VARIABLE IN_VIRTUALENV
   "from __future__ import print_function; import os;
 print('YES' if 'VIRTUAL_ENV' in os.environ else 'NO', end='')")
 
-set(INSTALL_CMD "${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install")
+set(INSTALL_CMD
+    "${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install")
 # if we're in a virtualenv, we install it in the virtualenv lib location
 if ("${IN_VIRTUALENV}" STREQUAL "NO")
   set(INSTALL_CMD "${INSTALL_CMD} --prefix=${CMAKE_INSTALL_PREFIX}")
@@ -94,4 +103,5 @@ endif()
 
 message("Python bindings install command: ${INSTALL_CMD}")
 
-install(CODE "execute_process(COMMAND ${INSTALL_CMD})"  FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
+install(CODE "execute_process(COMMAND ${INSTALL_CMD})"
+        FILE_PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)


### PR DESCRIPTION
Only regenerate files if dependencies changed. This avoids unnecessary
rebuilds of the Cython code.