### PR TITLE
Properly link Poly against GMP

### DIFF
--- a/cmake/FindPoly.cmake
+++ b/cmake/FindPoly.cmake
@@ -93,7 +93,6 @@ if(NOT Poly_FOUND_SYSTEM)
     DEPENDEES install
     COMMAND ${CMAKE_COMMAND} -E remove_directory <BINARY_DIR>/test/
   )
-  add_dependencies(Poly-EP GMP)
 
   set(Poly_INCLUDE_DIR "${DEPS_BASE}/include/")
   set(Poly_LIBRARIES "${DEPS_BASE}/lib/libpicpoly.a")
@@ -107,6 +106,7 @@ set_target_properties(Poly PROPERTIES IMPORTED_LOCATION "${Poly_LIBRARIES}")
 set_target_properties(
   Poly PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Poly_INCLUDE_DIR}"
 )
+target_link_libraries(Poly INTERFACE GMP)
 
 add_library(Polyxx STATIC IMPORTED GLOBAL)
 set_target_properties(Polyxx PROPERTIES IMPORTED_LOCATION "${PolyXX_LIBRARIES}")


### PR DESCRIPTION
This PR fixes a linker issue with libpoly and static builds where Poly and GMP would be linked against in the wrong order.