### PR TITLE
Make sure a ReferenceStat is set to values of the correct type

### DIFF
--- a/src/prop/bvminisat/core/Solver.cc
+++ b/src/prop/bvminisat/core/Solver.cc
@@ -1412,9 +1412,9 @@ bool Solver::withinBudget(Resource r) const
   d_notify->safePoint(r);
 
   return !asynch_interrupt &&
-         (conflict_budget < 0 || conflicts < (uint64_t)conflict_budget) &&
+         (conflict_budget < 0 || conflicts < conflict_budget) &&
          (propagation_budget < 0 ||
-          propagations < (uint64_t)propagation_budget);
+          propagations < propagation_budget);
 }
 
 }  // namespace BVMinisat

--- a/src/prop/bvminisat/core/Solver.h
+++ b/src/prop/bvminisat/core/Solver.h
@@ -235,8 +235,8 @@ public:
 
  // Statistics: (read-only member variable)
  //
- uint64_t solves, starts, decisions, rnd_decisions, propagations, conflicts;
- uint64_t dec_vars, clauses_literals, learnts_literals, max_literals,
+ int64_t solves, starts, decisions, rnd_decisions, propagations, conflicts;
+ int64_t dec_vars, clauses_literals, learnts_literals, max_literals,
      tot_literals;
 
  // Bitvector Propagations

--- a/src/prop/bvminisat/simp/SimpSolver.h
+++ b/src/prop/bvminisat/simp/SimpSolver.h
@@ -114,7 +114,7 @@ class SimpSolver : public Solver {
     //
     int     merges;
     int     asymm_lits;
-    int     eliminated_vars;
+    int64_t eliminated_vars;
     //    cvc5::TimerStat total_eliminate_time;
 
    protected:

--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -2383,10 +2383,8 @@ inline bool Solver::withinBudget(Resource r) const
   d_proxy->spendResource(r);
 
   bool within_budget =
-      !asynch_interrupt
-      && (conflict_budget < 0 || conflicts < (uint64_t)conflict_budget)
-      && (propagation_budget < 0
-          || propagations < (uint64_t)propagation_budget);
+      !asynch_interrupt && (conflict_budget < 0 || conflicts < conflict_budget)
+      && (propagation_budget < 0 || propagations < propagation_budget);
   return within_budget;
 }
 

--- a/src/prop/minisat/core/Solver.h
+++ b/src/prop/minisat/core/Solver.h
@@ -351,9 +351,9 @@ public:
 
  // Statistics: (read-only member variable)
  //
- uint64_t solves, starts, decisions, rnd_decisions, propagations, conflicts,
+ int64_t solves, starts, decisions, rnd_decisions, propagations, conflicts,
      resources_consumed;
- uint64_t dec_vars, clauses_literals, learnts_literals, max_literals,
+ int64_t dec_vars, clauses_literals, learnts_literals, max_literals,
      tot_literals;
 
 protected:

--- a/src/util/statistics_stats.h
+++ b/src/util/statistics_stats.h
@@ -122,8 +122,10 @@ class ReferenceStat
   /** Value stored for this statistic */
   using stat_type = StatisticReferenceValue<T>;
   /** Reset the reference to point to `t`. */
-  void set(const T& t)
+  template <typename TT>
+  void set(const TT& t)
   {
+    static_assert(std::is_same_v<T, TT>, "Incorrect type for ReferenceStat");
     if constexpr (Configuration::isStatisticsBuild())
     {
       d_data->d_value = &t;


### PR DESCRIPTION
This PR fixes a very subtle issue with setting the values a `ReferenceStat` refers to.
`ReferenceStat::set()` would take a variable by `const&` and then store the pointer to it. When giving it a different, but implicitly convertible, type, the pointer would assume the wrong type and consequently read incorrect values from it.
This PR makes `set()` a template function that explicitly checks that the given type is the correct one.
As we can only export `int64_t` to the API, this forces users of `ReferenceStat` to use `int64_t` stats.