### PR TITLE
Add missing --auto-download in CI

### DIFF
--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -63,7 +63,7 @@ jobs:
             PRHASH="${{ github.event.pull_request.head.sha }}"
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
-            git remote add pr "${{ github.event.pull_request.head.repo.url}}"
+            git remote add pr "${{ github.event.pull_request.head.repo.clone_url}}"
             git fetch pr "${{ github.event.pull_request.head.ref}}:pr"
             git checkout "${PRHASH}" -- \
               `git ls-tree "${PRHASH}" --name-only -r docs/ | grep -E ".*\.(rst|bib)"` \

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -64,6 +64,7 @@ jobs:
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
             # be careful here, see explanation above!
+            echo ${{ github.event.pull_request }}
             git remote -v
             git branch -a
             git fetch

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -64,6 +64,7 @@ jobs:
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
             # be careful here, see explanation above!
+            git remote -v
             git branch -a
             git fetch
             git checkout "${PRHASH}" -- \

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -63,6 +63,7 @@ jobs:
             PRHASH="${{ github.event.pull_request.head.sha }}"
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
+            # be careful here, see explanation above!
             git remote add pr "${{ github.event.pull_request.head.repo.clone_url}}"
             git fetch pr "${{ github.event.pull_request.head.ref}}:pr"
             git checkout "${PRHASH}" -- \

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -63,11 +63,8 @@ jobs:
             PRHASH="${{ github.event.pull_request.head.sha }}"
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
-            # be careful here, see explanation above!
-            echo ${{ toJSON(github.event.pull_request) }}
-            git remote -v
-            git branch -a
-            git fetch
+            git remote add pr "${{ github.event.pull_request.head.url}}"
+            git fetch pr "${{ github.event.pull_request.head.ref}}:pr"
             git checkout "${PRHASH}" -- \
               `git ls-tree "${PRHASH}" --name-only -r docs/ | grep -E ".*\.(rst|bib)"` \
               `git ls-tree "${PRHASH}" --name-only -r src/api/ | grep -E ".*\.(h|cpp|java|py)"` \

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -64,7 +64,7 @@ jobs:
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
             # be careful here, see explanation above!
-            echo ${{ github.event.pull_request }}
+            echo ${{ toJSON(github.event.pull_request) }}
             git remote -v
             git branch -a
             git fetch

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -63,7 +63,7 @@ jobs:
             PRHASH="${{ github.event.pull_request.head.sha }}"
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
-            git remote add pr "${{ github.event.pull_request.head.url}}"
+            git remote add pr "${{ github.event.pull_request.head.repo.url}}"
             git fetch pr "${{ github.event.pull_request.head.ref}}:pr"
             git checkout "${PRHASH}" -- \
               `git ls-tree "${PRHASH}" --name-only -r docs/ | grep -E ".*\.(rst|bib)"` \

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -64,6 +64,7 @@ jobs:
             echo "Identified PR #$NAME (from $PRHASH)"
             NAME="pr$NAME"
             # be careful here, see explanation above!
+            git branch -a
             git fetch
             git checkout "${PRHASH}" -- \
               `git ls-tree "${PRHASH}" --name-only -r docs/ | grep -E ".*\.(rst|bib)"` \

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -31,6 +31,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
 
@@ -72,7 +73,7 @@ jobs:
           echo "NAME=$NAME" >> $GITHUB_ENV
 
       - name: Configure
-        run: ./configure.sh production --docs --all-bindings
+        run: ./configure.sh production --docs --all-bindings --auto-download
 
       - name: Build
         run: make -j2 docs-gh


### PR DESCRIPTION
This PR adds `--auto-download` for the CI job that builds the documentation. Also makes sure that the documentation workflow never fails.