### PR TITLE
Fix printing of stats when aborted.

### DIFF
--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -762,6 +762,12 @@ std::string kindToString(Kind k)
                             : cvc5::kind::kindToString(extToIntKind(k));
 }
 
+const char* toString(Kind k)
+{
+  return k == INTERNAL_KIND ? "INTERNAL_KIND"
+                            : cvc5::kind::toString(extToIntKind(k));
+}
+
 std::ostream& operator<<(std::ostream& out, Kind k)
 {
   switch (k)

--- a/src/expr/kind_template.cpp
+++ b/src/expr/kind_template.cpp
@@ -62,23 +62,21 @@ bool isAssociative(::cvc5::Kind k)
   }
 }
 
-std::string kindToString(::cvc5::Kind k)
-{
-  std::stringstream ss;
-  ss << k;
-  return ss.str();
-}
+std::string kindToString(::cvc5::Kind k) { return toString(k); }
 
 }  // namespace kind
 
-std::ostream& operator<<(std::ostream& out, TypeConstant typeConstant) {
-  switch(typeConstant) {
-${type_constant_descriptions}
-  default:
-    out << "UNKNOWN_TYPE_CONSTANT";
-    break;
+const char* toString(TypeConstant tc)
+{
+  switch (tc)
+  {
+    ${type_constant_descriptions}
+    default: return "UNKNOWN_TYPE_CONSTANT";
   }
-  return out;
+}
+std::ostream& operator<<(std::ostream& out, TypeConstant typeConstant)
+{
+  return out << toString(typeConstant);
 }
 
 namespace theory {

--- a/src/expr/kind_template.h
+++ b/src/expr/kind_template.h
@@ -92,6 +92,7 @@ struct TypeConstantHashFunction {
   }
 };/* struct TypeConstantHashFunction */
 
+const char* toString(TypeConstant tc);
 std::ostream& operator<<(std::ostream& out, TypeConstant typeConstant);
 
 namespace theory {

--- a/src/expr/mkkind
+++ b/src/expr/mkkind
@@ -256,7 +256,7 @@ function register_sort {
 
   type_constant_list="${type_constant_list}  ${id}, /**< ${comment} */
 "
-  type_constant_descriptions="${type_constant_descriptions}  case $id:  out << \"${comment}\"; break;
+  type_constant_descriptions="${type_constant_descriptions}  case $id: return \"${comment}\";
 "
   type_constant_to_theory_id="${type_constant_to_theory_id}  case $id: return $theory_id;
 "

--- a/src/options/base_options.toml
+++ b/src/options/base_options.toml
@@ -85,23 +85,13 @@ header = "options/base_options.h"
 
 [[option]]
   name       = "statistics"
-  smt_name   = "statistics"
+  smt_name   = "stats"
   long       = "stats"
   category   = "common"
   type       = "bool"
-  predicates = ["statsEnabledBuild"]
+  predicates = ["setStats"]
   read_only  = true
   help       = "give statistics on exit"
-
-[[option]]
-  name       = "statisticsExpert"
-  smt_name   = "stats-expert"
-  long       = "stats-expert"
-  category   = "expert"
-  type       = "bool"
-  predicates = ["statsEnabledBuild"]
-  read_only  = true
-  help       = "print expert (non-public) statistics as well"
 
 [[option]]
   name       = "statisticsAll"
@@ -109,9 +99,19 @@ header = "options/base_options.h"
   long       = "stats-all"
   category   = "expert"
   type       = "bool"
-  predicates = ["statsEnabledBuild"]
+  predicates = ["setStats"]
   read_only  = true
   help       = "print unchanged (defaulted) statistics as well"
+
+[[option]]
+  name       = "statisticsExpert"
+  smt_name   = "stats-expert"
+  long       = "stats-expert"
+  category   = "expert"
+  type       = "bool"
+  predicates = ["setStats"]
+  read_only  = true
+  help       = "print expert (non-public) statistics as well"
 
 [[option]]
   name       = "statisticsEveryQuery"
@@ -119,7 +119,7 @@ header = "options/base_options.h"
   long       = "stats-every-query"
   category   = "regular"
   type       = "bool"
-  predicates = ["statsEnabledBuild"]
+  predicates = ["setStats"]
   default    = "false"
   read_only  = true
   help       = "in incremental mode, print stats after every satisfiability or validity query"

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -271,22 +271,22 @@ void OptionsHandler::setStats(const std::string& option, bool value)
 #endif /* CVC5_STATISTICS_ON */
   if (value)
   {
-    if (option == "stats-all")
+    if (option == options::statisticsAll.getName())
     {
       d_options->d_holder->statistics = true;
     }
-    else if (option == "stats-every-query")
+    else if (option == options::statisticsEveryQuery.getName())
     {
       d_options->d_holder->statistics = true;
     }
-    else if (option == "stats-expert")
+    else if (option == options::statisticsExpert.getName())
     {
       d_options->d_holder->statistics = true;
     }
   }
   else
   {
-    if (option == "stats")
+    if (option == options::statistics.getName())
     {
       d_options->d_holder->statisticsAll = false;
       d_options->d_holder->statisticsEveryQuery = false;

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -259,15 +259,40 @@ void OptionsHandler::setProduceAssertions(std::string option, bool value)
   options::interactiveMode.set(value);
 }
 
-void OptionsHandler::statsEnabledBuild(std::string option, bool value)
+void OptionsHandler::setStats(const std::string& option, bool value)
 {
 #ifndef CVC5_STATISTICS_ON
-  if(value) {
+  if (value)
+  {
     std::stringstream ss;
     ss << "option `" << option << "' requires a statistics-enabled build of CVC4; this binary was not built with statistics support";
     throw OptionException(ss.str());
   }
 #endif /* CVC5_STATISTICS_ON */
+  if (value)
+  {
+    if (option == "stats-all")
+    {
+      d_options->d_holder->statistics = true;
+    }
+    else if (option == "stats-every-query")
+    {
+      d_options->d_holder->statistics = true;
+    }
+    else if (option == "stats-expert")
+    {
+      d_options->d_holder->statistics = true;
+    }
+  }
+  else
+  {
+    if (option == "stats")
+    {
+      d_options->d_holder->statisticsAll = false;
+      d_options->d_holder->statisticsEveryQuery = false;
+      d_options->d_holder->statisticsExpert = false;
+    }
+  }
 }
 
 void OptionsHandler::threadN(std::string option) {

--- a/src/options/options_handler.h
+++ b/src/options/options_handler.h
@@ -86,7 +86,7 @@ public:
    */
   void setProduceAssertions(std::string option, bool value);
 
-  void statsEnabledBuild(std::string option, bool value);
+  void setStats(const std::string& option, bool value);
 
   unsigned long limitHandler(std::string option, std::string optarg);
   void setResourceWeight(std::string option, std::string optarg);

--- a/src/util/statistics_registry.cpp
+++ b/src/util/statistics_registry.cpp
@@ -97,7 +97,7 @@ void StatisticsRegistry::printSafe(int fd) const
       safe_print(fd, s.first);
       safe_print(fd, " = ");
       s.second->printSafe(fd);
-      safe_print(fd, '\n');
+      safe_print(fd, "\n");
     }
   }
 }

--- a/src/util/statistics_value.h
+++ b/src/util/statistics_value.h
@@ -154,11 +154,9 @@ struct StatisticHistogramValue : StatisticBaseValue
         {
           safe_print(fd, ", ");
         }
-        safe_print(fd, "(");
         safe_print<Integral>(fd, static_cast<Integral>(i + d_offset));
         safe_print(fd, ": ");
         safe_print<uint64_t>(fd, d_hist[i]);
-        safe_print(fd, ")");
       }
     }
     safe_print(fd, " }");


### PR DESCRIPTION
This PR improves/fixes printing of statistics when the solver has been aborted, i.e. when we use `printSafe()`, and a few other minor issues with the new statistics setup.
- add `toString()` methods for `TypeConstant`, `api::Kind` to allow for automatic printing by `print_safe<>()`
- improve `kindToString()` to avoid `std::stringstream`
- fix newlines between statistics in `printSafe()`
- make printing of histograms consistent
- make `--stats-all`, `--stats-expert` and `--stats-every-check` automatically enable `--stats` (and vice versa)