### PR TITLE
cmake: Build object libraries for base and context.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1092,25 +1092,17 @@ add_subdirectory(theory)
 add_subdirectory(util)
 
 #-----------------------------------------------------------------------------#
-# Build support library from base and context that can be used in the main
-# library as well as the parser library.
-
-add_library(cvc4support INTERFACE)
-target_link_libraries(cvc4support INTERFACE cvc4base)
-target_link_libraries(cvc4support INTERFACE cvc4context)
-
-#-----------------------------------------------------------------------------#
 # All sources for libcvc4 are now collected in LIBCVC4_SRCS and (if generated)
 # LIBCVC4_GEN_SRCS (via libcvc4_add_sources). We can now build libcvc4.
 
 set_source_files_properties(${LIBCVC4_GEN_SRCS} PROPERTIES GENERATED TRUE)
-add_library(cvc4 ${LIBCVC4_SRCS} ${LIBCVC4_GEN_SRCS})
+add_library(cvc4 ${LIBCVC4_SRCS} ${LIBCVC4_GEN_SRCS}
+  $<TARGET_OBJECTS:cvc4base> $<TARGET_OBJECTS:cvc4context>)
 target_include_directories(cvc4
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(cvc4 PRIVATE cvc4support)
 
 include(GenerateExportHeader)
 generate_export_header(cvc4)

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -79,7 +79,7 @@ set_source_files_properties(
   PROPERTIES GENERATED TRUE
 )
 
-add_library(cvc4base STATIC ${LIBBASE_SOURCES})
+add_library(cvc4base OBJECT ${LIBBASE_SOURCES})
 if(ENABLE_SHARED)
   set_target_properties(cvc4base PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()

--- a/src/context/CMakeLists.txt
+++ b/src/context/CMakeLists.txt
@@ -34,7 +34,7 @@ set(LIBCONTEXT_SOURCES
   context_mm.h
 )
 
-add_library(cvc4context STATIC ${LIBCONTEXT_SOURCES})
+add_library(cvc4context OBJECT ${LIBCONTEXT_SOURCES})
 if(ENABLE_SHARED)
   set_target_properties(cvc4context PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()


### PR DESCRIPTION
cmake complains that the static base and context libraries are not
exported as install targets. Since we do not want to install these
libraries we'll build object libraries instead.