### PR TITLE
Use newer version of update-pr-branch action.

### DIFF
--- a/.github/workflows/update_pr.yml
+++ b/.github/workflows/update_pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Automatically update PR
-        uses: adRise/update-pr-branch@v0.4.0
+        uses: adRise/update-pr-branch@v0.5.1
         with:
           token: ${{ secrets.ACTION_USER_TOKEN }}
           base: 'master'


### PR DESCRIPTION
The CI action we use to update PRs that are ready to merge has been updated and now only considers the last review of every reviewer. It now allows to automatically update (and then merge) PRs where a reviewer first requested changes, and then accepted the PR. See https://github.com/adRise/update-pr-branch/pull/11 for more details.
This PR bumps the version to the most recent one.