### PR TITLE
Fix dependencies for stats options

### DIFF
--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -275,25 +275,26 @@ void OptionsHandler::setStats(const std::string& option, bool value)
     throw OptionException(ss.str());
   }
 #endif /* CVC5_STATISTICS_ON */
+  Assert(option.substr(0, 2) == "--");
+  std::string opt = option.substr(2);
   if (value)
   {
-    if (option == std::string("--") + options::statisticsAll.getName())
+    if (opt == options::statisticsAll.getName())
     {
       d_options->d_holder->statistics = true;
     }
-    else if (option
-             == std::string("--") + options::statisticsEveryQuery.getName())
+    else if (opt == options::statisticsEveryQuery.getName())
     {
       d_options->d_holder->statistics = true;
     }
-    else if (option == std::string("--") + options::statisticsExpert.getName())
+    else if (opt == options::statisticsExpert.getName())
     {
       d_options->d_holder->statistics = true;
     }
   }
   else
   {
-    if (option == std::string("--") + options::statistics.getName())
+    if (opt == options::statistics.getName())
     {
       d_options->d_holder->statisticsAll = false;
       d_options->d_holder->statisticsEveryQuery = false;

--- a/src/options/options_handler.cpp
+++ b/src/options/options_handler.cpp
@@ -277,22 +277,23 @@ void OptionsHandler::setStats(const std::string& option, bool value)
 #endif /* CVC5_STATISTICS_ON */
   if (value)
   {
-    if (option == options::statisticsAll.getName())
+    if (option == std::string("--") + options::statisticsAll.getName())
     {
       d_options->d_holder->statistics = true;
     }
-    else if (option == options::statisticsEveryQuery.getName())
+    else if (option
+             == std::string("--") + options::statisticsEveryQuery.getName())
     {
       d_options->d_holder->statistics = true;
     }
-    else if (option == options::statisticsExpert.getName())
+    else if (option == std::string("--") + options::statisticsExpert.getName())
     {
       d_options->d_holder->statistics = true;
     }
   }
   else
   {
-    if (option == options::statistics.getName())
+    if (option == std::string("--") + options::statistics.getName())
     {
       d_options->d_holder->statisticsAll = false;
       d_options->d_holder->statisticsEveryQuery = false;


### PR DESCRIPTION
A last-minute edit in a previous PR broke the handling of dependencies between the statistic options.