### PR TITLE
Fix `ANTLR3_COMMAND` for system ANTLR3 JAR

### DIFF
--- a/cmake/FindANTLR3.cmake
+++ b/cmake/FindANTLR3.cmake
@@ -108,8 +108,7 @@ set(ANTLR3_FOUND TRUE)
 # This may not be a single binary: the EP has a whole commandline
 # We thus do not make this an executable target.
 # Just call ${ANTLR3_COMMAND} instead.
-set(ANTLR3_COMMAND ${Java_JAVA_EXECUTABLE} -cp
-    "${DEPS_BASE}/share/java/antlr-3.4-complete.jar" org.antlr.Tool
+set(ANTLR3_COMMAND ${Java_JAVA_EXECUTABLE} -cp "${ANTLR3_JAR}" org.antlr.Tool
     CACHE STRING "run ANTLR3" FORCE)
 
 add_library(ANTLR3 STATIC IMPORTED GLOBAL)
@@ -126,7 +125,9 @@ mark_as_advanced(ANTLR3_RUNTIME)
 
 if(ANTLR3_FOUND_SYSTEM)
     message(STATUS "Found ANTLR3 runtime: ${ANTLR3_RUNTIME}")
+    message(STATUS "Found ANTLR3 JAR: ${ANTLR3_JAR}")
 else()
     message(STATUS "Building ANTLR3 runtime: ${ANTLR3_RUNTIME}")
+    message(STATUS "Downloading ANTLR3 JAR: ${ANTLR3_JAR}")
     add_dependencies(ANTLR3 ANTLR3-EP-runtime ANTLR3-EP-jar)
 endif()


### PR DESCRIPTION
`ANTLR3_COMMAND` was using a fixed path instead of relying on the
`ANTLR3_JAR` variable. If the ANTLR3 JAR was found on the system (for
example due to an existing `deps` folder at the root of the CVC4
folder), then the command would fail because the JAR was not at the
expected location.  This commit changes the command to use the variable
and prints the location of the JAR file to make debugging easier.