### PR TITLE
Do not have quantifiers model inherit from theory model

### DIFF
--- a/src/theory/combination_engine.cpp
+++ b/src/theory/combination_engine.cpp
@@ -42,12 +42,6 @@ CombinationEngine::CombinationEngine(TheoryEngine& te,
       d_cmbsPg(pnm ? new EagerProofGenerator(pnm, te.getUserContext())
                    : nullptr)
 {
-}
-
-CombinationEngine::~CombinationEngine() {}
-
-void CombinationEngine::finishInit()
-{
   // create the equality engine, model manager, and shared solver
   if (options::eeMode() == options::EqEngineMode::DISTRIBUTED)
   {
@@ -64,7 +58,12 @@ void CombinationEngine::finishInit()
     Unhandled() << "CombinationEngine::finishInit: equality engine mode "
                 << options::eeMode() << " not supported";
   }
+}
 
+CombinationEngine::~CombinationEngine() {}
+
+void CombinationEngine::finishInit()
+{
   Assert(d_eemanager != nullptr);
 
   // initialize equality engines in all theories, including quantifiers engine

--- a/src/theory/model_manager.cpp
+++ b/src/theory/model_manager.cpp
@@ -136,13 +136,13 @@ void ModelManager::postProcessModel(bool incomplete)
     }
     Trace("model-builder-debug")
         << "  PostProcessModel on theory: " << theoryId << std::endl;
-    t->postProcessModel(d_model);
+    t->postProcessModel(d_model.get());
   }
   // also call the model builder's post-process model
-  d_modelBuilder->postProcessModel(incomplete, d_model);
+  d_modelBuilder->postProcessModel(incomplete, d_model.get());
 }
 
-theory::TheoryModel* ModelManager::getModel() { return d_model; }
+theory::TheoryModel* ModelManager::getModel() { return d_model.get(); }
 
 bool ModelManager::collectModelBooleanVariables()
 {

--- a/src/theory/model_manager.cpp
+++ b/src/theory/model_manager.cpp
@@ -32,7 +32,7 @@ ModelManager::ModelManager(TheoryEngine& te, EqEngineManager& eem)
       d_eem(eem),
       d_modelEqualityEngine(nullptr),
       d_modelEqualityEngineAlloc(nullptr),
-      d_model(nullptr),
+      d_model(new TheoryModel(te.getUserContext(), "DefaultModel", options::assignFunctionValues())),
       d_modelBuilder(nullptr),
       d_modelBuilt(false),
       d_modelBuiltSuccess(false)
@@ -51,14 +51,6 @@ void ModelManager::finishInit(eq::EqualityEngineNotify* notify)
     QuantifiersEngine* qe = d_te.getQuantifiersEngine();
     Assert(qe != nullptr);
     d_modelBuilder = qe->getModelBuilder();
-    d_model = qe->getModel();
-  }
-  else
-  {
-    context::Context* u = d_te.getUserContext();
-    d_alocModel.reset(
-        new TheoryModel(u, "DefaultModel", options::assignFunctionValues()));
-    d_model = d_alocModel.get();
   }
 
   // make the default builder, e.g. in the case that the quantifiers engine does

--- a/src/theory/model_manager.cpp
+++ b/src/theory/model_manager.cpp
@@ -32,7 +32,9 @@ ModelManager::ModelManager(TheoryEngine& te, EqEngineManager& eem)
       d_eem(eem),
       d_modelEqualityEngine(nullptr),
       d_modelEqualityEngineAlloc(nullptr),
-      d_model(new TheoryModel(te.getUserContext(), "DefaultModel", options::assignFunctionValues())),
+      d_model(new TheoryModel(te.getUserContext(),
+                              "DefaultModel",
+                              options::assignFunctionValues())),
       d_modelBuilder(nullptr),
       d_modelBuilt(false),
       d_modelBuiltSuccess(false)

--- a/src/theory/model_manager.h
+++ b/src/theory/model_manager.h
@@ -139,11 +139,11 @@ class ModelManager
   /** The equality engine of the model, if we allocated it */
   std::unique_ptr<eq::EqualityEngine> d_modelEqualityEngineAlloc;
   /** The model object we have allocated (if one exists) */
-  std::unique_ptr<theory::TheoryModel> d_model;
+  std::unique_ptr<TheoryModel> d_model;
   /** The model builder object we are using */
-  theory::TheoryEngineModelBuilder* d_modelBuilder;
+  TheoryEngineModelBuilder* d_modelBuilder;
   /** The model builder object we have allocated (if one exists) */
-  std::unique_ptr<theory::TheoryEngineModelBuilder> d_alocModelBuilder;
+  std::unique_ptr<TheoryEngineModelBuilder> d_alocModelBuilder;
   /** whether we have tried to build this model in the current context */
   bool d_modelBuilt;
   /** whether this model has been built successfully */

--- a/src/theory/model_manager.h
+++ b/src/theory/model_manager.h
@@ -73,7 +73,7 @@ class ModelManager
    */
   void postProcessModel(bool incomplete);
   /** Get a pointer to model object maintained by this class. */
-  theory::TheoryModel* getModel();
+  TheoryModel* getModel();
   //------------------------ finer grained control over model building
   /**
    * Prepare model, which is the manager-specific method for setting up the
@@ -138,10 +138,8 @@ class ModelManager
   eq::EqualityEngine* d_modelEqualityEngine;
   /** The equality engine of the model, if we allocated it */
   std::unique_ptr<eq::EqualityEngine> d_modelEqualityEngineAlloc;
-  /** The model object we are using */
-  theory::TheoryModel* d_model;
   /** The model object we have allocated (if one exists) */
-  std::unique_ptr<theory::TheoryModel> d_alocModel;
+  std::unique_ptr<theory::TheoryModel> d_model;
   /** The model builder object we are using */
   theory::TheoryEngineModelBuilder* d_modelBuilder;
   /** The model builder object we have allocated (if one exists) */

--- a/src/theory/model_manager_distributed.cpp
+++ b/src/theory/model_manager_distributed.cpp
@@ -85,7 +85,7 @@ bool ModelManagerDistributed::prepareModel()
     collectAssertedTerms(theoryId, termSet);
     // also get relevant terms
     t->computeRelevantTerms(termSet);
-    if (!t->collectModelInfo(d_model, termSet))
+    if (!t->collectModelInfo(d_model.get(), termSet))
     {
       Trace("model-builder")
           << "ModelManagerDistributed: fail collect model info" << std::endl;
@@ -106,7 +106,7 @@ bool ModelManagerDistributed::prepareModel()
 bool ModelManagerDistributed::finishBuildModel() const
 {
   // do not use relevant terms
-  if (!d_modelBuilder->buildModel(d_model))
+  if (!d_modelBuilder->buildModel(d_model.get()))
   {
     Trace("model-builder") << "ModelManager: fail build model" << std::endl;
     return false;

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -44,10 +44,8 @@ using ModelBasisArgAttribute = expr::Attribute<ModelBasisArgAttributeId, uint64_
 
 FirstOrderModel::FirstOrderModel(QuantifiersState& qs,
                                  QuantifiersRegistry& qr,
-                                 TermRegistry& tr,
-                                 std::string name)
-    : TheoryModel(qs.getSatContext(), name, true),
-      d_qe(nullptr),
+                                 TermRegistry& tr)
+    : d_qe(nullptr),
       d_qreg(qr),
       d_treg(tr),
       d_eq_query(qs, this),

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -54,35 +54,32 @@ FirstOrderModel::FirstOrderModel(QuantifiersState& qs,
 {
 }
 
-void FirstOrderModel::finishInit(TheoryModel * m)
-{
-  d_model = m;
-}
+void FirstOrderModel::finishInit(TheoryModel* m) { d_model = m; }
 
-Node FirstOrderModel::getValue(TNode n) const
-{
-  return d_model->getValue(n);
-}
+Node FirstOrderModel::getValue(TNode n) const { return d_model->getValue(n); }
 bool FirstOrderModel::hasTerm(TNode a) { return d_model->hasTerm(a); }
-Node FirstOrderModel::getRepresentative(TNode a) { return d_model->getRepresentative(a); }
-bool FirstOrderModel::areEqual(TNode a, TNode b) { return d_model->areEqual(a,b); }
-bool FirstOrderModel::areDisequal(TNode a, TNode b) { return d_model->areDisequal(a, b); }
+Node FirstOrderModel::getRepresentative(TNode a)
+{
+  return d_model->getRepresentative(a);
+}
+bool FirstOrderModel::areEqual(TNode a, TNode b)
+{
+  return d_model->areEqual(a, b);
+}
+bool FirstOrderModel::areDisequal(TNode a, TNode b)
+{
+  return d_model->areDisequal(a, b);
+}
 eq::EqualityEngine* FirstOrderModel::getEqualityEngine()
 {
   return d_model->getEqualityEngine();
 }
-  const RepSet* FirstOrderModel::getRepSet() const
-  {
-    return d_model->getRepSet();
-  }
-  RepSet* FirstOrderModel::getRepSetPtr()
-  {
-    return d_model->getRepSetPtr();
-  }
-  TheoryModel * FirstOrderModel::getTheoryModel()
-  {
-    return d_model;
-  }
+const RepSet* FirstOrderModel::getRepSet() const
+{
+  return d_model->getRepSet();
+}
+RepSet* FirstOrderModel::getRepSetPtr() { return d_model->getRepSetPtr(); }
+TheoryModel* FirstOrderModel::getTheoryModel() { return d_model; }
 
 Node FirstOrderModel::getInternalRepresentative(Node a, Node q, size_t index)
 {

--- a/src/theory/quantifiers/first_order_model.cpp
+++ b/src/theory/quantifiers/first_order_model.cpp
@@ -42,11 +42,10 @@ struct ModelBasisArgAttributeId
 };
 using ModelBasisArgAttribute = expr::Attribute<ModelBasisArgAttributeId, uint64_t>;
 
-FirstOrderModel::FirstOrderModel(TheoryModel* m,
-                                 QuantifiersState& qs,
+FirstOrderModel::FirstOrderModel(QuantifiersState& qs,
                                  QuantifiersRegistry& qr,
                                  TermRegistry& tr)
-    : d_model(m),
+    : d_model(nullptr),
       d_qreg(qr),
       d_treg(tr),
       d_eq_query(qs, this),
@@ -54,6 +53,36 @@ FirstOrderModel::FirstOrderModel(TheoryModel* m,
       d_forallRlvComputed(false)
 {
 }
+
+void FirstOrderModel::finishInit(TheoryModel * m)
+{
+  d_model = m;
+}
+
+Node FirstOrderModel::getValue(TNode n) const
+{
+  return d_model->getValue(n);
+}
+bool FirstOrderModel::hasTerm(TNode a) { return d_model->hasTerm(a); }
+Node FirstOrderModel::getRepresentative(TNode a) { return d_model->getRepresentative(a); }
+bool FirstOrderModel::areEqual(TNode a, TNode b) { return d_model->areEqual(a,b); }
+bool FirstOrderModel::areDisequal(TNode a, TNode b) { return d_model->areDisequal(a, b); }
+eq::EqualityEngine* FirstOrderModel::getEqualityEngine()
+{
+  return d_model->getEqualityEngine();
+}
+  const RepSet* FirstOrderModel::getRepSet() const
+  {
+    return d_model->getRepSet();
+  }
+  RepSet* FirstOrderModel::getRepSetPtr()
+  {
+    return d_model->getRepSetPtr();
+  }
+  TheoryModel * FirstOrderModel::getTheoryModel()
+  {
+    return d_model;
+  }
 
 Node FirstOrderModel::getInternalRepresentative(Node a, Node q, size_t index)
 {

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -156,7 +156,7 @@ class FirstOrderModel
   EqualityQuery* getEqualityQuery();
 
  protected:
-  /** The model */
+  /** Pointer to the underyling theory model */
   TheoryModel* d_model;
   /** The quantifiers registry */
   QuantifiersRegistry& d_qreg;

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -45,7 +45,7 @@ class FirstOrderModel
   virtual ~FirstOrderModel() {}
 
   /** finish init */
-  void finishInit(TheoryModel * m);
+  void finishInit(TheoryModel* m);
   //---------------------------------- access functions for underlying model
   /** Get value in the underlying theory model */
   Node getValue(TNode n) const;
@@ -64,7 +64,7 @@ class FirstOrderModel
   /** get the representative set object */
   RepSet* getRepSetPtr();
   /** get the entire theory model */
-  TheoryModel * getTheoryModel();
+  TheoryModel* getTheoryModel();
   //---------------------------------- end access functions for underlying model
   /** get internal representative
    *

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -38,10 +38,11 @@ class QuantifiersRegistry;
 class FirstOrderModel
 {
  public:
-  FirstOrderModel(QuantifiersState& qs,
+  FirstOrderModel(TheoryModel* m,
+                  QuantifiersState& qs,
                   QuantifiersRegistry& qr,
-                  TermRegistry& tr,
-                  std::string name);
+                  TermRegistry& tr);
+  virtual ~FirstOrderModel(){}
 
   //!!!!!!!!!!!!!!!!!!!!! temporary (project #15)
   /** finish initialize */
@@ -136,8 +137,8 @@ class FirstOrderModel
   EqualityQuery* getEqualityQuery();
 
  protected:
-  //!!!!!!!!!!!!!!!!!!!!!!! TODO (project #15): temporarily available
-  QuantifiersEngine* d_qe;
+  /** The model */
+  TheoryModel * d_model;
   /** The quantifiers registry */
   QuantifiersRegistry& d_qreg;
   /** Reference to the term registry */

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -42,7 +42,7 @@ class FirstOrderModel
                   QuantifiersState& qs,
                   QuantifiersRegistry& qr,
                   TermRegistry& tr);
-  virtual ~FirstOrderModel(){}
+  virtual ~FirstOrderModel() {}
 
   //!!!!!!!!!!!!!!!!!!!!! temporary (project #15)
   /** finish initialize */
@@ -138,7 +138,7 @@ class FirstOrderModel
 
  protected:
   /** The model */
-  TheoryModel * d_model;
+  TheoryModel* d_model;
   /** The quantifiers registry */
   QuantifiersRegistry& d_qreg;
   /** Reference to the term registry */

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -26,7 +26,8 @@
 namespace cvc5 {
 namespace theory {
 
-class QuantifiersEngine;
+class TheoryModel;
+class RepSet;
 
 namespace quantifiers {
 
@@ -38,15 +39,33 @@ class QuantifiersRegistry;
 class FirstOrderModel
 {
  public:
-  FirstOrderModel(TheoryModel* m,
-                  QuantifiersState& qs,
+  FirstOrderModel(QuantifiersState& qs,
                   QuantifiersRegistry& qr,
                   TermRegistry& tr);
   virtual ~FirstOrderModel() {}
 
-  //!!!!!!!!!!!!!!!!!!!!! temporary (project #15)
-  /** finish initialize */
-  void finishInit(QuantifiersEngine* qe);
+  /** finish init */
+  void finishInit(TheoryModel * m);
+  //---------------------------------- access functions for underlying model
+  /** Get value in the underlying theory model */
+  Node getValue(TNode n) const;
+  /** does the equality engine of this model have term a? */
+  bool hasTerm(TNode a);
+  /** get the representative of a in the equality engine of this model */
+  Node getRepresentative(TNode a);
+  /** are a and b equal in the equality engine of this model? */
+  bool areEqual(TNode a, TNode b);
+  /** are a and b disequal in the equality engine of this model? */
+  bool areDisequal(TNode a, TNode b);
+  /** get the equality engine for this model */
+  eq::EqualityEngine* getEqualityEngine();
+  /** get the representative set object */
+  const RepSet* getRepSet() const;
+  /** get the representative set object */
+  RepSet* getRepSetPtr();
+  /** get the entire theory model */
+  TheoryModel * getTheoryModel();
+  //---------------------------------- end access functions for underlying model
   /** get internal representative
    *
    * Choose a term that is equivalent to a in the current context that is the

--- a/src/theory/quantifiers/first_order_model.h
+++ b/src/theory/quantifiers/first_order_model.h
@@ -35,7 +35,7 @@ class TermRegistry;
 class QuantifiersRegistry;
 
 // TODO (#1301) : document and refactor this class
-class FirstOrderModel : public TheoryModel
+class FirstOrderModel
 {
  public:
   FirstOrderModel(QuantifiersState& qs,

--- a/src/theory/quantifiers/fmf/first_order_model_fmc.cpp
+++ b/src/theory/quantifiers/fmf/first_order_model_fmc.cpp
@@ -36,8 +36,7 @@ struct IsStarAttributeId
 };
 using IsStarAttribute = expr::Attribute<IsStarAttributeId, bool>;
 
-FirstOrderModelFmc::FirstOrderModelFmc(
-                  QuantifiersState& qs,
+FirstOrderModelFmc::FirstOrderModelFmc(QuantifiersState& qs,
                                        QuantifiersRegistry& qr,
                                        TermRegistry& tr)
     : FirstOrderModel(qs, qr, tr)

--- a/src/theory/quantifiers/fmf/first_order_model_fmc.cpp
+++ b/src/theory/quantifiers/fmf/first_order_model_fmc.cpp
@@ -36,11 +36,11 @@ struct IsStarAttributeId
 };
 using IsStarAttribute = expr::Attribute<IsStarAttributeId, bool>;
 
-FirstOrderModelFmc::FirstOrderModelFmc(QuantifiersState& qs,
+FirstOrderModelFmc::FirstOrderModelFmc(
+                  QuantifiersState& qs,
                                        QuantifiersRegistry& qr,
-                                       TermRegistry& tr,
-                                       std::string name)
-    : FirstOrderModel(qs, qr, tr, name)
+                                       TermRegistry& tr)
+    : FirstOrderModel(qs, qr, tr)
 {
 }
 

--- a/src/theory/quantifiers/fmf/first_order_model_fmc.h
+++ b/src/theory/quantifiers/fmf/first_order_model_fmc.h
@@ -39,10 +39,10 @@ class FirstOrderModelFmc : public FirstOrderModel
   void processInitializeModelForTerm(Node n) override;
 
  public:
-  FirstOrderModelFmc(QuantifiersState& qs,
+  FirstOrderModelFmc(
+                  QuantifiersState& qs,
                      QuantifiersRegistry& qr,
-                     TermRegistry& tr,
-                     std::string name);
+                     TermRegistry& tr);
   ~FirstOrderModelFmc() override;
   // initialize the model
   void processInitialize(bool ispre) override;

--- a/src/theory/quantifiers/fmf/first_order_model_fmc.h
+++ b/src/theory/quantifiers/fmf/first_order_model_fmc.h
@@ -39,8 +39,7 @@ class FirstOrderModelFmc : public FirstOrderModel
   void processInitializeModelForTerm(Node n) override;
 
  public:
-  FirstOrderModelFmc(
-                  QuantifiersState& qs,
+  FirstOrderModelFmc(QuantifiersState& qs,
                      QuantifiersRegistry& qr,
                      TermRegistry& tr);
   ~FirstOrderModelFmc() override;

--- a/src/theory/quantifiers/fmf/full_model_check.cpp
+++ b/src/theory/quantifiers/fmf/full_model_check.cpp
@@ -305,7 +305,7 @@ bool FullModelChecker::preProcessBuildModel(TheoryModel* m) {
   d_preinitialized_eqc.clear();
   d_preinitialized_types.clear();
   //traverse equality engine
-  eq::EqClassesIterator eqcs_i = eq::EqClassesIterator( fm->getEqualityEngine() );
+  eq::EqClassesIterator eqcs_i = eq::EqClassesIterator(fm->getEqualityEngine());
   while( !eqcs_i.isFinished() ){
     Node r = *eqcs_i;
     TypeNode tr = r.getType();
@@ -387,7 +387,7 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
   }
 
   //now, make models
-  TheoryModel * tm = fm->getTheoryModel();
+  TheoryModel* tm = fm->getTheoryModel();
   for( std::map<Node, Def * >::iterator it = fm->d_models.begin(); it != fm->d_models.end(); ++it ) {
     Node op = it->first;
     //reset the model
@@ -396,10 +396,13 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
     std::vector< Node > add_conds;
     std::vector< Node > add_values;      
     bool needsDefault = true;
-    if( tm->hasUfTerms(op) ){
+    if (tm->hasUfTerms(op))
+    {
       const std::vector<Node>& uft = tm->getUfTerms(op);
-      Trace("fmc-model-debug") << uft.size() << " model values for " << op << " ... " << std::endl;
-      for (const Node& n : uft){
+      Trace("fmc-model-debug")
+          << uft.size() << " model values for " << op << " ... " << std::endl;
+      for (const Node& n : uft)
+      {
         // only consider unique up to congruence (in model equality engine)?
         add_conds.push_back( n );
         add_values.push_back( n );
@@ -414,7 +417,8 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
     if( needsDefault ){
       Node nmb = fm->getModelBasisOpTerm(op);
       //add default value if necessary
-      if( tm->hasTerm( nmb ) ){
+      if (tm->hasTerm(nmb))
+      {
         Trace("fmc-model-debug") << "Add default " << nmb << std::endl;
         add_conds.push_back( nmb );
         add_values.push_back( nmb );
@@ -540,7 +544,7 @@ void FullModelChecker::preInitializeType( FirstOrderModelFmc * fm, TypeNode tn )
     d_preinitialized_types[tn] = true;
     if (tn.isFirstClass())
     {
-      TheoryModel * tm = fm->getTheoryModel();
+      TheoryModel* tm = fm->getTheoryModel();
       Trace("fmc") << "Get model basis term " << tn << "..." << std::endl;
       Node mb = fm->getModelBasisTerm(tn);
       Trace("fmc") << "...return " << mb << std::endl;

--- a/src/theory/quantifiers/fmf/full_model_check.cpp
+++ b/src/theory/quantifiers/fmf/full_model_check.cpp
@@ -286,19 +286,16 @@ void Def::debugPrint(const char * tr, Node op, FullModelChecker * m) {
 }
 
 FullModelChecker::FullModelChecker(QuantifiersState& qs,
-            QuantifiersInferenceManager& qim,
-            QuantifiersRegistry& qr,
-            TermRegistry& tr)
+                                   QuantifiersInferenceManager& qim,
+                                   QuantifiersRegistry& qr,
+                                   TermRegistry& tr)
     : QModelBuilder(qs, qim, qr, tr), d_fm(new FirstOrderModelFmc(qs, qr, tr))
 {
   d_true = NodeManager::currentNM()->mkConst(true);
   d_false = NodeManager::currentNM()->mkConst(false);
 }
 
-void FullModelChecker::finishInit()
-{
-  d_model = d_fm.get();
-}
+void FullModelChecker::finishInit() { d_model = d_fm.get(); }
 
 bool FullModelChecker::preProcessBuildModel(TheoryModel* m) {
   //standard pre-process
@@ -321,13 +318,14 @@ bool FullModelChecker::preProcessBuildModel(TheoryModel* m) {
   //must ensure model basis terms exists in model for each relevant type
   Trace("fmc") << "preInitialize types..." << std::endl;
   d_fm->initialize();
-  for( std::pair<const Node, Def * >& mp : d_fm->d_models) {
+  for (std::pair<const Node, Def*>& mp : d_fm->d_models)
+  {
     Node op = mp.first;
     Trace("fmc") << "preInitialize types for " << op << std::endl;
     TypeNode tno = op.getType();
     for( unsigned i=0; i<tno.getNumChildren(); i++) {
       Trace("fmc") << "preInitializeType " << tno[i] << std::endl;
-      preInitializeType( m, tno[i] );
+      preInitializeType(m, tno[i]);
       Trace("fmc") << "finished preInitializeType " << tno[i] << std::endl;
     }
   }
@@ -372,7 +370,7 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
     if( it->first.isSort() ){
       Trace("fmc") << "Cardinality( " << it->first << " )" << " = " << it->second.size() << std::endl;
       for( size_t a=0; a<it->second.size(); a++ ){
-        Node r = m->getRepresentative( it->second[a] );
+        Node r = m->getRepresentative(it->second[a]);
         if( Trace.isOn("fmc-model-debug") ){
           std::vector< Node > eqc;
           d_qstate.getEquivalenceClass(r, eqc);
@@ -392,7 +390,8 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
   }
 
   //now, make models
-  for( std::pair<const Node, Def * >& fmm : d_fm->d_models ) {
+  for (std::pair<const Node, Def*>& fmm : d_fm->d_models)
+  {
     Node op = fmm.first;
     //reset the model
     d_fm->d_models[op]->reset();
@@ -543,7 +542,8 @@ bool FullModelChecker::processBuildModel(TheoryModel* m){
   return TheoryEngineModelBuilder::processBuildModel( m );
 }
 
-void FullModelChecker::preInitializeType( TheoryModel * m, TypeNode tn ){
+void FullModelChecker::preInitializeType(TheoryModel* m, TypeNode tn)
+{
   if( d_preinitialized_types.find( tn )==d_preinitialized_types.end() ){
     d_preinitialized_types[tn] = true;
     if (tn.isFirstClass())

--- a/src/theory/quantifiers/fmf/full_model_check.h
+++ b/src/theory/quantifiers/fmf/full_model_check.h
@@ -113,7 +113,7 @@ protected:
    * if a bound variable is of type T, or an uninterpreted function has an
    * argument or a return value of type T.
    */
-  void preInitializeType( FirstOrderModelFmc * fm, TypeNode tn );
+  void preInitializeType( TheoryModel * m, TypeNode tn );
   /** for each type, an equivalence class of that type from the model */
   std::map<TypeNode, Node> d_preinitialized_eqc;
   /** map from types to whether we have called the method above */
@@ -175,8 +175,6 @@ protected:
   bool processBuildModel(TheoryModel* m) override;
 
   bool useSimpleModels();
-  /** get the model we are using */
-  FirstOrderModel * getModel() override;
  private:
   /**
    * Register quantified formula.
@@ -186,6 +184,8 @@ protected:
   void registerQuantifiedFormula(Node q);
   /** Is quantified formula q handled by model-based instantiation? */
   bool isHandled(Node q) const;
+  /** The first order model */
+  std::unique_ptr<FirstOrderModelFmc> d_fm;
 };/* class FullModelChecker */
 
 }  // namespace fmcheck

--- a/src/theory/quantifiers/fmf/full_model_check.h
+++ b/src/theory/quantifiers/fmf/full_model_check.h
@@ -156,9 +156,11 @@ protected:
 
  public:
   FullModelChecker(QuantifiersState& qs,
-                   QuantifiersRegistry& qr,
-                   QuantifiersInferenceManager& qim);
-
+            QuantifiersInferenceManager& qim,
+            QuantifiersRegistry& qr,
+            TermRegistry& tr);
+  /** finish init, which sets the model object */
+  void finishInit() override;
   void debugPrintCond(const char * tr, Node n, bool dispStar = false);
   void debugPrint(const char * tr, Node n, bool dispStar = false);
 
@@ -173,7 +175,8 @@ protected:
   bool processBuildModel(TheoryModel* m) override;
 
   bool useSimpleModels();
-
+  /** get the model we are using */
+  FirstOrderModel * getModel() override;
  private:
   /**
    * Register quantified formula.

--- a/src/theory/quantifiers/fmf/full_model_check.h
+++ b/src/theory/quantifiers/fmf/full_model_check.h
@@ -184,7 +184,7 @@ protected:
   void registerQuantifiedFormula(Node q);
   /** Is quantified formula q handled by model-based instantiation? */
   bool isHandled(Node q) const;
-  /** 
+  /**
    * The first order model. This is an extended form of the first order model
    * class that is specialized for this class.
    */

--- a/src/theory/quantifiers/fmf/full_model_check.h
+++ b/src/theory/quantifiers/fmf/full_model_check.h
@@ -184,7 +184,10 @@ protected:
   void registerQuantifiedFormula(Node q);
   /** Is quantified formula q handled by model-based instantiation? */
   bool isHandled(Node q) const;
-  /** The first order model */
+  /** 
+   * The first order model. This is an extended form of the first order model
+   * class that is specialized for this class.
+   */
   std::unique_ptr<FirstOrderModelFmc> d_fm;
 };/* class FullModelChecker */
 

--- a/src/theory/quantifiers/fmf/full_model_check.h
+++ b/src/theory/quantifiers/fmf/full_model_check.h
@@ -113,7 +113,7 @@ protected:
    * if a bound variable is of type T, or an uninterpreted function has an
    * argument or a return value of type T.
    */
-  void preInitializeType( TheoryModel * m, TypeNode tn );
+  void preInitializeType(TheoryModel* m, TypeNode tn);
   /** for each type, an equivalence class of that type from the model */
   std::map<TypeNode, Node> d_preinitialized_eqc;
   /** map from types to whether we have called the method above */
@@ -156,9 +156,9 @@ protected:
 
  public:
   FullModelChecker(QuantifiersState& qs,
-            QuantifiersInferenceManager& qim,
-            QuantifiersRegistry& qr,
-            TermRegistry& tr);
+                   QuantifiersInferenceManager& qim,
+                   QuantifiersRegistry& qr,
+                   TermRegistry& tr);
   /** finish init, which sets the model object */
   void finishInit() override;
   void debugPrintCond(const char * tr, Node n, bool dispStar = false);

--- a/src/theory/quantifiers/fmf/model_builder.cpp
+++ b/src/theory/quantifiers/fmf/model_builder.cpp
@@ -30,9 +30,9 @@ using namespace cvc5::theory;
 using namespace cvc5::theory::quantifiers;
 
 QModelBuilder::QModelBuilder(QuantifiersState& qs,
-            QuantifiersInferenceManager& qim,
-            QuantifiersRegistry& qr,
-            TermRegistry& tr)
+                             QuantifiersInferenceManager& qim,
+                             QuantifiersRegistry& qr,
+                             TermRegistry& tr)
     : TheoryEngineModelBuilder(),
       d_addedLemmas(0),
       d_triedLemmas(0),
@@ -73,9 +73,13 @@ bool QModelBuilder::preProcessBuildModelStd(TheoryModel* m) {
       ++eqcs_i;
     }
     //look at quantified formulas
-    for( size_t i=0, nquant = d_model->getNumAssertedQuantifiers(); i<nquant; i++ ){
-      Node q = d_model->getAssertedQuantifier( i, true );
-      if( d_model->isQuantifierActive( q ) ){
+    for (size_t i = 0, nquant = d_model->getNumAssertedQuantifiers();
+         i < nquant;
+         i++)
+    {
+      Node q = d_model->getAssertedQuantifier(i, true);
+      if (d_model->isQuantifierActive(q))
+      {
         //check if any of these quantified formulas can be set inactive
         if (q[0].getNumChildren() == 1)
         {
@@ -87,7 +91,7 @@ bool QModelBuilder::preProcessBuildModelStd(TheoryModel* m) {
             {
               Trace("model-engine-debug")
                   << "Irrelevant function definition : " << q << std::endl;
-              d_model->setQuantifierActive( q, false );
+              d_model->setQuantifierActive(q, false);
             }
           }
         }
@@ -123,7 +127,7 @@ void QModelBuilder::debugModel( TheoryModel* m ){
             terms.push_back( riter.getCurrentTerm( k ) );
           }
           Node n = inst->getInstantiation(f, vars, terms);
-          Node val = m->getValue( n );
+          Node val = m->getValue(n);
           if (!val.isConst() || !val.getConst<bool>())
           {
             Trace("quant-check-model") << "*******  Instantiation " << n << " for " << std::endl;
@@ -146,7 +150,4 @@ void QModelBuilder::debugModel( TheoryModel* m ){
     }
   }
 }
-FirstOrderModel * QModelBuilder::getModel()
-{
-  return d_model;
-}
+FirstOrderModel* QModelBuilder::getModel() { return d_model; }

--- a/src/theory/quantifiers/fmf/model_builder.cpp
+++ b/src/theory/quantifiers/fmf/model_builder.cpp
@@ -46,7 +46,8 @@ QModelBuilder::QModelBuilder(QuantifiersState& qs,
 
 void QModelBuilder::finishInit()
 {
-  d_qmodel.reset(new FirstOrderModel(d_qstate, d_qreg, d_treg));
+  d_modelAloc.reset(new FirstOrderModel(d_qstate, d_qreg, d_treg));
+  d_model = d_modelAloc.get();
 }
 
 bool QModelBuilder::optUseModel() {
@@ -62,20 +63,19 @@ bool QModelBuilder::preProcessBuildModelStd(TheoryModel* m) {
   d_triedLemmas = 0;
   if (options::fmfFunWellDefinedRelevant())
   {
-    FirstOrderModel * fm = m;
     //traverse equality engine
     std::map< TypeNode, bool > eqc_usort;
     eq::EqClassesIterator eqcs_i =
-        eq::EqClassesIterator(fm->getEqualityEngine());
+        eq::EqClassesIterator(m->getEqualityEngine());
     while( !eqcs_i.isFinished() ){
       TypeNode tr = (*eqcs_i).getType();
       eqc_usort[tr] = true;
       ++eqcs_i;
     }
     //look at quantified formulas
-    for( unsigned i=0; i<fm->getNumAssertedQuantifiers(); i++ ){
-      Node q = fm->getAssertedQuantifier( i, true );
-      if( fm->isQuantifierActive( q ) ){
+    for( size_t i=0, nquant = d_model->getNumAssertedQuantifiers(); i<nquant; i++ ){
+      Node q = d_model->getAssertedQuantifier( i, true );
+      if( d_model->isQuantifierActive( q ) ){
         //check if any of these quantified formulas can be set inactive
         if (q[0].getNumChildren() == 1)
         {
@@ -87,7 +87,7 @@ bool QModelBuilder::preProcessBuildModelStd(TheoryModel* m) {
             {
               Trace("model-engine-debug")
                   << "Irrelevant function definition : " << q << std::endl;
-              fm->setQuantifierActive( q, false );
+              d_model->setQuantifierActive( q, false );
             }
           }
         }
@@ -100,7 +100,7 @@ bool QModelBuilder::preProcessBuildModelStd(TheoryModel* m) {
 void QModelBuilder::debugModel( TheoryModel* m ){
   //debug the model: cycle through all instantiations for all quantifiers, report ones that are not true
   if( Trace.isOn("quant-check-model") ){
-    FirstOrderModel* fm = getModel();
+    FirstOrderModel* fm = d_model;
     Trace("quant-check-model") << "Testing quantifier instantiations..." << std::endl;
     int tests = 0;
     int bad = 0;
@@ -113,7 +113,7 @@ void QModelBuilder::debugModel( TheoryModel* m ){
         vars.push_back( f[0][j] );
       }
       QRepBoundExt qrbe(qbi, fm);
-      RepSetIterator riter(fm->getRepSet(), &qrbe);
+      RepSetIterator riter(m->getRepSet(), &qrbe);
       if( riter.setQuantifier( f ) ){
         while( !riter.isFinished() ){
           tests++;
@@ -123,7 +123,7 @@ void QModelBuilder::debugModel( TheoryModel* m ){
             terms.push_back( riter.getCurrentTerm( k ) );
           }
           Node n = inst->getInstantiation(f, vars, terms);
-          Node val = fm->getValue( n );
+          Node val = m->getValue( n );
           if (!val.isConst() || !val.getConst<bool>())
           {
             Trace("quant-check-model") << "*******  Instantiation " << n << " for " << std::endl;

--- a/src/theory/quantifiers/fmf/model_builder.cpp
+++ b/src/theory/quantifiers/fmf/model_builder.cpp
@@ -46,6 +46,7 @@ QModelBuilder::QModelBuilder(QuantifiersState& qs,
 
 void QModelBuilder::finishInit()
 {
+  // allocate the default model
   d_modelAloc.reset(new FirstOrderModel(d_qstate, d_qreg, d_treg));
   d_model = d_modelAloc.get();
 }

--- a/src/theory/quantifiers/fmf/model_builder.cpp
+++ b/src/theory/quantifiers/fmf/model_builder.cpp
@@ -30,15 +30,23 @@ using namespace cvc5::theory;
 using namespace cvc5::theory::quantifiers;
 
 QModelBuilder::QModelBuilder(QuantifiersState& qs,
-                             QuantifiersRegistry& qr,
-                             QuantifiersInferenceManager& qim)
+            QuantifiersInferenceManager& qim,
+            QuantifiersRegistry& qr,
+            TermRegistry& tr)
     : TheoryEngineModelBuilder(),
       d_addedLemmas(0),
       d_triedLemmas(0),
       d_qstate(qs),
+      d_qim(qim),
       d_qreg(qr),
-      d_qim(qim)
+      d_treg(tr),
+      d_model(nullptr)
 {
+}
+
+void QModelBuilder::finishInit()
+{
+  d_qmodel.reset(new FirstOrderModel(d_qstate, d_qreg, d_treg));
 }
 
 bool QModelBuilder::optUseModel() {
@@ -54,7 +62,7 @@ bool QModelBuilder::preProcessBuildModelStd(TheoryModel* m) {
   d_triedLemmas = 0;
   if (options::fmfFunWellDefinedRelevant())
   {
-    FirstOrderModel * fm = (FirstOrderModel*)m;
+    FirstOrderModel * fm = m;
     //traverse equality engine
     std::map< TypeNode, bool > eqc_usort;
     eq::EqClassesIterator eqcs_i =
@@ -92,7 +100,7 @@ bool QModelBuilder::preProcessBuildModelStd(TheoryModel* m) {
 void QModelBuilder::debugModel( TheoryModel* m ){
   //debug the model: cycle through all instantiations for all quantifiers, report ones that are not true
   if( Trace.isOn("quant-check-model") ){
-    FirstOrderModel* fm = (FirstOrderModel*)m;
+    FirstOrderModel* fm = getModel();
     Trace("quant-check-model") << "Testing quantifier instantiations..." << std::endl;
     int tests = 0;
     int bad = 0;
@@ -137,4 +145,8 @@ void QModelBuilder::debugModel( TheoryModel* m ){
       }
     }
   }
+}
+FirstOrderModel * QModelBuilder::getModel()
+{
+  return d_model;
 }

--- a/src/theory/quantifiers/fmf/model_builder.h
+++ b/src/theory/quantifiers/fmf/model_builder.h
@@ -44,9 +44,9 @@ class QModelBuilder : public TheoryEngineModelBuilder
 
  public:
   QModelBuilder(QuantifiersState& qs,
-            QuantifiersInferenceManager& qim,
-            QuantifiersRegistry& qr,
-            TermRegistry& tr);
+                QuantifiersInferenceManager& qim,
+                QuantifiersRegistry& qr,
+                TermRegistry& tr);
   /** finish init, which sets the model object */
   virtual void finishInit();
   //do exhaustive instantiation  
@@ -64,7 +64,8 @@ class QModelBuilder : public TheoryEngineModelBuilder
   unsigned getNumAddedLemmas() { return d_addedLemmas; }
   unsigned getNumTriedLemmas() { return d_triedLemmas; }
   /** get the model we are using */
-  FirstOrderModel * getModel();
+  FirstOrderModel* getModel();
+
  protected:
   /** The quantifiers state object */
   QuantifiersState& d_qstate;
@@ -75,7 +76,7 @@ class QModelBuilder : public TheoryEngineModelBuilder
   /** Term registry */
   TermRegistry& d_treg;
   /** Pointer to the model object we are using */
-  FirstOrderModel * d_model;
+  FirstOrderModel* d_model;
   /** The model object we have allocated */
   std::unique_ptr<FirstOrderModel> d_modelAloc;
 };

--- a/src/theory/quantifiers/fmf/model_builder.h
+++ b/src/theory/quantifiers/fmf/model_builder.h
@@ -30,6 +30,7 @@ class FirstOrderModel;
 class QuantifiersState;
 class QuantifiersRegistry;
 class QuantifiersInferenceManager;
+class TermRegistry;
 
 class QModelBuilder : public TheoryEngineModelBuilder
 {
@@ -73,8 +74,10 @@ class QModelBuilder : public TheoryEngineModelBuilder
   QuantifiersRegistry& d_qreg;
   /** Term registry */
   TermRegistry& d_treg;
-  /** The model object we are using */
-  std::unique_ptr<FirstOrderModel> d_model;
+  /** Pointer to the model object we are using */
+  FirstOrderModel * d_model;
+  /** The model object we have allocated */
+  std::unique_ptr<FirstOrderModel> d_modelAloc;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/fmf/model_builder.h
+++ b/src/theory/quantifiers/fmf/model_builder.h
@@ -43,9 +43,11 @@ class QModelBuilder : public TheoryEngineModelBuilder
 
  public:
   QModelBuilder(QuantifiersState& qs,
-                QuantifiersRegistry& qr,
-                QuantifiersInferenceManager& qim);
-
+            QuantifiersInferenceManager& qim,
+            QuantifiersRegistry& qr,
+            TermRegistry& tr);
+  /** finish init, which sets the model object */
+  virtual void finishInit();
   //do exhaustive instantiation  
   // 0 :  failed, but resorting to true exhaustive instantiation may work
   // >0 : success
@@ -60,16 +62,19 @@ class QModelBuilder : public TheoryEngineModelBuilder
   //statistics 
   unsigned getNumAddedLemmas() { return d_addedLemmas; }
   unsigned getNumTriedLemmas() { return d_triedLemmas; }
-
+  /** get the model we are using */
+  FirstOrderModel * getModel();
  protected:
-  /** Pointer to quantifiers engine */
-  QuantifiersEngine* d_qe;
   /** The quantifiers state object */
   QuantifiersState& d_qstate;
+  /** The quantifiers inference manager */
+  QuantifiersInferenceManager& d_qim;
   /** Reference to the quantifiers registry */
   QuantifiersRegistry& d_qreg;
-  /** The quantifiers inference manager */
-  quantifiers::QuantifiersInferenceManager& d_qim;
+  /** Term registry */
+  TermRegistry& d_treg;
+  /** The model object we are using */
+  std::unique_ptr<FirstOrderModel> d_model;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/quantifiers_modules.cpp
+++ b/src/theory/quantifiers/quantifiers_modules.cpp
@@ -44,7 +44,7 @@ void QuantifiersModules::initialize(QuantifiersState& qs,
                                     QuantifiersInferenceManager& qim,
                                     QuantifiersRegistry& qr,
                                     TermRegistry& tr,
-                  QModelBuilder * builder,
+                                    QModelBuilder* builder,
                                     std::vector<QuantifiersModule*>& modules)
 {
   // add quantifiers modules
@@ -80,7 +80,7 @@ void QuantifiersModules::initialize(QuantifiersState& qs,
     d_bint.reset(new BoundedIntegers(qs, qim, qr, tr));
     modules.push_back(d_bint.get());
   }
-  
+
   if (options::finiteModelFind() || options::fmfBound())
   {
     d_model_engine.reset(new ModelEngine(qs, qim, qr, tr, builder));

--- a/src/theory/quantifiers/quantifiers_modules.cpp
+++ b/src/theory/quantifiers/quantifiers_modules.cpp
@@ -85,17 +85,25 @@ void QuantifiersModules::initialize(QuantifiersState& qs,
     Trace("quant-init-debug")
         << "Initialize model engine, mbqi : " << options::mbqiMode() << " "
         << options::fmfBound() << std::endl;
-    if (tr.useFmcModel())
+    // Finite model finding requires specialized ways of building the model.
+    // We require constructing the model here, since it is required for
+    // initializing the CombinationEngine and the rest of quantifiers engine.
+    if ((options::finiteModelFind() || options::fmfBound())
+        && (options::mbqiMode() == options::MbqiMode::FMC
+            || options::mbqiMode() == options::MbqiMode::TRUST
+            || options::fmfBound()))
     {
       Trace("quant-init-debug") << "...make fmc builder." << std::endl;
-      d_builder.reset(new fmcheck::FullModelChecker(qs, qr, qim));
+      d_builder.reset(new fmcheck::FullModelChecker(qs, qim, qr, tr));
     }
     else
     {
       Trace("quant-init-debug")
           << "...make default model builder." << std::endl;
-      d_builder.reset(new QModelBuilder(qs, qr, qim));
+      d_builder.reset(new QModelBuilder(qs, qim, qr, tr));
     }
+    // set the model object
+    d_builder->finishInit();
     d_model_engine.reset(new ModelEngine(qs, qim, qr, tr, d_builder.get()));
     modules.push_back(d_model_engine.get());
   }

--- a/src/theory/quantifiers/quantifiers_modules.cpp
+++ b/src/theory/quantifiers/quantifiers_modules.cpp
@@ -28,7 +28,6 @@ QuantifiersModules::QuantifiersModules()
       d_alpha_equiv(nullptr),
       d_inst_engine(nullptr),
       d_model_engine(nullptr),
-      d_builder(nullptr),
       d_bint(nullptr),
       d_qcf(nullptr),
       d_sg_gen(nullptr),
@@ -45,6 +44,7 @@ void QuantifiersModules::initialize(QuantifiersState& qs,
                                     QuantifiersInferenceManager& qim,
                                     QuantifiersRegistry& qr,
                                     TermRegistry& tr,
+                  QModelBuilder * builder,
                                     std::vector<QuantifiersModule*>& modules)
 {
   // add quantifiers modules
@@ -80,31 +80,10 @@ void QuantifiersModules::initialize(QuantifiersState& qs,
     d_bint.reset(new BoundedIntegers(qs, qim, qr, tr));
     modules.push_back(d_bint.get());
   }
+  
   if (options::finiteModelFind() || options::fmfBound())
   {
-    Trace("quant-init-debug")
-        << "Initialize model engine, mbqi : " << options::mbqiMode() << " "
-        << options::fmfBound() << std::endl;
-    // Finite model finding requires specialized ways of building the model.
-    // We require constructing the model here, since it is required for
-    // initializing the CombinationEngine and the rest of quantifiers engine.
-    if ((options::finiteModelFind() || options::fmfBound())
-        && (options::mbqiMode() == options::MbqiMode::FMC
-            || options::mbqiMode() == options::MbqiMode::TRUST
-            || options::fmfBound()))
-    {
-      Trace("quant-init-debug") << "...make fmc builder." << std::endl;
-      d_builder.reset(new fmcheck::FullModelChecker(qs, qim, qr, tr));
-    }
-    else
-    {
-      Trace("quant-init-debug")
-          << "...make default model builder." << std::endl;
-      d_builder.reset(new QModelBuilder(qs, qim, qr, tr));
-    }
-    // set the model object
-    d_builder->finishInit();
-    d_model_engine.reset(new ModelEngine(qs, qim, qr, tr, d_builder.get()));
+    d_model_engine.reset(new ModelEngine(qs, qim, qr, tr, builder));
     modules.push_back(d_model_engine.get());
   }
   if (options::quantDynamicSplit() != options::QuantDSplitMode::NONE)

--- a/src/theory/quantifiers/quantifiers_modules.h
+++ b/src/theory/quantifiers/quantifiers_modules.h
@@ -61,7 +61,7 @@ class QuantifiersModules
                   QuantifiersInferenceManager& qim,
                   QuantifiersRegistry& qr,
                   TermRegistry& tr,
-                  QModelBuilder * builder,
+                  QModelBuilder* builder,
                   std::vector<QuantifiersModule*>& modules);
 
  private:

--- a/src/theory/quantifiers/quantifiers_modules.h
+++ b/src/theory/quantifiers/quantifiers_modules.h
@@ -61,6 +61,7 @@ class QuantifiersModules
                   QuantifiersInferenceManager& qim,
                   QuantifiersRegistry& qr,
                   TermRegistry& tr,
+                  QModelBuilder * builder,
                   std::vector<QuantifiersModule*>& modules);
 
  private:
@@ -74,8 +75,6 @@ class QuantifiersModules
   std::unique_ptr<InstantiationEngine> d_inst_engine;
   /** model engine */
   std::unique_ptr<ModelEngine> d_model_engine;
-  /** model builder */
-  std::unique_ptr<quantifiers::QModelBuilder> d_builder;
   /** bounded integers utility */
   std::unique_ptr<BoundedIntegers> d_bint;
   /** Conflict find mechanism for quantifiers */

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -29,12 +29,12 @@ namespace quantifiers {
 
 TermRegistry::TermRegistry(QuantifiersState& qs, QuantifiersRegistry& qr)
     : d_presolve(qs.getUserContext(), true),
-      d_useFmcModel(false),
       d_presolveCache(qs.getUserContext()),
       d_termEnum(new TermEnumeration),
       d_termPools(new TermPools(qs)),
       d_termDb(new TermDb(qs, qr)),
-      d_sygusTdb(nullptr)
+      d_sygusTdb(nullptr),
+      d_qmodel(nullptr)
 {
   if (options::sygus() || options::sygusInst())
   {
@@ -44,26 +44,11 @@ TermRegistry::TermRegistry(QuantifiersState& qs, QuantifiersRegistry& qr)
   Trace("quant-engine-debug") << "Initialize quantifiers engine." << std::endl;
   Trace("quant-engine-debug")
       << "Initialize model, mbqi : " << options::mbqiMode() << std::endl;
-  // Finite model finding requires specialized ways of building the model.
-  // We require constructing the model here, since it is required for
-  // initializing the CombinationEngine and the rest of quantifiers engine.
-  if ((options::finiteModelFind() || options::fmfBound())
-      && (options::mbqiMode() == options::MbqiMode::FMC
-          || options::mbqiMode() == options::MbqiMode::TRUST
-          || options::fmfBound()))
-  {
-    d_useFmcModel = true;
-    d_qmodel.reset(new quantifiers::fmcheck::FirstOrderModelFmc(qs, qr, *this));
-  }
-  else
-  {
-    d_qmodel.reset(new quantifiers::FirstOrderModel(qs, qr, *this));
-  }
 }
 
-void TermRegistry::finishInit(TheoryModel* m, QuantifiersInferenceManager* qim)
+void TermRegistry::finishInit(FirstOrderModel * fm, QuantifiersInferenceManager* qim)
 {
-  d_qmodel->finishInit(m);
+  d_qmodel = fm;
   d_termDb->finishInit(qim);
   if (d_sygusTdb.get())
   {
@@ -148,9 +133,7 @@ TermEnumeration* TermRegistry::getTermEnumeration() const
 
 TermPools* TermRegistry::getTermPools() const { return d_termPools.get(); }
 
-FirstOrderModel* TermRegistry::getModel() const { return d_qmodel.get(); }
-
-bool TermRegistry::useFmcModel() const { return d_useFmcModel; }
+FirstOrderModel* TermRegistry::getModel() const { return d_qmodel; }
 
 }  // namespace quantifiers
 }  // namespace theory

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -46,7 +46,8 @@ TermRegistry::TermRegistry(QuantifiersState& qs, QuantifiersRegistry& qr)
       << "Initialize model, mbqi : " << options::mbqiMode() << std::endl;
 }
 
-void TermRegistry::finishInit(FirstOrderModel * fm, QuantifiersInferenceManager* qim)
+void TermRegistry::finishInit(FirstOrderModel* fm,
+                              QuantifiersInferenceManager* qim)
 {
   d_qmodel = fm;
   d_termDb->finishInit(qim);

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -53,17 +53,15 @@ TermRegistry::TermRegistry(QuantifiersState& qs, QuantifiersRegistry& qr)
           || options::fmfBound()))
   {
     d_useFmcModel = true;
-    d_qmodel.reset(new quantifiers::fmcheck::FirstOrderModelFmc(
-        qs, qr, *this));
+    d_qmodel.reset(new quantifiers::fmcheck::FirstOrderModelFmc(qs, qr, *this));
   }
   else
   {
-    d_qmodel.reset(
-        new quantifiers::FirstOrderModel(qs, qr, *this));
+    d_qmodel.reset(new quantifiers::FirstOrderModel(qs, qr, *this));
   }
 }
 
-void TermRegistry::finishInit(TheoryModel * m, QuantifiersInferenceManager* qim)
+void TermRegistry::finishInit(TheoryModel* m, QuantifiersInferenceManager* qim)
 {
   d_qmodel->finishInit(m);
   d_termDb->finishInit(qim);

--- a/src/theory/quantifiers/term_registry.cpp
+++ b/src/theory/quantifiers/term_registry.cpp
@@ -54,17 +54,18 @@ TermRegistry::TermRegistry(QuantifiersState& qs, QuantifiersRegistry& qr)
   {
     d_useFmcModel = true;
     d_qmodel.reset(new quantifiers::fmcheck::FirstOrderModelFmc(
-        qs, qr, *this, "FirstOrderModelFmc"));
+        qs, qr, *this));
   }
   else
   {
     d_qmodel.reset(
-        new quantifiers::FirstOrderModel(qs, qr, *this, "FirstOrderModel"));
+        new quantifiers::FirstOrderModel(qs, qr, *this));
   }
 }
 
-void TermRegistry::finishInit(QuantifiersInferenceManager* qim)
+void TermRegistry::finishInit(TheoryModel * m, QuantifiersInferenceManager* qim)
 {
+  d_qmodel->finishInit(m);
   d_termDb->finishInit(qim);
   if (d_sygusTdb.get())
   {

--- a/src/theory/quantifiers/term_registry.h
+++ b/src/theory/quantifiers/term_registry.h
@@ -45,7 +45,7 @@ class TermRegistry
   TermRegistry(QuantifiersState& qs,
                QuantifiersRegistry& qr);
   /** Finish init, which sets the inference manager on modules of this class */
-  void finishInit(TheoryModel * m, QuantifiersInferenceManager* qim);
+  void finishInit(TheoryModel* m, QuantifiersInferenceManager* qim);
   /** Presolve */
   void presolve();
 

--- a/src/theory/quantifiers/term_registry.h
+++ b/src/theory/quantifiers/term_registry.h
@@ -45,7 +45,7 @@ class TermRegistry
   TermRegistry(QuantifiersState& qs,
                QuantifiersRegistry& qr);
   /** Finish init, which sets the inference manager on modules of this class */
-  void finishInit(QuantifiersInferenceManager* qim);
+  void finishInit(TheoryModel * m, QuantifiersInferenceManager* qim);
   /** Presolve */
   void presolve();
 

--- a/src/theory/quantifiers/term_registry.h
+++ b/src/theory/quantifiers/term_registry.h
@@ -45,7 +45,7 @@ class TermRegistry
   TermRegistry(QuantifiersState& qs,
                QuantifiersRegistry& qr);
   /** Finish init, which sets the inference manager on modules of this class */
-  void finishInit(TheoryModel* m, QuantifiersInferenceManager* qim);
+  void finishInit(FirstOrderModel * fm, QuantifiersInferenceManager* qim);
   /** Presolve */
   void presolve();
 
@@ -79,9 +79,6 @@ class TermRegistry
   void processInstantiation(Node q, const std::vector<Node>& terms);
   void processSkolemization(Node q, const std::vector<Node>& skolems);
 
-  /** Whether we use the full model check builder and corresponding model */
-  bool useFmcModel() const;
-
   /** get term database */
   TermDb* getTermDatabase() const;
   /** get term database sygus */
@@ -109,7 +106,7 @@ class TermRegistry
   /** sygus term database */
   std::unique_ptr<TermDbSygus> d_sygusTdb;
   /** extended model object */
-  std::unique_ptr<FirstOrderModel> d_qmodel;
+  FirstOrderModel * d_qmodel;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/term_registry.h
+++ b/src/theory/quantifiers/term_registry.h
@@ -45,7 +45,7 @@ class TermRegistry
   TermRegistry(QuantifiersState& qs,
                QuantifiersRegistry& qr);
   /** Finish init, which sets the inference manager on modules of this class */
-  void finishInit(FirstOrderModel * fm, QuantifiersInferenceManager* qim);
+  void finishInit(FirstOrderModel* fm, QuantifiersInferenceManager* qim);
   /** Presolve */
   void presolve();
 
@@ -106,7 +106,7 @@ class TermRegistry
   /** sygus term database */
   std::unique_ptr<TermDbSygus> d_sygusTdb;
   /** extended model object */
-  FirstOrderModel * d_qmodel;
+  FirstOrderModel* d_qmodel;
 };
 
 }  // namespace quantifiers

--- a/src/theory/quantifiers/theory_quantifiers.cpp
+++ b/src/theory/quantifiers/theory_quantifiers.cpp
@@ -49,18 +49,8 @@ TheoryQuantifiers::TheoryQuantifiers(Context* c,
   out.handleUserAttribute( "quant-elim", this );
   out.handleUserAttribute( "quant-elim-partial", this );
 
-  // Finish initializing the term registry by hooking it up to the inference
-  // manager. This is required due to a cyclic dependency between the term
-  // database and the instantiate module. Term database needs inference manager
-  // since it sends out lemmas when term indexing is inconsistent, instantiate
-  // needs term database for entailment checks.
-  d_treg.finishInit(&d_qim);
-
   // construct the quantifiers engine
   d_qengine.reset(new QuantifiersEngine(d_qstate, d_qreg, d_treg, d_qim, pnm));
-
-  //!!!!!!!!!!!!!! temporary (project #15)
-  d_treg.getModel()->finishInit(d_qengine.get());
 
   // indicate we are using the quantifiers theory state object
   d_theoryState = &d_qstate;

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -65,10 +65,10 @@ QuantifiersEngine::QuantifiersEngine(
   // Finite model finding requires specialized ways of building the model.
   // We require constructing the model here, since it is required for
   // initializing the CombinationEngine and the rest of quantifiers engine.
-  if ((options::finiteModelFind() || options::fmfBound())
-      && (options::mbqiMode() == options::MbqiMode::FMC
-          || options::mbqiMode() == options::MbqiMode::TRUST
-          || options::fmfBound()))
+  if (options::fmfBound()
+      || (options::finiteModelFind()
+          && (options::mbqiMode() == options::MbqiMode::FMC
+              || options::mbqiMode() == options::MbqiMode::TRUST)))
   {
     Trace("quant-init-debug") << "...make fmc builder." << std::endl;
     d_builder.reset(

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -105,6 +105,7 @@ QuantifiersEngine::~QuantifiersEngine() {}
 
 void QuantifiersEngine::finishInit(TheoryEngine* te)
 {
+  // connect the quantifiers model to the underlying theory model
   d_model->finishInit(te->getModel());
   d_te = te;
   // Initialize the modules and the utilities here.
@@ -131,10 +132,6 @@ quantifiers::QuantifiersRegistry& QuantifiersEngine::getQuantifiersRegistry()
 quantifiers::QModelBuilder* QuantifiersEngine::getModelBuilder() const
 {
   return d_builder.get();
-}
-quantifiers::FirstOrderModel* QuantifiersEngine::getModel() const
-{
-  return d_model;
 }
 
 /// !!!!!!!!!!!!!! temporary (project #15)

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -73,8 +73,10 @@ QuantifiersEngine::~QuantifiersEngine() {}
 void QuantifiersEngine::finishInit(TheoryEngine* te)
 {
   d_te = te;
-  // Finish initializing the term registry by hooking it up to the inference
-  // manager. This is required due to a cyclic dependency between the term
+  // Finish initializing the term registry by hooking it up to the model and the
+  // inference manager. The former is required since theories are not given
+  // access to the model in their constructors currently.
+  // The latter is required due to a cyclic dependency between the term
   // database and the instantiate module. Term database needs inference manager
   // since it sends out lemmas when term indexing is inconsistent, instantiate
   // needs term database for entailment checks.

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -44,21 +44,54 @@ namespace cvc5 {
 namespace theory {
 
 QuantifiersEngine::QuantifiersEngine(
-    quantifiers::QuantifiersState& qstate,
+    quantifiers::QuantifiersState& qs,
     quantifiers::QuantifiersRegistry& qr,
     quantifiers::TermRegistry& tr,
     quantifiers::QuantifiersInferenceManager& qim,
     ProofNodeManager* pnm)
-    : d_qstate(qstate),
+    : d_qstate(qs),
       d_qim(qim),
       d_te(nullptr),
       d_pnm(pnm),
       d_qreg(qr),
       d_treg(tr),
-      d_model(d_treg.getModel()),
-      d_quants_prereg(qstate.getUserContext()),
-      d_quants_red(qstate.getUserContext())
+      d_model(nullptr),
+      d_quants_prereg(qs.getUserContext()),
+      d_quants_red(qs.getUserContext())
 {
+  Trace("quant-init-debug")
+      << "Initialize model engine, mbqi : " << options::mbqiMode() << " "
+      << options::fmfBound() << std::endl;
+  // Finite model finding requires specialized ways of building the model.
+  // We require constructing the model here, since it is required for
+  // initializing the CombinationEngine and the rest of quantifiers engine.
+  if ((options::finiteModelFind() || options::fmfBound())
+      && (options::mbqiMode() == options::MbqiMode::FMC
+          || options::mbqiMode() == options::MbqiMode::TRUST
+          || options::fmfBound()))
+  {
+    Trace("quant-init-debug") << "...make fmc builder." << std::endl;
+    d_builder.reset(new quantifiers::fmcheck::FullModelChecker(qs, qim, qr, tr));
+  }
+  else
+  {
+    Trace("quant-init-debug")
+        << "...make default model builder." << std::endl;
+    d_builder.reset(new quantifiers::QModelBuilder(qs, qim, qr, tr));
+  }
+  // set the model object
+  d_builder->finishInit();
+  d_model = d_builder->getModel();
+  
+  // Finish initializing the term registry by hooking it up to the model and the
+  // inference manager. The former is required since theories are not given
+  // access to the model in their constructors currently.
+  // The latter is required due to a cyclic dependency between the term
+  // database and the instantiate module. Term database needs inference manager
+  // since it sends out lemmas when term indexing is inconsistent, instantiate
+  // needs term database for entailment checks.
+  d_treg.finishInit(d_model, &d_qim);
+  
   // initialize the utilities
   d_util.push_back(d_model->getEqualityQuery());
   // quantifiers registry must come before the remaining utilities
@@ -72,25 +105,18 @@ QuantifiersEngine::~QuantifiersEngine() {}
 
 void QuantifiersEngine::finishInit(TheoryEngine* te)
 {
+  d_model->finishInit(te->getModel());
   d_te = te;
-  // Finish initializing the term registry by hooking it up to the model and the
-  // inference manager. The former is required since theories are not given
-  // access to the model in their constructors currently.
-  // The latter is required due to a cyclic dependency between the term
-  // database and the instantiate module. Term database needs inference manager
-  // since it sends out lemmas when term indexing is inconsistent, instantiate
-  // needs term database for entailment checks.
-  d_treg.finishInit(d_te->getModel(), &d_qim);
   // Initialize the modules and the utilities here.
   d_qmodules.reset(new quantifiers::QuantifiersModules);
-  d_qmodules->initialize(d_qstate, d_qim, d_qreg, d_treg, d_modules);
+  d_qmodules->initialize(d_qstate, d_qim, d_qreg, d_treg, d_builder.get(), d_modules);
   if (d_qmodules->d_rel_dom.get())
   {
     d_util.push_back(d_qmodules->d_rel_dom.get());
   }
 
   // handle any circular dependencies
-
+  
   // quantifiers bound inference needs to be informed of the bounded integers
   // module, which has information about which quantifiers have finite bounds
   d_qreg.getQuantifiersBoundInference().finishInit(d_qmodules->d_bint.get());
@@ -103,7 +129,7 @@ quantifiers::QuantifiersRegistry& QuantifiersEngine::getQuantifiersRegistry()
 
 quantifiers::QModelBuilder* QuantifiersEngine::getModelBuilder() const
 {
-  return d_qmodules->d_builder.get();
+  return d_builder.get();
 }
 quantifiers::FirstOrderModel* QuantifiersEngine::getModel() const
 {

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -72,7 +72,7 @@ QuantifiersEngine::~QuantifiersEngine() {}
 
 void QuantifiersEngine::finishInit(TheoryEngine* te)
 {
-  d_te = te;  
+  d_te = te;
   // Finish initializing the term registry by hooking it up to the inference
   // manager. This is required due to a cyclic dependency between the term
   // database and the instantiate module. Term database needs inference manager

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -71,18 +71,18 @@ QuantifiersEngine::QuantifiersEngine(
           || options::fmfBound()))
   {
     Trace("quant-init-debug") << "...make fmc builder." << std::endl;
-    d_builder.reset(new quantifiers::fmcheck::FullModelChecker(qs, qim, qr, tr));
+    d_builder.reset(
+        new quantifiers::fmcheck::FullModelChecker(qs, qim, qr, tr));
   }
   else
   {
-    Trace("quant-init-debug")
-        << "...make default model builder." << std::endl;
+    Trace("quant-init-debug") << "...make default model builder." << std::endl;
     d_builder.reset(new quantifiers::QModelBuilder(qs, qim, qr, tr));
   }
   // set the model object
   d_builder->finishInit();
   d_model = d_builder->getModel();
-  
+
   // Finish initializing the term registry by hooking it up to the model and the
   // inference manager. The former is required since theories are not given
   // access to the model in their constructors currently.
@@ -91,7 +91,7 @@ QuantifiersEngine::QuantifiersEngine(
   // since it sends out lemmas when term indexing is inconsistent, instantiate
   // needs term database for entailment checks.
   d_treg.finishInit(d_model, &d_qim);
-  
+
   // initialize the utilities
   d_util.push_back(d_model->getEqualityQuery());
   // quantifiers registry must come before the remaining utilities
@@ -109,14 +109,15 @@ void QuantifiersEngine::finishInit(TheoryEngine* te)
   d_te = te;
   // Initialize the modules and the utilities here.
   d_qmodules.reset(new quantifiers::QuantifiersModules);
-  d_qmodules->initialize(d_qstate, d_qim, d_qreg, d_treg, d_builder.get(), d_modules);
+  d_qmodules->initialize(
+      d_qstate, d_qim, d_qreg, d_treg, d_builder.get(), d_modules);
   if (d_qmodules->d_rel_dom.get())
   {
     d_util.push_back(d_qmodules->d_rel_dom.get());
   }
 
   // handle any circular dependencies
-  
+
   // quantifiers bound inference needs to be informed of the bounded integers
   // module, which has information about which quantifiers have finite bounds
   d_qreg.getQuantifiersBoundInference().finishInit(d_qmodules->d_bint.get());

--- a/src/theory/quantifiers_engine.cpp
+++ b/src/theory/quantifiers_engine.cpp
@@ -72,7 +72,13 @@ QuantifiersEngine::~QuantifiersEngine() {}
 
 void QuantifiersEngine::finishInit(TheoryEngine* te)
 {
-  d_te = te;
+  d_te = te;  
+  // Finish initializing the term registry by hooking it up to the inference
+  // manager. This is required due to a cyclic dependency between the term
+  // database and the instantiate module. Term database needs inference manager
+  // since it sends out lemmas when term indexing is inconsistent, instantiate
+  // needs term database for entailment checks.
+  d_treg.finishInit(d_te->getModel(), &d_qim);
   // Initialize the modules and the utilities here.
   d_qmodules.reset(new quantifiers::QuantifiersModules);
   d_qmodules->initialize(d_qstate, d_qim, d_qreg, d_treg, d_modules);

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -69,8 +69,6 @@ class QuantifiersEngine {
   //---------------------- utilities
   /** get the model builder */
   quantifiers::QModelBuilder* getModelBuilder() const;
-  /** get model */
-  quantifiers::FirstOrderModel* getModel() const;
   /** get term database sygus */
   quantifiers::TermDbSygus* getTermDatabaseSygus() const;
   //---------------------- end utilities

--- a/src/theory/quantifiers_engine.h
+++ b/src/theory/quantifiers_engine.h
@@ -194,6 +194,8 @@ public:
   quantifiers::QuantifiersRegistry& d_qreg;
   /** The term registry */
   quantifiers::TermRegistry& d_treg;
+  /** model builder */
+  std::unique_ptr<quantifiers::QModelBuilder> d_builder;
   /** extended model object */
   quantifiers::FirstOrderModel* d_model;
   //------------- end quantifiers utilities

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -683,14 +683,14 @@ bool TheoryModel::areDisequal(TNode a, TNode b)
 
 bool TheoryModel::hasUfTerms(Node f) const
 {
-  std::map< Node, std::vector< Node > >::const_iterator it = d_uf_terms.find(f);
-  return it!=d_uf_terms.end();
+  std::map<Node, std::vector<Node> >::const_iterator it = d_uf_terms.find(f);
+  return it != d_uf_terms.end();
 }
 
 const std::vector<Node>& TheoryModel::getUfTerms(Node f) const
 {
-  std::map< Node, std::vector< Node > >::const_iterator it = d_uf_terms.find(f);
-  Assert( it!=d_uf_terms.end() );
+  std::map<Node, std::vector<Node> >::const_iterator it = d_uf_terms.find(f);
+  Assert(it != d_uf_terms.end());
   return it->second;
 }
 

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -683,13 +683,12 @@ bool TheoryModel::areDisequal(TNode a, TNode b)
 
 bool TheoryModel::hasUfTerms(Node f) const
 {
-  std::map<Node, std::vector<Node> >::const_iterator it = d_uf_terms.find(f);
-  return it != d_uf_terms.end();
+  return d_uf_terms.find(f) != d_uf_terms.end();
 }
 
 const std::vector<Node>& TheoryModel::getUfTerms(Node f) const
 {
-  std::map<Node, std::vector<Node> >::const_iterator it = d_uf_terms.find(f);
+  const auto it = d_uf_terms.find(f);
   Assert(it != d_uf_terms.end());
   return it->second;
 }

--- a/src/theory/theory_model.cpp
+++ b/src/theory/theory_model.cpp
@@ -681,6 +681,19 @@ bool TheoryModel::areDisequal(TNode a, TNode b)
   }
 }
 
+bool TheoryModel::hasUfTerms(Node f) const
+{
+  std::map< Node, std::vector< Node > >::const_iterator it = d_uf_terms.find(f);
+  return it!=d_uf_terms.end();
+}
+
+const std::vector<Node>& TheoryModel::getUfTerms(Node f) const
+{
+  std::map< Node, std::vector< Node > >::const_iterator it = d_uf_terms.find(f);
+  Assert( it!=d_uf_terms.end() );
+  return it->second;
+}
+
 bool TheoryModel::areFunctionValuesEnabled() const
 {
   return d_enableFuncModels;

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -424,9 +424,10 @@ public:
 
   //---------------------------- function values
   /** a map from functions f to a list of all APPLY_UF terms with operator f */
-  std::map< Node, std::vector< Node > > d_uf_terms;
-  /** a map from functions f to a list of all HO_APPLY terms with first argument f */
-  std::map< Node, std::vector< Node > > d_ho_uf_terms;
+  std::map<Node, std::vector<Node> > d_uf_terms;
+  /** a map from functions f to a list of all HO_APPLY terms with first argument
+   * f */
+  std::map<Node, std::vector<Node> > d_ho_uf_terms;
   /** whether function models are enabled */
   bool d_enableFuncModels;
   /** map from function terms to the (lambda) definitions

--- a/src/theory/theory_model.h
+++ b/src/theory/theory_model.h
@@ -328,10 +328,10 @@ public:
   Cardinality getCardinality(TypeNode t) const;
 
   //---------------------------- function values
-  /** a map from functions f to a list of all APPLY_UF terms with operator f */
-  std::map< Node, std::vector< Node > > d_uf_terms;
-  /** a map from functions f to a list of all HO_APPLY terms with first argument f */
-  std::map< Node, std::vector< Node > > d_ho_uf_terms;
+  /** Does this model have terms for the given uninterpreted function? */
+  bool hasUfTerms(Node f) const;
+  /** Get the terms for uninterpreted function f */
+  const std::vector<Node>& getUfTerms(Node f) const;
   /** are function values enabled? */
   bool areFunctionValuesEnabled() const;
   /** assign function value f to definition f_def */
@@ -423,6 +423,10 @@ public:
   //---------------------------- end separation logic
 
   //---------------------------- function values
+  /** a map from functions f to a list of all APPLY_UF terms with operator f */
+  std::map< Node, std::vector< Node > > d_uf_terms;
+  /** a map from functions f to a list of all HO_APPLY terms with first argument f */
+  std::map< Node, std::vector< Node > > d_ho_uf_terms;
   /** whether function models are enabled */
   bool d_enableFuncModels;
   /** map from function terms to the (lambda) definitions


### PR DESCRIPTION
This is work towards making the initialization of theory engine, theory models, quantifiers engine more flexible.

This makes it so that the specialized quantifiers models classes (FirstOrderModel) do not inherit from TheoryModel.  There is no longer any reason for this, since FirstOrderModel does not have any override methods.

As a result of this PR, there is only one kind of TheoryModel and it is constructed immediately when ModelManager is constructed.

This required refactoring the initialization of when FirstOrderModel is constructed in ModelBuilder classes in quantifiers.

This also avoids the need for casting TheoryModel to FirstOrderModel.