### PR TITLE
Fix assertions in SAT solver

### DIFF
--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -2249,8 +2249,7 @@ CRef Solver::updateLemmas() {
   // Last index in the trail
   int backtrack_index = trail.size();
 
-  Assert(options::unsatCoresMode() == options::UnsatCoresMode::OFF
-         || options::unsatCoresMode() != options::UnsatCoresMode::OLD_PROOF
+  Assert(options::unsatCoresMode() != options::UnsatCoresMode::OLD_PROOF
          || lemmas.size() == static_cast<int>(lemmas_cnf_assertion.size()));
 
   // Attach all the clauses and enqueue all the propagations
@@ -2335,8 +2334,7 @@ CRef Solver::updateLemmas() {
     }
   }
 
-  Assert(options::unsatCoresMode() == options::UnsatCoresMode::OFF
-         || options::unsatCoresMode() != options::UnsatCoresMode::OLD_PROOF
+  Assert(options::unsatCoresMode() != options::UnsatCoresMode::OLD_PROOF
          || lemmas.size() == static_cast<int>(lemmas_cnf_assertion.size()));
   // Clear the lemmas
   lemmas.clear();

--- a/src/prop/minisat/core/Solver.cc
+++ b/src/prop/minisat/core/Solver.cc
@@ -2249,8 +2249,9 @@ CRef Solver::updateLemmas() {
   // Last index in the trail
   int backtrack_index = trail.size();
 
-  Assert(!options::unsatCores() || needProof()
-         || lemmas.size() == (int)lemmas_cnf_assertion.size());
+  Assert(options::unsatCoresMode() == options::UnsatCoresMode::OFF
+         || options::unsatCoresMode() != options::UnsatCoresMode::OLD_PROOF
+         || lemmas.size() == static_cast<int>(lemmas_cnf_assertion.size()));
 
   // Attach all the clauses and enqueue all the propagations
   for (int j = 0; j < lemmas.size(); ++j)
@@ -2334,8 +2335,9 @@ CRef Solver::updateLemmas() {
     }
   }
 
-  Assert(!options::unsatCores() || needProof()
-         || lemmas.size() == (int)lemmas_cnf_assertion.size());
+  Assert(options::unsatCoresMode() == options::UnsatCoresMode::OFF
+         || options::unsatCoresMode() != options::UnsatCoresMode::OLD_PROOF
+         || lemmas.size() == static_cast<int>(lemmas_cnf_assertion.size()));
   // Clear the lemmas
   lemmas.clear();
   lemmas_cnf_assertion.clear();


### PR DESCRIPTION
Due to our recent changes in the unsat core infrastructure we were doing a couple assertions wrong during conflict analysis. This commit fixes them.