### PR TITLE
Make sure reference stats are reset properly

### DIFF
--- a/src/prop/bvminisat/bvminisat.cpp
+++ b/src/prop/bvminisat/bvminisat.cpp
@@ -38,9 +38,7 @@ BVMinisatSatSolver::BVMinisatSatSolver(StatisticsRegistry& registry,
   d_statistics.init(d_minisat.get());
 }
 
-
-BVMinisatSatSolver::~BVMinisatSatSolver() {
-}
+BVMinisatSatSolver::~BVMinisatSatSolver() { d_statistics.deinit(); }
 
 void BVMinisatSatSolver::MinisatNotify::notify(
     BVMinisat::vec<BVMinisat::Lit>& clause)
@@ -276,6 +274,25 @@ void BVMinisatSatSolver::Statistics::init(BVMinisat::SimpSolver* minisat){
   d_statMaxLiterals.set(minisat->max_literals);
   d_statTotLiterals.set(minisat->tot_literals);
   d_statEliminatedVars.set(minisat->eliminated_vars);
+}
+
+void BVMinisatSatSolver::Statistics::deinit()
+{
+  if (!d_registerStats)
+  {
+    return;
+  }
+
+  d_statStarts.reset();
+  d_statDecisions.reset();
+  d_statRndDecisions.reset();
+  d_statPropagations.reset();
+  d_statConflicts.reset();
+  d_statClausesLiterals.reset();
+  d_statLearntsLiterals.reset();
+  d_statMaxLiterals.reset();
+  d_statTotLiterals.reset();
+  d_statEliminatedVars.reset();
 }
 
 }  // namespace prop

--- a/src/prop/bvminisat/bvminisat.h
+++ b/src/prop/bvminisat/bvminisat.h
@@ -141,6 +141,7 @@ public:
    bool d_registerStats;
    Statistics(StatisticsRegistry& registry, const std::string& prefix);
    void init(BVMinisat::SimpSolver* minisat);
+   void deinit();
   };
 
   Statistics d_statistics;

--- a/src/prop/minisat/minisat.cpp
+++ b/src/prop/minisat/minisat.cpp
@@ -37,6 +37,7 @@ MinisatSatSolver::MinisatSatSolver(StatisticsRegistry& registry)
 
 MinisatSatSolver::~MinisatSatSolver()
 {
+  d_statistics.deinit();
   delete d_minisat;
 }
 
@@ -315,6 +316,18 @@ void MinisatSatSolver::Statistics::init(Minisat::SimpSolver* minisat){
   d_statLearntsLiterals.set(minisat->learnts_literals);
   d_statMaxLiterals.set(minisat->max_literals);
   d_statTotLiterals.set(minisat->tot_literals);
+}
+void MinisatSatSolver::Statistics::deinit()
+{
+  d_statStarts.reset();
+  d_statDecisions.reset();
+  d_statRndDecisions.reset();
+  d_statPropagations.reset();
+  d_statConflicts.reset();
+  d_statClausesLiterals.reset();
+  d_statLearntsLiterals.reset();
+  d_statMaxLiterals.reset();
+  d_statTotLiterals.reset();
 }
 
 }  // namespace prop

--- a/src/prop/minisat/minisat.h
+++ b/src/prop/minisat/minisat.h
@@ -123,6 +123,7 @@ class MinisatSatSolver : public CDCLTSatSolverInterface
   public:
    Statistics(StatisticsRegistry& registry);
    void init(Minisat::SimpSolver* d_minisat);
+   void deinit();
   };/* class MinisatSatSolver::Statistics */
   Statistics d_statistics;
 

--- a/src/util/statistics_stats.h
+++ b/src/util/statistics_stats.h
@@ -131,6 +131,15 @@ class ReferenceStat
       d_data->d_value = &t;
     }
   }
+  /** Commit the value currently pointed to and release it. */
+  void reset()
+  {
+    if constexpr (Configuration::isStatisticsBuild())
+    {
+      d_data->commit();
+      d_data->d_value = nullptr;
+    }
+  }
   /** Copy the current value of the referenced object. */
   ~ReferenceStat()
   {


### PR DESCRIPTION
This PR adds a `reset()` method to the `ReferenceStat` class. It then uses it to properly reset such statistics in the minisat solvers where lifetime is an issue.