### PR TITLE
Fix GitHub Actions macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
     - name: Install Packages (macOS)
       if: runner.os == 'macOS'
       run: |
+        brew update
         brew install \
           ccache \
           cln \


### PR DESCRIPTION
The build is currently failing because it tries to download an older
version of the `ccache` package. This commit makes sure that Homebrew is
up-to-date before trying to install packages.