### PR TITLE
Do not use proof CNF stream with assumptions-based cores

### DIFF
--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -267,10 +267,9 @@ void PropEngine::assertInternal(
     TNode node, bool negated, bool removable, bool input, ProofGenerator* pg)
 {
   // Assert as (possibly) removable
-  if (isProofEnabled())
+  if (options::unsatCoresMode() == options::UnsatCoresMode::ASSUMPTIONS)
   {
-    if (options::unsatCoresMode() == options::UnsatCoresMode::ASSUMPTIONS
-        && input)
+    if (input)
     {
       Assert(!negated);
       d_cnfStream->ensureLiteral(node);
@@ -278,10 +277,13 @@ void PropEngine::assertInternal(
     }
     else
     {
-      d_pfCnfStream->convertAndAssert(node, negated, removable, pg);
+      d_cnfStream->convertAndAssert(node, removable, negated, input);
     }
-
-    // if input, register the assertion
+  }
+  else if (isProofEnabled())
+  {
+    d_pfCnfStream->convertAndAssert(node, negated, removable, pg);
+    // if input, register the assertion in the proof manager
     if (input)
     {
       d_ppm->registerAssertion(node);

--- a/src/prop/prop_engine.cpp
+++ b/src/prop/prop_engine.cpp
@@ -111,11 +111,17 @@ PropEngine::PropEngine(TheoryEngine* te,
   // connect theory proxy
   d_theoryProxy->finishInit(d_cnfStream);
   // connect SAT solver
-  d_satSolver->initialize(d_context, d_theoryProxy, userContext, pnm);
+  d_satSolver->initialize(
+      d_context,
+      d_theoryProxy,
+      userContext,
+      options::unsatCoresMode() != options::UnsatCoresMode::ASSUMPTIONS
+          ? pnm
+          : nullptr);
 
   d_decisionEngine->setSatSolver(d_satSolver);
   d_decisionEngine->setCnfStream(d_cnfStream);
-  if (pnm)
+  if (pnm && options::unsatCoresMode() != options::UnsatCoresMode::ASSUMPTIONS)
   {
     d_pfCnfStream.reset(new ProofCnfStream(
         userContext,
@@ -267,7 +273,7 @@ void PropEngine::assertInternal(
         && input)
     {
       Assert(!negated);
-      d_pfCnfStream->ensureLiteral(node);
+      d_cnfStream->ensureLiteral(node);
       d_assumptions.push_back(node);
     }
     else

--- a/src/prop/theory_proxy.cpp
+++ b/src/prop/theory_proxy.cpp
@@ -98,7 +98,8 @@ void TheoryProxy::explainPropagation(SatLiteral l, SatClause& explanation) {
 
   theory::TrustNode tte = d_theoryEngine->getExplanation(lNode);
   Node theoryExplanation = tte.getNode();
-  if (options::produceProofs())
+  if (options::produceProofs()
+      && options::unsatCoresMode() != options::UnsatCoresMode::ASSUMPTIONS)
   {
     Assert(options::unsatCoresMode() != options::UnsatCoresMode::FULL_PROOF
            || tte.getGenerator());

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -421,7 +421,7 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
   // whether we want to force safe unsat cores, i.e., if we are in the OLD_PROOF
   // unsat core mode, since new ones are experimental
   bool safeUnsatCores =
-      options::unsatCoresMode() == options::UnsatCoresMode::OLD_PROOF;
+      options::unsatCoresMode() != options::UnsatCoresMode::OFF;
 
   // Disable options incompatible with incremental solving, unsat cores or
   // output an error if enabled explicitly. It is also currently incompatible

--- a/src/smt/set_defaults.cpp
+++ b/src/smt/set_defaults.cpp
@@ -421,7 +421,7 @@ void setDefaults(LogicInfo& logic, bool isInternalSubsolver)
   // whether we want to force safe unsat cores, i.e., if we are in the OLD_PROOF
   // unsat core mode, since new ones are experimental
   bool safeUnsatCores =
-      options::unsatCoresMode() != options::UnsatCoresMode::OFF;
+      options::unsatCoresMode() == options::UnsatCoresMode::OLD_PROOF;
 
   // Disable options incompatible with incremental solving, unsat cores or
   // output an error if enabled explicitly. It is also currently incompatible


### PR DESCRIPTION
Previously using proof CNF stream together with assumptions-based unsat cores added unnecessary performance overhead.

Co-authored-by: Mathias Preiner <mathias.preiner@gmail.com>